### PR TITLE
[index] reduce jitter from SSR

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -40,8 +40,8 @@ export const Label = twel('div', 'text-sm font-bold text-gray-700');
 
 export const LogoIcon = ({ size = 'mini' }: { size?: 'mini' | 'normal' }) => {
   const sizeToClass = {
-    mini: 'h-4',
-    normal: 'h-6',
+    mini: 'h-4 w-4',
+    normal: 'h-6 w-6',
   };
   return <img src="/img/icon/logo-512.svg" className={sizeToClass[size]} />;
 };

--- a/client/www/lib/muxVideos.ts
+++ b/client/www/lib/muxVideos.ts
@@ -27,7 +27,7 @@ export const walkthrough: MuxPlayerProps = {
   playbackId: 'mU6GjiVdRulYNsb34hGu9dfvghjQibq6pWoOzCmpYiM',
   primaryColor: '#FFFFFF',
   secondaryColor: '#000000',
-  placeholder: `data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><filter id="b" color-interpolation-filters="sRGB"><feGaussianBlur stdDeviation="20"/><feComponentTransfer><feFuncA type="discrete" tableValues="1 1"/></feComponentTransfer></filter><g filter="url(%23b)"><image width="100%" height="100%" preserveAspectRatio="xMidYMid slice" href="data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADwAQCdASoQAAoAAQAcJZwC7AEP1gbH4QAA/v6Fugo8OsXgHI1pt+w4YcVbbxams0Wd6ZUuP5+rnTO3BdTt/uDzILcoZodXz1B2nKXej+LibMnsoVGZzJxJzv/oAA=="/></g></svg>`,
+  placeholder: `data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><filter id="b" color-interpolation-filters="sRGB"><feGaussianBlur stdDeviation="20"/><feComponentTransfer><feFuncA type="discrete" tableValues="1 1"/></feComponentTransfer></filter><g filter="url(%23b)"><image width="100%" height="100%" preserveAspectRatio="xMidYMid slice" href="data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAAAwAgCdASoQAAoAAQAcJaQC7H8AGBvm9JqyAAD+/mVFyNo3XECtBS+Gp2qGzM7SRSe7VcvFyt53Oecwgr8gIDgQPEFW7dIg+7AtgAAA"/></g></svg>`,
   style: { aspectRatio: '209/135' },
   thumbnailTime: 242,
 };

--- a/client/www/pages/index.tsx
+++ b/client/www/pages/index.tsx
@@ -133,7 +133,7 @@ function LandingHero() {
               </Button>
             </div>
             <div className="flex items-center justify-start space-x-2">
-              <img src="/img/yc_logo.png" className="inline h-4" />
+              <img src="/img/yc_logo.png" className="inline h-4 w-4" />
               <span className="text-sm">Backed by Y Combinator</span>
             </div>
           </div>


### PR DESCRIPTION
There were to 'jittery' bugs:
- We didn't have widths on our logo and yc icon. This led to a horizontal jitter
- I also realized our blurup for the video was too dark. It's because it was using an image from the wrong thumbnailTime. I updated it. 

@nezaj @dwwoelfel @markyfyi @reichert621 

**Before**

https://github.com/user-attachments/assets/b7a06393-ee50-4e16-976d-2b8c2fd4eedc

**After**

https://github.com/user-attachments/assets/d68396f9-c357-4e46-ad7c-ccd3f8777b47


