### PR TITLE
Add refinery for honeycomb sampling

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -149,7 +149,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [ clj-check ]
-    if: github.ref == 'refs/heads/main'
+    # XXX: refinery BACK TO main
+    if: github.ref == 'refs/heads/refinery'
     permissions:
       id-token: write
       contents: read
@@ -200,7 +201,7 @@ jobs:
       uses: "./.github/actions/elastic-beanstalk"
       with:
         working-directory: "server"
-        files: '["docker-compose.yml", ".platform/hooks/prebuild/logdna.sh"]'
+        files: '["docker-compose.yml", ".platform/hooks/prebuild/logdna.sh", "refinery/config.yaml", "refinery/rules.yaml"]'
         aws-region: "us-east-1"
         bucket: "elasticbeanstalk-us-east-1-597134865416"
         application-name: "instant-docker-prod"

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -146,9 +146,8 @@ jobs:
       working-directory: server
       run: clojure -M:lint "--config" ".clj-kondo/ci-config.edn"
 
-  publish:
+  publish-image:
     runs-on: ubuntu-latest
-    needs: [ clj-check ]
     # XXX: refinery BACK TO main
     if: github.ref == 'refs/heads/refinery'
     permissions:
@@ -180,6 +179,25 @@ jobs:
           --cache-to mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:cache \
           --cache-from type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:cache \
           -t 597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:$IMAGE_TAG .
+
+  publish-eb:
+    runs-on: ubuntu-latest
+    needs:
+      - clj-check
+      - publish-image
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::597134865416:role/aws-credentials-for-github-actions-Role-x0lUbtwJNb7G
+        aws-region: us-east-1
+
     - name: Update docker-compose.yml
       working-directory: server
       env:
@@ -195,7 +213,6 @@ jobs:
       run: |
         sed -i "s|SHA_REPLACE_ME|${SHA}|g" .platform/hooks/prebuild/logdna.sh
         cat .platform/hooks/prebuild/logdna.sh
-
 
     - name: Create eb application version
       uses: "./.github/actions/elastic-beanstalk"

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -148,8 +148,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    # XXX: refinery BACK TO main
-    if: github.ref == 'refs/heads/refinery'
+    if: github.ref == 'refs/heads/main'
+    # Start publish image if we have clj changes
+    needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -182,6 +183,7 @@ jobs:
 
   publish-eb:
     runs-on: ubuntu-latest
+    # Publish to elastic beanstalk only if we pass the tests
     needs:
       - clj-check
       - publish-image

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - BEANSTALK_PORT=5000
       - PRODUCTION=true
+      - HONEYCOMB_ENDPOINT=http://localhost:8082
     env_file:
       - .env
     ports:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - BEANSTALK_PORT=5000
       - PRODUCTION=true
-      - HONEYCOMB_ENDPOINT=http://localhost:8082
+      - HONEYCOMB_ENDPOINT=http://refinery:8082
     env_file:
       - .env
     ports:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '3'
 services:
   web:
     image: IMAGE_REPLACE_ME
+    depends_on:
+      - refinery
     environment:
       - BEANSTALK_PORT=5000
       - PRODUCTION=true
@@ -22,3 +23,12 @@ services:
       - /var/log/eb-engine.log:/var/log/eb-engine.log:ro
       - /var/log/messages:/var/log/messages:ro
       - /var/log/eb-docker:/var/log/eb-docker:ro
+  refinery:
+    image: honeycombio/refinery:2.7.1
+    volumes:
+      - ./refinery/config.yaml:/etc/refinery/refinery.yaml
+      - ./refinery/rules.yaml:/etc/refinery/rules.yaml
+    environment:
+      - REFINERY_HONEYCOMB_API_KEY=${REFINERY_HONEYCOMB_API_KEY}
+    ports:
+      - 8082:8082

--- a/server/refinery/config.yaml
+++ b/server/refinery/config.yaml
@@ -1,0 +1,19 @@
+General:
+  ConfigurationVersion: 2
+Network:
+  ListenAddr: "0.0.0.0:8080"
+  PeerListenAddr: "0.0.0.0:8081"
+GRPCServerParameters:
+  Enabled: true
+  ListenAddr: "0.0.0.0:8082"
+RefineryTelemetry:
+  AddRuleReasonToTrace: true
+OTelMetrics:
+  Enabled: true
+PeerManagement:
+  Peers: []
+Logger:
+  Level: info
+Debugging:
+  # Set to true to see which events would have been filtered
+  DryRun: false

--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -1,0 +1,21 @@
+RulesVersion: 2
+Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 1
+    production:
+      RulesBasedSampler:
+        Rules:
+          - Name: keep errors
+            SampleRate: 1
+            Conditions:
+              - Field: error
+                Operator: exists
+
+          - Name: default rule
+            Sampler:
+              EMAThroughputSampler:
+                # With one server, that's about 80MM/month
+                GoalThroughputPerSec: 30
+                FieldList:
+                  - name

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -140,6 +140,10 @@
 (defn get-google-oauth-client []
   (-> @config-map :google-oauth-client))
 
+(defn get-honeycomb-endpoint []
+  (or (System/getenv "HONEYCOMB_ENDPOINT")
+      "https://api.honeycomb.io:443"))
+
 (def server-origin (case (get-env)
                      :prod "https://api.instantdb.com"
                      "http://localhost:8888"))

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -137,12 +137,12 @@
 (defn get-honeycomb-api-key []
   (some-> @config-map :honeycomb-api-key (.value)))
 
-(defn get-google-oauth-client []
-  (-> @config-map :google-oauth-client))
-
 (defn get-honeycomb-endpoint []
   (or (System/getenv "HONEYCOMB_ENDPOINT")
       "https://api.honeycomb.io:443"))
+
+(defn get-google-oauth-client []
+  (-> @config-map :google-oauth-client))
 
 (def server-origin (case (get-env)
                      :prod "https://api.instantdb.com"

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -167,21 +167,21 @@
            (end-span! *span*))))))
 
 ;; (XXX)
-;; Given a `sample-rate`, we will randomly skip spans at that rate 
+;; Given a `sample-rate`, we will randomly skip spans at that rate
 ;; All children of a skipped span will also be skipped.
-;; 
+;;
 ;; There are more 'idiomatic' ways to do this:
 ;; 1. We could use honeycomb's 'refinery'
-;;     This is a service that takes a full trace, 
-;;     and lets us make a decision about whether to keep it or not. 
-;;     For example, if a trace has an error, we 100% keep it 
-;;   
+;;     This is a service that takes a full trace,
+;;     and lets us make a decision about whether to keep it or not.
+;;     For example, if a trace has an error, we 100% keep it
+;;
 ;;     The con: This requires us to create a cluster of 'refinery' services.
 ;;             That's ops overhead
-;; 2. Another option is to use a `Sampler` when we set up the SDK. 
-;;     
+;; 2. Another option is to use a `Sampler` when we set up the SDK.
+;;
 ;;     The con: our SDK is a bit out of date, and we didn't want to write more code for this version
-;; 
+;;
 ;; Going with some manual clojure macros for now.
 (defmacro with-span!
   [span-opts & body]
@@ -210,7 +210,7 @@
     (with-span! {:name "foo" :sample-rate 0.5}
       (+ 1 1)))
 
-  ;; this will never print, since the parent span is skipped 
+  ;; this will never print, since the parent span is skipped
   (with-redefs [new-span! (fn [& args] (println "new-span!" args))
                 end-span! (fn [& _] _)]
     (with-span! {:name "foo" :sample-rate 0}
@@ -219,13 +219,13 @@
 
 (defn record-info!
   "Analogous to log/info.
-  
-  Sometimes you want to just log some information, but there is no parent span. 
-  
-  For example, if you have a long-running process, it wouldn't make sense to have a 
-  parent span that encompasses the entire process. 
- 
-  This function creates a one-off span for you, which you can use to send information 
+
+  Sometimes you want to just log some information, but there is no parent span.
+
+  For example, if you have a long-running process, it wouldn't make sense to have a
+  parent span that encompasses the entire process.
+
+  This function creates a one-off span for you, which you can use to send information
   to Honeycomb."
   [opts]
   (with-span! opts))

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -45,6 +45,7 @@
         log-processor (SimpleSpanProcessor/create (logging-exporter/create))]
     (-> builder
         (.setApiKey honeycomb-api-key)
+        (.setEndpoint (config/get-honeycomb-endpoint))
         (.setDataset "metrics")
         (.setServiceName "instant-server")
         (.addSpanProcessor log-processor)


### PR DESCRIPTION
Adds refinery to do honeycomb tail sampling for us.

Our configuration is set up to send all events that have an `error` property, and throttle all other events so that we send a max of about 30/second. That should keep us below our Honeycomb plan limits.

The refinery container sits next to the server container and we redirect all of our honeycomb API calls to the refinery container. Then the refinery container makes a decision on what to send based on the rules we defined in `server/refinery/rules.yaml`. More docs on those [here](https://docs.honeycomb.io/manage-data-volume/sample/honeycomb-refinery/sampling-methods/) and [here](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml).

We use a `EMAThroughputSampler` to set a target throughput for non-errors. It uses the `name` field to group spans for throttling, so that it doesn't completely drop certain spans. If we want to throttle certain spans more or with more granularity, we can add additional rules to the yaml file.