### PR TITLE
Update useQuery code snippet

### DIFF
--- a/client/www/pages/docs/strong-init.md
+++ b/client/www/pages/docs/strong-init.md
@@ -62,7 +62,7 @@ const firstUser = data.users[0];
 const author = firstUser.author[0];
 
 // after
-const author = data.users.author; // no more array! 🎉
+const author = firstUser.author; // no more array! 🎉
 ```
 
 If you don't want to migrate your components just yet, you can opt out by adding a `cardinalityInference` flag set to `false` in your `init_experimental` call. This way, you'll get all the typechecking benefits without having to update your logic.

--- a/client/www/pages/docs/strong-init.md
+++ b/client/www/pages/docs/strong-init.md
@@ -55,12 +55,14 @@ Previously, all responses in a `useQuery` returned arrays. Now, we can use your 
 Since the new `useQuery` is schema-aware, we know when to return a single item instead of an array. 🎉 Bear in mind that if you're migrating from `init`, you'll need to update all of your call sites that reference these "has-one" relationships.
 
 ```ts
-const { data } = useQuery({ users: { author: {} });
+const { data } = useQuery({ users: { author: {} }});
+const firstUser = data.users[0];
 
-const firstUser = data.users[0]
+// before
+const author = firstUser.author[0];
 
-// 🎉 after
-const author = user.author // no more array! 🎉
+// after
+const author = data.users.author; // no more array! 🎉
 ```
 
 If you don't want to migrate your components just yet, you can opt out by adding a `cardinalityInference` flag set to `false` in your `init_experimental` call. This way, you'll get all the typechecking benefits without having to update your logic.


### PR DESCRIPTION
**I am still not 100% sure** but I tried to make a few corrections in the `useQuery` code snippet.
- Add missing unclosed curly bracket `}` in the `useQuery`.
- Add "before" code and use `firstUser` instead of undefined `user` variable. 
- For "after" code, use `data.users` instead of undefined `user` variable. (I am still not sure if `data.users` will really return a single object instead of an array)

