### PR TITLE
Fix the refinery sampler rules

### DIFF
--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -3,7 +3,7 @@ Samplers:
     __default__:
         DeterministicSampler:
             SampleRate: 1
-    production:
+    prod:
       RulesBasedSampler:
         Rules:
           - Name: keep errors


### PR DESCRIPTION
Had the wrong environment, it should have been "prod" instead of "production".

Tested in production and it's sampling now.