### PR TITLE
[Honeycomb] Increase honeycomb sample rate

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -119,7 +119,8 @@
     (when (seq changed-rooms)
       (tracer/with-span!
         {:name "refresh-rooms"
-         :attributes {:room-ids (pr-str (map first changed-rooms))}}
+         :attributes {:room-ids (pr-str (map first changed-rooms))}
+         :sample-rate 0.01}
         (ua/vfuture-pmap
          (fn [[room-id {:keys [data session-ids]}]]
            (rs/try-broadcast-event! store-conn session-ids {:op :refresh-presence

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -298,9 +298,10 @@
 ;; receive hundreds of `set-presence` events per second. 
 ;; Throttling these, so we don't overwhelm Honeycomb.
 (defn event-sample-rate [{:keys [op]}]
-  (if (#{:set-presence :client-broadcast :join-room} op)
-    0.1
-    1.0))
+  (cond
+    (= op :set-presence) 0.01
+    (#{:client-broadcast :join-room} op) 0.1
+    :else 1))
 
 (defn handle-event [store-conn eph-store-atom session event]
   (tracer/with-span! {:name "receive-worker/handle-event"

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -40,7 +40,6 @@
         (.setTracerProvider (.build trace-provider-builder))
         (.build))))
 
-
 (defn make-honeycomb-sdk [honeycomb-api-key]
   (let [builder (OpenTelemetryConfiguration/builder)
         log-processor (SimpleSpanProcessor/create (logging-exporter/create))]


### PR DESCRIPTION
We reduced events from ~17M → ~12M [via sampling refresh-rooms and set presence](https://github.com/instantdb/instant/pull/109). The problem is `handle-receive` and `handle-events` [generate a ton of subtraces](https://ui.honeycomb.io/instantdb/environments/prod/result/bGk9tRFm9tk?hideCompare) for querying/book-keeping. So let's just wholesale increase the sample rate for all event types