### PR TITLE
Fix bug where duplicated attrs would cause transaction to fail

### DIFF
--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -156,10 +156,10 @@
    (hsql/format
     {:with [[[:attr-values
               {:columns attr-table-cols}]
-             {:values (attr-table-values app-id attrs)}]
+             {:values (distinct (attr-table-values app-id attrs))}]
             [[:ident-values
               {:columns ident-table-cols}]
-             {:values (ident-table-values app-id attrs)}]
+             {:values (distinct (ident-table-values app-id attrs))}]
             [:ident-inserts
              {:insert-into
               [[:idents ident-table-cols]


### PR DESCRIPTION
Fixes a bug where duplicate `add-attr` tx-steps would cause the transaction to fail.

The bug was introduced yesterday when I fixed the problem with `lookup` not working until `init` finished: https://github.com/instantdb/instant/commit/ef8b6b5811b99cfb31480d7d6ea59dd4de5e90a3

Now we deduplicate those on the server.