### PR TITLE
Coerce NULL_VALUE to null in cel check

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -162,7 +162,7 @@
 (defn eval-program!
   [{:keys [cel-program etype action]} bindings]
   (try
-    (.eval ^CelRuntime$Program cel-program ^java.util.Map bindings)
+    (= true (.eval ^CelRuntime$Program cel-program ^java.util.Map bindings))
     (catch CelEvaluationException e
       (ex/throw-permission-evaluation-failed!
        etype action e))))

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -162,7 +162,10 @@
 (defn eval-program!
   [{:keys [cel-program etype action]} bindings]
   (try
-    (= true (.eval ^CelRuntime$Program cel-program ^java.util.Map bindings))
+    (let [result (.eval ^CelRuntime$Program cel-program ^java.util.Map bindings)]
+      (if (= result NullValue/NULL_VALUE)
+        nil
+        result))
     (catch CelEvaluationException e
       (ex/throw-permission-evaluation-failed!
        etype action e))))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -1225,6 +1225,19 @@
                 :users
                 (map :handle)
                 set))))
+
+      (testing "only true should evaluate to true"
+        (rule-model/put!
+         aurora/conn-pool
+         {:app-id app-id :code {:users {:allow {:view "auth.isAdmin"}}}})
+        (is
+         (empty?
+          (->>  (pretty-perm-q
+                 {:app-id app-id :current-user nil}
+                 {:users {}})
+                :users
+                (map :handle)
+                set))))
       (testing "can only view authed user data"
         (rule-model/put!
          aurora/conn-pool

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -1226,7 +1226,7 @@
                 (map :handle)
                 set))))
 
-      (testing "only true should evaluate to true"
+      (testing "null shouldn't evaluate to true"
         (rule-model/put!
          aurora/conn-pool
          {:app-id app-id :code {:users {:allow {:view "auth.isAdmin"}}}})


### PR DESCRIPTION
If you do `user.isAdmin` in your rule, that will return a NullObject from cel and we'll evaluate that to truthy.

This change coerces NULL_VALUE to nil before we return from `eval-program!`