### PR TITLE
[superadmin] support for transferring apps 

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -615,7 +615,7 @@ function Invites({
               className="flex flex-col justify-between gap-2"
             >
               <div>
-                <strong>{invite.inviter_email}</strong> invited you to on{' '}
+                <strong>{invite.inviter_email}</strong> invited you to {' '}
                 <strong>{invite.app_title}</strong> as{' '}
                 <strong>{invite.invitee_role}</strong>.
               </div>

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -446,14 +446,17 @@
 
 (defn ephemeral-claim-post [req]
   (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
-        admin-token (ex/get-param! req [:body :token] uuid-util/coerce)
+        token (ex/get-param! req [:body :token] uuid-util/coerce)
         {app-creator-id :creator_id} (app-model/get-by-id! {:id app-id})
         {user-id :id} (req->auth-user! req)]
     (ex/assert-permitted!
      :ephemeral-app?
      app-id
      (= (:id @ephemeral-app/ephemeral-creator) app-creator-id))
-    (app-model/change-creator! {:id app-id :new-creator-id user-id :admin-token admin-token})
+    ;; make sure the request comes with a valid admin token
+    (app-admin-token-model/fetch! {:app-id app-id :token token})
+    (app-model/change-creator! {:id app-id
+                                :new-creator-id user-id})
     (response/ok {})))
 
 ;; --------
@@ -751,13 +754,21 @@
   (let [{user-email :email user-id :id} (req->auth-user! req)
         invite-id (ex/get-param! req [:body :invite-id] uuid-util/coerce)
         {:keys [invitee_role status app_id invitee_email]} (instant-app-member-invites-model/get-by-id! {:id invite-id})]
+    (tool/def-locals!)
     (ex/assert-permitted! :invitee? invitee_email (= invitee_email user-email))
     (ex/assert-permitted! :acceptable? invite-id (not= status "revoked"))
     (next-jdbc/with-transaction [tx-conn aurora/conn-pool]
       (instant-app-member-invites-model/accept-by-id! tx-conn {:id invite-id})
-      (instant-app-members/create! tx-conn {:user-id user-id
-                                            :app-id app_id
-                                            :role invitee_role}))
+      (condp = invitee_role
+        "creator"
+        (app-model/change-creator!
+         tx-conn
+         {:id app_id
+          :new-creator-id user-id})
+        :else
+        (instant-app-members/create! tx-conn {:user-id user-id
+                                              :app-id app_id
+                                              :role invitee_role})))
     (response/ok {})))
 
 (comment
@@ -826,7 +837,6 @@
     (fn [{:keys [owner-req member]}]
       (team-member-update-post
        (assoc owner-req :body {:role "admin" :id (:id member)})))))
-
 
 ;; ---
 ;; Personal access tokens

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -754,7 +754,6 @@
   (let [{user-email :email user-id :id} (req->auth-user! req)
         invite-id (ex/get-param! req [:body :invite-id] uuid-util/coerce)
         {:keys [invitee_role status app_id invitee_email]} (instant-app-member-invites-model/get-by-id! {:id invite-id})]
-    (tool/def-locals!)
     (ex/assert-permitted! :invitee? invitee_email (= invitee_email user-email))
     (ex/assert-permitted! :acceptable? invite-id (not= status "revoked"))
     (next-jdbc/with-transaction [tx-conn aurora/conn-pool]

--- a/server/src/instant/jdbc/pgerrors.clj
+++ b/server/src/instant/jdbc/pgerrors.clj
@@ -349,7 +349,6 @@
   (let [sql-state (.getSQLState e)
         condition (or (sql-state->condition sql-state) :unknown)
         server-err (.getServerErrorMessage e)]
-    (tool/def-locals!)
     (cond->
      {:sql-state sql-state
       :condition condition}

--- a/server/src/instant/jdbc/pgerrors.clj
+++ b/server/src/instant/jdbc/pgerrors.clj
@@ -347,12 +347,14 @@
 
 (defn extract-data [^PSQLException e]
   (let [sql-state (.getSQLState e)
-        condition (sql-state->condition sql-state)
-        server-err (.getServerErrorMessage e)
-        table (.getTable server-err)
-        constraint (.getConstraint server-err)]
-    {:sql-state sql-state
-     :condition condition
-     :table table
-     :constraint constraint
-     :server-message (.getMessage server-err)}))
+        condition (or (sql-state->condition sql-state) :unknown)
+        server-err (.getServerErrorMessage e)]
+    (tool/def-locals!)
+    (cond->
+     {:sql-state sql-state
+      :condition condition}
+      server-err
+      (assoc
+       :table (.getTable server-err)
+       :constraint (.getConstraint server-err)
+       :server-message (.getMessage server-err)))))

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -267,14 +267,11 @@
 
 (defn change-creator!
   ([params] (change-creator! aurora/conn-pool params))
-  ([conn {:keys [id new-creator-id admin-token]}]
+  ([conn {:keys [id new-creator-id]}]
    (sql/execute-one! conn ["UPDATE apps a
                             SET creator_id = ?::uuid
-                            FROM app_admin_tokens at
-                            WHERE a.id = at.app_id
-                              AND a.id = ?::uuid
-                              AND at.token = ?::uuid"
-                           new-creator-id id admin-token])))
+                            WHERE a.id = ?::uuid"
+                           new-creator-id id])))
 
 (defn delete-by-ids!
   ([params] (delete-by-ids! aurora/conn-pool params))

--- a/server/src/instant/model/app_member_invites.clj
+++ b/server/src/instant/model/app_member_invites.clj
@@ -78,6 +78,18 @@
                        AND status = 'pending'"
                       id])))
 
+(defn reject-by-email-and-role
+  ([params] (reject-by-email-and-role aurora/conn-pool params))
+  ([conn {:keys [inviter-id invitee-email role]}]
+   (sql/execute! conn
+                 ["UPDATE app_member_invites
+                  SET status = 'revoked'
+                  WHERE inviter_id = ?::uuid 
+                  AND invitee_email = ? 
+                  AND invitee_role = ?
+                  AND status = 'pending'"
+                  inviter-id invitee-email role])))
+
 (defn delete-by-id!
   ([params] (delete-by-id! aurora/conn-pool params))
   ([conn {:keys [id]}]

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -7,7 +7,10 @@
             [instant.model.instant-user :as instant-user-model]
             [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
             [instant.util.exception :as ex]
-            [instant.util.http :as http-util])
+            [instant.util.http :as http-util]
+            [instant.util.email :as email]
+            [instant.postmark :as postmark]
+            [instant.model.app-member-invites :as instant-app-member-invites-model])
 
   (:import
    (java.util UUID)))
@@ -54,8 +57,62 @@
         app (app-model/delete-by-id! {:id app-id})]
     (response/ok {:app app})))
 
+(defn transfer-app-invite-email [{:keys [invitee-email inviter-id app-id]}]
+  (let [title "Instant"
+        user (instant-user-model/get-by-id! {:id inviter-id})
+        app (app-model/get-by-id! {:id app-id})]
+    {:from (str title " <teams@pm.instantdb.com>")
+     :to invitee-email
+     :subject (str "[Instant] You've been asked to take ownership of " (:title app))
+     :html
+     (postmark/standard-body
+      "<p><strong>Hey there!</strong></p>
+       <p>
+         " (:email user) " invited you to become the new owner of " (:title app) ".
+       </p>
+       <p>
+         Navigate to <a href=\"https://instantdb.com/dash?s=invites\">Instant</a> to accept the invite.
+       </p>
+       <p>
+         Note: This invite will expire in 3 days. If you
+         don't know the user inviting you, please reply to this email.
+       </p>")}))
+
+(defn app-transfer-send-invite-post [req]
+  (let [{user-id :id} (req->superadmin-user! req)
+        id (ex/get-param! req [:params :app_id] uuid-util/coerce)
+        {app-id :id} (app-model/get-by-id-and-creator! {:user-id user-id
+                                                        :app-id id})
+        invitee-email (ex/get-param! req [:body :dest_email] email/coerce)
+        {invite-id :id} (instant-app-member-invites-model/create!
+                         {:app-id app-id
+                          :inviter-id user-id
+                          :email invitee-email
+                          :role "creator"})]
+    (instant-app-member-invites-model/create!
+     {:app-id app-id
+      :inviter-id user-id
+      :email invitee-email
+      :role "creator"})
+    (postmark/send!
+     (transfer-app-invite-email
+      {:inviter-id user-id
+       :invitee-email invitee-email
+       :app-id app-id}))
+    (response/ok {:id invite-id})))
+
+(defn app-transfer-revoke-post [req]
+  (let [{user-id :id} (req->superadmin-user! req)
+        dest-email (ex/get-param! req [:body :dest_email] email/coerce)
+        rejected-count (count (instant-app-member-invites-model/reject-by-email-and-role
+                               {:inviter-id user-id
+                                :invitee-email dest-email
+                                :role "creator"}))]
+
+    (response/ok {:count rejected-count})))
+
 (comment
-  (def user (instant-user-model/get-by-email {:email "alex@instantdb.com"}))
+  (def user (instant-user-model/get-by-email {:email "stepan.p@gmail.com"}))
   (def token (instant-personal-access-token-model/create! {:id (UUID/randomUUID)
                                                            :user-id (:id user)
                                                            :name "Test Token"}))
@@ -66,6 +123,12 @@
   (apps-list-get {:headers headers})
   (app-details-get {:headers headers :params {:app_id app-id}})
   (app-update-post {:headers headers :params {:app_id app-id} :body {:title "Updated Demo App"}})
+  (app-transfer-send-invite-post {:headers headers
+                                  :params {:app_id app-id}
+                                  :body {:dest_email "stopa@instantdb.com"}})
+  (app-transfer-revoke-post {:headers headers
+                             :params {:app_id app-id}
+                             :body {:dest_email "stopa@instantdb.com"}})
   (app-delete {:headers headers :params {:app_id app-id}}))
 
 (defroutes routes
@@ -73,4 +136,6 @@
   (POST "/superadmin/apps" [] apps-create-post)
   (GET "/superadmin/apps/:app_id" [] app-details-get)
   (POST "/superadmin/apps/:app_id" [] app-update-post)
+  (POST "/superadmin/apps/:app_id/transfers/send" [] app-transfer-send-invite-post)
+  (POST "/superadmin/apps/:app_id/transfers/revoke" [] app-transfer-revoke-post)
   (DELETE "/superadmin/apps/:app_id" [] app-delete))


### PR DESCRIPTION
**1)** Added An endpoint to initiate transferring an app. This will send an email like so: 
<img width="1461" alt="CleanShot 2024-09-09 at 19 54 42@2x" src="https://github.com/user-attachments/assets/2b7fc480-53a8-4859-a270-6886843f84a5">

**2)** A user can then login, and claim ownership of the app: 
<img width="779" alt="CleanShot 2024-09-09 at 19 57 46@2x" src="https://github.com/user-attachments/assets/8ac1abf4-ebc3-475c-8f79-73c5e008d848">

**3)** The superadmin also has an API to _revoke_ access

Notes: 
1. Right now, only the superadmin api lets you create a 'creator' transfer. Eventually we could enhance our normal invitation flow to also allow this. 

@nezaj @dwwoelfel @markyfyi