### PR TITLE
Lookup by a ref attr

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -3,7 +3,6 @@ name: JS CI
 
 on:
   push:
-    branches: ["main"]
   pull_request:
     types: [opened, synchronize]
 

--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -177,6 +177,19 @@ test("lookup creates unique ref attrs for ref lookup", () => {
   }
 });
 
+test("it throws if you use an invalid link attr", () => {
+  expect(() =>
+    instaml.transform(
+      {},
+      instatx.tx.users[
+        instatx.lookup("user_pref.email", "test@example.com")
+      ].update({
+        a: 1,
+      }),
+    ),
+  ).toThrowError('user_pref.email is not a valid lookup attribute.');
+});
+
 test("it doesn't create duplicate ref attrs", () => {
   const aid = uuid();
   const bid = uuid();

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -136,8 +136,9 @@ function expandUnlink(attrs, [etype, eidA, obj]) {
 
 function expandUpdate(attrs, [etype, eid, obj]) {
   const lookup = extractLookup(attrs, etype, eid);
-  const attrTuples = Object.entries(obj)
-    .concat([["id", extractLookup(attrs, etype, eid)]])
+  // id first so that we don't clobber updates on the lookup field
+  const attrTuples = [["id", extractLookup(attrs, etype, eid)]]
+    .concat(Object.entries(obj))
     .map(([identName, value]) => {
       const attr = getAttrByFwdIdentName(attrs, etype, identName);
       return ["add-triple", lookup, attr.id, value];
@@ -165,7 +166,8 @@ function expandDeepMerge(attrs, [etype, eid, obj]) {
     lookup,
   ];
 
-  return attrTuples.concat([idTuple]);
+  // id first so that we don't clobber updates on the lookup field
+  return [idTuple].concat(attrTuples);
 }
 
 function toTxSteps(attrs, [action, ...args]) {
@@ -264,7 +266,7 @@ function createMissingAttrs(existingAttrs, ops) {
         if (isRefLookupIdent(identName)) {
           const label = extractRefLookupFwdName(identName);
           const fwdAttr = getAttrByFwdIdentName(attrs, etype, label);
-          const revAttr = getAttrByReverseIdentName(attrs, etype, label);
+          const revAttr = getAttrByReverseIdentName(attrs, etype, label);          
           if (!fwdAttr && !revAttr) {
             addAttr(createRefAttr(etype, label, refLookupProps));
           }

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -38,7 +38,7 @@ function isRefLookupIdent(identName) {
 function extractRefLookupFwdName(identName) {
   const [fwdName, idIdent, ...rest] = identName.split(".");
   if (rest.length > 0 || idIdent !== "id") {
-    throw new Error(`${identName} is not a valid attribute.`);
+    throw new Error(`${identName} is not a valid lookup attribute.`);
   }
 
   return fwdName;
@@ -266,7 +266,7 @@ function createMissingAttrs(existingAttrs, ops) {
         if (isRefLookupIdent(identName)) {
           const label = extractRefLookupFwdName(identName);
           const fwdAttr = getAttrByFwdIdentName(attrs, etype, label);
-          const revAttr = getAttrByReverseIdentName(attrs, etype, label);          
+          const revAttr = getAttrByReverseIdentName(attrs, etype, label);
           if (!fwdAttr && !revAttr) {
             addAttr(createRefAttr(etype, label, refLookupProps));
           }

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -64,7 +64,7 @@
       (ex/throw-validation-err!
        :lookup
        lookup
-       [{:message (str ident-name " is not a valid link lookup.")}]))
+       [{:message (str ident-name " is not a valid lookup attribute.")}]))
     fwdName))
 
 (defn extract-lookup [attrs etype eid]

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -1,19 +1,19 @@
 (ns instant.admin.model
-  "Context: 
-   
-   Internally, we process transactions as `tx-steps`. The model for that is in 
-   `instant.db.transaction`, and looks like: 
-   
-   [[:add-triple eid ...] 
+  "Context:
+
+   Internally, we process transactions as `tx-steps`. The model for that is in
+   `instant.db.transaction`, and looks like:
+
+   [[:add-triple eid ...]
     [:retract-triple eid ..]]
-   
-   However, when users make POST requests through the admin API, we take a different 
-   structure. It looks something like: 
-   
+
+   However, when users make POST requests through the admin API, we take a different
+   structure. It looks something like:
+
    [[\"update\" \"goals\" (str-uuid) {\"title\" \"moop\"}]
-    [\"link\" \"goals\" (str-uuid) {\"todos\" (str-uuid)}] 
+    [\"link\" \"goals\" (str-uuid) {\"todos\" (str-uuid)}]
     ...]
-   
+
    This namespace transforms the user-facing `steps` to the internal `tx-steps`."
   (:require
    [instant.db.model.attr :as attr-model]
@@ -46,21 +46,40 @@
        eid
        [{:message "lookup must be an object with a single unique attr and value."}]))))
 
-(defn extract-lookup [attrs etype eid]
-  (if (and (string? eid)
-           (not (lookup? eid)))
-    eid
+(defn eid->lookup-pair
+  "Extract the [label, value] from a lookup, returns nil if eid isn't a lookup"
+  [eid]
+  (if (string? eid)
+    (when (lookup? eid)
+      (parse-lookup eid))
+    (explode-lookup eid)))
 
-    (let [[ident-name value] (if (lookup? eid)
-                               (parse-lookup eid)
-                               (explode-lookup eid))
-          attr (attr-model/seek-by-fwd-ident-name [etype ident-name] attrs)]
+(defn ref-lookup? [[ident-name _value]]
+  (not= (.indexOf ident-name ".") -1))
+
+(defn extract-ref-lookup-fwd-name [lookup]
+  (let [[ident-name _value] lookup
+        [fwdName idIdent & more] (string/split ident-name #"\.")]
+    (when (or (seq more) (not= idIdent "id"))
+      (ex/throw-validation-err!
+       :lookup
+       lookup
+       [{:message (str ident-name " is not a valid link lookup.")}]))
+    fwdName))
+
+(defn extract-lookup [attrs etype eid]
+  (if-let [[ident-name value :as lookup] (eid->lookup-pair eid)]
+    (let [label (if (ref-lookup? lookup)
+                  (extract-ref-lookup-fwd-name lookup)
+                  ident-name)
+          attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]
       (when (not (:unique? attr))
         (ex/throw-validation-err!
          :lookup
          eid
          [{:message (str ident-name " is not a unique attribute on " etype)}]))
-      [(:id attr) value])))
+      [(:id attr) value])
+    eid))
 
 (defn expand-link [attrs [etype eid-a obj]]
   (mapcat (fn [[label eid-or-eids]]
@@ -122,7 +141,8 @@
     (map (fn [[label value]]
            (let [attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]
              [:add-triple lookup (:id attr) value]))
-         (concat obj [["id" lookup]]))))
+         ;; id first so that we don't clobber updates on the lookup field
+         (concat [["id" lookup]] obj))))
 
 (defn expand-merge [attrs [etype eid obj]]
   (let [lookup (extract-lookup attrs etype eid)]
@@ -130,7 +150,8 @@
            (let [attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)
                  op (if (= label "id") :add-triple :deep-merge-triple)]
              [op lookup (:id attr) value]))
-         (concat obj [["id" lookup]]))))
+         ;; id first so that we don't clobber updates on the lookup field
+         (concat [["id" lookup]] obj))))
 
 (defn expand-delete [attrs [etype eid]]
   (let [lookup (extract-lookup attrs etype eid)]
@@ -156,34 +177,36 @@
     "delete-attr" (expand-delete-attr attrs args)
     (throw (ex-info (str "unsupported action " action) {}))))
 
-(defn extract-ident-names [[_action etype _eid obj]]
-  (let [ks (set (concat (keys obj) ["id"]))]
-    (map (fn [label] [etype label]) ks)))
+(defn create-object-attr
+  ([etype label] (create-object-attr etype label nil))
+  ([etype label props]
+   (let [attr-id (UUID/randomUUID)
+         fwd-ident-id (UUID/randomUUID)
+         fwd-ident [fwd-ident-id etype label]]
+     (merge {:id attr-id
+             :forward-identity fwd-ident
+             :value-type :blob
+             :cardinality :one
+             :unique? false
+             :index? false}
+            props))))
 
-(defn create-object-attr [[etype label]]
-  (let [attr-id (UUID/randomUUID)
-        fwd-ident-id (UUID/randomUUID)
-        fwd-ident [fwd-ident-id etype label]]
-    {:id attr-id
-     :forward-identity fwd-ident
-     :value-type :blob
-     :cardinality :one
-     :unique? false
-     :index? false}))
-
-(defn create-ref-attr [[etype label]]
-  (let [attr-id (UUID/randomUUID)
-        fwd-ident-id (UUID/randomUUID)
-        rev-ident-id (UUID/randomUUID)
-        fwd-ident [fwd-ident-id etype label]
-        rev-ident [rev-ident-id label etype]]
-    {:id attr-id
-     :forward-identity fwd-ident
-     :reverse-identity rev-ident
-     :value-type :ref
-     :cardinality :many
-     :unique? false
-     :index? false}))
+(defn create-ref-attr
+  ([etype label] (create-ref-attr etype label nil))
+  ([etype label props]
+   (let [attr-id (UUID/randomUUID)
+         fwd-ident-id (UUID/randomUUID)
+         rev-ident-id (UUID/randomUUID)
+         fwd-ident [fwd-ident-id etype label]
+         rev-ident [rev-ident-id label etype]]
+     (merge {:id attr-id
+             :forward-identity fwd-ident
+             :reverse-identity rev-ident
+             :value-type :ref
+             :cardinality :many
+             :unique? false
+             :index? false}
+            props))))
 
 (defn create-missing-object-attrs [attrs ops]
   (let [object-ops (filter #(contains? #{"update" "merge"} (first %)) ops)
@@ -205,11 +228,90 @@
         attr-tx-steps (map (fn [attr] [:add-attr attr]) ref-attrs)]
     [new-attrs attr-tx-steps]))
 
+(def obj-actions #{"link" "unlink" "update" "merge"})
+(def update-actions #{"update", "merge"})
+(def ref-actions #{"link" "unlink"})
+(def supports-lookup-actions #{"link" "unlink" "update" "merge" "delete"})
+
+(defn add-attr [{:keys [attrs add-ops]} attr]
+  {:attrs (conj attrs attr)
+   :add-ops (conj add-ops [:add-attr attr])})
+
+(defn add-attrs-for-obj [{:keys [attrs add-ops] :as acc} op]
+  (let [[action etype eid obj] op
+        labels (conj (keys obj) "id")]
+    (reduce (fn [{:keys [attrs add-ops] :as acc} label]
+              (let [fwd-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)
+                    rev-attr (when (contains? ref-actions action)
+                               (attr-model/seek-by-rev-ident-name [etype label] attrs))]
+                (cond (and (contains? update-actions action)
+                           (not fwd-attr))
+                      (add-attr acc (create-object-attr etype label))
+
+                      (and (contains? ref-actions action)
+                           (not fwd-attr)
+                           (not rev-attr))
+                      (add-attr acc (create-ref-attr etype label))
+
+                      :else acc)))
+            acc
+            labels)))
+
+(defn add-attrs-for-lookup [{:keys [attrs add-ops] :as acc} lookup etype]
+  (if (ref-lookup? lookup)
+    (let [label (extract-ref-lookup-fwd-name lookup)
+          fwd-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)
+          rev-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]
+      (if (and (not fwd-attr) (not rev-attr))
+        (add-attr acc (create-ref-attr etype
+                                       label
+                                       {:unique? true
+                                        :index? true
+                                        :cardinality :one}))
+        acc))
+    (let [[label _value] lookup]
+      (if-let [attr (attr-model/seek-by-fwd-ident-name [etype label]
+                                                       attrs)]
+        acc
+        (add-attr acc (create-object-attr etype
+                                          label
+                                          {:unique? true
+                                           :index? true}))))))
+
+(defn create-lookup-attrs [acc ops]
+  (reduce (fn [{:keys [attrs add-ops] :as acc} op]
+            (let [[action etype eid obj] op
+                  lookup (when (contains? supports-lookup-actions action)
+                           (eid->lookup-pair eid))]
+              (if-let [lookup (when (contains? supports-lookup-actions action)
+                                (eid->lookup-pair eid))]
+                (add-attrs-for-lookup acc lookup etype)
+                acc)))
+          acc
+          ops))
+
+(defn create-attrs-from-objs [acc ops]
+  (reduce (fn [{:keys [attrs add-ops] :as acc} op]
+            (let [[action etype eid obj] op
+                  lookup (when (contains? supports-lookup-actions action)
+                           (eid->lookup-pair eid))]
+              (if (contains? obj-actions action)
+                (add-attrs-for-obj acc op)
+                acc)))
+          acc
+          ops))
+
+(defn create-missing-attrs [attrs ops]
+  (-> {:attrs attrs
+       :add-ops []}
+      (create-lookup-attrs ops)
+      (create-attrs-from-objs ops)))
+
 (defn transform [attrs steps]
-  (let [[with-new-obj-attrs add-obj-attr-tx-steps] (create-missing-object-attrs attrs steps)
-        [with-new-ref-attrs add-ref-attr-tx-steps] (create-missing-ref-attrs with-new-obj-attrs steps)
-        tx-steps (mapcat (fn [step] (to-tx-steps with-new-ref-attrs step)) steps)]
-    (concat add-obj-attr-tx-steps add-ref-attr-tx-steps tx-steps)))
+  (tool/def-locals)
+  (let [{attrs :attrs add-attr-tx-steps :add-ops} (create-missing-attrs attrs steps)
+        tx-steps (mapcat (fn [step] (to-tx-steps attrs step)) steps)]
+    (concat add-attr-tx-steps tx-steps)))
 
 (defn coercible-uuid? [x]
   (or (uuid? x) (and (string? x) (parse-uuid x))))

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -208,26 +208,6 @@
              :index? false}
             props))))
 
-(defn create-missing-object-attrs [attrs ops]
-  (let [object-ops (filter #(contains? #{"update" "merge"} (first %)) ops)
-        object-idents (set (mapcat extract-ident-names object-ops))
-        missing-idents (remove #(attr-model/seek-by-fwd-ident-name % attrs) object-idents)
-        object-attrs (map create-object-attr missing-idents)
-        new-attrs (concat attrs object-attrs)
-        attr-tx-steps (map (fn [attr] [:add-attr attr]) object-attrs)]
-    [new-attrs attr-tx-steps]))
-
-(defn create-missing-ref-attrs [attrs ops]
-  (let [object-ops (filter #(or (= "link" (first %)) (= "unlink" (first %))) ops)
-        object-idents (set (mapcat extract-ident-names object-ops))
-        missing-idents (remove #(or (attr-model/seek-by-fwd-ident-name % attrs)
-                                    (attr-model/seek-by-rev-ident-name % attrs))
-                               object-idents)
-        ref-attrs (map create-ref-attr missing-idents)
-        new-attrs (concat attrs ref-attrs)
-        attr-tx-steps (map (fn [attr] [:add-attr attr]) ref-attrs)]
-    [new-attrs attr-tx-steps]))
-
 (def obj-actions #{"link" "unlink" "update" "merge"})
 (def update-actions #{"update", "merge"})
 (def ref-actions #{"link" "unlink"})

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -284,7 +284,6 @@
       (create-attrs-from-objs ops)))
 
 (defn transform [attrs steps]
-  (tool/def-locals)
   (let [{attrs :attrs add-attr-tx-steps :add-ops} (create-missing-attrs attrs steps)
         tx-steps (mapcat (fn [step] (to-tx-steps attrs step)) steps)]
     (concat add-attr-tx-steps tx-steps)))

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -7,8 +7,10 @@
    [clojure.spec.alpha :as s]
    [instant.util.spec :as uspec]
    [instant.util.json :refer [->json]]
+   [instant.util.string :refer [multiline->single-line]]
    [instant.util.tracer :as tracer]
-   [instant.data.constants :refer [empty-app-id]])
+   [instant.data.constants :refer [empty-app-id]]
+   [instant.util.exception :as ex])
 
   (:import
    (java.util UUID)))
@@ -246,159 +248,174 @@
    write. So if [1 user/pet 2] already exists, inserting [1 user/pet 3] will
    not trigger a conflict, but trying to insert [1 user/pet 2] will no-op"
   [conn app-id triples]
-  (sql/do-execute!
-   conn
-   (hsql/format
-    (let [lookup-refs (distinct (keep (fn [[e]]
-                                        (when (eid-lookup-ref? e)
-                                          e))
-                                      triples))]
-      {:with (concat
-              (when (seq lookup-refs)
-                [[[:input-lookup-refs
-                   {:columns [:app-id :attr-id :value]}]
-                  {:values (map (fn [[a v]]
-                                  [app-id a (->json v)])
-                                lookup-refs)}]
+  (let [lookup-refs (distinct (keep (fn [[e]]
+                                      (when (eid-lookup-ref? e)
+                                        e))
+                                    triples))
+        query {:with (concat
+                      (when (seq lookup-refs)
+                        [[[:input-lookup-refs
+                           {:columns [:app-id :attr-id :value]}]
+                          {:values (map (fn [[a v]]
+                                          [app-id a (->json v)])
+                                        lookup-refs)}]
 
-                 ;; create data for lookup refs
-                 [:enhanced-lookup-refs
-                  {:select
-                   [[[:cast :ilr.app_id :uuid] :app-id]
-                    [[:gen_random_uuid] :entity-id]
-                    [[:cast :ilr.attr-id :uuid] :attr-id]
-                    [[:cast :ilr.value :jsonb] :value]
-                    [[:md5 :ilr.value] :value-md5]
-                    [[:case [:= :a.cardinality [:inline "one"]] true :else false]
-                     :ea]
-                    [[:case [:= :a.value-type [:inline "ref"]] true :else false]
-                     :eav]
-                    [[:case :a.is-unique true :else [[:raise_exception_message [:inline "attribute is not unique"]]]] :av]
-                    [[:case :a.is-indexed true :else false] :ave]
-                    [[:case [:= :a.value-type [:inline "ref"]] true :else false]
-                     :vae]]
-                   :from [[:input-lookup-refs :ilr]]
-                   :left-join [[:attrs :a] [:and
-                                            :a.is-unique
-                                            [:= :a.app-id [:cast :ilr.app-id :uuid]]
-                                            [:= :a.id [:cast :ilr.attr-id :uuid]]]]}]
+                         ;; create data for lookup refs
+                         [:enhanced-lookup-refs
+                          {:select
+                           [[[:cast :ilr.app_id :uuid] :app-id]
+                            [[:gen_random_uuid] :entity-id]
+                            [[:cast :ilr.attr-id :uuid] :attr-id]
+                            [[:cast :ilr.value :jsonb] :value]
+                            [[:md5 :ilr.value] :value-md5]
+                            [[:case [:= :a.cardinality [:inline "one"]] true :else false]
+                             :ea]
+                            [[:case [:= :a.value-type [:inline "ref"]] true :else false]
+                             :eav]
+                            [[:case :a.is-unique true :else [[:raise_exception_message [:inline "attribute is not unique"]]]] :av]
+                            [[:case :a.is-indexed true :else false] :ave]
+                            [[:case [:= :a.value-type [:inline "ref"]] true :else false]
+                             :vae]]
+                           :from [[:input-lookup-refs :ilr]]
+                           :left-join [[:attrs :a] [:and
+                                                    :a.is-unique
+                                                    [:= :a.app-id [:cast :ilr.app-id :uuid]]
+                                                    [:= :a.id [:cast :ilr.attr-id :uuid]]]]}]
+                         ;; insert lookup refs
+                         [:lookup-ref-inserts
+                          {:insert-into [[:triples triple-cols]
+                                         {:select triple-cols
+                                          :from :enhanced-lookup-refs}]
+                           :on-conflict [:app-id :attr-id :value {:where :av}]
+                           :do-nothing true
+                           :returning :*}]
 
-                 ;; insert lookup refs
-                 [:lookup-ref-inserts
-                  {:insert-into [[:triples triple-cols]
-                                 {:select triple-cols
-                                  :from :enhanced-lookup-refs}]
-                   :on-conflict [:app-id :attr-id :value {:where :av}]
-                   :do-nothing true
-                   :returning :*}]
+                         ;; collect lookup ref entities
+                         ;; if we do this inline instead of creating a CTE, the lookup
+                         ;; ref entity might get created anew when it's updated (e.g.
+                         ;; users[lookup({handle: 'me'})].update({handle: 'mee'}) will
+                         ;; generate a new triple with value = 'me'
+                         [:lookup-ref-lookups
+                          {:union-all [{:select :*
+                                        :from :lookup-ref-inserts}
+                                       {:select :*
+                                        :from :triples
+                                        :where [:and
+                                                [:= :app-id app-id]
+                                                (list* :or (for [[a v] lookup-refs]
+                                                             [:and
+                                                              [:= :attr-id a]
+                                                              [:= :value [:cast (->json v) :jsonb]]]))]}]}]])
+                      [[[:input-triples
+                         {:columns [:idx :app-id :entity-id :attr-id :value]}]
+                        {:values (map-indexed
+                                  (fn [idx [e a v]]
+                                    [idx
+                                     app-id
+                                     (if-not (eid-lookup-ref? e)
+                                       e
+                                       {:select :entity-id
+                                        :from :lookup-ref-lookups
+                                        :where [:and
+                                                [:= :app-id app-id]
+                                                [:= :attr-id (first e)]
+                                                [:= :value [:cast (->json (second e)) :jsonb]]]
+                                        :limit 1})
 
-                 ;; collect lookup ref entities
-                 ;; if we do this inline instead of creating a CTE, the lookup
-                 ;; ref entity might get created anew when it's updated (e.g.
-                 ;; users[lookup({handle: 'me'})].update({handle: 'mee'}) will
-                 ;; generate a new triple with value = 'me'
-                 [:lookup-ref-lookups
-                  {:union-all [{:select :*
-                                :from :lookup-ref-inserts}
-                               {:select :*
-                                :from :triples
-                                :where [:and
-                                        [:= :app-id app-id]
-                                        (list* :or (for [[a v] lookup-refs]
-                                                     [:and
-                                                      [:= :attr-id a]
-                                                      [:= :value [:cast (->json v) :jsonb]]]))]}]}]])
-              [[[:input-triples
-                 {:columns [:idx :app-id :entity-id :attr-id :value]}]
-                {:values (map-indexed
-                          (fn [idx [e a v]]
-                            [idx
-                             app-id
-                             (if-not (eid-lookup-ref? e)
-                               e
-                               {:select :entity-id
-                                :from :lookup-ref-lookups
-                                :where [:and
-                                        [:= :app-id app-id]
-                                        [:= :attr-id (first e)]
-                                        [:= :value [:cast (->json (second e)) :jsonb]]]
-                                :limit 1})
-
-                             a
-                             (if-not (value-lookup-ref? v)
-                               (->json v)
-                               [[[:case (value-lookupable-sql app-id a)
-                                  {:select [[[:cast [:to_jsonb :entity-id] :text]]]
-                                   :from (if (seq lookup-refs)
-                                           [[{:union-all [{:select :entity-id
-                                                           :from :lookup-ref-lookups
-                                                           :where [:and
-                                                                   [:= :app-id app-id]
-                                                                   [:= :attr-id (first v)]
-                                                                   [:= :value [:cast (->json (second v)) :jsonb]]]}
-                                                          {:select :entity-id
-                                                           :from :triples
-                                                           :where [:and
-                                                                   [:= :app-id app-id]
-                                                                   [:= :attr-id (first v)]
-                                                                   [:= :value [:cast (->json (second v)) :jsonb]]]}]}
-                                             :lookups]]
-                                           [[{:select :entity-id
-                                              :from :triples
-                                              :where [:and
-                                                      [:= :app-id app-id]
-                                                      [:= :attr-id (first v)]
-                                                      [:= :value [:cast (->json (second v)) :jsonb]]]}
-                                             :lookups]])
-                                   :limit 1}
-                                  :else (->json v)]]])])
-                          triples)}]
-               [:enhanced-triples
-                {:select
-                 [[:it.idx :idx]
-                  [[:cast :it.app_id :uuid] :app-id]
-                  [[:cast :it.entity-id :uuid] :entity-id]
-                  [[:cast :it.attr-id :uuid] :attr-id]
-                  [[:cast :it.value :jsonb] :value]
-                  [[:md5 :it.value] :value-md5]
-                  [[:case [:= :a.cardinality [:inline "one"]] true :else false]
-                   :ea]
-                  [[:case [:= :a.value-type [:inline "ref"]] true :else false]
-                   :eav]
-                  [[:case :a.is-unique true :else false] :av]
-                  [[:case :a.is-indexed true :else false] :ave]
-                  [[:case [:= :a.value-type [:inline "ref"]] true :else false]
-                   :vae]]
-                 :from [[:input-triples :it]]
-                 :left-join [[:attrs :a] [:and
-                                          [:= :a.app-id [:cast :it.app-id :uuid]]
-                                          [:= :a.id [:cast :it.attr-id :uuid]]]]}]
-               [:ea-triples-distinct
-                {:select-distinct-on [[:entity-id :attr-id] :*]
-                 :from :enhanced-triples
-                 :where [:= :ea true]
-                 :order-by [[:entity-id :desc] [:attr-id :desc] [:idx :desc]]}]
-               [:remaining-triples
-                {:select :* :from :enhanced-triples :where [:not :ea]}]
-               [:ea-index-inserts
-                {:insert-into [[:triples triple-cols]
-                               {:select triple-cols
-                                :from :ea-triples-distinct}]
-                 :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
-                 :do-update-set {:value :excluded.value
-                                 :value-md5 :excluded.value-md5}
-                 :returning :entity-id}]
-               [:remaining-inserts
-                {:insert-into [[:triples triple-cols]
-                               {:select triple-cols
-                                :from :remaining-triples}]
-                 :on-conflict [:app-id :entity-id :attr-id :value-md5]
-                 :do-nothing true
-                 :returning :entity-id}]]
-              (when-let [attr-inferred-types (insert-attr-inferred-types-cte app-id triples)]
-                [attr-inferred-types]))
-       :union-all [{:select :entity-id :from :ea-index-inserts}
-                   {:select :entity-id :from :remaining-inserts}]}))))
+                                     a
+                                     (if-not (value-lookup-ref? v)
+                                       (->json v)
+                                       [[[:case (value-lookupable-sql app-id a)
+                                          {:select [[[:cast [:to_jsonb :entity-id] :text]]]
+                                           :from (if (seq lookup-refs)
+                                                   [[{:union-all [{:select :entity-id
+                                                                   :from :lookup-ref-lookups
+                                                                   :where [:and
+                                                                           [:= :app-id app-id]
+                                                                           [:= :attr-id (first v)]
+                                                                           [:= :value [:cast (->json (second v)) :jsonb]]]}
+                                                                  {:select :entity-id
+                                                                   :from :triples
+                                                                   :where [:and
+                                                                           [:= :app-id app-id]
+                                                                           [:= :attr-id (first v)]
+                                                                           [:= :value [:cast (->json (second v)) :jsonb]]]}]}
+                                                     :lookups]]
+                                                   [[{:select :entity-id
+                                                      :from :triples
+                                                      :where [:and
+                                                              [:= :app-id app-id]
+                                                              [:= :attr-id (first v)]
+                                                              [:= :value [:cast (->json (second v)) :jsonb]]]}
+                                                     :lookups]])
+                                           :limit 1}
+                                          :else (->json v)]]])])
+                                  triples)}]
+                       [:enhanced-triples
+                        {:select
+                         [[:it.idx :idx]
+                          [[:cast :it.app_id :uuid] :app-id]
+                          [[:cast :it.entity-id :uuid] :entity-id]
+                          [[:cast :it.attr-id :uuid] :attr-id]
+                          [[:cast :it.value :jsonb] :value]
+                          [[:md5 :it.value] :value-md5]
+                          [[:case [:= :a.cardinality [:inline "one"]] true :else false]
+                           :ea]
+                          [[:case [:= :a.value-type [:inline "ref"]] true :else false]
+                           :eav]
+                          [[:case :a.is-unique true :else false] :av]
+                          [[:case :a.is-indexed true :else false] :ave]
+                          [[:case [:= :a.value-type [:inline "ref"]] true :else false]
+                           :vae]]
+                         :from [[:input-triples :it]]
+                         :left-join [[:attrs :a] [:and
+                                                  [:= :a.app-id [:cast :it.app-id :uuid]]
+                                                  [:= :a.id [:cast :it.attr-id :uuid]]]]}]
+                       [:ea-triples-distinct
+                        {:select-distinct-on [[:entity-id :attr-id] :*]
+                         :from :enhanced-triples
+                         :where [:= :ea true]
+                         :order-by [[:entity-id :desc] [:attr-id :desc] [:idx :desc]]}]
+                       [:remaining-triples
+                        {:select :* :from :enhanced-triples :where [:not :ea]}]
+                       [:ea-index-inserts
+                        {:insert-into [[:triples triple-cols]
+                                       {:select triple-cols
+                                        :from :ea-triples-distinct}]
+                         :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
+                         :do-update-set {:value :excluded.value
+                                         :value-md5 :excluded.value-md5}
+                         :returning :entity-id}]
+                       [:remaining-inserts
+                        {:insert-into [[:triples triple-cols]
+                                       {:select triple-cols
+                                        :from :remaining-triples}]
+                         :on-conflict [:app-id :entity-id :attr-id :value-md5]
+                         :do-nothing true
+                         :returning :entity-id}]]
+                      (when-let [attr-inferred-types (insert-attr-inferred-types-cte app-id triples)]
+                        [attr-inferred-types]))
+               :union-all [{:select :entity-id :from :ea-index-inserts}
+                           {:select :entity-id :from :remaining-inserts}]}]
+    (try (sql/do-execute! conn (hsql/format query))
+         (catch Exception e
+           (let [pg-server-message (-> e
+                                       ex-data
+                                       ::ex/pg-error-data
+                                       :server-message)]
+             (if (and (seq lookup-refs)
+                      (= pg-server-message "ON CONFLICT DO UPDATE command cannot affect row a second time"))
+               ;; We may be able to avoid this with `merge`, but we'd need
+               ;; to upgrade postgres to version 16
+               ;; https://www.postgresql.org/docs/current/sql-merge.html
+               (ex/throw-validation-err!
+                :lookup
+                lookup-refs
+                [{:message (multiline->single-line
+                            "Updates with lookups can only update
+                             the lookup attribute if an entity with
+                             the unique attribute value already exists.")}])
+               (throw e)))))))
 
 (defn delete-entity-multi!
   "Deleting an entity does two things:

--- a/server/src/instant/jdbc/pgerrors.clj
+++ b/server/src/instant/jdbc/pgerrors.clj
@@ -356,4 +356,3 @@
      :table table
      :constraint constraint
      :server-message (.getMessage server-err)}))
-

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -248,35 +248,39 @@
       :foreign-key-violation
       (throw+ {::type ::record-foreign-key-invalid
                ::message (format "Foreign Key Invalid: %s" (name condition))
-               ::hint hint}
+               ::hint hint
+               ::pg-error-data data}
               e)
 
       :check-violation
       (throw+ {::type ::record-check-violation
                ::message (format "Check Violation: %s" (name condition))
-               ::hint hint}
+               ::hint hint
+               ::pg-error-data data}
               e)
 
       :raise-exception
       (throw+ {::type ::sql-raise
                ::message (format "Raised Exception: %s" server-message)
-               ::hint hint}
+               ::hint hint
+               ::pg-error-data data}
               e)
 
       (throw+ {::type ::sql-exception
                ::message (format "SQL Exception: %s" (name condition))
-               ::hint hint}
+               ::hint hint
+               ::pg-error-data data}
               e))))
 
-;; -------- 
-;; Oauth 
+;; --------
+;; Oauth
 
 (defn throw-oauth-err! [message]
   (throw+ {::type ::oauth-error
            ::message message}))
 
-;; ------------- 
-;; Wrappers 
+;; -------------
+;; Wrappers
 
 (defn find-instant-exception [^Exception e]
   (loop [cause e]

--- a/server/src/instant/util/string.clj
+++ b/server/src/instant/util/string.clj
@@ -36,4 +36,4 @@
   "Helper to remove extra spaces from multiline strings. Lets you spread the
    string across multiple lines to meet line-width requirements in code."
   [s]
-  (string/replace s #"\s+" (fn [x] " ")))
+  (string/replace s #"\s+" (fn [_] " ")))

--- a/server/src/instant/util/string.clj
+++ b/server/src/instant/util/string.clj
@@ -31,3 +31,11 @@
                   (string/trim s))
 
     :else nil))
+
+(defn multiline->single-line
+  "Helper to remove extra spaces from multiline strings. Lets you spread the
+   string across multiple lines to meet line-width requirements in code."
+  [s]
+  (string/replace s #"\s+" (fn [x]
+                             (println "XX" x)
+                             " ")))

--- a/server/src/instant/util/string.clj
+++ b/server/src/instant/util/string.clj
@@ -36,6 +36,4 @@
   "Helper to remove extra spaces from multiline strings. Lets you spread the
    string across multiple lines to meet line-width requirements in code."
   [s]
-  (string/replace s #"\s+" (fn [x]
-                             (println "XX" x)
-                             " ")))
+  (string/replace s #"\s+" (fn [x] " ")))

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -100,13 +100,15 @@
     (sql-pretty
      (clojure.string/replace q
                              #"\?"
-                             (fn [_] (let [i @idx]
+                             (fn [_] (let [i @idx
+                                           v (nth params i)]
                                        (swap! idx inc)
-                                       (format "'%s'%s"
-                                               (nth params i)
-                                               (if (uuid? (nth params i))
-                                                 "::uuid"
-                                                 ""))))))))
+                                       (str (if (int? v)
+                                              (format "%s" v)
+                                              (format "'%s'" v))
+                                            (if (uuid? v)
+                                              "::uuid"
+                                              ""))))))))
 
 (defn unsafe-hsql-format
   "Use with caution: this inlines parameters in the query, so it could

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -613,7 +613,10 @@
             attrs [["add-attr" "goals" (UUID/randomUUID) 2]])))
     (is (= {:message "title is not a unique attribute on books"}
            (tx-validation-err
-            attrs [["update" "books" ["title" "test"] {"title" "test"}]])))))
+            attrs [["update" "books" ["title" "test"] {"title" "test"}]])))
+    (is (= {:message "test.isbn is not a valid lookup attribute."}
+           (tx-validation-err
+            attrs [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -30,6 +30,9 @@
 (defn sign-out-post [& args]
   (apply (http-util/wrap-errors admin-routes/sign-out-post) args))
 
+(defn transact-ok? [transact-res]
+  (= 200 (:status transact-res)))
+
 (deftest query-test
   (with-zeneca-app
     (fn [{app-id :id admin-token :admin-token :as _app} _r]
@@ -532,6 +535,65 @@
           (is (= (count bookshelves-before)
                  (count bookshelves-after-relink))))))))
 
+(deftest lookup-creates-attrs
+  (with-empty-app
+    (fn [{app-id :id admin-token :admin-token}]
+      (testing "good error message for create + update with lookup"
+        ;; We may be able to fix with merge in postgres 16
+        ;; https://www.postgresql.org/docs/current/sql-merge.html
+        (= "Updates with lookups can only update the lookup attribute if an entity with the unique attribute value already exists."
+           (-> (transact-post
+                {:body {:steps [["update" "users" ["handle" "stopa"] {"handle" "stopa2"}]]}
+                 :headers {"app-id" (str app-id)
+                           "authorization" (str "Bearer " admin-token)}})
+               :body
+               :hint
+               :errors
+               first
+               :message)))
+      (testing "update"
+        (is (transact-ok?
+             (transact-post
+              {:body {:steps [["update" "users" ["handle" "stopa"] {"name" "Stepan"}]]}
+               :headers {"app-id" (str app-id)
+                         "authorization" (str "Bearer " admin-token)}})))
+        (is (= "Stepan"
+               (-> (query-post
+                    {:body {:query {:users {:$ {:where {:handle "stopa"}}}}}
+                     :headers {"app-id" (str app-id)
+                               "authorization" (str "Bearer " admin-token)}})
+                   :body
+                   (get "users")
+                   first
+                   (get "name")))))
+      (testing "create link attrs"
+        (let [pref-id (str (random-uuid))
+              stopa-id (-> (query-post
+                            {:body {:query {:users {:$ {:where {:handle "stopa"}}}}}
+                             :headers {"app-id" (str app-id)
+                                       "authorization" (str "Bearer " admin-token)}})
+                           :body
+                           (get "users")
+                           first
+                           (get "id"))]
+          (is (transact-ok?
+               (transact-post
+                {:body {:steps [["update" "user_prefs" ["users.id" stopa-id] {"pref_b" "pref_b_value"}]]}
+                 :headers {"app-id" (str app-id)
+                           "authorization" (str "Bearer " admin-token)}}))))
+        (is (= "pref_b_value"
+               (-> (query-post
+                    {:body {:query {:users {:$ {:where {:handle "stopa"}}
+                                            :user_prefs {}}}}
+                     :headers {"app-id" (str app-id)
+                               "authorization" (str "Bearer " admin-token)}})
+                   :body
+                   (get "users")
+                   first
+                   (get "user_prefs")
+                   first
+                   (get "pref_b"))))))))
+
 (defn tx-validation-err [attrs steps]
   (try
     (admin-model/->tx-steps! attrs steps)
@@ -549,9 +611,9 @@
     (is (= '{:expected map?, :in [0 1]}
            (tx-validation-err
             attrs [["add-attr" "goals" (UUID/randomUUID) 2]])))
-    (is (= {:message "title is not a unique attribute on goals"}
+    (is (= {:message "title is not a unique attribute on books"}
            (tx-validation-err
-            attrs [["update" "goals" ["title" "test"] {"title" "test"}]])))))
+            attrs [["update" "books" ["title" "test"] {"title" "test"}]])))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
If the user has a unique ref attr with cardinality one, this allows them to use `lookup` to update an entity in the namespace using `forward-name.id` as the lookup key.

Here's an example:

If the `user_prefs` namespace has a unique link to `users`, then the developer can update `user_prefs` with:

```js
tx.user_prefs[lookup("users.id", userId)].update({new_pref: 'new-value})
```

Updated the backend to support this with the admin api.

I attempted to solve the problem where you can't create a new entity with a lookup set the lookup value at the same time, but could not find any easy solutions, so I just gave it a better error message. Now when you do:

```js
db.transact([
    tx.users[lookup('handle', 'h')].update({handle: 'h'})
]);
```

It will throw a validation error with message: `"Updates with lookups can only update the lookup attribute if an entity with the unique attribute value already exists."`