### PR TITLE
[clerk] use clerk last-active links

### DIFF
--- a/client/www/components/dash/AppAuth.tsx
+++ b/client/www/components/dash/AppAuth.tsx
@@ -1169,7 +1169,7 @@ function AddClerkClientForm({
               className="underline"
               target="_blank"
               rel="noopener noreferer"
-              href="https://dashboard.clerk.com"
+              href="https://dashboard.clerk.com/last-active?path=api-keys"
             >
               Clerk dashboard
             </a>
@@ -1182,7 +1182,7 @@ function AddClerkClientForm({
           Navigate to your{' '}
           <a
             className="underline"
-            href={`https://dashboard.clerk.com`}
+            href={"https://dashboard.clerk.com/last-active?path=sessions"}
             target="_blank"
             rel="noopener noreferer"
           >

--- a/client/www/pages/docs/auth/clerk.md
+++ b/client/www/pages/docs/auth/clerk.md
@@ -8,7 +8,7 @@ Instant supports delegating auth to Clerk.
 
 **Step 1: Configure Clerk**
 
-Go to your [Clerk dashboard](https://console.cloud.google.com/apis/credentials), navigate to `Sessions`, then click the `Edit` button in the `Customize session token` section.
+Go to your Clerk dashboard, navigate to [`Sessions`](https://dashboard.clerk.com/last-active?path=sessions), then click the `Edit` button in the `Customize session token` section.
 
 Add the email claim to your session token:
 
@@ -24,7 +24,7 @@ You can have additional claims as long as the `email` claim is set to `{{user.pr
 
 **Step 2: Get your Clerk Publishable key**
 
-On the [Clerk dashboard](https://console.cloud.google.com/apis/credentials), navigate to `API keys`, then copy the `Publishable key`. It should start with `pk_`.
+On the Clerk dashboard, navigate to [`API keys`](https://dashboard.clerk.com/last-active?path=api-keys), then copy the `Publishable key`. It should start with `pk_`.
 
 **Step 3: Register your Clerk Publishable key with your instant app**
 


### PR DESCRIPTION
I updated `Sessions` and `API Keys` links to deep-link into Clerk's dashboard. Found a nice trick they used in clerk docs, which lets us go to the active app, on those specific pages! 

Reference on Clerk:  https://github.com/clerk/clerk-docs/pull/1512

@dwwoelfel 