### PR TITLE
Generate lookup attrs optimistically

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -1,0 +1,91 @@
+import { test, expect } from "vitest";
+import * as instaml from "../../src/instaml";
+import * as instatx from "../../src/instatx";
+import zenecaAttrs from "./data/zeneca/attrs.json";
+import uuid from "../../src/utils/uuid";
+
+const zenecaAttrToId = zenecaAttrs.reduce((res, x) => {
+  res[`${x["forward-identity"][1]}/${x["forward-identity"][2]}`] = x.id;
+  return res;
+}, {});
+
+test("simple update transform", () => {
+  const testId = uuid();
+
+  const ops = instatx.tx.books[testId].update({ title: "New Title" });
+
+  expect(instaml.transform(zenecaAttrs, ops)).toEqual([
+    ["add-triple", testId, zenecaAttrToId["books/title"], "New Title"],
+    ["add-triple", testId, zenecaAttrToId["books/id"], testId],
+  ]);
+});
+
+test("optimistically adds attrs if they don't exist", () => {
+  const testId = uuid();
+
+  const ops = instatx.tx.books[testId].update({ newAttr: "New Title" });
+
+  expect(instaml.transform(zenecaAttrs, ops)).toEqual([
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "books", "newAttr"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "unique?": false,
+        "value-type": "blob",
+      },
+    ],
+
+    ["add-triple", testId, expect.any(String), "New Title"],
+    ["add-triple", testId, zenecaAttrToId["books/id"], testId],
+  ]);
+});
+
+test("lookup resolves attr ids", () => {
+  const ops = instatx.tx.users[
+    instatx.lookup("email", "stopa@instantdb.com")
+  ].update({
+    handle: "stopa",
+  });
+
+  const stopaLookup = [zenecaAttrToId["users/email"], "stopa@instantdb.com"];
+
+  expect(instaml.transform(zenecaAttrs, ops)).toEqual([
+    ["add-triple", stopaLookup, zenecaAttrToId["users/handle"], "stopa"],
+    ["add-triple", stopaLookup, zenecaAttrToId["users/id"], stopaLookup],
+  ]);
+});
+
+test("lookup creates unique attrs for custom lookups", () => {
+  const ops = instatx.tx.users[
+    instatx.lookup("newAttr", "newAttrValue")
+  ].update({
+    handle: "stopa",
+  });
+
+  const lookup = [
+    // The attr is going to be created, so we don't know its value yet
+    expect.any(String),
+    "newAttrValue",
+  ];
+
+  expect(instaml.transform(zenecaAttrs, ops)).toEqual([
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "users", "newAttr"],
+        id: expect.any(String),
+        "index?": true,
+        isUnsynced: true,
+        "unique?": true,
+        "value-type": "blob",
+      },
+    ],
+    ["add-triple", lookup, zenecaAttrToId["users/handle"], "stopa"],
+    ["add-triple", lookup, zenecaAttrToId["users/id"], lookup],
+  ]);
+});

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -166,7 +166,7 @@ function extractIdents([_action, etype, eid, obj]) {
   const idents = [...ks].map((label) => [etype, label]);
   const lookupPair = lookupPairOfEid(eid);
   if (lookupPair) {
-    idents.push([etype, lookupPair[0], { "unique?": true }]);
+    idents.push([etype, lookupPair[0], { "unique?": true, "index?": true }]);
   }
   return idents;
 }

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -31,14 +31,25 @@ function explodeLookupRef(eid) {
   return entries[0];
 }
 
-function extractLookup(attrs, etype, eid) {
+// Returns [attr, value] for the eid if the eid is a lookup.
+// If it's a regular eid, returns null
+function lookupPairOfEid(eid) {
   if (typeof eid === "string" && !isLookup(eid)) {
+    return null;
+  }
+  return typeof eid === "string" && isLookup(eid)
+    ? parseLookup(eid)
+    : explodeLookupRef(eid);
+}
+
+function extractLookup(attrs, etype, eid) {
+  const lookupPair = lookupPairOfEid(eid);
+
+  if (lookupPair === null) {
     return eid;
   }
-  const [identName, value] =
-    typeof eid === "string" && isLookup(eid)
-      ? parseLookup(eid)
-      : explodeLookupRef(eid);
+
+  const [identName, value] = lookupPair;
   const attr = getAttrByFwdIdentName(attrs, etype, identName);
   if (!attr || !attr["unique?"]) {
     throw new Error(`${identName} is not a unique attribute.`);
@@ -150,13 +161,17 @@ function toTxSteps(attrs, [action, ...args]) {
 // ---------
 // transform
 
-function extractIdents([_action, etype, _eid, obj]) {
+function extractIdents([_action, etype, eid, obj]) {
   const ks = new Set(Object.keys(obj).concat("id"));
   const idents = [...ks].map((label) => [etype, label]);
+  const lookupPair = lookupPairOfEid(eid);
+  if (lookupPair) {
+    idents.push([etype, lookupPair[0], { "unique?": true }]);
+  }
   return idents;
 }
 
-function createObjectAttr([etype, label]) {
+function createObjectAttr([etype, label, props]) {
   const attrId = uuid();
   const fwdIdentId = uuid();
   const fwdIdent = [fwdIdentId, etype, label];
@@ -168,6 +183,7 @@ function createObjectAttr([etype, label]) {
     "unique?": false,
     "index?": false,
     isUnsynced: true,
+    ...(props || {}),
   };
 }
 

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -124,8 +124,8 @@ export function isLookup(k: string): boolean {
 }
 
 export function parseLookup(k: string): LookupRef {
-  const [_, eid, ...vJSON] = k.split("__");
-  return [eid, JSON.parse(vJSON.join("__"))];
+  const [_, attribute, ...vJSON] = k.split("__");
+  return [attribute, JSON.parse(vJSON.join("__"))];
 }
 
 function etypeChunk(etype: EType): ETypeChunk {


### PR DESCRIPTION
Fixes a problem where you can get an error when the attrs have not finished initializing before you call `transact` with a lookup (https://github.com/instantdb/instant/issues/42).

This change will optimistically generate an attr for the lookup if we don't have it locally. Just like the regular attrs, it will be 

