### PR TITLE
CLI pull v0

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -253,7 +253,7 @@ async function pullSchema(appId) {
     !countEntities(pullResData.schema.refs) &&
     !countEntities(pullResData.schema.blobs)
   ) {
-    console.log("Schema is empty.  Exiting.");
+    console.log("Schema is empty. Exiting.");
     return;
   }
 

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -249,8 +249,6 @@ async function pullSchema(appId) {
     console.log(pullResData);
   }
 
-  console.log();
-
   if (
     !countEntities(pullResData.schema.refs) &&
     !countEntities(pullResData.schema.blobs)
@@ -328,8 +326,6 @@ async function pullPerms(_appId) {
   if (verbose) {
     console.log(pullResData);
   }
-
-  console.log();
 
   if (!pullResData.perms || !countEntities(pullResData.perms)) {
     console.log("No perms.  Exiting.");
@@ -423,8 +419,6 @@ async function pushSchema() {
     return;
   }
 
-  console.log();
-
   console.log(
     "The following changes will be applied to your production schema:",
   );
@@ -447,8 +441,6 @@ async function pushSchema() {
       );
     }
   }
-
-  console.log();
 
   const okPush = await promptOk("OK to proceed?");
 

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -128,6 +128,6 @@ npx instant-cli pull <APP_ID> # pulls both schema and perms
 
 {% callout type="warning" %}
 
-Note: Strongly typed attributes are under active development, so for now, `pull-schema` will default all attribute types to `i.any()`.
+Note: Strongly typed attributes are under active development. For now, `pull-schema` will default all attribute types to `i.any()`.
 
 {% /callout %}

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -115,18 +115,19 @@ export default {
 };
 ```
 
-## Migrating from the dashboard
+### Pull: migrating from the dashboard
 
 If you already created an app in the dashboard and created some schema and
-permissions you can migrate to using the CLI by manually creating `instant.schema.ts` and `instant.perms.ts` files.
-Follow these steps to ensure a smooth transition.
+permissions, you can run `npx instant-cli pull <APP_ID>` to generate an `instant.schema.ts` and `instant.perms.ts` files based on your production configuration.
 
-1. Create a new app from the root of your project with `instant-cli init`. This will create a new app in the dashboard and generate default `instant.schema.ts` and `instant.perms.ts` files.
-2. Replace permissions from the dashboard to your `instant.perms.ts`.
-3. Transcribe your schema from the dashboard to [instant's schema format](/docs/schema). Run `npx instant-cli push-schema` to apply the schema to your new app. Iterate on this until the schema of your new app matches your existing app.
-4. With your schema and permissions in place, you can update the `APP_ID` in `instant.schema.ts` to your existing app.
+```bash
+npx instant-cli pull-schema <APP_ID>
+npx instant-cli pull-perms [APP_ID] # ID optional if there's already an instant.schema.ts
+npx instant-cli pull <APP_ID> # pulls both schema and perms
+```
 
-You can now manage your app via `push-schema` and `push-perms` commands. In the future we will add a more automated migration process.
-We also recommend you stick to the CLI for managing your app going forward to
-keep your configuration in sync with your database (we'll also make this easier
-in the future).
+{% callout type="warning" %}
+
+Note: Strongly typed attributes are under active development, so for now, `pull-schema` will default all attribute types to `i.any()`.
+
+{% /callout %}

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -51,13 +51,69 @@ npx instant-cli push-schema
 
 Note, to avoid accidental data loss, `push-schema` does not delete entities or fields you've removed from your schema. You can manually delete them in the [Explorer](https://www.instantdb.com/dash?s=main&t=explorer).
 
+Here's an example `instant.schema.ts` file.
+
+```ts
+import { i } from '@instantdb/core';
+
+const INSTANT_APP_ID = 'YOUR_APP_ID_HERE';
+
+const graph = i.graph(
+  INSTANT_APP_ID,
+  {
+    authors: i.entity({
+      userId: i.string(),
+      name: i.string(),
+    }),
+    posts: i.entity({
+      name: i.string(),
+      content: i.string(),
+    }),
+  },
+  {
+    authorPosts: {
+      forward: {
+        on: 'authors',
+        has: 'many',
+        label: 'posts',
+      },
+      reverse: {
+        on: 'posts',
+        has: 'one',
+        label: 'author',
+      },
+    },
+  }
+);
+
+export default graph;
+```
+
 ### Push perms
 
 ```sh
 npx instant-cli push-schema
 ```
 
-`push-schema` evals your `instant.perms.ts` file and applies it your app's production database. [Read more about permissions](/docs/permissions).
+`push-schema` evals your `instant.perms.ts` file and applies it your app's production database. `instant.perms.ts` should export an object implementing Instant's standard permissions CEL+JSON format. [Read more about permissions in Instant](/docs/permissions).
+
+Here's an example `instant.perms.ts` file.
+
+```ts
+export default {
+  allow: {
+    posts: {
+      bind: ['isAuthor', "auth.id in data.ref('authors.userId')"],
+      allow: {
+        view: 'true',
+        create: 'isAuthor',
+        update: 'isAuthor',
+        delete: 'isAuthor',
+      },
+    },
+  },
+};
+```
 
 ## Migrating from the dashboard
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1058,6 +1058,13 @@
         _ (permissioned-tx/transact! tx-ctx (:steps r))]
     (response/ok r)))
 
+(defn schema-pull [req]
+  (let [{{app-id :id app-title :title} :app} (req->app-and-user! req)
+        current-attrs (attr-model/get-by-app-id aurora/conn-pool app-id)
+        current-schema (attrs->schema current-attrs)
+        r {:schema current-schema :app-title app-title}]
+    (response/ok r)))
+
 (comment
   (def counters-app-id  #uuid "137ace7a-efdd-490f-b0dc-a3c73a14f892")
   (def u (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))
@@ -1175,6 +1182,7 @@
 
   (POST "/dash/apps/:app_id/schema/push/plan" [] schema-push-plan-post)
   (POST "/dash/apps/:app_id/schema/push/apply" [] schema-push-apply-post)
+  (GET "/dash/apps/:app_id/schema/pull" [] schema-pull)
 
   (GET "/dash/ws_playground" [] ws-playground-get)
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1058,11 +1058,19 @@
         _ (permissioned-tx/transact! tx-ctx (:steps r))]
     (response/ok r)))
 
-(defn schema-pull [req]
+(defn schema-pull-get [req]
   (let [{{app-id :id app-title :title} :app} (req->app-and-user! req)
         current-attrs (attr-model/get-by-app-id aurora/conn-pool app-id)
         current-schema (attrs->schema current-attrs)
         r {:schema current-schema :app-title app-title}]
+    (response/ok r)))
+
+(defn perms-pull-get [req]
+  (let [{{app-id :id} :app} (req->app-and-user! req)
+        perms (rule-model/get-by-app-id
+               aurora/conn-pool
+               {:app-id app-id})
+        r {:perms (:code perms)}]
     (response/ok r)))
 
 (comment
@@ -1182,7 +1190,8 @@
 
   (POST "/dash/apps/:app_id/schema/push/plan" [] schema-push-plan-post)
   (POST "/dash/apps/:app_id/schema/push/apply" [] schema-push-apply-post)
-  (GET "/dash/apps/:app_id/schema/pull" [] schema-pull)
+  (GET "/dash/apps/:app_id/schema/pull" [] schema-pull-get)
+  (GET "/dash/apps/:app_id/perms/pull" [] perms-pull-get)
 
   (GET "/dash/ws_playground" [] ws-playground-get)
 


### PR DESCRIPTION
Adds 
- `npx instant-cli pull-schema <APP_ID>`
- `npx instant-cli pull-perms [APP_ID]`
- `npx instant-cli pull <APP_ID>` (pulls both)

Details
- Updates docs with more examples, replaces the "transitioning from dash" section
- A basic utility to grab the current prod attrs and best-effort write a `instant.schema.ts`.
- Accepts an app ID as an argument.
- Since we don't store type info in the db (yet!), everything's an `i.any()`.  Users will have to go and update them down the line when we support strong types.

To try it locally:
```sh
cd client/packages/cli
DEV=1 VERBOSE=1 ./bin/index.js pull-schema YOUR_APP_ID
DEV=1 VERBOSE=1 ./bin/index.js pull-perms YOUR_APP_ID
DEV=1 VERBOSE=1 ./bin/index.js pull YOUR_APP_ID
```

@nezaj @stopachka 