### PR TITLE
Run clojure tests on every push

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -3,8 +3,6 @@ name: Clojure CI
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 jobs:
   detect_clj:


### PR DESCRIPTION
Now that we're open source, the repo gets unlimited action minutes.

Runs the clojure tests on every push so you don't have to open a PR to see what the build thinks of your changes.