### PR TITLE
Encode more cel values to JSON

### DIFF
--- a/server/src/instant/util/json.clj
+++ b/server/src/instant/util/json.clj
@@ -7,7 +7,7 @@
            (com.google.protobuf.util JsonFormat)))
 
 ;; Encode NullValue as nil
-(add-encoder com.google.protobuf.NullValue encode-nil)
+(add-encoder NullValue encode-nil)
 
 (defn encode-cel-expr-value
   "Encode cel expression values using the protobuf json encoder"
@@ -16,7 +16,7 @@
         json-str (.print json-printer v)]
     (.writeRawValue jg json-str)))
 
-(add-encoder dev.cel.expr.Value encode-cel-expr-value)
+(add-encoder Value encode-cel-expr-value)
 
 (def ->json
   "Converts a Clojure data structure to a JSON string."

--- a/server/src/instant/util/json.clj
+++ b/server/src/instant/util/json.clj
@@ -1,5 +1,22 @@
 (ns instant.util.json
-  (:require [cheshire.core :as cheshire]))
+  (:require [cheshire.core :as cheshire]
+            [cheshire.generate :refer [add-encoder encode-nil]])
+  (:import (com.google.protobuf NullValue)
+           (dev.cel.expr Value)
+           (com.fasterxml.jackson.core JsonGenerator)
+           (com.google.protobuf.util JsonFormat)))
+
+;; Encode NullValue as nil
+(add-encoder com.google.protobuf.NullValue encode-nil)
+
+(defn encode-cel-expr-value
+  "Encode cel expression values using the protobuf json encoder"
+  [v ^JsonGenerator jg]
+  (let [json-printer (JsonFormat/printer)
+        json-str (.print json-printer v)]
+    (.writeRawValue jg json-str)))
+
+(add-encoder dev.cel.expr.Value encode-cel-expr-value)
 
 (def ->json
   "Converts a Clojure data structure to a JSON string."
@@ -8,4 +25,3 @@
 (def <-json
   "Converts a JSON string to a Clojure data structure."
   cheshire/parse-string)
-


### PR DESCRIPTION
Fixes encoding null and cel expression values to JSON so that the sandbox doesn't break on rules that return null.