### PR TITLE
Fix query validation errors

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -682,9 +682,12 @@
   [ctx etype level label]
   (try
     (attr-pat/->ref-attr-pat ctx attr-pat/default-level-sym etype level label)
-    (catch clojure.lang.ExceptionInfo _e
-      (list (attr-pat/default-level-sym label level)
-            [(attr-pat/default-level-sym label level) '_ '_]))))
+    (catch clojure.lang.ExceptionInfo e
+      (if (contains? #{::ex/validation-failed}
+                     (::ex/type (ex-data e)))
+        (throw e)
+        (list (attr-pat/default-level-sym label level)
+              [(attr-pat/default-level-sym label level) '_ '_])))))
 
 (defn- form->child-forms
   "Given a form and eid, return a seq of all the possible child queries.

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -89,8 +89,8 @@
 
         _ (when-not (= value-type :ref)
             (ex/throw-validation-err!
-             attr
              :attr
+             attr
              [{:message (format "%s.%s needs to be a link" etype label)}]))
 
         {:keys [forward-identity reverse-identity]} attr


### PR DESCRIPTION
Fixes the query validation error where the user expected a link in the query, but the attr is not a ref, e.g.

```
{users: { handle: {} }}
```

It also makes the server return a validation error in this case instead of treating it like a attr that hasn't been defined yet.