### PR TITLE
Fix muts offline bug

### DIFF
--- a/client/packages/core/src/utils/PersistedObject.js
+++ b/client/packages/core/src/utils/PersistedObject.js
@@ -62,6 +62,10 @@ export class PersistedObject {
     await loadedPromise;
   }
 
+  isLoading() {
+    return this._isLoading;
+  }
+
   async waitForSync() {
     if (!this._nextSave) {
       return;


### PR DESCRIPTION
Fixes a bug where we were resolving query data before folding in pending mutations.  This was due to us resolving queries after loading cached query responses, but not waiting for cached mutations.

Context: https://discord.com/channels/1031957483243188235/1148284450992574535/1280807824334782484