### PR TITLE
Track how long things are queued

### DIFF
--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -279,8 +279,8 @@
                 (doseq [{:keys [id]} sockets]
                   (tracer/with-span! {:name "invalidator/send-refresh"
                                       :session-id id}
-                    (.put session/receive-q
-                          {:op :refresh :session-id id}))))
+                    (session/enqueue->receive-q session/receive-q
+                                                {:op :refresh :session-id id}))))
               (catch Throwable t
                 (def -wal-record wal-record)
                 (def -store-value @store-conn)
@@ -295,8 +295,8 @@
         (doseq [{:keys [id]} sockets]
           (tracer/with-span! {:name "invalidator/send-refresh"
                               :session-id id}
-            (.put session/receive-q {:op :refresh
-                                     :session-id id}))))
+            (session/enqueue->receive-q session/receive-q {:op :refresh
+                                                           :session-id id}))))
       (catch Throwable t
         (def -wal-record wal-record)
         (def -store-value @store-conn)

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -56,13 +56,15 @@
 
 (defn exclude? [[k]]
   (or (exclude-ks k)
-      ;; `detailed_` columns in our logs are just 
-      ;; too noisy. It's still nice to have in honeycomb, 
-      ;; but it distracts in stdout. 
+      ;; `detailed_` columns in our logs are just
+      ;; too noisy. It's still nice to have in honeycomb,
+      ;; but it distracts in stdout.
       (string/starts-with? k "detailed_")
-      ;; `jvm.` columns are used to associate metrics to 
-      ;; every span. This is too noisy for stdout 
-      (string/starts-with? k "jvm.")))
+      ;; `jvm.` columns are used to associate metrics to
+      ;; every span. This is too noisy for stdout
+      (string/starts-with? k "jvm.")
+      ;; gauge metrics for a namespace
+      (string/starts-with? k "instant.")))
 
 (defn attr-str [attrs]
   (->>  attrs


### PR DESCRIPTION
Adds metrics to track how long items are in the receive queue and in the worker queue.

Also tracks the receive-q length in instant.gauges. To support this without cyclic-dependency errors, you use `gauges/add-gauge-metrics-fn` to register a function that will run whenever the gauges are calculated and should return a list of `:path, :value` maps. It returns a cleanup function you can call on `stop`.