### PR TITLE
Destroy token on app logout

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1050,7 +1050,19 @@ export default class Reactor {
     this.changeCurrentUser(res.user);
   }
 
-  signOut() {
+  async signOut() {
+    const currentUser = await this.getCurrentUser();
+    const refreshToken = currentUser?.user?.refresh_token;
+    if (refreshToken) {
+      try {
+        await authAPI.signOut({
+          apiURI: this.config.apiURI,
+          appId: this.config.appId,
+          refreshToken,
+        });
+      } catch (e) {}
+    }
+
     this.changeCurrentUser(null);
   }
 

--- a/client/packages/core/src/authAPI.js
+++ b/client/packages/core/src/authAPI.js
@@ -81,3 +81,23 @@ export async function signInWithIdToken({
   });
   return res;
 }
+
+/**
+ * @param {Object} params
+ * @param {string} params.apiURI
+ * @param {string} params.appId
+ * @param {string} params.refreshToken
+ */
+export async function signOut({ apiURI, appId, refreshToken }) {
+  const res = await jsonFetch(`${apiURI}/runtime/signout`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      app_id: appId,
+      refresh_token: refreshToken,
+    }),
+  });
+  return res;
+}


### PR DESCRIPTION
Destroys the user's token on `auth.signOut()`.

Changes the signature of `signOut` to return a promise, so might require a version bump.