### PR TITLE
[bugfix] fix the 'accept' bug for collaborators

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -762,7 +762,6 @@
          tx-conn
          {:id app_id
           :new-creator-id user-id})
-        :else
         (instant-app-members/create! tx-conn {:user-id user-id
                                               :app-id app_id
                                               :role invitee_role})))


### PR DESCRIPTION
Archil reported a bug, where they were not able to invite a team member to their app. 

This is because of a recent change to `accept-post`. I added the `:else` keyword to `condp` by accident. 

@dwwoelfel @markyfyi @nezaj 