### PR TITLE
Better cel errors for data.ref

### DIFF
--- a/server/src/instant/db/dataloader.clj
+++ b/server/src/instant/db/dataloader.clj
@@ -42,7 +42,10 @@
 
 (defn create-loader [dataloader-opts]
   (fn [& args]
-    (get-one dataloader-opts args)))
+    (let [result (get-one dataloader-opts args)]
+      (if (instance? Exception result)
+        (throw result)
+        result))))
 
 (comment
   (defn get-batched [args]


### PR DESCRIPTION
Gives a better error when you call data.ref on a non-existent ref.

Fixes a bug where the get-ref dataloader wouldn't throw exceptions.

Before:

```json
{
    "type": "permission-evaluation-failed",
    "message": "Could not evaluate permission rule for [\"users\" \"create\"]. You may have a typo.  Go to the permission tab in your dashboard to update your rule.",
    "hint": {
        "rule": [
            "users",
            "create"
        ]
    }
}
```

After:

```json
{
    "type": "permission-evaluation-failed",
    "message": "Could not evaluate permission rule for `users.create`. Record not found: attr. Go to the permission tab in your dashboard to update your rule.",
    "hint": {
        "rule": [
            "users",
            "create"
        ],
        "error": {
            "type": "record-not-found",
            "message": "Record not found: attr",
            "hint": {
                "args": [
                    "users",
                    "creator"
                ],
                "record-type": "attr"
            }
        }
    }
}
```

Still not super happy with the error we get, since `:attr` and `Record`s aren't things they know about. But that's what we return for the query side too, so we'd need to have some discussion on what we want those errors to look like.