### PR TITLE
Log session origin for better error tracking

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -231,6 +231,10 @@
           (.get "origin")
           first))
 
+(defn socket-ip [{:keys [http-req]}]
+  (some-> http-req
+          (.getRequestHeader "cf-connecting-ip")))
+
 (defn- handle-join-room! [store-conn eph-store-atom sess-id {:keys [client-event-id room-id] :as _event}]
   (let [auth (get-auth! store-conn sess-id)
         app-id (-> auth :app :id)
@@ -381,7 +385,8 @@
                         :sample-rate (event-sample-rate event)
                         :attributes (assoc event-attrs
                                            :worker-n worker-n
-                                           :socket-origin (socket-origin socket))}
+                                           :socket-origin (socket-origin socket)
+                                           :socket-ip (socket-ip socket))}
 
       (try
         (let [event-fut (ua/vfuture (handle-event store-conn eph-store-atom session event))


### PR DESCRIPTION
Logs the `cf-connecting-ip` for the request so that when we can see if errors for sessions are coming from multiple users or just the same user reconnecting.