### PR TITLE
[Docs] Add links for clerk and vanilla js

### DIFF
--- a/client/www/pages/docs/auth.md
+++ b/client/www/pages/docs/auth.md
@@ -17,5 +17,8 @@ Instant comes with support for auth. We currently offer [magic codes](/docs/auth
             title="Custom Auth"
             description="Integrate your own auth flow with the Admin SDK."
             /%}
-
+  {% nav-button href="https://github.com/stopachka/clerk_auth_example"
+            title="Clerk (Alpha)"
+            description="Github repo showing how to integrate with Clerk."
+            /%}
 {% /nav-group %}

--- a/client/www/pages/docs/auth/magic-codes.md
+++ b/client/www/pages/docs/auth/magic-codes.md
@@ -8,6 +8,11 @@ how you can do it with react.
 
 ## Full Magic Code Example
 
+{% callout type="info" %}
+The example below shows how to use magic codes in a React app. If you're looking
+for an example with vanilla JS, check out this [sandbox](https://github.com/instantdb/instant/blob/main/client/sandbox/vanilla-js-vite/src/main.ts).
+{% /callout %}
+
 ```javascript {% showCopy=true %}
 'use client';
 


### PR DESCRIPTION
Been seeing asks for using auth with vanilla js and with clerk. We have examples of this in github and figured it may be nice to link to them from the docs

### Clerk
<img width="705" alt="image" src="https://github.com/user-attachments/assets/5dbf2192-4cd4-4a87-99a0-37aedf181168">

### Vanilla JS
<img width="716" alt="image" src="https://github.com/user-attachments/assets/f2050c28-6324-4d2f-818b-06eafb650482">
