### PR TITLE
Don't assume periods are refs in lookups if the attr exists

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -187,7 +187,51 @@ test("it throws if you use an invalid link attr", () => {
         a: 1,
       }),
     ),
-  ).toThrowError('user_pref.email is not a valid lookup attribute.');
+  ).toThrowError("user_pref.email is not a valid lookup attribute.");
+});
+
+test("it doesn't throw if you have a period in your attr", () => {
+  const aid = uuid();
+  const iid = uuid();
+  const pid = uuid();
+  const attrs = {
+    [aid]: {
+      id: aid,
+      cardinality: "one",
+      "forward-identity": [uuid(), "users", "attr.with.dot"],
+      "index?": true,
+      "unique?": true,
+      "value-type": "blob",
+    },
+    [iid]: {
+      id: iid,
+      cardinality: "one",
+      "forward-identity": [uuid(), "users", "id"],
+      "index?": false,
+      "unique?": false,
+      "value-type": "blob",
+    },
+    [pid]: {
+      id: pid,
+      cardinality: "one",
+      "forward-identity": [uuid(), "users", "a"],
+      "index?": false,
+      "unique?": false,
+      "value-type": "blob",
+    },
+  };
+
+  expect(
+    instaml.transform(
+      attrs,
+      instatx.tx.users[instatx.lookup("attr.with.dot", "value")].update({
+        a: 1,
+      }),
+    ),
+  ).toEqual([
+    ["add-triple", [aid, "value"], iid, [aid, "value"]],
+    ["add-triple", [aid, "value"], pid, 1],
+  ]);
 });
 
 test("it doesn't create duplicate ref attrs", () => {

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -33,10 +33,10 @@ function explodeLookupRef(eid) {
 
 function isRefLookupIdent(attrs, etype, identName) {
   return (
+    identName.indexOf(".") !== -1 &&
     // attr names can have `.` in them, so use the attr we find with a `.`
     // before assuming it's a ref lookup.
-    !getAttrByFwdIdentName(attrs, etype, identName) &&
-    identName.indexOf(".") !== -1
+    !getAttrByFwdIdentName(attrs, etype, identName)
   );
 }
 

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -31,8 +31,13 @@ function explodeLookupRef(eid) {
   return entries[0];
 }
 
-function isRefLookupIdent(identName) {
-  return identName.indexOf(".") !== -1;
+function isRefLookupIdent(attrs, etype, identName) {
+  return (
+    // attr names can have `.` in them, so use the attr we find with a `.`
+    // before assuming it's a ref lookup.
+    !getAttrByFwdIdentName(attrs, etype, identName) &&
+    identName.indexOf(".") !== -1
+  );
 }
 
 function extractRefLookupFwdName(identName) {
@@ -45,7 +50,7 @@ function extractRefLookupFwdName(identName) {
 }
 
 function lookupIdentToAttr(attrs, etype, identName) {
-  if (!isRefLookupIdent(identName)) {
+  if (!isRefLookupIdent(attrs, etype, identName)) {
     return getAttrByFwdIdentName(attrs, etype, identName);
   }
 
@@ -263,7 +268,7 @@ function createMissingAttrs(existingAttrs, ops) {
       const lookupPair = lookupPairOfEid(eid);
       if (lookupPair) {
         const identName = lookupPair[0];
-        if (isRefLookupIdent(identName)) {
+        if (isRefLookupIdent(attrs, etype, identName)) {
           const label = extractRefLookupFwdName(identName);
           const fwdAttr = getAttrByFwdIdentName(attrs, etype, label);
           const revAttr = getAttrByReverseIdentName(attrs, etype, label);

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -54,8 +54,11 @@
       (parse-lookup eid))
     (explode-lookup eid)))
 
-(defn ref-lookup? [[ident-name _value]]
-  (not= (.indexOf ident-name ".") -1))
+(defn ref-lookup? [attrs etype [ident-name _value]]
+  ;; attr names can have `.` in them, so check for the attr with a `.` before
+  ;; assuming it's a ref
+  (and (not (attr-model/seek-by-fwd-ident-name [etype ident-name] attrs))
+       (not= (.indexOf ident-name ".") -1)))
 
 (defn extract-ref-lookup-fwd-name [lookup]
   (let [[ident-name _value] lookup
@@ -69,7 +72,7 @@
 
 (defn extract-lookup [attrs etype eid]
   (if-let [[ident-name value :as lookup] (eid->lookup-pair eid)]
-    (let [label (if (ref-lookup? lookup)
+    (let [label (if (ref-lookup? attrs etype lookup)
                   (extract-ref-lookup-fwd-name lookup)
                   ident-name)
           attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]
@@ -238,7 +241,7 @@
             labels)))
 
 (defn add-attrs-for-lookup [{:keys [attrs] :as acc} lookup etype]
-  (if (ref-lookup? lookup)
+  (if (ref-lookup? attrs etype lookup)
     (let [label (extract-ref-lookup-fwd-name lookup)
           fwd-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)
           rev-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -57,8 +57,8 @@
 (defn ref-lookup? [attrs etype [ident-name _value]]
   ;; attr names can have `.` in them, so check for the attr with a `.` before
   ;; assuming it's a ref
-  (and (not (attr-model/seek-by-fwd-ident-name [etype ident-name] attrs))
-       (not= (.indexOf ident-name ".") -1)))
+  (and (not= (.indexOf ident-name ".") -1)
+       (not (attr-model/seek-by-fwd-ident-name [etype ident-name] attrs))))
 
 (defn extract-ref-lookup-fwd-name [lookup]
   (let [[ident-name _value] lookup

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -616,7 +616,13 @@
             attrs [["update" "books" ["title" "test"] {"title" "test"}]])))
     (is (= {:message "test.isbn is not a valid lookup attribute."}
            (tx-validation-err
-            attrs [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))))
+            attrs [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))
+    (is (= {:message "test.isbn is not a unique attribute on books"}
+           (tx-validation-err
+            (conj attrs {:id (random-uuid)
+                         :forward-identity [(random-uuid) "books" "test.isbn"]
+                         :unique? false})
+            [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Allows `lookup` to succeed if the attr with a dot in it exists instead of assuming it's a ref lookup.