### PR TITLE
Reconnect the wal listener on connection errors

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/stickers.tsx
+++ b/client/sandbox/react-nextjs/pages/play/stickers.tsx
@@ -85,6 +85,14 @@ function Main({ universeId }: { universeId: string }) {
     }
   }, [data, error, isLoading]);
 
+  const ensureUniverse = async () => {
+    await transact(tx.universes[universeId].update({}));
+  };
+
+  useEffect(() => {
+    ensureUniverse();
+  }, []);
+
   const createStickers = async () => {
     let stickers = [];
     const batches = [];

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -25,6 +25,7 @@
    [instant.util.tracer :as tracer]
    [instant.reactive.store :as rs]
    [instant.reactive.session :as session]
+   [instant.jdbc.wal :as wal]
    [instant.reactive.invalidator :as inv]
    [instant.reactive.ephemeral :as eph]
    [instant.session-counter :as session-counter]
@@ -105,6 +106,20 @@
   (stop)
   (start))
 
+(defn add-shutdown-hook []
+  (.addShutdownHook (Runtime/getRuntime)
+                    (Thread. (fn []
+                               (tracer/record-info! {:name "shut-down"})
+                               (tracer/with-span! {:name "stop-server"}
+                                 (stop))
+                               (tracer/with-span! {:name "stop-invalidator"}
+                                 ;; Hack to get the invalidator to shut down in
+                                 ;; dev. Otherwise the stream takes forever to close.
+                                 (when (= :dev (config/get-env))
+                                   (future (Thread/sleep 100)
+                                           (wal/kick-wal aurora/conn-pool)))
+                                 (inv/stop))))))
+
 (defn -main [& _args]
   (let [{:keys [aead-keyset]} (config/init)]
     (crypt-util/init aead-keyset))
@@ -130,9 +145,11 @@
   (stripe/init)
   (session/start)
   (inv/start)
+  (wal/init-cleanup aurora/conn-pool)
   (ephemeral-app/start)
   (session-counter/start)
   (when (= (config/get-env) :prod)
     (log/info "Starting analytics")
     (analytics/start))
-  (start))
+  (start)
+  (add-shutdown-hook))

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -116,8 +116,11 @@
                                  ;; Hack to get the invalidator to shut down in
                                  ;; dev. Otherwise the stream takes forever to close.
                                  (when (= :dev (config/get-env))
-                                   (future (Thread/sleep 100)
-                                           (wal/kick-wal aurora/conn-pool)))
+                                   (future
+                                     (loop []
+                                       (wal/kick-wal aurora/conn-pool)
+                                       (Thread/sleep 100)
+                                       (recur))))
                                  (inv/stop))))))
 
 (defn -main [& _args]

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -309,7 +309,7 @@
          (let [inactive-slots (get-inactive-replication-slots conn-pool)]
            (when (seq inactive-slots)
              (chime-core/chime-at
-              [(.plusSeconds (Instant/now) 20)]
+              [(.plusSeconds (Instant/now) 300)]
               (fn [_time]
                 (tracer/with-span! {:name "wal/cleanup-inactive-slots"}
                   (let [slot-names (map :slot_name inactive-slots)

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -21,6 +21,7 @@
      2. Create a special kind of PGConnection, configured for replication.
      3. Use pgjdbc's `replicationAPI` to start a stream."
   (:require
+   [chime.core :as chime-core]
    [instant.config :as config]
    [instant.jdbc.sql :as sql]
    [instant.jdbc.aurora :as aurora]
@@ -33,6 +34,7 @@
   (:import
    (java.util Properties)
    (java.nio ByteBuffer)
+   (java.time Duration Instant)
    (org.postgresql PGProperty PGConnection)
    (org.postgresql.replication PGReplicationStream LogSequenceNumber)
    (java.sql DriverManager)))
@@ -89,6 +91,35 @@
                         pg_create_logical_replication_slot(?, ?, true);"
                      slot-name output-plugin]))
 
+(defn create-logical-replication-slot!
+  "A replication slot is like a 'registration' to the master DB,
+   saying 'I want to subscribe to you'
+
+   Once slots are created, you can use them to start replication streams.
+   Each slot tracks the LSN it has processed, so PG knows when to clean up
+   old WAL records.
+
+   The slot is not temporary and must be cleaned up manually."
+  [replication-conn slot-name output-plugin]
+  (sql/execute-one! replication-conn
+                    ["SELECT
+                        *
+                      FROM
+                        pg_create_logical_replication_slot(?, ?, false);"
+                     slot-name output-plugin]))
+
+(defn get-logical-replication-slot
+  [conn slot-name]
+  (sql/select-one conn
+                  ["SELECT slot_name, confirmed_flush_lsn as lsn
+                      FROM pg_replication_slots
+                     WHERE slot_name = ?"
+                   slot-name]))
+
+(defn drop-logical-replication-slot [conn slot-name]
+  (sql/execute! conn
+                ["SELECT pg_drop_replication_slot(?)" slot-name]))
+
 (defn get-all-slots
   "Returns a list of all replication slots.
 
@@ -96,6 +127,18 @@
    https://www.postgresql.org/docs/current/view-pg-replication-slots.html"
   [conn]
   (sql/select conn ["SELECT * FROM pg_replication_slots;"]))
+
+(defn get-inactive-replication-slots [conn]
+  (sql/select conn ["select slot_name
+                       from pg_replication_slots
+                      where active = false"]))
+
+(defn cleanup-inactive-replication-slots [conn slot-names]
+  (sql/select conn ["select slot_name, pg_drop_replication_slot(slot_name)
+                       from pg_replication_slots
+                      where active = false
+                        and slot_name in (select unnest(?::text[]))"
+                    (with-meta (vec slot-names) {:pgtype "text[]"})]))
 
 (comment
   (def pg-conn (get-pg-replication-conn (config/get-aurora-config)))
@@ -159,16 +202,45 @@
 
    We do some book-keeping for the replication stream, by recording the LSN
    for the last record that was pushed to `to`."
-  [stream to shutdown?]
-  (while (not @shutdown?)
-    (let [buffer (.readPending stream)]
+  [stream to close-signal-chan]
+  (loop []
+    (let [buffer (.read stream)]
       (if-not buffer
-        (Thread/sleep 10)
+        (when-not (.isClosed stream)
+          (recur))
         (let [last-receive-lsn ^LogSequenceNumber (.getLastReceiveLSN stream)
-              record (wal-buffer->record buffer)]
-          (a/>!! to record)
-          (.setAppliedLSN stream last-receive-lsn)
-          (.setFlushedLSN stream last-receive-lsn))))))
+              record (wal-buffer->record buffer)
+              put-result (a/alt!! [[to record]] :put
+                                  ;; The close signal chan keeps us from
+                                  ;; waiting to put on a closed `to` channel
+                                  close-signal-chan :closed)]
+          (when (and (= put-result :put)
+                     (not (.isClosed stream)))
+            (.setAppliedLSN stream last-receive-lsn)
+            (.setFlushedLSN stream last-receive-lsn)
+            (recur)))))))
+
+(defn make-wal-opts [{:keys [wal-chan close-signal-chan
+                             ex-handler conn-config slot-name]}]
+  {:to wal-chan
+   :close-signal-chan close-signal-chan
+   :ex-handler ex-handler
+   :conn-config conn-config
+   :slot-name slot-name
+   :shutdown-fn (atom nil)})
+
+(defn set-shutdown-fn [wal-opts shutdown-fn]
+  (swap! (:shutdown-fn wal-opts)
+         (fn [existing]
+           (if existing
+             (throw (Exception. "shutdown-fn already set for wal worker"))
+             shutdown-fn))))
+
+(defn close-nicely [closeable]
+  (when-not (.isClosed closeable)
+    (let [close-error (try (.close closeable) (catch Exception e e))]
+      (when-not (.isClosed closeable)
+        (throw (ex-info "Unable to close" {} close-error))))))
 
 (defn start-worker
   "Starts a logical replication stream and pushes records to
@@ -177,30 +249,79 @@
    Note: Blocks the calling thread. Call with fut-bg.
 
    Use `shutdown!` to stop the stream and clean up."
-  [{:keys [conn-config slot-name to shutdown? ex-handler] :as _opts}]
+  [{:keys [conn-config slot-name to ex-handler close-signal-chan] :as wal-opts}]
   (let [replication-conn (get-pg-replication-conn conn-config)
-        {:keys [lsn]} (create-temporary-logical-replication-slot!
-                       replication-conn slot-name "wal2json")
-        stream (create-replication-stream replication-conn slot-name lsn)]
-    (tracer/record-info! {:name "wal-worker/start" :slot-name slot-name})
-    (try
-      (produce stream to shutdown?)
-      (catch Exception e
-        (ex-handler e)))
-    (tracer/record-info! {:name "wal-worker/shutdown-complete" :slot-name slot-name})
-    (.close replication-conn)
-    (a/close! to)))
+        {:keys [lsn]} (create-logical-replication-slot! replication-conn
+                                                        slot-name
+                                                        "wal2json")
+        shutdown? (atom false)]
+    (loop [replication-conn replication-conn
+           stream (create-replication-stream replication-conn slot-name lsn)]
+      (tracer/record-info! {:name "wal-worker/start"
+                            :attributes {:slot-name slot-name}})
+      (set-shutdown-fn wal-opts (fn []
+                                  (reset! shutdown? true)
+                                  (close-nicely stream)
+                                  (drop-logical-replication-slot replication-conn slot-name)
+                                  (close-nicely replication-conn)))
+      (let [produce-error (try
+                            (produce stream to close-signal-chan)
+                            (catch Exception e
+                              (tracer/with-span! {:name "wal-worker/produce-error"
+                                                  :attributes {:exception e}}
+                                e)))]
+        (try (close-nicely stream) (catch Exception _e nil))
+        (when-not @shutdown?
+          (tracer/record-exception-span! (Exception. "Wal handler closed unexpectedly, trying to restart")
+                                         {:name "wal-worker/unexpected-reconnect"
+                                          :escpaing? false})
+          (let [new-conn (get-pg-replication-conn conn-config)
+                slot (get-logical-replication-slot new-conn slot-name)]
+            (if-not slot
+              (ex-handler produce-error)
+              (do
+                (tracer/record-info! {:name "wal-worker/reconnect"
+                                      :attributes {:slot-name slot-name
+                                                   :exception produce-error}})
+                (let [stream (create-replication-stream new-conn slot-name (:lsn slot))]
+                  (reset! (:shutdown-fn wal-opts) nil)
+                  (recur new-conn stream))))))))))
 
-(defn shutdown! [{:keys [to shutdown? slot-name] :as _opts}]
-  (tracer/record-info! {:name "wal-worker/shutdown!" :slot-name slot-name})
-  (reset! shutdown? true)
-  (a/close! to)
-  ;; The producer has a has a blocking put (>!!) into `to`.
-  ;; This means that even when shut down, the producer will be
-  ;; parked at that point. If `to` has no takers, the
-  ;; producer will get stuck. This one extra take just
-  ;; makes sure the producer can exit.
-  (a/<!! to))
+(defn shutdown! [wal-opts]
+  (tracer/with-span! {:name "wal-worker/shutdown!"
+                      :attributes {:slot-name (:slot-name wal-opts)}}
+    (if-let [shutdown-fn @(:shutdown-fn wal-opts)]
+      (shutdown-fn)
+      (tracer/record-exception-span! (Exception. "Wal worker shutdown before startup")
+                                     {:name "wal-worker/shutdown-called-before-startup"
+                                      :escaping? false}))))
+
+(defn init-cleanup [conn-pool]
+  (def schedule
+    (chime-core/chime-at
+     (chime-core/periodic-seq (Instant/now) (Duration/ofHours 1))
+     (fn [_time]
+       ;; First, get any slots that are inactive, then drop them if they're
+       ;; still inactive in 5 minutes. This will prevent dropping slots that
+       ;; are still being set up.
+       (try
+         (let [inactive-slots (get-inactive-replication-slots conn-pool)]
+           (when (seq inactive-slots)
+             (chime-core/chime-at
+              [(.plusSeconds (Instant/now) 20)]
+              (fn [_time]
+                (tracer/with-span! {:name "wal/cleanup-inactive-slots"}
+                  (let [slot-names (map :slot_name inactive-slots)
+                        removed (cleanup-inactive-replication-slots conn-pool
+                                                                    slot-names)
+                        cleaned (set (map :slot_name removed))
+                        uncleaned (remove #(contains? cleaned %) slot-names)]
+                    (tracer/add-data! {:attributes {:cleaned-slot-names cleaned
+                                                    :active-uncleaned-slots uncleaned}})))))))
+         (catch Exception e
+           (tracer/record-exception-span! e {:name "wal/cleanup-error"
+                                             :escaping? false})))))))
+
 
 (comment
   (def shutdown? (atom false))
@@ -211,11 +332,16 @@
              :shutdown? shutdown?
              :ex-handler (fn [e] (tracer/record-exception-span! e {:name "wal-ex-handler"
                                                                    :escpaing? false}))})
-  (ua/fut-bg (start-worker opts)) 
+  (ua/fut-bg (start-worker opts))
   (do
     (require 'instant.db.transaction-test)
     #_{:clj-kondo/ignore [:unresolved-namespace]}
     (clojure.test/run-tests 'instant.db.transaction-test))
   (ua/<!!-timeout to 1000)
-  (shutdown! opts)
-  )
+  (shutdown! opts))
+
+(defn kick-wal
+  "A hacky way to trigger the stream reader so that it will close faster.
+   Useful to speed up exit in dev where there isn't much activity on the wal."
+  [conn]
+  (sql/execute! conn ["update schema_migrations set version = version"]))

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -345,4 +345,4 @@
   "A hacky way to trigger the stream reader so that it will close faster.
    Useful to speed up exit in dev where there isn't much activity on the wal."
   [conn]
-  (sql/execute! conn ["update schema_migrations set version = version"]))
+  (sql/execute! conn ["select pg_notify('random-channel', 'payload')"]))

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -335,6 +335,7 @@
   (if-not config/instant-on-instant-app-id
     (let [chan (a/chan 1 (wal-record-xf))]
       {:wal-chan chan
+       :close-signal-chan (a/chan)
        :worker-chan chan})
     (let [wal-chan (a/chan 1)
           mult (a/mult wal-chan)
@@ -343,6 +344,11 @@
       (a/tap mult worker-chan)
       (a/tap mult byop-chan)
       {:wal-chan wal-chan
+       ;; Nothing will ever be put on this chan,
+       ;; it will be closed when the wal-chan is closed
+       ;; so that the consumer can know to stop waiting for
+       ;; its puts to complete
+       :close-signal-chan (a/chan)
        :worker-chan worker-chan
        :byop-chan byop-chan})))
 
@@ -350,26 +356,31 @@
   "Entry point for invalidator. Starts a WAL listener and pipes WAL records to
   our parition router. Partion router dispatches records to app workers who run `go-work`"
   []
-  (let [{:keys [wal-chan worker-chan byop-chan]} (create-wal-chans)
-        wal-opts {:to wal-chan
-                  :ex-handler wal-ex-handler
-                  :conn-config (config/get-aurora-config)
-                  :slot-name @config/process-id
-                  :shutdown? (atom false)}]
+  (let [{:keys [wal-chan worker-chan byop-chan close-signal-chan]}
+        (create-wal-chans)
+
+        wal-opts (wal/make-wal-opts {:wal-chan wal-chan
+                                     :close-signal-chan close-signal-chan
+                                     :ex-handler wal-ex-handler
+                                     :conn-config (config/get-aurora-config)
+                                     :slot-name @config/process-id})]
 
     (def wal-opts wal-opts)
 
     (ua/fut-bg
-     (wal/start-worker wal-opts))
+      (wal/start-worker wal-opts))
     (ua/fut-bg
-     (start-worker rs/store-conn worker-chan))
+      (start-worker rs/store-conn worker-chan))
 
     (when byop-chan
       (ua/fut-bg
-       (start-byop-worker rs/store-conn byop-chan)))))
+        (start-byop-worker rs/store-conn byop-chan)))))
 
 (defn stop []
-  (wal/shutdown! wal-opts))
+  (when wal-opts
+    (wal/shutdown! wal-opts)
+    (a/close! (:to wal-opts))
+    (a/close! (:close-signal-chan wal-opts))))
 
 (defn restart []
   (stop)

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -66,6 +66,14 @@
       ;; gauge metrics for a namespace
       (string/starts-with? k "instant.")))
 
+(defn format-attr-value
+  "Formats attr values for logs."
+  [v]
+  (condp identical? (type v)
+    ;; format will print e.g. "clojure.lang.LazySeq@7861"
+    clojure.lang.LazySeq (pr-str v)
+    v))
+
 (defn attr-str [attrs]
   (->>  attrs
         (map (fn [[k v]] [(str k) v]))
@@ -75,7 +83,7 @@
                        (if (= k "exception.message")
                          (colorize error-color k)
                          k)
-                       v)))
+                       (format-attr-value v))))
         (interpose " ")
         string/join))
 


### PR DESCRIPTION
Adds reconnect logic when the wal listener connection fails.

We don't want to miss any updates while the connection is down, so this PR switches our replication slot from temporary to non-temporary.

When the slots were temporary, they automatically got cleaned up when the connection closed. We need to make sure that we clean up old slots so that postgres can delete the wal logs.

There are two things we do to keep on top of inactive slots:

1. There is a new shutdown handler that will call `stop` on the invalidator, which will shutdown the wal listener and drop the slot. It works if you hit Ctrl+c locally, but I'll have to monitor to see if it actually works in elastic beanstalk.
2. There is a background process that will check for inactive slots every hour and drop them if they're still inactive 5 minutes later.

Other changes:
1. Uses `read` on the stream instead of `readPending`. `read` is blocking, so we won't have to do the `Thread/sleep` and we should have slightly less latency on handling updates. I'm not sure why it was switched to `readPending` before, so I might be missing something important here.
2. Better logging of lists in the logging_exportert (no more `list=clojure.lang.LazySeq@7861`)

Tested by running `select pg_terminate_backend(active_pid) from pg_replication_slots` and checking that the invalidator still worked afterwards.