### PR TITLE
Increase honeycomb sample rates

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -300,8 +300,7 @@
 (defn event-sample-rate [{:keys [op]}]
   (cond
     (= op :set-presence) 0.01
-    (#{:client-broadcast :join-room} op) 0.1
-    :else 1))
+    :else 0.1))
 
 (defn handle-event [store-conn eph-store-atom session event]
   (tracer/with-span! {:name "receive-worker/handle-event"


### PR DESCRIPTION
We reduced events from ~17M → ~12M https://github.com/instantdb/instant/pull/109. The problem is handle-receive and handle-events [generate a ton of subtraces](https://ui.honeycomb.io/instantdb/environments/prod/result/bGk9tRFm9tk?hideCompare) for querying/book-keeping. So let's just wholesale increase the sample rate for all event types