### PR TITLE
Add yourkit to production

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -148,7 +148,7 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/yourkit'
     # Start publish image if we have clj changes
     needs: [ detect_clj ]
     permissions:

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -148,7 +148,7 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/yourkit'
+    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
     needs: [ detect_clj ]
     permissions:

--- a/README.md
+++ b/README.md
@@ -127,3 +127,9 @@ If you have any questions, you can jump in on our [discord](https://discord.com/
 You can start by joining our [discord](https://discord.com/invite/VU53p7uQcE) and introducing yourself. Even if you don't contribute code, we always love feedback.
 
 If you want to make changes, start by reading the [`client`](./client/) and [`server`](./server/) READMEs. There you'll find instructions to start Instant locally.
+
+## YourKit
+
+We're using YourKit to help us monitor Instant. They are kindly supporting Instant and other open source projects with their [full-featured Java Profiler](https://www.yourkit.com/java/profiler/index.jsp).
+
+![yklogo](https://github.com/user-attachments/assets/64788da3-1dc4-4aa6-84cd-e051fd059fd0)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,8 +6,6 @@ RUN yum -y install tar gzip git unzip
 
 RUN curl -L -O https://github.com/clojure/brew-install/releases/download/1.11.3.1463/linux-install.sh
 
-RUN echo hi
-
 RUN echo '0c41063a2fefb53a31bc1bc236899955f759c5103dc0495489cdd74bf8f114bb  linux-install.sh' |  sha256sum -c
 
 RUN chmod +x linux-install.sh

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,12 +2,22 @@ FROM amazoncorretto:22 AS builder
 
 WORKDIR /app
 
-RUN yum -y install tar gzip git
+RUN yum -y install tar gzip git unzip
 
 RUN curl -L -O https://github.com/clojure/brew-install/releases/download/1.11.3.1463/linux-install.sh
 
+RUN echo hi
+
+RUN echo '0c41063a2fefb53a31bc1bc236899955f759c5103dc0495489cdd74bf8f114bb  linux-install.sh' |  sha256sum -c
+
 RUN chmod +x linux-install.sh
 RUN ./linux-install.sh
+
+RUN curl -L -O https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2024.3-docker.zip
+
+RUN echo '4fb651cef6a4c0cb9c27a07ecb8d9438c0f258119c78aa743385ef4b2c0edd1e  YourKit-JavaProfiler-2024.3-docker.zip' | sha256sum -c
+
+RUN unzip YourKit-JavaProfiler-2024.3-docker.zip
 
 COPY deps.edn .
 
@@ -24,6 +34,7 @@ FROM amazoncorretto:22
 WORKDIR /app
 
 COPY --from=builder /app/target/instant-standalone.jar ./target/instant-standalone.jar
+COPY --from=builder /app/YourKit-JavaProfiler-2024.3 /usr/local/YourKit-JavaProfiler-2024.3
 
 EXPOSE 5000
 EXPOSE 6005

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     ports:
       - "80:5000"
       - "6005:6005"
-    command: sh -c 'java $${JAVA_OPTS} -server -jar target/instant-standalone.jar'
+      - "10001:10001"
+    command: sh -c 'java $${JAVA_OPTS} -agentpath:/usr/local/YourKit-JavaProfiler-2024.3/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all -server -jar target/instant-standalone.jar'
   logdna:
     image: logdna/logdna-agent:3.8
     environment:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "6005:6005"
       - "10001:10001"
     command: sh -c 'java $${JAVA_OPTS} -agentpath:/usr/local/YourKit-JavaProfiler-2024.3/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all -server -jar target/instant-standalone.jar'
+
   logdna:
     image: logdna/logdna-agent:3.8
     environment:
@@ -25,6 +26,7 @@ services:
       - /var/log/eb-engine.log:/var/log/eb-engine.log:ro
       - /var/log/messages:/var/log/messages:ro
       - /var/log/eb-docker:/var/log/eb-docker:ro
+
   refinery:
     image: honeycombio/refinery:2.7.1
     volumes:

--- a/server/scripts/yourkit_tunnel.sh
+++ b/server/scripts/yourkit_tunnel.sh
@@ -2,7 +2,7 @@
 # set -x
 # set -e
 
-port=6005  # Default port
+port=10001  # Default port
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -24,14 +24,10 @@ fi
 
 echo "Setting up tunnel to $instance_id on port $port"
 
-echo "6005" > .nrepl-port
-
 aws ssm start-session \
     --document-name "AWS-StartPortForwardingSession" \
     --target "$instance_id" \
     --parameters '{"portNumber":["6005"],"localPortNumber":["6005"]}' \
     --region "us-east-1"
-
-rm .nrepl-port
 
 echo "Tunnel closed"


### PR DESCRIPTION
Adds yourkit to production with a new `scripts/yourkit_tunnel.sh` to connect.

I have it running on a staging server, but I can't test it out yet because my trial is expired and waiting to hear back from the yourkit folks.

Also updates the prod_tunnel script to take an optional `--instance-id` arg and an optional `--port` arg.