### PR TITLE
Remove current-user when the token is bad on init

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -389,6 +389,15 @@ export default class Reactor {
 
     const isInitError = msg["original-event"]?.op === "init";
     if (isInitError) {
+      if (
+        msg.type === "record-not-found" &&
+        msg.hint?.["record-type"] === "app-user"
+      ) {
+        // User has been logged out
+        this.changeCurrentUser(null);
+        return;
+      }
+
       // We failed to init
       const errorMessage = {
         message:


### PR DESCRIPTION
If a user's token was revoked, we would never clear the `user` object out of localstorage so it would look like they were still logged in.

With this change, we will unset the current user if `init` returns a user not found error.