### PR TITLE
Wrap `id` so that it exports the type

### DIFF
--- a/client/packages/core/src/utils/uuid.ts
+++ b/client/packages/core/src/utils/uuid.ts
@@ -21,4 +21,8 @@ export function uuidCompare(uuid_a: string, uuid_b: string) {
   return compareByteArrays(uuidToByteArray(uuid_a), uuidToByteArray(uuid_b));
 }
 
-export default v4;
+function id(): string {
+  return v4();
+}
+
+export default id;


### PR DESCRIPTION
Wraps the uuid generator with our own function so that users don't have to import `@types/uuid` to get a type for `id`.

Fixes https://github.com/instantdb/instant/issues/36