### PR TITLE
Fix for duplicate ref attrs

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -89,3 +89,80 @@ test("lookup creates unique attrs for custom lookups", () => {
     ["add-triple", lookup, zenecaAttrToId["users/id"], lookup],
   ]);
 });
+
+test("it doesn't create duplicate ref attrs", () => {
+  const aid = uuid();
+  const bid = uuid();
+  const ops = [
+    instatx.tx.nsA[aid].update({}).link({ nsB: bid }),
+    instatx.tx.nsB[bid].update({}).link({ nsA: aid }),
+  ];
+
+  expect(instaml.transform({}, ops)).toEqual([
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "nsA", "id"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "unique?": false,
+        "value-type": "blob",
+      },
+    ],
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "nsB", "id"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "unique?": false,
+        "value-type": "blob",
+      },
+    ],
+    [
+      "add-attr",
+      {
+        cardinality: "many",
+        "forward-identity": [expect.any(String), "nsA", "nsB"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "reverse-identity": [expect.any(String), "nsB", "nsA"],
+        "unique?": false,
+        "value-type": "ref",
+      },
+    ],
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "nsA", "id"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "unique?": false,
+        "value-type": "blob",
+      },
+    ],
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "nsB", "id"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "unique?": false,
+        "value-type": "blob",
+      },
+    ],
+    ["add-triple", aid, expect.any(String), aid],
+    ["add-triple", aid, expect.any(String), bid],
+    ["add-triple", bid, expect.any(String), bid],
+    ["add-triple", aid, expect.any(String), bid],
+  ]);
+});


### PR DESCRIPTION
Fixes a bug on the client where we would add duplicate ref attrs if you tried to add the reverse and forward ref in the same transaction, here's a simple example:

```js
const userId = id();
const bookId = id();
db.transact([
  tx.users[userId].update({}).link({books: bookId}),
  tx.books[bookId].update({}).link({users: userId})
]);
```

We would try to create two ref attrs for that transaction, which would throw an error because two idents tried to be `users.books` (or `books.users`).

Now we use a reduce to build up the attrs and we don't run into that problem.

Fixes https://github.com/jsventures/instldraw/issues/3
