### PR TITLE
Invalidation fixes

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -600,11 +600,14 @@
 (defn guarded-where-query [ctx {:keys [etype level] :as form}]
   (try
     (where-query ctx form)
-    (catch clojure.lang.ExceptionInfo _e
-      (list true
-            (attr-pat/default-level-sym etype level)
-            [[:ea (attr-pat/default-level-sym etype level)]
-             [:eav]]))))
+    (catch clojure.lang.ExceptionInfo e
+      (if (contains? #{::ex/validation-failed}
+                     (::ex/type (ex-data e)))
+        (throw e)
+        (list true
+              (attr-pat/default-level-sym etype level)
+              [[:ea (attr-pat/default-level-sym etype level)]
+               [:eav]])))))
 
 ;; ----------
 ;; pagination

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -2,6 +2,7 @@
   (:require [instant.db.datalog :as d]
             [instant.db.model.attr :as attr-model]
             [instant.util.exception :as ex]
+            [instant.util.uuid :as uuid-util]
             [instant.jdbc.aurora :as aurora]
             [instant.data.constants :refer [zeneca-app-id]]
             [clojure.spec.alpha :as s]
@@ -155,13 +156,23 @@
    This creates the attr-pat for the `value` portion:
 
    [?books title-attr \"Foo\"]"
-  [{:keys [attrs]} level-sym value-etype value-level value-label v]
-  (let [{:keys [id]}
+  [{:keys [state attrs]} level-sym value-etype value-level value-label v]
+  (let [{:keys [id value-type]}
         (ex/assert-record!
          (attr-model/seek-by-fwd-ident-name [value-etype value-label] attrs)
          :attr
-         {:args [value-etype value-label]})]
-    [(level-sym value-etype value-level) id v]))
+         {:args [value-etype value-label]})
+        v-coerced (if (not= :ref value-type)
+                    v
+                    (if-let [v-uuid (uuid-util/coerce v)]
+                      v-uuid
+                      (ex/throw-validation-err!
+                       :query
+                       (:root state)
+                       [{:expected 'uuid?
+                         :in (conj (:in state) [:$ :where value-label])
+                         :message (format "Expected %s to be a uuid, got %s", value-label v)}])))]
+    [(level-sym value-etype value-level) id v-coerced]))
 
 (defn attr-pats->patterns-impl
   "Helper for attr-pats->patterns that allows recursion"

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -2,6 +2,7 @@
   (:require [instant.db.datalog :as d]
             [instant.db.model.attr :as attr-model]
             [instant.util.exception :as ex]
+            [instant.util.json :as json]
             [instant.util.uuid :as uuid-util]
             [instant.jdbc.aurora :as aurora]
             [instant.data.constants :refer [zeneca-app-id]]
@@ -173,7 +174,10 @@
                                      (:root state)
                                      [{:expected 'uuid?
                                        :in (conj (:in state) [:$ :where value-label])
-                                       :message (format "Expected %s to match on a uuid, got %s in %s", value-label vv v)}])))
+                                       :message (format "Expected %s to match on a uuid, found %s in %s"
+                                                        value-label
+                                                        (json/->json vv)
+                                                        (json/->json v))}])))
                                 v))
 
                       (if-let [v-uuid (uuid-util/coerce v)]
@@ -183,7 +187,9 @@
                          (:root state)
                          [{:expected 'uuid?
                            :in (conj (:in state) [:$ :where value-label])
-                           :message (format "Expected %s to be a uuid, got %s", value-label v)}]))))]
+                           :message (format "Expected %s to be a uuid, got %s"
+                                            value-label
+                                            (json/->json v))}]))))]
     [(level-sym value-etype value-level) id v-coerced]))
 
 (defn attr-pats->patterns-impl

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -164,14 +164,26 @@
          {:args [value-etype value-label]})
         v-coerced (if (not= :ref value-type)
                     v
-                    (if-let [v-uuid (uuid-util/coerce v)]
-                      v-uuid
-                      (ex/throw-validation-err!
-                       :query
-                       (:root state)
-                       [{:expected 'uuid?
-                         :in (conj (:in state) [:$ :where value-label])
-                         :message (format "Expected %s to be a uuid, got %s", value-label v)}])))]
+                    (if (set? v)
+                      (set (map (fn [vv]
+                                  (if-let [v-uuid (uuid-util/coerce vv)]
+                                    v-uuid
+                                    (ex/throw-validation-err!
+                                     :query
+                                     (:root state)
+                                     [{:expected 'uuid?
+                                       :in (conj (:in state) [:$ :where value-label])
+                                       :message (format "Expected %s to match on a uuid, got %s in %s", value-label vv v)}])))
+                                v))
+
+                      (if-let [v-uuid (uuid-util/coerce v)]
+                        v-uuid
+                        (ex/throw-validation-err!
+                         :query
+                         (:root state)
+                         [{:expected 'uuid?
+                           :in (conj (:in state) [:$ :where value-label])
+                           :message (format "Expected %s to be a uuid, got %s", value-label v)}]))))]
     [(level-sym value-etype value-level) id v-coerced]))
 
 (defn attr-pats->patterns-impl

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -104,13 +104,9 @@
                              :where [:and
                                      [:= :attrs.id :updates.id]
                                      [:= :attrs.app_id app-id]
-                                     [:!=
-                                      :attrs.inferred-types
-                                      [:|
-                                       [:coalesce
-                                        :attrs.inferred_types
-                                        [:cast :0 [:bit :32]]]
-                                       :updates.typ]]]}])))
+                                     [[:raw "inferred_types is distinct from (
+                                              coalesce(inferred_types, cast(0 AS bit(32))) | updates.typ
+                                            )"]]]}])))
 
 (defn deep-merge-multi!
   [conn app-id triples]

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -103,7 +103,14 @@
                                      [:updates {:columns [:id :typ]}]]]
                              :where [:and
                                      [:= :attrs.id :updates.id]
-                                     [:= :attrs.app_id app-id]]}])))
+                                     [:= :attrs.app_id app-id]
+                                     [:!=
+                                      :attrs.inferred-types
+                                      [:|
+                                       [:coalesce
+                                        :attrs.inferred_types
+                                        [:cast :0 [:bit :32]]]
+                                       :updates.typ]]]}])))
 
 (defn deep-merge-multi!
   [conn app-id triples]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -76,19 +76,19 @@
 (defn- topics-for-ident-upsert [{:keys [columnvalues]}]
   (let [indexes #{:ea :eav :av :ave :vae}
         attr-id (UUID/fromString (nth columnvalues 2))
-        topics (map (fn [k] [k '_ attr-id '_]) indexes)]
+        topics (map (fn [k] [k '_ #{attr-id} '_]) indexes)]
     (set topics)))
 
 (defn- topics-for-attr-upsert [{:keys [columnvalues]}]
   (let [indexes #{:ea :eav :av :ave :vae}
         attr-id (UUID/fromString (first columnvalues))
-        topics (map (fn [k] [k '_ attr-id '_]) indexes)]
+        topics (map (fn [k] [k '_ #{attr-id} '_]) indexes)]
     (set topics)))
 
 (defn- topics-for-attr-delete [{:keys [oldkeys]}]
   (let [attr-id (UUID/fromString (first (:keyvalues oldkeys)))
         indexes #{:ea :eav :av :ave :vae}
-        topics (map (fn [k] [k '_ attr-id '_]) indexes)]
+        topics (map (fn [k] [k '_ #{attr-id} '_]) indexes)]
     (set topics)))
 
 (defn topics-for-ident-change [{:keys [kind] :as change}]

--- a/server/test/instant/reactive/invalidator_test.clj
+++ b/server/test/instant/reactive/invalidator_test.clj
@@ -309,41 +309,41 @@
                _]}
            (inv/topics-for-changes {:triple-changes delete-triple-changes}))))
   (testing "create attrs + idents (these happen together)"
-    (is (= '#{[:ave _ #uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3" _]
-              [:eav _ #uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3" _]
-              [:vae _ #uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3" _]
-              [:av _ #uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3" _]
-              [:ea _ #uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3" _]}
+    (is (= '#{[:ave _ #{#uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3"} _]
+              [:eav _ #{#uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3"} _]
+              [:vae _ #{#uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3"} _]
+              [:av _ #{#uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3"} _]
+              [:ea _ #{#uuid "ea72edf9-036a-413b-9c72-2bf92ec137d3"} _]}
            (inv/topics-for-changes {:ident-changes create-ident-changes
                                     :attr-changes create-attr-changes}))))
   (testing "update idents isolated"
-    (is (= '#{[:av _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:ea _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:eav _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:vae _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:ave _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]}
+    (is (= '#{[:av _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:ea _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:eav _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:vae _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:ave _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]}
            (inv/topics-for-changes {:ident-changes update-ident-changes}))))
   (testing "update attrs isolated"
-    (is (= '#{[:av _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:ea _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:eav _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:vae _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:ave _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]}
+    (is (= '#{[:av _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:ea _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:eav _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:vae _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:ave _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]}
            (inv/topics-for-changes {:attr-changes update-attr-changes}))))
   (testing "update attr + idents"
-    (is (= '#{[:av _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:ea _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:eav _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:vae _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]
-              [:ave _ #uuid "a684c2ba-27af-4d54-8c02-68832b4566f0" _]}
+    (is (= '#{[:av _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:ea _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:eav _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:vae _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]
+              [:ave _ #{#uuid "a684c2ba-27af-4d54-8c02-68832b4566f0"} _]}
            (inv/topics-for-changes {:ident-changes update-ident-changes
                                     :attr-changes update-attr-changes}))))
   (testing "delete attr + idents (these happen together)"
-    (is (= '#{[:ea _ #uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5" _]
-              [:vae _ #uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5" _]
-              [:ave _ #uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5" _]
-              [:eav _ #uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5" _]
-              [:av _ #uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5" _]}
+    (is (= '#{[:ea _ #{#uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5"} _]
+              [:vae _ #{#uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5"} _]
+              [:ave _ #{#uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5"} _]
+              [:eav _ #{#uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5"} _]
+              [:av _ #{#uuid "48c22b06-ecc8-4459-a3b4-3c0b640780b5"} _]}
            (inv/topics-for-changes {:ident-changes delete-ident-changes
                                     :attr-changes delete-attr-changes})))))
 


### PR DESCRIPTION
Fixes some issues with the invalidator:

1. Updates attr change topics to put the attr id in a set so that it will match against ordinary topics.
2. Prevents the inferred types from updating the attr row on every update. If not for the first issue, we would have been doing a lot more unnecessary invalidating. Now it only creates a wal log if the inferred types change.
 
   i. This could be even better--if you set `replica identity full` on the table we should get a full diff (https://github.com/eulerto/wal2json/issues/152), then we could only re-render on attr changes we care about.
4. Coerces `where` inputs to uuids when they're a ref, e.g. `{users: {$: {where: {bookshelves: "bookshelf-uuid"}}}`

   i. This was causing the topic not to match because the string didn't equal the uuid.