### PR TITLE
Allow empty `:in` in the where clause

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -47,7 +47,7 @@
 ;; Pattern
 
 (defn pattern-component [v-type]
-  (s/or :constant (s/coll-of v-type :kind set? :min-count 1)
+  (s/or :constant (s/coll-of v-type :kind set? :min-count 0)
         :any #{'_}
         :variable symbol?))
 
@@ -477,9 +477,10 @@
   "If the set has only one element,
    return an = clause. Otherwise, return an :in clause."
   [k v-set]
-  (if (= (count v-set) 1)
-    [:= k (first v-set)]
-    [:in k v-set]))
+  (case (count v-set)
+    0 [:= 0 1]
+    1 [:= k (first v-set)]
+    :else [:in k v-set]))
 
 (defn- value->jsonb [x]
   [:cast (->json x) :jsonb])

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -480,7 +480,7 @@
   (case (count v-set)
     0 [:= 0 1]
     1 [:= k (first v-set)]
-    :else [:in k v-set]))
+    [:in k v-set]))
 
 (defn- value->jsonb [x]
   [:cast (->json x) :jsonb])

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -29,6 +29,7 @@
   (or (string? x) (uuid? x) (number? x) (boolean? x)))
 
 (s/def ::in (s/coll-of where-value-valid?
+                       :kind vector?
                        :min-count 0
                        :into #{}))
 

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -29,7 +29,7 @@
   (or (string? x) (uuid? x) (number? x) (boolean? x)))
 
 (s/def ::in (s/coll-of where-value-valid?
-                       :min-count 1
+                       :min-count 0
                        :into #{}))
 
 (defn where-value-valid-keys? [m]

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -106,8 +106,7 @@
              :in [:users :$],
              :message "We only support `where`, `order`, `limit`, `offset`, `before`, and `after` clauses."}
            (validation-err {:users {:$ {:forgot-where ["foo"]}}})))
-    (is (= '{:expected (<= 1 (count %) Integer/MAX_VALUE),
-             :in [0 :option-map :where-conds 0 1 :in]}
+    (is (= '{:expected vector?, :in [0 :option-map :where-conds 0 1 :in]}
            (validation-err {:users {:$ {:where {:handle {:in {}}}}}})))
     (is (= '{:expected instant.db.instaql/where-value-valid-keys?,
              :in [0 :option-map :where-conds 0 1]}


### PR DESCRIPTION
Allows a query like `{:users {:$ {:where {:id {:in []}}}}}` to succeed (with an empty set of join rows).

It would be more efficient to skip the trip to the db here, but I worry about how complicated that will make queries where a nested ref query has an empty `in` array or where there are multiple sibling top-level queries.