### PR TITLE
[schema][cli] don't codegen id attr

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -865,6 +865,7 @@ function generateSchemaTypescriptFile(id, schema, title, instantModuleName) {
         `\n`,
         // a line of code for each attribute in the entity
         sortedEntries(attrs)
+          .filter(([name]) => name !== "id")
           .map(([name, config]) => {
             return [
               `    `,


### PR DESCRIPTION
`id` is implicit and managed at the system-level.  Users shouldn't have to define it in the schema file, and we shouldn't generate it for them, either. ;)