### PR TITLE
Use a single db connection for transact

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -135,16 +135,14 @@
                        (ucoll/array-of CelType [type-obj SimpleType/STRING]))]))
              :runtime (let [impl (reify CelFunctionOverload$Binary
                                    (apply [_ {:strs [_ctx id _etype] :as _self} path-str]
-                                     (let [ref {:eid (parse-uuid id)
-                                                :etype _etype
-                                                :path-str path-str}]
+                                     (let [ref-data {:eid (parse-uuid id)
+                                                     :etype _etype
+                                                     :path-str path-str}]
                                        (if-let [preloaded-ref (-> _ctx
                                                                   :preloaded-refs
-                                                                  (get ref))]
+                                                                  (get ref-data))]
                                          (vec preloaded-ref)
-                                         (vec (get-ref _ctx {:eid (parse-uuid id)
-                                                             :etype _etype
-                                                             :path-str path-str}))))))]
+                                         (vec (get-ref _ctx ref-data))))))]
                         (CelRuntime$CelFunctionBinding/from
                          "data_ref"
                          Map
@@ -306,9 +304,6 @@
                                                  {:patterns patterns})
                                                patterns)}}
         results (:data (datalog-query-fn ctx query))]
-    (def -pp patterns)
-    (def -qq query)
-    (def -rr results)
     (reduce (fn [acc [ref pattern result]]
               (let [group-by-path [0 0]
                     val-path (find-val-path pattern)

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -87,11 +87,7 @@
                  (fn [eid]
                    (let [rows (grouped-join-rows eid)]
                      (map #(get-in % val-path) rows)))
-                 eids)
-        prefetch-result (prefetch-data-refs ctx [{:etype etype
-                                                  :eids eids
-                                                  :path-str path-str}])]
-    (tool/def-locals)
+                 eids)]
     results))
 
 (defonce loader-state (atom {}))

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -145,8 +145,7 @@
                                        (if-let [preloaded-ref (-> _ctx
                                                                   :preloaded-refs
                                                                   (get ref))]
-                                         (tracer/with-span! {:name "using-preloaded"}
-                                           (vec preloaded-ref))
+                                         (vec preloaded-ref)
                                          (vec (get-ref _ctx {:eid (parse-uuid id)
                                                              :etype _etype
                                                              :path-str path-str}))))))]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -18,6 +18,7 @@
             [instant.model.rule :as rule-model]
             [instant.db.cel :as cel]
             [instant.util.exception :as ex]
+            [instant.util.io :as io]
             [instant.util.uuid :as uuid-util]
             [instant.db.model.entity :as entity-model])
   (:import [java.util UUID]))
@@ -1439,22 +1440,52 @@
                            (datalog-query-fn ctx datalog-query))]
     (entity-model/datalog-result->map {:attr-map attr-map} datalog-result)))
 
+(defn extract-refs
+  "Extracts a list of refs that can be passed to cel/prefetch-data-refs.
+   Returns: [{:etype string path-str string eids #{uuid}}]"
+  [eid->etype etype->program]
+  (let [etype->eid (ucoll/map-invert-key-set eid->etype)]
+    (reduce (fn [acc [etype program]]
+              (if-let [ast (:cel-ast program)]
+                (let [path-strs (seq (cel/collect-data-ref-uses ast))]
+                  (reduce (fn [acc path-str]
+                            (conj acc {:etype etype
+                                       :path-str path-str
+                                       :eids (get etype->eid etype)}))
+                          acc
+                          path-strs))
+                acc))
+            []
+            etype->program)))
+
+(defn preload-refs [ctx eid->etype etype->program]
+  (let [refs (extract-refs eid->etype etype->program)]
+    (if (seq refs)
+      (cel/prefetch-data-refs ctx refs)
+      {})))
+
 (defn get-eid-check-result! [{:keys [current-user] :as ctx} {:keys [eid->etype etype->program query-cache]} attr-map]
   (tracer/with-span! {:name "instaql/get-eid-check-result!"}
-    (->> eid->etype
-         (ua/vfuture-pmap
-          (fn [[eid etype]]
-            (let [p (etype->program etype)]
-              [eid (if-not p
-                     true
-                     (let [em (entity-map ctx query-cache attr-map eid)]
-                       (cel/eval-program! p
-                                          {"auth" (cel/->cel-map (<-json (->json current-user)))
-                                           "data" (cel/->cel-map (assoc (<-json (->json em))
-                                                                        "_ctx" ctx
-                                                                        "_etype" etype))})))])))
+    (let [preloaded-refs (preload-refs ctx eid->etype etype->program)]
+      (->> eid->etype
+           (ua/vfuture-pmap
+            (fn [[eid etype]]
+              (let [p (etype->program etype)]
+                [eid (if-not p
+                       true
+                       (let [em (io/warn-io :instaql/entity-map
+                                  (entity-map ctx query-cache attr-map eid))
+                             ctx (assoc ctx
+                                        :preloaded-refs preloaded-refs)]
+                         (io/warn-io :instaql/eval-program
+                           (cel/eval-program!
+                            p
+                            {"auth" (cel/->cel-map (<-json (->json current-user)))
+                             "data" (cel/->cel-map (assoc (<-json (->json em))
+                                                          "_ctx" ctx
+                                                          "_etype" etype))}))))])))
 
-         (into {}))))
+           (into {})))))
 
 (defn permissioned-query [{:keys [app-id current-user admin?] :as ctx} o]
   (tracer/with-span! {:name "instaql/permissioned-query"

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1466,7 +1466,10 @@
 
 (defn get-eid-check-result! [{:keys [current-user] :as ctx} {:keys [eid->etype etype->program query-cache]} attr-map]
   (tracer/with-span! {:name "instaql/get-eid-check-result!"}
-    (let [preloaded-refs (preload-refs ctx eid->etype etype->program)]
+    (let [preloaded-refs (tracer/with-span! {:name "instaql/preload-refs"}
+                           (let [res (preload-refs ctx eid->etype etype->program)]
+                             (tracer/add-data! {:attributes {:ref-count (count res)}})
+                             res))]
       (->> eid->etype
            (ua/vfuture-pmap
             (fn [[eid etype]]

--- a/server/src/instant/db/model/entity.clj
+++ b/server/src/instant/db/model/entity.clj
@@ -4,10 +4,14 @@
 (defn get-triples-batch
   "Takes a list of eids and returns a map of eid to triples."
   [{:keys [datalog-query-fn] :as ctx} eids]
-  (let [datalog-result (datalog-query-fn ctx {:children {:pattern-groups
-                                                         (map (fn [eid]
-                                                                {:patterns [[:ea eid]]})
-                                                              eids)}})
+  (let [query {:children {:pattern-groups
+                          (map (fn [eid]
+                                 {:patterns [[:ea eid]]})
+                               eids)}}
+        ;; you might be tempted to simplify the query to [[:ea (set eids)]]
+        ;; but the eid might be a lookup ref and you won't know how to get
+        ;; the join rows for that lookup
+        datalog-result (datalog-query-fn ctx query)
 
         triples (map (fn [result]
                        (->> result

--- a/server/src/instant/db/model/entity.clj
+++ b/server/src/instant/db/model/entity.clj
@@ -1,6 +1,22 @@
 (ns instant.db.model.entity
   (:require [instant.db.model.attr :as attr-model]))
 
+(defn get-triples-batch
+  "Takes a list of eids and returns a map of eid to triples."
+  [{:keys [datalog-query-fn] :as ctx} eids]
+  (let [datalog-result (datalog-query-fn ctx {:children {:pattern-groups
+                                                         (map (fn [eid]
+                                                                {:patterns [[:ea eid]]})
+                                                              eids)}})
+
+        triples (map (fn [result]
+                       (->> result
+                            :result
+                            :join-rows
+                            (mapcat identity)))
+                     (:data datalog-result))]
+    (zipmap eids triples)))
+
 (defn get-triples [{:keys [datalog-query-fn] :as ctx} eid]
   (let [datalog-result (datalog-query-fn ctx [[:ea eid]])
         triples (->> datalog-result

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -12,13 +12,14 @@
    [next.jdbc :as next-jdbc]
    [instant.jdbc.sql :as sql]
    [instant.util.async :as ua]
-   [instant.util.exception :as ex]))
+   [instant.util.exception :as ex]
+   [instant.util.io :as io]))
 
 (defn extract-etype [{:keys [attrs]} attr-id]
   (attr-model/fwd-etype (attr-model/seek-by-id attr-id attrs)))
 
-;; -------------- 
-;; Check Commands 
+;; --------------
+;; Check Commands
 
 (defn tx-change-type [[action]]
   (cond
@@ -79,15 +80,22 @@
    original
    tx-steps))
 
+(defn get-triples [ctx eid]
+  (or (-> ctx
+          :preloaded-triples
+          (get eid))
+      (io/tag-io (entity-model/get-triples ctx eid))))
+
 ;; Why do we have to decide whether something is an update or a create?
-;; When a user makes a transaction, the only option they have currently is to do an `update`: 
+;; When a user makes a transaction, the only option they have currently is to do an `update`:
 ;; tx.users[id].update({name: "Joe"})
 ;; It's up to use to decide whether this object existed before or not.
 (defn object-upsert-check [{:keys [attrs rules current-user] :as ctx} eid tx-steps]
   (let [triples (map rest tx-steps)
         etype-attr-id (-> triples first second)
         etype (extract-etype ctx etype-attr-id)
-        original (entity-model/get-map ctx eid)
+        triples (get-triples ctx eid)
+        original (entity-model/triples->map ctx triples)
         action (if (seq original) "update" "create")
         program (rule-model/get-program! rules etype action)
         action-kw (keyword action)
@@ -98,6 +106,7 @@
      :eid eid
      :data {:original original
             :updated new-data}
+     :program program
      :check (fn [ctx]
               (cond (not program)
                     true
@@ -128,7 +137,7 @@
                       (cel/->cel-map (<-json (->json new-data)))})))}))
 
 (defn object-delete-check [{:keys [rules current-user] :as ctx} eid]
-  (let [triples (entity-model/get-triples ctx eid)
+  (let [triples (get-triples ctx eid)
         original (entity-model/triples->map ctx triples)
         etype-attr-id (-> triples first second)
         etype (extract-etype ctx etype-attr-id)
@@ -137,6 +146,8 @@
     {:scope :object
      :etype (keyword etype)
      :action :delete
+     :eid eid
+     :program program
      :check (fn [ctx]
               (if-not program
                 true
@@ -158,23 +169,23 @@
     (object-delete-check ctx eid)))
 
 (defn object-checks
-  "Creates check commands for each object in the transaction. 
-  
-   We take tx-steps like: 
-   [ 
-     [:add-triple joe-eid :users/name \"Joe\"]  
+  "Creates check commands for each object in the transaction.
+
+   We take tx-steps like:
+   [
+     [:add-triple joe-eid :users/name \"Joe\"]
      [:add-triple joe-eid :users/age 32]
-     [:add-triple stopa-eid :users/name \"Stopa\"] 
+     [:add-triple stopa-eid :users/name \"Stopa\"]
      [:add-triple stopa-eid :users/age 30]
    ]
 
-   And we group them by `eid`. 
-   
+   And we group them by `eid`.
+
    {
-     joe-eid [[:add-triple joe-eid :users/name \"Joe\"]  
+     joe-eid [[:add-triple joe-eid :users/name \"Joe\"]
               [:add-triple joe-eid :users/age 32]]
-     stopa-eid [[:add-triple stopa-eid :users/name \"Stopa\"] 
-                [:add-triple stopa-eid :users/age 30]]  
+     stopa-eid [[:add-triple stopa-eid :users/name \"Stopa\"]
+                [:add-triple stopa-eid :users/age 30]]
    }
 
    With this, we can generate a grouped `check` command for each `eid`."
@@ -182,7 +193,7 @@
   (let [eid->tx-steps (group-by second tx-steps)
         eid-actions (mapcat ->eid-actions eid->tx-steps)]
     (->> eid-actions
-         (ua/vfuture-pmap (partial object-check ctx)))))
+         (map (partial object-check ctx)))))
 
 (defn attr-delete-check [{:keys [admin?] :as _ctx} _aid]
   {:scope :attr
@@ -222,7 +233,7 @@
 
 (defn attr-checks [ctx tx-steps]
   (->> tx-steps
-       (ua/vfuture-pmap (partial attr-check ctx))))
+       (map (partial attr-check ctx))))
 
 (defn get-new-atrrs [attr-changes]
   (->> attr-changes
@@ -233,20 +244,20 @@
 
 (defn get-check-commands [{:keys [attrs] :as ctx} tx-steps]
   (let [{:keys [attr-changes object-changes]} (group-by tx-change-type tx-steps)
-        attr-checks-fut (ua/vfuture (attr-checks ctx attr-changes))
-        ;; Why do we need optimistic attrs? 
-        ;; Consider tx-steps like: 
+        attr-checks (attr-checks ctx attr-changes)
+        ;; Why do we need optimistic attrs?
+        ;; Consider tx-steps like:
         ;; [
         ;;    [:add-attr {:id goal-attr-id
-        ;;                :forward-identity [... "goals" "title"]}] 
-        ;;    [:add-triple goal-eid goal-attr-id "Hack"]   
-        ;; ] 
-        ;; If user 'creates' an attr in the same transaction, 
+        ;;                :forward-identity [... "goals" "title"]}]
+        ;;    [:add-triple goal-eid goal-attr-id "Hack"]
+        ;; ]
+        ;; If user 'creates' an attr in the same transaction,
         ;; We need to be able to resolve the attr-id for this `add-triple`
         optmistic-attrs (into attrs (get-new-atrrs attr-changes))
         new-ctx (assoc ctx :attrs optmistic-attrs)
-        object-checks-fut (ua/vfuture (object-checks new-ctx object-changes))]
-    (into @attr-checks-fut @object-checks-fut)))
+        object-checks (object-checks new-ctx object-changes)]
+    (into attr-checks object-checks)))
 
 (defn run-check-commands! [ctx checks]
   (->> checks
@@ -261,54 +272,81 @@
                                [etype action]
                                check-result)))))))
 
+;; ------------
+;; Data preload
+
+(defn extract-eids [tx-steps]
+  (reduce (fn [acc tx-step]
+            (if (= :object-changes (tx-change-type tx-step))
+              (conj acc (second tx-step))
+              acc))
+          #{}
+          tx-steps))
+
+(defn preload-triples [ctx tx-steps]
+  (let [eids (extract-eids tx-steps)]
+    (if (seq eids)
+      (entity-model/get-triples-batch ctx eids)
+      {})))
+
 (defn lock-tx-on! [tx-conn big-int]
   (sql/execute! tx-conn ["SELECT pg_advisory_xact_lock(?)" big-int]))
 
 (defn transact!
-  "Runs transactions alongside permission checks. The overall flow looks like this: 
-   
-   1. We take a list of tx-steps (add-attr, delete-attr, add-triple, etc)  
+  "Runs transactions alongside permission checks. The overall flow looks like this:
+
+   1. We take a list of tx-steps (add-attr, delete-attr, add-triple, etc)
    2. We group tx-steps `check` commands.
-     a. Multiple `add-triple` commands for the same `eid` will collect into a single 
-        `check` command 
-   3. We run queries to get existing data for each `eid` in the transaction. 
-   
+     a. Multiple `add-triple` commands for the same `eid` will collect into a single
+        `check` command
+   3. We run queries to get existing data for each `eid` in the transaction.
+
    Here's the order that checks run:
-   
-   1. We run all `update` and `delete` checks first. 
-   2. Then, we run the actual transaction 
-   3. Then, we run all the `create` checks. 
-   
-   We run `create` checks _after_ the transaction, so we can query off of the 
-   object. For example, if we created a new `post`, we may want a check that says: 
+
+   1. We run all `update` and `delete` checks first.
+   2. Then, we run the actual transaction
+   3. Then, we run all the `create` checks.
+
+   We run `create` checks _after_ the transaction, so we can query off of the
+   object. For example, if we created a new `post`, we may want a check that says:
    `auth.id in data.ref('creator.id')`"
   [{:keys [db app-id admin? admin-check? admin-dry-run?] :as ctx} tx-steps]
-  (tracer/with-span!
-    {:name "permissioned-transaction/transact!"
-     :attributes {:app-id app-id}}
+  (tracer/with-span! {:name "permissioned-transaction/transact!"
+                      :attributes {:app-id app-id}}
     (let [{:keys [conn-pool]} db]
       (next-jdbc/with-transaction [tx-conn conn-pool]
-        ;; transact does read and then a write. 
-        ;; We need to protect against a case where a different 
-        ;; write happens between our read and write. 
-        ;; To protect against this, we ensure writes for an 
-        ;; app happen serially. We take an advisory lock on app-id 
-        ;; when we start transact and we don't release it until 
-        ;; we are done. This ensures that other transactions 
-        ;; for this app will wait. 
+        ;; transact does read and then a write.
+        ;; We need to protect against a case where a different
+        ;; write happens between our read and write.
+        ;; To protect against this, we ensure writes for an
+        ;; app happen serially. We take an advisory lock on app-id
+        ;; when we start transact and we don't release it until
+        ;; we are done. This ensures that other transactions
+        ;; for this app will wait.
         (lock-tx-on! tx-conn (hash app-id))
         (if admin?
           (tx/transact-without-tx-conn! tx-conn app-id tx-steps)
-          (let [check-commands (get-check-commands ctx tx-steps)
+          (let [
+                ;; Use the db connection we have so that we don't cause a deadlock
+                ctx (assoc ctx :db {:conn-pool tx-conn})
+                preloaded-triples (preload-triples ctx
+                                                   tx-steps)
+                ctx (assoc ctx :preloaded-triples preloaded-triples)
+                check-commands (io/warn-io :check-commands
+                                 (get-check-commands ctx tx-steps))
                 create-checks (filter create-check? check-commands)
                 update-delete-checks (remove create-check? check-commands)
-                update-delete-checks-results (run-check-commands! ctx update-delete-checks)
-                tx-data  (tx/transact-without-tx-conn! tx-conn app-id tx-steps)
-                create-checks-results (run-check-commands!
-                                       ;; We need to be able to read our own writes. 
-                                       ;; We can only do this if we query the same connection
-                                       (assoc ctx :db {:conn-pool tx-conn})
-                                       create-checks)
+
+                update-delete-checks-results (io/warn-io :run-check-commands!
+                                               (run-check-commands! ctx update-delete-checks))
+                tx-data (tx/transact-without-tx-conn! tx-conn app-id tx-steps)
+
+                create-checks-results (io/warn-io :create-check-results
+                                        (run-check-commands!
+                                         ;; We need to be able to read our own writes.
+                                         ;; We can only do this if we query the same connection
+                                         (assoc ctx :db {:conn-pool tx-conn})
+                                         create-checks))
                 all-check-results (concat update-delete-checks-results create-checks-results)
                 all-checks-ok? (every? (fn [r] (-> r :check-result)) all-check-results)
                 rollback? (and admin-check?

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -324,14 +324,6 @@
 (defn lock-tx-on! [tx-conn big-int]
   (sql/execute! tx-conn ["SELECT pg_advisory_xact_lock(?)" big-int]))
 
-;; Here's how I see it working
-;;  1. We fetch all dependencies for the check commands
-;;  1a. We fetch deps for update/delete checks?
-;;  2. We run the update/delete check commands with the dependencies
-;;  3. We execute the transaction
-;;  4. We fetch any outstanding data we need for the create checks
-;;  5. We run the create checks
-
 (defn transact!
   "Runs transactions alongside permission checks. The overall flow looks like this:
 
@@ -368,7 +360,7 @@
           (tx/transact-without-tx-conn! tx-conn app-id tx-steps)
           (let [
                 ;; Use the db connection we have so that we don't cause a deadlock
-                ;; Also needed to be able to read our own writes for the create checks
+                ;; Also need to be able to read our own writes for the create checks
                 ctx (assoc ctx :db {:conn-pool tx-conn})
 
                 ;; If we were really smart, we would fetch the triples and the

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -40,28 +40,19 @@
 
 (defn get-program! [rules etype action]
   (when-let [code (some-> rules :code (extract etype action))]
-    (let [ast (try
-                (-> code
-                    cel/->ast)
-                (catch CelValidationException e
-                  (ex/throw-validation-err!
-                   :permission
-                   [etype action]
-                   (->> (.getErrors e)
-                        (map (fn [cel-issue]
-                               {:message (.getMessage cel-issue)}))))))]
-      {:etype etype
-       :action action
-       :cel-ast ast
-       :cel-program (try
-                      (cel/->program ast)
-                      (catch CelValidationException e
-                        (ex/throw-validation-err!
-                         :permission
-                         [etype action]
-                         (->> (.getErrors e)
-                              (map (fn [cel-issue]
-                                     {:message (.getMessage cel-issue)}))))))})))
+    (try
+      (let [ast (cel/->ast code)]
+        {:etype etype
+         :action action
+         :cel-ast ast
+         :cel-program (cel/->program ast)})
+      (catch CelValidationException e
+        (ex/throw-validation-err!
+         :permission
+         [etype action]
+         (->> (.getErrors e)
+              (map (fn [cel-issue]
+                     {:message (.getMessage cel-issue)}))))))))
 
 (defn validation-errors [rules]
   (->> (keys rules)
@@ -82,5 +73,3 @@
                               "create" "true"
                               "update" "moop"}}})
   (validation-errors code))
-
-

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -130,3 +130,12 @@
   "Returns the third element in a collection."
   [coll]
   (nth coll 2))
+
+(defn map-invert-key-set
+  "Like clojure.set/map-invert, but the resulting values are sets.
+  {:a :b, :c :b, :e :f} => {:b #{:a :c} :f #{:e}}"
+  [m]
+  (reduce (fn [acc [k v]]
+            (update acc v (fnil conj #{}) k))
+          {}
+          m))

--- a/server/src/instant/util/io.clj
+++ b/server/src/instant/util/io.clj
@@ -3,11 +3,18 @@
 
 (def ^:dynamic *tracking-io* nil)
 
-(defmacro warn-io [context & body]
+(defmacro warn-io
+  "Wrap a body with `warn-io` when you want to get a honeycomb trace if any
+   functions wrapped with `tag-io` are called in the body.
+   Useful for finding places where we're not prefetching enough data."
+  [context & body]
   `(binding [*tracking-io* ~context]
      ~@body))
 
-(defmacro tag-io [& body]
+(defmacro tag-io
+  "Wrap a body with `tag-io` if it does i/o and should log a warning inside of
+   a body wrapped with `warn-io`."
+  [& body]
   (let [file *file*
         {:keys [line column]} (meta &form)]
   `(do

--- a/server/src/instant/util/io.clj
+++ b/server/src/instant/util/io.clj
@@ -1,0 +1,21 @@
+(ns instant.util.io
+  (:require [instant.util.tracer :as tracer]))
+
+(def ^:dynamic *tracking-io* nil)
+
+(defmacro warn-io [context & body]
+  `(binding [*tracking-io* ~context]
+     ~@body))
+
+(defmacro tag-io [& body]
+  (let [file *file*
+        {:keys [line column]} (meta &form)]
+  `(do
+     (when *tracking-io*
+       (tracer/record-info! {:name "warn-io"
+                             :attributes {:context *tracking-io*
+                                          :body '~body
+                                          :file ~file
+                                          :line ~line
+                                          :column ~column}}))
+     ~@body)))

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -582,7 +582,6 @@
         (is
          (= ::ex/record-not-unique
             (::ex/type (instant-ex-data
-                        #"Record not unique"
                         (tx/transact!
                          aurora/conn-pool
                          app-id


### PR DESCRIPTION
_Easier to review with whitespace off https://github.com/instantdb/instant/pull/204/files?w=1_

We can get into a situation in `permissioned-transaction/transact!` where all of the db connections are in use, but we're waiting on a connection to fetch data for permissions before we can close our connection, leading to a deadlock. Eventually the connection will time out and things will proceed, but the db will be locked up in the meantime.

The solution is to use the connection we opened for all queries in the transaction, but we do a lot of parallel querying (`O(count(eids))`) to get permissions information and a single connection might hurt throughput. This PR adds pre-fetching so that we can only need to run 3 queries to get permissions (though we could get that down to 2 (or maybe even 1 if we're optimistic) if we really tried).

There are two kinds of prefetching we do: 
1. we prefetch triples for all eids from the tx-steps so that we can build the entity maps.
2. we prefetch relations for `data.ref` in the permissions rules.

To make 2. work, we walk the cel asts looking for `data.ref` calls and extract the paths.

There may be situations where we somehow don't prefetch the data we need. In that case, we'll just fall back to the old behavior and make another call to the database. In order to catch those situations, there are a couple of new macros in `instant.util.io`:

1. `io/tag-io` is used to tag a function as using io. I added `io/tag-io` to all of the sql helpers, since that's the majority of our io.
2. `io/warn-io` takes a keyword `context` arg and a body and will warn with a honeycomb trace if anybody tries to do any io in the body. We can look for `warn-io` in the logs to find places where we're not prefetching properly and improve our prefetching.

Since we have it, I also prefetch `data.ref` relations in instaql/permissioned-query. Testing with the `stickers` example saw a slight speedup, but nothing dramatic.