### PR TITLE
[tutorial] add use client directive to the tutorial example code

### DIFF
--- a/client/www/data/tutorial-snippets/todos-add-react.tsx
+++ b/client/www/data/tutorial-snippets/todos-add-react.tsx
@@ -1,3 +1,5 @@
+'use client'; 
+
 import { useState } from 'react';
 
 function addMessage(setMessages: any, text: string) {

--- a/client/www/pages/tutorial-examples/1-todos-add.tsx
+++ b/client/www/pages/tutorial-examples/1-todos-add.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import config from '@/lib/config'; // hide-line
 import { init, tx, id } from '@instantdb/react';
 

--- a/client/www/pages/tutorial-examples/2-todos-edit.tsx
+++ b/client/www/pages/tutorial-examples/2-todos-edit.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import config from '@/lib/config'; // hide-line
 import { init, tx, id } from '@instantdb/react';
 

--- a/client/www/pages/tutorial-examples/3-todos-attributes.tsx
+++ b/client/www/pages/tutorial-examples/3-todos-attributes.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import config from '@/lib/config'; // hide-line
 import { init, tx, id } from '@instantdb/react';
 


### PR DESCRIPTION
Feedback from an Instant Hacker: 

> Hey there - really enjoying InstantDB - quick call out, on your [https://instantdb.com/tutorial](https://t.co/JPqEwHoxcs) page you may want to add in "use client"; at the top of the page.tsx example on the right. 

This makes sense; since we are explaining this is a NextJS app, it would be good to include the 'use client' directive. 

@nezaj @dwwoelfel @markyfyi @reichert621 