### PR TITLE
[core][merge] Fix client deep-merge null logic

### DIFF
--- a/client/packages/core/src/utils/object.js
+++ b/client/packages/core/src/utils/object.js
@@ -42,11 +42,12 @@ export function immutableDeepMerge(target, source) {
   const result = {};
 
   for (const key of Object.keys(target)) {
+    if (source[key] === null) continue;
+
     result[key] = target[key];
   }
 
   for (const key of Object.keys(source)) {
-    // null acts as a "delete key"
     if (source[key] === null) continue;
 
     const areBothObjects = isObject(target[key]) && isObject(source[key]);

--- a/client/sandbox/react-nextjs/pages/play/patch.tsx
+++ b/client/sandbox/react-nextjs/pages/play/patch.tsx
@@ -35,6 +35,9 @@ export default function Patch() {
       <button className="border border-black" onClick={mergeWithNull}>
         merge `nestedData` with `null`
       </button>
+      <button className="border border-black" onClick={mergeWithDeepUndef}>
+        merge `nestedData` with `{`{new_key:undefined}`}`
+      </button>
       <button className="border border-black" onClick={deleteAttr}>
         delete `nestedData` attribute
       </button>
@@ -61,6 +64,14 @@ export default function Patch() {
     db.transact([
       tx.blocks[singletonIdX].merge({
         nestedData: null,
+      }),
+    ]);
+  }
+
+  function mergeWithDeepUndef() {
+    db.transact([
+      tx.blocks[singletonIdX].merge({
+        nestedData: { new_key: undefined },
       }),
     ]);
   }


### PR DESCRIPTION
Fixes https://github.com/instantdb/instant/issues/54.  I added a util to the `patch` example to replicate the case outlined.

Our logic in `immutableDeepMerge` was plain wrong, and we weren't deleted properties that were "nulled" out.