### PR TITLE
[strong-init] add guarded ref attr pat in admin routes

### DIFF
--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -81,11 +81,11 @@
 
 (defn enrich-node [attrs parent-etype node]
   (let [label (-> node :data :k)
-        pat (attr-pat/->ref-attr-pat {:attrs attrs}
-                                     attr-pat/default-level-sym
-                                     parent-etype
-                                     0
-                                     label)
+        pat (attr-pat/->guarded-ref-attr-pat
+             {:attrs attrs}
+             parent-etype
+             0
+             label)
         [next-etype _ _ attr forward?] pat
         enriched-node (update node
                               :data
@@ -103,7 +103,6 @@
                              (map (partial enrich-node attrs etype))
                              (instaql-ref-nodes->object-tree ctx attrs))]
     (merge blob-entries ref-entries)))
-
 
 (defn singular-entry? [data]
   (if (-> data :forward?)
@@ -378,11 +377,9 @@
                      :headers {"authorization" (str "Bearer " admin-token)
                                "app-id" (str counters-app-id)}})
 
-
   (app-users-delete {:params {:id "moop"}
                      :headers {"authorization" (str "Bearer " admin-token)
                                "app-id" (str counters-app-id)}}))
-
 
 ;; ---
 ;; Storage

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -679,17 +679,6 @@
 ;; -----
 ;; query
 
-(defn ->guarded-ref-attr-pat
-  [ctx etype level label]
-  (try
-    (attr-pat/->ref-attr-pat ctx attr-pat/default-level-sym etype level label)
-    (catch clojure.lang.ExceptionInfo e
-      (if (contains? #{::ex/validation-failed}
-                     (::ex/type (ex-data e)))
-        (throw e)
-        (list (attr-pat/default-level-sym label level)
-              [(attr-pat/default-level-sym label level) '_ '_])))))
-
 (defn- form->child-forms
   "Given a form and eid, return a seq of all the possible child queries.
    This determines the etype for the child form, and adds a join condition on
@@ -699,7 +688,7 @@
     (let [{:keys [k]} form
 
           [next-etype next-level attr-pat]
-          (->guarded-ref-attr-pat ctx etype level k)
+          (attr-pat/->guarded-ref-attr-pat ctx etype level k)
 
           join-attr-pat (attr-pat/replace-in-attr-pat
                          attr-pat (attr-pat/default-level-sym etype level) eid)

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -106,6 +106,19 @@
         next-etype (if attr-fwd rev-etype fwd-etype)]
     (list next-etype next-level attr-pat attr (boolean attr-fwd))))
 
+(defn ->guarded-ref-attr-pat
+  [ctx etype level label]
+  (try
+    (->ref-attr-pat ctx default-level-sym etype level label)
+    (catch clojure.lang.ExceptionInfo e
+      (if (contains? #{::ex/validation-failed}
+                     (::ex/type (ex-data e)))
+        (throw e)
+        (list (default-level-sym label level)
+              [(default-level-sym label level) '_ '_]
+              nil
+              nil)))))
+
 (defn ->ref-attr-pats
   "Take the where-cond:
 

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -218,7 +218,6 @@
                                  ("eid-joe-averbukh" :users/email "joe@instantdb.com")
                                  ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637")}})))
 
-
   (testing "offset"
     (is-pretty-eq? (query-pretty {:users {:$ {:offset 2
                                               :order {:serverCreatedAt :desc}}}})


### PR DESCRIPTION
Hunter from Palette pointed out a bug introduced by strong init. If you have queries with an attribute that doesn't exist, i.e: 

```
{goals: {todos: {}}
```
But `todos` doesn't exist, we _should_ return an empty array. 

But in the admin SDK, we added a change which would throw. 

This catches that specific throw. We do it in instaql.clj. I just moved the logic into attr_pat.clj, and use it in both places 


@nezaj @dwwoelfel @markyfyi @reichert621 