### PR TITLE
[schema] move schema ops into a shared namespace

### DIFF
--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -45,5 +45,5 @@ const graph = i.graph(
     },
   },
 );
-
+console.log(graph);
 export default graph;

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -45,5 +45,5 @@ const graph = i.graph(
     },
   },
 );
-console.log(graph);
+
 export default graph;

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -435,17 +435,6 @@
                         :headers {"app-id" (str counters-app-id)
                                   "authorization" (str "Bearer " admin-token)}}))
 
-(defn schema-experimental-get [req]
-  (let [{app-id :app_id} (req->admin-token! req)
-        attrs (attr-model/get-by-app-id aurora/conn-pool app-id)]
-    (response/ok {:attrs attrs})))
-
-(comment
-  (def counters-app-id  #uuid "137ace7a-efdd-490f-b0dc-a3c73a14f892")
-  (def admin-token #uuid "82900c15-faac-495b-b385-9f9e7743b629")
-  (schema-experimental-get {:headers {"app-id" (str counters-app-id)
-                                      "authorization" (str "Bearer " admin-token)}}))
-
 (defroutes routes
   (POST "/admin/query" [] query-post)
   (POST "/admin/transact" [] transact-post)
@@ -462,5 +451,4 @@
   (GET "/admin/storage/files" [] files-get)
   (DELETE "/admin/storage/files" [] file-delete) ;; single delete
   (POST "/admin/storage/files/delete" [] files-delete) ;; bulk delete
-
-  (GET "/admin/schema_experimental" [] schema-experimental-get))
+  )

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -105,11 +105,13 @@
 (defn req->app-and-user!
   ([req] (req->app-and-user! :owner req))
   ([least-privilege req]
+   (tool/def-locals!)
    (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
          {app-creator-id :creator_id :as app} (app-model/get-by-id! {:id app-id})
          {user-id :id :as user} (req->auth-user! req)
          subscription (instant-subscription-model/get-by-user-app {:user-id (:creator_id app)
                                                                    :app-id (:id app)})]
+
      (assert-least-privilege!
       least-privilege
       (cond

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -5,8 +5,6 @@
             [clojure.tools.logging :as log]
             [compojure.core :refer [defroutes GET POST DELETE] :as compojure]
             [instant.dash.admin :as dash-admin]
-            [instant.db.datalog :as d]
-            [instant.db.permissioned-transaction :as permissioned-tx]
             [instant.model.app :as app-model]
             [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
             [instant.model.app-oauth-client :as app-oauth-client-model]
@@ -30,7 +28,6 @@
             [instant.model.instant-cli-login :as instant-cli-login-model]
             [instant.postmark :as postmark]
             [instant.util.async :refer [fut-bg]]
-            [instant.util.coll :as coll]
             [instant.util.crypt :as crypt-util]
             [instant.util.email :as email]
             [instant.util.json :as json]
@@ -59,7 +56,6 @@
             [instant.storage.beta :as storage-beta]
             [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
             [instant.model.schema :as schema-model])
-
   (:import
    (java.util UUID)
    (com.stripe.model.checkout Session)))
@@ -980,143 +976,6 @@
 ;; --- 
 ;; CLI
 
-(defn map-map [f m]
-  (into {} (map (fn [[k v]] [k (f [k v])]) m)))
-
-(defn schemas->ops [current-schema new-schema]
-  (let [{new-blobs :blobs new-refs :refs} new-schema
-        eid-ops (map (fn [[ns-name _]] (if (get-in current-schema [:blobs ns-name])
-                                         nil
-                                         [:add-attr
-                                          {:value-type :blob
-                                           :cardinality :one
-                                           :id (UUID/randomUUID)
-                                           :forward-identity [(UUID/randomUUID) (name ns-name) "id"]
-                                           :unique? false
-                                           :index? false}])) new-blobs)
-        blob-ops (mapcat
-                  (fn [[ns-name attrs]]
-                    (map (fn [[attr-name new-attr]]
-                           (let
-                            [current-attr (get-in current-schema [:blobs ns-name attr-name])
-                             name-id? (= "id" (name attr-name))
-                             new-attr? (not current-attr)
-                             unchanged-attr? (and
-                                              (= (get new-attr :unique?) (get current-attr :unique?))
-                                              (= (get new-attr :index?) (get current-attr :index?)))]
-                             (cond
-                               name-id? nil
-                               unchanged-attr? nil
-                               new-attr?  [:add-attr
-                                           {:value-type :blob
-                                            :cardinality :one
-                                            :id (UUID/randomUUID)
-                                            :forward-identity [(UUID/randomUUID) (name ns-name) (name attr-name)]
-                                            :unique? (:unique? new-attr)
-                                            :index? (:index? new-attr)}]
-                               :else [:update-attr
-                                      {:value-type :blob
-                                       :cardinality :one
-                                       :id (:id current-attr)
-                                       :forward-identity (:forward-identity current-attr)
-                                       :unique? (:unique? new-attr)
-                                       :index? (:index? new-attr)}])))
-                         attrs))
-                  new-blobs)
-        ref-ops (map
-                 (fn [[link-desc new-attr]]
-                   (let
-                    [[from-ns from-attr to-ns to-attr] link-desc
-                     current-attr (get-in current-schema [:refs link-desc])
-                     new-attr? (not current-attr)
-                     unchanged-attr? (and
-                                      (= (get new-attr :cardinality) (get current-attr :cardinality))
-                                      (= (get new-attr :unique?) (get current-attr :unique?)))]
-                     (cond
-                       unchanged-attr? nil
-                       new-attr? [:add-attr
-                                  {:value-type :ref
-                                   :id (UUID/randomUUID)
-                                   :forward-identity [(UUID/randomUUID) from-ns from-attr]
-                                   :reverse-identity [(UUID/randomUUID) to-ns to-attr]
-                                   :cardinality (:cardinality new-attr)
-                                   :unique? (:unique? new-attr)
-                                   :index? (:index? new-attr)}]
-                       :else [:update-attr
-                              {:value-type :ref
-                               :id (:id current-attr)
-                               :forward-identity (:forward-identity current-attr)
-                               :reverse-identity (:reverse-identity current-attr)
-                               :cardinality (:cardinality new-attr)
-                               :unique? (:unique? new-attr)
-                               :index? (:index? new-attr)}])))
-                 new-refs)]
-    (->> (concat eid-ops blob-ops ref-ops)
-         (filter some?)
-         vec)))
-
-(defn attrs->schema [attrs]
-  (let [{blobs :blob refs :ref} (group-by :value-type attrs)
-        refs-indexed (into {} (map (fn [{:keys [forward-identity reverse-identity] :as attr}]
-                                     [[(second forward-identity)
-                                       (coll/third forward-identity)
-                                       (second reverse-identity)
-                                       (coll/third reverse-identity)] attr])
-                                   refs))
-        blobs-indexed (->> blobs
-                           (group-by #(-> % attr-model/fwd-etype keyword))
-                           (map-map (fn [[_ attrs]]
-                                      (into {}
-                                            (map (fn [a]
-                                                   [(keyword (-> a :forward-identity coll/third))
-                                                    a])
-                                                 attrs)))))]
-    {:refs refs-indexed :blobs blobs-indexed}))
-
-(def relationships->schema-params {[:many :many] {:cardinality :many
-                                                  :unique? false}
-                                   [:one :one] {:cardinality :one
-                                                :unique? true}
-                                   [:many :one] {:cardinality :many
-                                                 :unique? true}
-                                   [:one :many] {:cardinality :one
-                                                 :unique? false}})
-
-(defn defs->schema [defs]
-  (let [{entities :entities links :links} defs
-        refs-indexed (into {} (map (fn [[_ {forward :forward reverse :reverse}]]
-                                     [[(:on forward) (:label forward) (:on reverse) (:label reverse)]
-                                      (merge
-                                       {:id nil
-                                        :value-type :ref
-                                        :index? false
-                                        :forward-identity [nil (:on forward) (:label forward)]
-                                        :reverse-identity [nil (:on reverse) (:label reverse)]}
-                                       (get relationships->schema-params
-                                            [(keyword (:has forward)) (keyword (:has reverse))]))])
-                                   links))
-        blobs-indexed (map-map (fn [[ns-name def]]
-                                 (map-map (fn [[attr-name attr-def]]
-                                            {:id nil
-                                             :value-type :blob
-                                             :cardinality :one
-                                             :forward-identity [nil (name ns-name) (name attr-name)]
-                                             :unique? (or (-> attr-def :config :unique) false)
-                                             :index? (or (-> attr-def :config :indexed) false)})
-                                          (:attrs def)))
-                               entities)]
-    {:refs refs-indexed :blobs blobs-indexed}))
-
-(defn schema-push-steps [app-id client-defs]
-  (let [new-schema (defs->schema client-defs)
-        current-attrs (attr-model/get-by-app-id aurora/conn-pool app-id)
-        current-schema (attrs->schema current-attrs)
-        steps (schemas->ops current-schema new-schema)]
-    {:new-schema new-schema
-     :current-schema current-schema
-     :current-attrs current-attrs
-     :steps steps}))
-
 (defn schema-push-plan-post [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         client-defs (-> req :body :schema)]
@@ -1147,7 +1006,7 @@
   (def counters-app-id  #uuid "137ace7a-efdd-490f-b0dc-a3c73a14f892")
   (def u (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))
   (def r (instant-user-refresh-token-model/create! {:id (UUID/randomUUID) :user-id (:id u)}))
-  (schemas->ops
+  (schema-model/schemas->ops
    {:refs {}
     :blobs {}}
    {:refs {["posts" "comments" "comments" "post"] {:unique? false :cardinality "many"}}

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -106,7 +106,6 @@
 (defn req->app-and-user!
   ([req] (req->app-and-user! :owner req))
   ([least-privilege req]
-   (tool/def-locals!)
    (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
          {app-creator-id :creator_id :as app} (app-model/get-by-id! {:id app-id})
          {user-id :id :as user} (req->auth-user! req)

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -1,0 +1,160 @@
+(ns instant.model.schema
+  (:require [instant.db.model.attr :as attr-model]
+            [instant.util.coll :as coll]
+            [instant.jdbc.aurora :as aurora]
+            [instant.db.datalog :as d]
+            [instant.model.rule :as rule-model]
+            [instant.db.permissioned-transaction :as permissioned-tx])
+  (:import (java.util UUID)))
+
+(defn map-map [f m]
+  (into {} (map (fn [[k v]] [k (f [k v])]) m)))
+
+(defn schemas->ops [current-schema new-schema]
+  (let [{new-blobs :blobs new-refs :refs} new-schema
+        eid-ops (map (fn [[ns-name _]] (if (get-in current-schema [:blobs ns-name])
+                                         nil
+                                         [:add-attr
+                                          {:value-type :blob
+                                           :cardinality :one
+                                           :id (UUID/randomUUID)
+                                           :forward-identity [(UUID/randomUUID) (name ns-name) "id"]
+                                           :unique? false
+                                           :index? false}])) new-blobs)
+        blob-ops (mapcat
+                  (fn [[ns-name attrs]]
+                    (map (fn [[attr-name new-attr]]
+                           (let
+                            [current-attr (get-in current-schema [:blobs ns-name attr-name])
+                             name-id? (= "id" (name attr-name))
+                             new-attr? (not current-attr)
+                             unchanged-attr? (and
+                                              (= (get new-attr :unique?) (get current-attr :unique?))
+                                              (= (get new-attr :index?) (get current-attr :index?)))]
+                             (cond
+                               name-id? nil
+                               unchanged-attr? nil
+                               new-attr?  [:add-attr
+                                           {:value-type :blob
+                                            :cardinality :one
+                                            :id (UUID/randomUUID)
+                                            :forward-identity [(UUID/randomUUID) (name ns-name) (name attr-name)]
+                                            :unique? (:unique? new-attr)
+                                            :index? (:index? new-attr)}]
+                               :else [:update-attr
+                                      {:value-type :blob
+                                       :cardinality :one
+                                       :id (:id current-attr)
+                                       :forward-identity (:forward-identity current-attr)
+                                       :unique? (:unique? new-attr)
+                                       :index? (:index? new-attr)}])))
+                         attrs))
+                  new-blobs)
+        ref-ops (map
+                 (fn [[link-desc new-attr]]
+                   (let
+                    [[from-ns from-attr to-ns to-attr] link-desc
+                     current-attr (get-in current-schema [:refs link-desc])
+                     new-attr? (not current-attr)
+                     unchanged-attr? (and
+                                      (= (get new-attr :cardinality) (get current-attr :cardinality))
+                                      (= (get new-attr :unique?) (get current-attr :unique?)))]
+                     (cond
+                       unchanged-attr? nil
+                       new-attr? [:add-attr
+                                  {:value-type :ref
+                                   :id (UUID/randomUUID)
+                                   :forward-identity [(UUID/randomUUID) from-ns from-attr]
+                                   :reverse-identity [(UUID/randomUUID) to-ns to-attr]
+                                   :cardinality (:cardinality new-attr)
+                                   :unique? (:unique? new-attr)
+                                   :index? (:index? new-attr)}]
+                       :else [:update-attr
+                              {:value-type :ref
+                               :id (:id current-attr)
+                               :forward-identity (:forward-identity current-attr)
+                               :reverse-identity (:reverse-identity current-attr)
+                               :cardinality (:cardinality new-attr)
+                               :unique? (:unique? new-attr)
+                               :index? (:index? new-attr)}])))
+                 new-refs)]
+    (->> (concat eid-ops blob-ops ref-ops)
+         (filter some?)
+         vec)))
+
+(defn attrs->schema [attrs]
+  (let [{blobs :blob refs :ref} (group-by :value-type attrs)
+        refs-indexed (into {} (map (fn [{:keys [forward-identity reverse-identity] :as attr}]
+                                     [[(second forward-identity)
+                                       (coll/third forward-identity)
+                                       (second reverse-identity)
+                                       (coll/third reverse-identity)] attr])
+                                   refs))
+        blobs-indexed (->> blobs
+                           (group-by #(-> % attr-model/fwd-etype keyword))
+                           (map-map (fn [[_ attrs]]
+                                      (into {}
+                                            (map (fn [a]
+                                                   [(keyword (-> a :forward-identity coll/third))
+                                                    a])
+                                                 attrs)))))]
+    {:refs refs-indexed :blobs blobs-indexed}))
+
+
+(def relationships->schema-params {[:many :many] {:cardinality :many
+                                                  :unique? false}
+                                   [:one :one] {:cardinality :one
+                                                :unique? true}
+                                   [:many :one] {:cardinality :many
+                                                 :unique? true}
+                                   [:one :many] {:cardinality :one
+                                                 :unique? false}})
+
+(defn defs->schema [defs]
+  (let [{entities :entities links :links} defs
+        refs-indexed (into {} (map (fn [[_ {forward :forward reverse :reverse}]]
+                                     [[(:on forward) (:label forward) (:on reverse) (:label reverse)]
+                                      (merge
+                                       {:id nil
+                                        :value-type :ref
+                                        :index? false
+                                        :forward-identity [nil (:on forward) (:label forward)]
+                                        :reverse-identity [nil (:on reverse) (:label reverse)]}
+                                       (get relationships->schema-params
+                                            [(keyword (:has forward)) (keyword (:has reverse))]))])
+                                   links))
+        blobs-indexed (map-map (fn [[ns-name def]]
+                                 (map-map (fn [[attr-name attr-def]]
+                                            {:id nil
+                                             :value-type :blob
+                                             :cardinality :one
+                                             :forward-identity [nil (name ns-name) (name attr-name)]
+                                             :unique? (or (-> attr-def :config :unique) false)
+                                             :index? (or (-> attr-def :config :indexed) false)})
+                                          (:attrs def)))
+                               entities)]
+    {:refs refs-indexed :blobs blobs-indexed}))
+
+;; ---- 
+;; API
+
+(defn plan
+  [app-id client-defs]
+  (let [new-schema (defs->schema client-defs)
+        current-attrs (attr-model/get-by-app-id aurora/conn-pool app-id)
+        current-schema (attrs->schema current-attrs)
+        steps (schemas->ops current-schema new-schema)]
+    {:new-schema new-schema
+     :current-schema current-schema
+     :current-attrs current-attrs
+     :steps steps}))
+
+(defn apply-plan! [app-id {:keys [steps] :as _plan}]
+  (let [ctx {:admin? true
+             :db {:conn-pool aurora/conn-pool}
+             :app-id app-id
+             :attrs (attr-model/get-by-app-id aurora/conn-pool app-id)
+             :datalog-query-fn d/query
+             :rules (rule-model/get-by-app-id aurora/conn-pool
+                                              {:app-id app-id})}]
+    (permissioned-tx/transact! ctx steps)))


### PR DESCRIPTION
Refactoring our schema functions into a single namespace. This way we can use them in both `dash-routes` and `superadmin`

@nezaj @dwwoelfel @markyfyi 