### PR TITLE
[Docs] Add showcase title

### DIFF
--- a/client/www/pages/docs/showcase.md
+++ b/client/www/pages/docs/showcase.md
@@ -1,3 +1,7 @@
+---
+title: Showcase
+---
+
 ## Sample Apps
 Here are some sample apps showing how to use Instant to build a real app.
 


### PR DESCRIPTION
Didn't add a title in the previous PR which rendered `undefined` in the head tag. It would be nice if we could default to the label in the docs navigation instead but can make a fix for that later