### PR TITLE
Svelte SDK

### DIFF
--- a/client/packages/svelte/README.md
+++ b/client/packages/svelte/README.md
@@ -1,0 +1,46 @@
+<p align="center">
+  <a href="https://instantdb.com">
+    <img alt="Shows the Instant logo" src="https://instantdb.com/img/icon/android-chrome-512x512.png" width="10%">
+  </a>
+  <h1 align="center">@instantdb/core</h1>
+</p>
+
+<p align="center">
+  <a 
+    href="https://discord.com/invite/VU53p7uQcE" >
+    <img height=20 src="https://img.shields.io/discord/1031957483243188235" />
+  </a>
+  <img src="https://img.shields.io/github/stars/instantdb/instant" alt="stars">
+</p>
+
+<p align="center">
+   <a href="https://www.instantdb.com/docs/start-vanilla">Get Started</a> · 
+   <a href="https://instantdb.com/examples">Examples</a> · 
+   <a href="https://instantdb.com/tutorial">Try the Demo</a> · 
+   <a href="https://www.instantdb.com/docs/start-vanilla">Docs</a> · 
+   <a href="https://discord.com/invite/VU53p7uQcE">Discord</a>
+<p>
+
+Welcome to [Instant's](http://instantdb.com) vanilla javascript SDK.
+
+```javascript
+db.subscribeQuery({ todos: {} }, (resp) => {
+  if (resp.error) {
+    renderError(resp.error.message);
+    return;
+  }
+  if (resp.data) {
+    render(resp.data); // wohoo!
+  }
+});
+```
+
+# Get Started
+
+Follow the [getting started in vanilla Javascript](https://www.instantdb.com/docs/start-vanilla) tutorial to set up a live app in under 5 minutes! Or you can try a [demo](https://instantdb.com/tutorial) in your browser :).
+
+# Questions?
+
+If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE)
+
+

--- a/client/packages/svelte/package.json
+++ b/client/packages/svelte/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@instantdb/svelte",
+  "version": "v0.12.19",
+  "description": "Instant DB for Svelte",
+  "main": "dist/index.js",
+  "module": "dist/module/index.js",
+  "types": "dist/module/index.d.ts",
+  "unpkg": "standalone/index.umd.js",
+  "scripts": {
+    "test": "vitest",
+    "build": "rm -rf dist; npm run build:main && npm run build:module && npm run build:standalone",
+    "dev:main": "tsc -p tsconfig.json -w --skipLibCheck",
+    "dev:module": "tsc -p tsconfig.module.json -w --skipLibCheck",
+    "dev": "run-p dev:main dev:module",
+    "build:main": "tsc -p tsconfig.json",
+    "build:module": "tsc -p tsconfig.module.json",
+    "build:standalone": "vite build",
+    "publish-package": "npm publish --access public"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.17.9",
+    "@babel/preset-env": "^7.16.11",
+    "@types/react": ">=16",
+    "@vitejs/plugin-react": "^4.3.1",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.5.4",
+    "vite": "^5.2.0",
+    "vitest": "^0.21.0"
+  },
+  "peerDependencies": {
+    "svelte": "5.x"
+  },
+  "dependencies": {
+    "@instantdb/core": "workspace:*"
+  }
+}

--- a/client/packages/svelte/src/InstantSvelte.svelte.ts
+++ b/client/packages/svelte/src/InstantSvelte.svelte.ts
@@ -60,19 +60,19 @@ export abstract class InstantSvelte<
 	 * @example
 	 *   // Create a new object in the `goals` namespace
 	 *   const goalId = id();
-	 *   db.transact(tx.goals[goalId].update({title: "Get fit"}))
+	 *   db.transact(db.tx.goals[goalId].update({title: "Get fit"}))
 	 *
 	 *   // Update the title
-	 *   db.transact(tx.goals[goalId].update({title: "Get super fit"}))
+	 *   db.transact(db.tx.goals[goalId].update({title: "Get super fit"}))
 	 *
 	 *   // Delete it
-	 *   db.transact(tx.goals[goalId].delete())
+	 *   db.transact(db.tx.goals[goalId].delete())
 	 *
 	 *   // Or create an association:
 	 *   todoId = id();
 	 *   db.transact([
-	 *    tx.todos[todoId].update({ title: 'Go on a run' }),
-	 *    tx.goals[goalId].link({todos: todoId}),
+	 *    db.tx.todos[todoId].update({ title: 'Go on a run' }),
+	 *    db.tx.goals[goalId].link({todos: todoId}),
 	 *  ])
 	 */
 	transact = (chunks: TransactionChunk<any, any> | TransactionChunk<any, any>[]) => {
@@ -104,7 +104,7 @@ export abstract class InstantSvelte<
 				Exactly<Query, Q>
 	>(
 		_query: null | Q
-	): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+	): { state: LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> } => {
 		return useQuery(this._core, _query);
 	};
 
@@ -187,4 +187,26 @@ export abstract class InstantSvelte<
 		});
 		return result;
 	};
+}
+
+export class InstantSvelteWeb<
+	Schema extends i.InstantGraph<any, any> | {} = {},
+	RoomSchema extends RoomSchemaShape = {},
+	WithCardinalityInference extends boolean = false
+> extends InstantSvelte<Schema, RoomSchema, WithCardinalityInference> {}
+
+export function init_experimental<
+	Schema extends i.InstantGraph<any, any, any>,
+	WithCardinalityInference extends boolean = true
+>(
+	config: Config & {
+		schema: Schema;
+		cardinalityInference?: WithCardinalityInference;
+	}
+) {
+	return new InstantSvelteWeb<
+		Schema,
+		Schema extends i.InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never,
+		WithCardinalityInference
+	>(config);
 }

--- a/client/packages/svelte/src/InstantSvelte.svelte.ts
+++ b/client/packages/svelte/src/InstantSvelte.svelte.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+	_init_internal,
+	type Auth,
+	type AuthState,
+	coerceQuery,
+	type Config,
+	type ConfigWithSchema,
+	type Exactly,
+	type i,
+	InstantClient,
+	type InstaQLQueryParams,
+	type LifecycleSubscriptionState,
+	type Query,
+	type RoomSchemaShape,
+	type Storage,
+	type SubscriptionState,
+	type TransactionChunk,
+	txInit
+} from '@instantdb/core';
+import { useQuery } from './useQuery.svelte';
+
+export abstract class InstantSvelte<
+	Schema extends i.InstantGraph<any, any> | {} = {},
+	RoomSchema extends RoomSchemaShape = {},
+	WithCardinalityInference extends boolean = false
+> {
+	public tx =
+		txInit<Schema extends i.InstantGraph<any, any> ? Schema : i.InstantGraph<any, any>>();
+
+	public auth: Auth;
+	public storage: Storage;
+	public _core: InstantClient<Schema, RoomSchema, WithCardinalityInference>;
+
+	static Storage?: any;
+	static NetworkListener?: any;
+
+	constructor(config: Config | ConfigWithSchema<any>) {
+		this._core = _init_internal<Schema, RoomSchema, WithCardinalityInference>(
+			config,
+			// @ts-expect-error because TS can't resolve subclass statics
+			this.constructor.Storage,
+			// @ts-expect-error because TS can't resolve subclass statics
+			this.constructor.NetworkListener
+		);
+		this.auth = this._core.auth;
+		this.storage = this._core.storage;
+	}
+
+	getLocalId = (name: string) => {
+		return this._core.getLocalId(name);
+	};
+
+	/**
+	 * Use this to write data! You can create, update, delete, and link objects
+	 *
+	 * @see https://instantdb.com/docs/instaml
+	 *
+	 * @example
+	 *   // Create a new object in the `goals` namespace
+	 *   const goalId = id();
+	 *   db.transact(tx.goals[goalId].update({title: "Get fit"}))
+	 *
+	 *   // Update the title
+	 *   db.transact(tx.goals[goalId].update({title: "Get super fit"}))
+	 *
+	 *   // Delete it
+	 *   db.transact(tx.goals[goalId].delete())
+	 *
+	 *   // Or create an association:
+	 *   todoId = id();
+	 *   db.transact([
+	 *    tx.todos[todoId].update({ title: 'Go on a run' }),
+	 *    tx.goals[goalId].link({todos: todoId}),
+	 *  ])
+	 */
+	transact = (chunks: TransactionChunk<any, any> | TransactionChunk<any, any>[]) => {
+		return this._core.transact(chunks);
+	};
+
+	/**
+	 * Use this to query your data!
+	 *
+	 * @see https://instantdb.com/docs/instaql
+	 *
+	 * @example
+	 *  // listen to all goals
+	 *  db.useQuery({ goals: {} })
+	 *
+	 *  // goals where the title is "Get Fit"
+	 *  db.useQuery({ goals: { $: { where: { title: "Get Fit" } } } })
+	 *
+	 *  // all goals, _alongside_ their todos
+	 *  db.useQuery({ goals: { todos: {} } })
+	 *
+	 *  // skip if `user` is not logged in
+	 *  db.useQuery(auth.user ? { goals: {} } : null)
+	 */
+	useQuery = <
+		Q extends Schema extends i.InstantGraph<any, any>
+			? InstaQLQueryParams<Schema>
+			: // @ts-expect-error type taken directly from Instant react source code
+				Exactly<Query, Q>
+	>(
+		_query: null | Q
+	): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+		return useQuery(this._core, _query);
+	};
+
+	/**
+	 * Listen for the logged in state. This is useful
+	 * for deciding when to show a login screen.
+	 *
+	 * @see https://instantdb.com/docs/auth
+	 * @example
+	 * 	<script>
+	 * 		import { db } from '$lib/db';
+	 *  	const authState = db.useAuth()
+	 *  </script>
+	 *
+	 * {#if authState.isLoading}
+	 * 	<div>Loading...</div>
+	 * {/if}
+	 * {#if authState.error}
+	 * 	<div>Uh oh! {authState.error.message}</div>
+	 * {/if}
+	 * {#if authState.user}
+	 * 	<Main user={authState.user} />
+	 * {:else}
+	 * 	<Login />
+	 * {/if}
+	 *
+	 */
+	useAuth = (): AuthState => {
+		let isLoading = $state<AuthState['isLoading']>(true);
+		let user = $state<AuthState['user']>(undefined);
+		let error = $state<AuthState['error']>(undefined);
+
+		$effect(() => {
+			const unsubscribe = this._core.subscribeAuth((result) => {
+				isLoading = false;
+				user = result.user;
+				error = result.error;
+			});
+
+			return unsubscribe;
+		});
+
+		return {
+			get isLoading() {
+				return isLoading;
+			},
+			get user() {
+				return user;
+			},
+			get error() {
+				return error;
+			}
+		} as unknown as AuthState;
+	};
+
+	query = async <
+		Q extends Schema extends i.InstantGraph<any, any>
+			? InstaQLQueryParams<Schema>
+			: // @ts-expect-error type taken directly from Instant react source code
+				Exactly<Query, Q>
+	>(
+		_query: null | Q
+	): Promise<SubscriptionState<Q, Schema, WithCardinalityInference>> => {
+		const query = _query ? coerceQuery(_query) : null;
+		let unsubscribe: () => void;
+		const result = await new Promise<SubscriptionState<Q, Schema, WithCardinalityInference>>(
+			(resolve, reject) => {
+				unsubscribe = this._core.subscribeQuery(query, (result) => {
+					if (result.error) {
+						reject(result.error);
+					}
+					if (result.data) {
+						resolve(result as SubscriptionState<Q, Schema, WithCardinalityInference>);
+					}
+				});
+			}
+		).then((result) => {
+			unsubscribe();
+			return result;
+		});
+		return result;
+	};
+}

--- a/client/packages/svelte/src/InstantSvelte.svelte.ts
+++ b/client/packages/svelte/src/InstantSvelte.svelte.ts
@@ -9,6 +9,7 @@ import {
 	type ConfigWithSchema,
 	type Exactly,
 	type i,
+	type IDatabase,
 	InstantClient,
 	type InstaQLQueryParams,
 	type LifecycleSubscriptionState,
@@ -21,11 +22,14 @@ import {
 } from '@instantdb/core';
 import { useQuery } from './useQuery.svelte';
 
+
 export abstract class InstantSvelte<
 	Schema extends i.InstantGraph<any, any> | {} = {},
 	RoomSchema extends RoomSchemaShape = {},
 	WithCardinalityInference extends boolean = false
-> {
+> implements IDatabase<Schema, RoomSchema, WithCardinalityInference>
+{
+	public withCardinalityInference?: WithCardinalityInference;
 	public tx =
 		txInit<Schema extends i.InstantGraph<any, any> ? Schema : i.InstantGraph<any, any>>();
 
@@ -187,26 +191,4 @@ export abstract class InstantSvelte<
 		});
 		return result;
 	};
-}
-
-export class InstantSvelteWeb<
-	Schema extends i.InstantGraph<any, any> | {} = {},
-	RoomSchema extends RoomSchemaShape = {},
-	WithCardinalityInference extends boolean = false
-> extends InstantSvelte<Schema, RoomSchema, WithCardinalityInference> {}
-
-export function init_experimental<
-	Schema extends i.InstantGraph<any, any, any>,
-	WithCardinalityInference extends boolean = true
->(
-	config: Config & {
-		schema: Schema;
-		cardinalityInference?: WithCardinalityInference;
-	}
-) {
-	return new InstantSvelteWeb<
-		Schema,
-		Schema extends i.InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never,
-		WithCardinalityInference
-	>(config);
 }

--- a/client/packages/svelte/src/InstantSvelteWeb.svelte.ts
+++ b/client/packages/svelte/src/InstantSvelteWeb.svelte.ts
@@ -1,0 +1,12 @@
+import {
+  _init_internal,
+	type i,
+	type RoomSchemaShape,
+} from '@instantdb/core';
+import { InstantSvelte } from "./InstantSvelte.svelte";
+
+export class InstantSvelteWeb<
+	Schema extends i.InstantGraph<any, any> | {} = {},
+	RoomSchema extends RoomSchemaShape = {},
+	WithCardinalityInference extends boolean = false
+> extends InstantSvelte<Schema, RoomSchema, WithCardinalityInference> {}

--- a/client/packages/svelte/src/index.ts
+++ b/client/packages/svelte/src/index.ts
@@ -1,0 +1,39 @@
+import {
+  id,
+  tx,
+  lookup,
+  i,
+
+  // types
+  type QueryResponse,
+  type InstantObject,
+  type User,
+  type AuthState,
+  type Query,
+  type Config,
+} from "@instantdb/core";
+
+import { InstantSvelte } from "./InstantSvelte.svelte";
+import { init, init_experimental } from "./init";
+import { Cursors } from "./Cursors";
+
+export {
+  id,
+  tx,
+  lookup,
+  init,
+  init_experimental,
+  Cursors,
+
+  // internal
+  InstantSvelte,
+
+  // types
+  Config,
+  Query,
+  QueryResponse,
+  InstantObject,
+  User,
+  AuthState,
+  i,
+};

--- a/client/packages/svelte/src/init.ts
+++ b/client/packages/svelte/src/init.ts
@@ -1,0 +1,49 @@
+import {
+  // types
+  Config,
+  i,
+  RoomSchemaShape,
+} from "@instantdb/core";
+import { InstantSvelteWeb } from "./InstantSvelteWeb.svelte";
+
+/**
+ *
+ * The first step: init your application!
+ *
+ * Visit https://instantdb.com/dash to get your `appId` :)
+ *
+ * @example
+ *  const db = init({ appId: "my-app-id" })
+ *
+ * // You can also provide a schema for type safety and editor autocomplete!
+ *
+ *  type Schema = {
+ *    goals: {
+ *      title: string
+ *    }
+ *  }
+ *
+ *  const db = init<Schema>({ appId: "my-app-id" })
+ *
+ */
+export function init<Schema = {}, RoomSchema extends RoomSchemaShape = {}>(
+  config: Config,
+) {
+  return new InstantSvelteWeb<Schema, RoomSchema>(config);
+}
+
+export function init_experimental<
+	Schema extends i.InstantGraph<any, any, any>,
+	WithCardinalityInference extends boolean = true
+>(
+	config: Config & {
+		schema: Schema;
+		cardinalityInference?: WithCardinalityInference;
+	}
+) {
+	return new InstantSvelteWeb<
+		Schema,
+		Schema extends i.InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never,
+		WithCardinalityInference
+	>(config);
+}

--- a/client/packages/svelte/src/useQuery.svelte.ts
+++ b/client/packages/svelte/src/useQuery.svelte.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+	coerceQuery,
+	type Exactly,
+	i,
+	InstantClient,
+	type InstaQLQueryParams,
+	type LifecycleSubscriptionState,
+	type Query
+} from '@instantdb/core';
+
+export const useQuery = <
+	Q extends Schema extends i.InstantGraph<any, any>
+		? InstaQLQueryParams<Schema>
+		: // @ts-expect-error type taken directly from Instant react source code
+			Exactly<Query, Q>,
+	Schema,
+	WithCardinalityInference extends boolean
+>(
+	// @ts-expect-error type taken directly from Instant react source code
+	_core: InstantClient<Schema, any, WithCardinalityInference>,
+	_query: null | Q
+): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+	const query = _query ? coerceQuery(_query) : null;
+
+	let isLoading =
+		$state<LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>['isLoading']>(true);
+	let data =
+		$state<LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>['data']>(undefined);
+	let pageInfo =
+		$state<LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>['pageInfo']>(
+			undefined
+		);
+	let error =
+		$state<LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>['error']>(undefined);
+
+	$effect(() => {
+		const unsubscribe = _core.subscribeQuery<Q>(query, (result) => {
+			isLoading = !result;
+			data = result?.data;
+			pageInfo = result?.pageInfo;
+			error = result?.error;
+		});
+
+		return unsubscribe;
+	});
+
+	return {
+		get isLoading() {
+			return isLoading;
+		},
+		get data() {
+			return data;
+		},
+		get pageInfo() {
+			return pageInfo;
+		},
+		get error() {
+			return error;
+		}
+	} as unknown as LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>;
+};

--- a/client/packages/svelte/tsconfig.json
+++ b/client/packages/svelte/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "checkJs": false,
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "target": "es2015",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "stripInternal": true,
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+  },
+}

--- a/client/packages/svelte/tsconfig.module.json
+++ b/client/packages/svelte/tsconfig.module.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "module": "es2015",
+    "outDir": "dist/module"
+  }
+}

--- a/client/packages/svelte/vite.config.ts
+++ b/client/packages/svelte/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import { resolve } from "path";
+
+export default defineConfig({
+  build: {
+    outDir: "dist/standalone",
+    lib: {
+      formats: ["umd", "es"],
+      // this is the file that exports our components
+      entry: resolve(__dirname, "src", "index.ts"),
+      name: "instant",
+      fileName: "index",
+    },
+  },
+  define: {
+    "process.env": {},
+  },
+});


### PR DESCRIPTION
This is a starting point for a Svelte 5 SDK. 

It aims to follow the interface of the react SDK to keep the APIs consistent.

- [ ] Implement `InstantSvelteRoom`
- [ ] Implement `Cursors.svelte`
- [ ] Make a Svelte 4 compatible SDK (up for debate)
- [ ] Add code examples