### PR TITLE
String Init: Use schema instead of attrs when resolving cardinality

### DIFF
--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -13,6 +13,7 @@ export {
   // types
   type InstantGraph,
   type EntitiesDef,
+  type LinkDef,
   type LinksDef,
   type LinkAttrDef,
   type DataAttrDef,

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -78,7 +78,6 @@ export function createStore(
   enableCardinalityInference,
   linkIndex,
 ) {
-  console.log(linkIndex);
   const store = createIndexMap(attrs, triples);
   store.attrs = attrs;
   store.cardinalityInference = enableCardinalityInference;

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -72,10 +72,18 @@ function createIndexMap(attrs, triples) {
   return { eav, aev, vae };
 }
 
-export function createStore(attrs, triples, enableCardinalityInference) {
+export function createStore(
+  attrs,
+  triples,
+  enableCardinalityInference,
+  linkIndex,
+) {
+  console.log(linkIndex);
   const store = createIndexMap(attrs, triples);
   store.attrs = attrs;
   store.cardinalityInference = enableCardinalityInference;
+  store.linkIndex = linkIndex;
+
   return store;
 }
 

--- a/client/packages/core/src/utils/linkIndex.ts
+++ b/client/packages/core/src/utils/linkIndex.ts
@@ -1,0 +1,33 @@
+import { InstantGraph, LinkDef, LinksDef } from "../schema";
+
+export type LinkIndex = Record<
+  string,
+  Record<
+    string,
+    {
+      isForward: boolean;
+      isSingular: boolean;
+      link: LinkDef<any, any, any, any, any, any, any>;
+    }
+  >
+>;
+
+export function createLinkIndex(schema: InstantGraph<any, LinksDef<{}>>) {
+  return Object.values(schema.links).reduce((linkIndex, link) => {
+    linkIndex[link.forward.on] ??= {};
+    linkIndex[link.forward.on][link.forward.label] = {
+      isForward: true,
+      isSingular: link.forward.has === "one",
+      link,
+    };
+
+    linkIndex[link.reverse.on] ??= {};
+    linkIndex[link.reverse.on][link.reverse.label] = {
+      isForward: false,
+      isSingular: link.reverse.has === "one",
+      link,
+    };
+
+    return linkIndex;
+  }, {} as LinkIndex);
+}

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -87,6 +87,8 @@ export default function Main() {
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;
 
+  console.log(data);
+
   const du = data.discriminatedUnionExample.at(0);
   if (du?.x === "foo") {
     // this should be constrained to 1

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -87,8 +87,6 @@ export default function Main() {
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;
 
-  console.log(data);
-
   const du = data.discriminatedUnionExample.at(0);
   if (du?.x === "foo") {
     // this should be constrained to 1


### PR DESCRIPTION
To maintain type-safety, honor the specified schema and not the synced attrs when determining whether to return one/many results.