### PR TITLE
[chrome-ext] Make Reactor run in a chrome extension

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -37,8 +37,12 @@ const OAUTH_REDIRECT_PARAM = "_instant_oauth_redirect";
 const currentUserKey = `currentUser`;
 
 function isClient() {
+  const hasWindow = typeof window !== "undefined";
+  // this checks if we are running in a chrome extension
   // @ts-expect-error
-  return typeof window !== "undefined" || typeof chrome !== "undefined";
+  const isChrome = typeof chrome !== 'undefined';
+  
+  return hasWindow || isChrome;
 }
 
 /**

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 import log from "./utils/log";
 import weakHash from "./utils/weakHash";
 import instaql from "./instaql";
@@ -36,6 +35,11 @@ const defaultConfig = {
 const OAUTH_REDIRECT_PARAM = "_instant_oauth_redirect";
 
 const currentUserKey = `currentUser`;
+
+function isClient() {
+  // @ts-expect-error
+  return typeof window !== "undefined" || typeof chrome !== "undefined";
+}
 
 /**
  * @template {import('./presence').RoomSchemaShape} [RoomSchema = {}]
@@ -76,16 +80,10 @@ export default class Reactor {
     this.config = { ...defaultConfig, ...config };
     // This is to protect us against running
     // server-side.
-    // Incidentally, window is defined in react-native
-    // so this check won't pass, giving us the behavior
-    // we want. It would be nicer if we had a better
-    // check for server-side.
-    if (typeof window === "undefined") {
+    if (!isClient()) {
       return;
     }
-
     if (
-      "BroadcastChannel" in window &&
       typeof BroadcastChannel === "function"
     ) {
       this._broadcastChannel = new BroadcastChannel("@instantdb");
@@ -667,11 +665,11 @@ export default class Reactor {
       // If a transaction is pending for over 3 seconds,
       // we want to unblock the UX, so mark it as pending
       // and keep trying to process the transaction in the background
-      window.setTimeout(() => {
+      setTimeout(() => {
         this._finishTransaction(true, "pending", eventId);
       }, 3_000);
 
-      window.setTimeout(() => {
+      setTimeout(() => {
         if (!this._isOnline) {
           return;
         }

--- a/client/packages/core/src/WindowNetworkListener.js
+++ b/client/packages/core/src/WindowNetworkListener.js
@@ -1,6 +1,6 @@
 export default class WindowNetworkListener {
   static async getIsOnline() {
-    return window.navigator.onLine;
+    return navigator.onLine;
   }
   static listen(f) {
     const onOnline = () => {
@@ -9,11 +9,11 @@ export default class WindowNetworkListener {
     const onOffline = () => {
       f(false);
     };
-    window.addEventListener("online", onOnline);
-    window.addEventListener("offline", onOffline);
+    addEventListener("online", onOnline);
+    addEventListener("offline", onOffline);
     return () => {
-      window.removeEventListener("online", onOnline);
-      window.removeEventListener("offline", onOffline);
+      removeEventListener("online", onOnline);
+      removeEventListener("offline", onOffline);
     };
   }
 }

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -87,16 +87,9 @@ const defaultConfig = {
 };
 
 // hmr
-
 function initGlobalInstantCoreStore(): Record<string, InstantCore<any>> {
-  if (typeof window !== "undefined") {
-    // @ts-expect-error
-    window.__instantDbStore = window.__instantDbStore ?? {};
-    // @ts-expect-error
-    return window.__instantDbStore;
-  }
-
-  return {};
+  globalThis.__instantDbStore = globalThis.__instantDbStore ?? {};
+  return globalThis.__instantDbStore;
 }
 
 const globalInstantCoreStore = initGlobalInstantCoreStore();


### PR DESCRIPTION
In a chrome extension service worker, `window` is not defined. But websockets, BroadcastChannel, and IndexedDB _still_ work. 

This means we can have a light lift and support chrome extensions. I updated our call in Reactor, to handle the chrome extension case.   I checked web, native, and a chrome extension to see that everything works. 

To check the chrome extension, I used this repo from tph: https://github.com/ayoung19/buzz-extension
We may want to extract out a basic chrome extension, and keep it in sandbox for development.

@nezaj @dwwoelfel @markyfyi @reichert621 

