### PR TITLE
Add support for `config/overlay.edn` for local overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 server/resources/config/override.edn
+server/resources/config/overlay.edn
 
 # vercel
 .vercel

--- a/server/src/instant/config_edn.clj
+++ b/server/src/instant/config_edn.clj
@@ -84,7 +84,10 @@
   (s/valid? (config-spec prod?) config-edn))
 
 (defn read-config [env]
-  (let [override (io/resource "config/override.edn")]
+  (let [override (io/resource "config/override.edn")
+        overlay (some-> (io/resource "config/overlay.edn")
+                        slurp
+                        edn/read-string)]
     (when override
       ;; Can't use tracer because it requires config to be decoded before
       ;; it is initialized
@@ -92,7 +95,8 @@
     (-> (or override
             (io/resource (format "config/%s.edn" (name env))))
         slurp
-        edn/read-string)))
+        edn/read-string
+        (merge overlay))))
 
 (def associated-data (.getBytes "config"))
 


### PR DESCRIPTION
If you create a `server/resources/config/overlay.edn`, we'll merge the values there with the values we normally pick up from config. Useful for adding small local-only changes to the config.