### PR TITLE
Add missing todos namespace

### DIFF
--- a/client/www/pages/docs/strong-init.md
+++ b/client/www/pages/docs/strong-init.md
@@ -29,7 +29,7 @@ export default function App() {
   function addTodo({ title: string }) {
     db.transact([
       // 4. mutations are typechecked too!
-      db.tx[id()].update({ title }),
+      db.tx.todos[id()].update({ title }),
     ]);
   }
 


### PR DESCRIPTION
I guess `todos` namespace was forgotten in db.tx.