### PR TITLE
[phantom-presence] handle stray websockets

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -896,6 +896,7 @@ export default class Reactor {
       return;
     }
     if (this._isManualClose) {
+      this._isManualClose = false;
       log.info("[socket-close] manual close, will not reconnect");
       return;
     }

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -895,6 +895,10 @@ export default class Reactor {
       );
       return;
     }
+    if (this._isManualClose) {
+      log.info("[socket-close] manual close, will not reconnect");
+      return;
+    }
 
     log.info("[socket-close] scheduling reconnect", this._reconnectTimeoutMs);
     setTimeout(() => {
@@ -910,7 +914,15 @@ export default class Reactor {
     }, this._reconnectTimeoutMs);
   };
 
+  _ensurePreviousSocketClosed() {
+    if (this._ws && this._ws.readyState === WS_OPEN_STATUS) {
+      this._isManualClose = true;
+      this._ws.close();
+    }
+  }
+
   _startSocket() {
+    this._ensurePreviousSocketClosed();
     this._ws = new WebSocket(
       `${this.config.websocketURI}?app_id=${this.config.appId}`,
     );
@@ -1206,7 +1218,7 @@ export default class Reactor {
           appId: this.config.appId,
           refreshToken,
         });
-      } catch (e) {}
+      } catch (e) { }
     }
 
     this.changeCurrentUser(null);

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -10,7 +10,8 @@
   (:refer-clojure :exclude [send])
   (:require [ring.adapter.undertow.headers :refer [set-headers]]
             [instant.util.json :refer [->json]]
-            [instant.util.tracer :as tracer])
+            [instant.util.tracer :as tracer]
+            [instant.util.delay :as delay])
   (:import
    [io.undertow.server HttpServerExchange]
    [io.undertow.websockets
@@ -21,7 +22,7 @@
     BufferedBinaryMessage
     BufferedTextMessage
     CloseMessage
-    WebSocketChannel
+    StreamSourceFrameChannel WebSocketChannel
     WebSockets
     WebSocketCallback]
    [io.undertow.websockets.spi WebSocketHttpExchange]
@@ -29,34 +30,62 @@
    [ring.adapter.undertow Util]
    [clojure.lang IPersistentMap]
    [io.undertow.websockets.extensions PerMessageDeflateHandshake]
-   [java.util.concurrent.locks ReentrantLock]))
+   [java.util.concurrent.locks ReentrantLock]
+   [java.util.concurrent.atomic AtomicLong]
+   [java.nio ByteBuffer]
+   [org.xnio IoUtils]))
 
 (defn ws-listener
   "Creates an `AbstractReceiveListener`. This relays calls to 
    `on-message`, `on-close-message`, and `on-error` callbacks. 
    
    See `ws-callback` for more details."
-  [{:keys [on-message on-close-message on-error channel-wrapper]}]
+  [{:keys [on-message on-close-message on-error channel-wrapper atomic-last-received-at]}]
   (let [on-message       (or on-message (constantly nil))
         on-error         (or on-error (constantly nil))
         on-close-message (or on-close-message (constantly nil))]
     (proxy [AbstractReceiveListener] []
       (onFullTextMessage [^WebSocketChannel channel ^BufferedTextMessage message]
+
+        (.set atomic-last-received-at (System/currentTimeMillis))
         (on-message {:channel (channel-wrapper channel)
                      :data    (.getData message)}))
       (onFullBinaryMessage [^WebSocketChannel channel ^BufferedBinaryMessage message]
+        (.set atomic-last-received-at (System/currentTimeMillis))
         (let [pooled (.getData message)]
           (try
             (let [payload (.getResource pooled)]
               (on-message {:channel (channel-wrapper channel)
                            :data    (Util/toArray payload)}))
             (finally (.free pooled)))))
+      (onPong [^WebSocketChannel channel ^StreamSourceFrameChannel channel]
+        (tracer/with-span! {:name "socket/pong"}
+          (.set atomic-last-received-at (System/currentTimeMillis))))
       (onCloseMessage [^CloseMessage message ^WebSocketChannel channel]
         (on-close-message {:channel (channel-wrapper  channel)
                            :message message}))
       (onError [^WebSocketChannel channel ^Throwable error]
         (on-error {:channel (channel-wrapper channel)
                    :error   error})))))
+
+(defonce ping-pool (delay/make-pool!))
+
+(defn straight-jacket-run-ping-job [^WebSocketChannel channel
+                                    ^AtomicLong atomic-last-received-at
+                                    idle-timeout-ms]
+  (tracer/with-span! {:name "socket/ping"}
+    (try
+      (let [now (System/currentTimeMillis)
+            last-received-at (.get atomic-last-received-at)
+            ms-since-last-message (- now last-received-at)]
+        (if (> ms-since-last-message idle-timeout-ms)
+          (tracer/with-span! {:name "socket/close-inactive"}
+            (IoUtils/safeClose channel))
+          (WebSockets/sendPingBlocking (ByteBuffer/allocate 0)
+                                       channel)))
+      (catch Exception e
+        (tracer/record-exception-span! e {:name "socket/ping-err"
+                                          :escaping? false})))))
 
 (defn ws-callback
   "Creates a `WebsocketConnectionCallback`. This relays data to the 
@@ -85,26 +114,49 @@
 
    on-error: Called when the server encounters an error sending a message 
      :channel - The `WebSocketChannel` object 
-     :error - The error Throwable"
-  [{:keys [on-open on-close listener]
-    :or   {on-open (constantly nil) on-close (constantly nil)}
+     :error - The error Throwable
+     
+   We also kick off a ping worker. It sends a `ping` message every 
+   `ping-interval-ms`. If the client doesn't send any message for 
+   `idle-timeout-ms`, we close the connection.  
+   "
+  [{:keys [on-open on-close listener ping-interval-ms idle-timeout-ms]
+    :or   {on-open (constantly nil)
+           on-close (constantly nil)
+           ping-interval-ms 5000
+           idle-timeout-ms 15000}
     :as   ws-opts}]
   (let [send-lock (ReentrantLock.)
+        atomic-last-received-at (AtomicLong. (System/currentTimeMillis))
         channel-wrapper (fn [ch]
                           {:undertow-websocket ch
                            :send-lock send-lock})
         listener (if (instance? ChannelListener listener)
                    listener
-                   (ws-listener (assoc ws-opts :channel-wrapper channel-wrapper)))
-        close-task (reify ChannelListener
-                     (handleEvent [_this channel]
-                       (on-close (channel-wrapper channel))))]
+                   (ws-listener (assoc ws-opts
+                                       :channel-wrapper channel-wrapper
+                                       :atomic-last-received-at atomic-last-received-at)))]
+
     (reify WebSocketConnectionCallback
       (^void onConnect [_ ^WebSocketHttpExchange exchange ^WebSocketChannel channel]
-        (on-open {:exchange exchange :channel (channel-wrapper channel)})
-        (.addCloseTask channel close-task)
-        (.set (.getReceiveSetter channel) listener)
-        (.resumeReceives channel)))))
+        (let [ping-job (delay/repeat-fn
+                        ping-pool
+                        ping-interval-ms
+                        (fn []
+                          (straight-jacket-run-ping-job channel
+                                                        atomic-last-received-at
+                                                        idle-timeout-ms)))
+
+              close-task (reify ChannelListener
+                           (handleEvent [_this channel]
+                             (.cancel ping-job false)
+                             (on-close (channel-wrapper channel))))]
+          (.set atomic-last-received-at (System/currentTimeMillis))
+          (on-open {:exchange exchange
+                    :channel (channel-wrapper channel)})
+          (.addCloseTask channel close-task)
+          (.set (.getReceiveSetter channel) listener)
+          (.resumeReceives channel))))))
 
 (defn ws-request [^HttpServerExchange exchange ^IPersistentMap headers ^WebSocketConnectionCallback callback]
   (let [handler (->  (WebSocketProtocolHandshakeHandler. callback)

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -492,15 +492,6 @@
 ;; -----------------
 ;; Websocket Interop
 
-(defonce ping-pool (delay/make-pool!))
-
-(defn start-ping-job [store-conn id]
-  (delay/repeat-fn
-   ping-pool
-   5000
-   (fn []
-     (rs/try-send-event! store-conn id {:op :ping}))))
-
 (defn on-open [store-conn {:keys [id] :as socket}]
   (tracer/with-span! {:name "socket/on-open"
                       :attributes {:session-id (:id socket)}}
@@ -521,23 +512,17 @@
 (defn on-close [store-conn eph-store-atom {:keys [id pending-handlers]}]
   (tracer/with-span! {:name "socket/on-close"
                       :attributes {:session-id id}}
-    (let [{:keys [ping-job]} (rs/get-socket @store-conn id)]
-      (if ping-job
-        (.cancel ping-job false)
-        (tracer/record-info! {:name "socket/on-close-no-ping-job"
-                              :attributes {:session-id id}}))
+    (doseq [{:keys [future silence-exceptions op]} @pending-handlers]
+      (tracer/with-span! {:name "cancel-pending-handler"
+                          :attributes {:op op}}
+        (silence-exceptions true)
+        (future-cancel future)))
 
-      (doseq [{:keys [future silence-exceptions op]} @pending-handlers]
-        (tracer/with-span! {:name "cancel-pending-handler"
-                            :attributes {:op op}}
-          (silence-exceptions true)
-          (future-cancel future)))
-
-      (let [app-id (-> (rs/get-auth @store-conn id)
-                       :app
-                       :id)]
-        (eph/leave-by-session-id! eph-store-atom app-id id)
-        (rs/remove-session! store-conn id)))))
+    (let [app-id (-> (rs/get-auth @store-conn id)
+                     :app
+                     :id)]
+      (eph/leave-by-session-id! eph-store-atom app-id id)
+      (rs/remove-session! store-conn id))))
 
 (defn undertow-config
   [store-conn eph-store-atom receive-q {:keys [id]}]
@@ -548,7 +533,6 @@
                                :http-req http-req
                                :ws-conn ws-conn
                                :receive-q receive-q
-                               :ping-job (start-ping-job store-conn id)
                                :pending-handlers pending-handlers}]
                    (on-open store-conn socket)))
       :on-message (fn [{:keys [data]}]


### PR DESCRIPTION
This PR: 
1. On the client, we make sure to close the previous websocket connection, when we are about to start a new one 
2. On the server, we started a ping-pong mechanism, where we detect idle connections and proactively kill them 

### Context

Kosmik reported a curious bug: If you went offline and went back online, you would get a phantom presence object. What happened?

### Bugs

The fundamental bug was this: tcp connections stayed 'active', _even when we went offline_. 

We assumed that the underlying websocket would close when we went offline. But this is not the case. Google Chrome does not close the socket automatically when you go offline. [1] 

What happens to idle TCP connections really depends on the machine [2]. Sometimes it can take minutes to close the connection.

### Solutions

I did two things in this PR: 

**1) Client: Close previous connections when starting new ones**

In Reactor, when we go back online, we run _startSocket. We used to assume that previous `_ws` would have been closed. Now no more: when we start a new socket, we'll make sure to close the previous one. 

**2) Server: Start ping/pong** 

Having the client close stray connections is a good step. But it doesn't quite cover it. For example, if the user goes offline, and _never_ goes back online, then what? 

The server could keep the connection around for minutes. Here's what we do now: the server sends `ping` messages every 5 seconds. If we don't receive some message within 10 seconds, we close the connection. 

[1] [Here's an interesting chrome bug report](https://code.google.com/p/chromium/issues/detail?id=76358)
[2] [Interesting microsoft article hiredman shared with us](https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/tcp-ip-port-exhaustion-troubleshooting#:~:text=After%20a%20graceful%20closure%20or%20an%20abrupt%20closure%20of%20a%20session%2C%20after%20a%20period%20of%204%20minutes%20(default)%2C%20the%20port%20used%20by%20the%20process%20or%20application%20would%20be%20released%20back%20to%20the%20available%20pool.%20During%20this%204%20minutes%2C%20the%20TCP%20connection%20state%20will%20be%20TIME_WAIT%20state.)


I kicked off a conversation about this on the [clojurians slack](https://clojurians.slack.com/archives/C03S1KBA2/p1726170248831079)

