### PR TITLE
[fix] suppress IOException errors on sendPingBlocking

### DIFF
--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -79,8 +79,10 @@
       (if (> ms-since-last-message idle-timeout-ms)
         (tracer/with-span! {:name "socket/close-inactive"}
           (IoUtils/safeClose channel))
-        (WebSockets/sendPingBlocking (ByteBuffer/allocate 0)
-                                     channel)))
+        (try (WebSockets/sendPingBlocking
+              (ByteBuffer/allocate 0)
+              channel)
+             (catch java.io.IOException _))))
     (catch Exception e
       (tracer/record-exception-span! e {:name "socket/ping-err"
                                         :escaping? false}))))

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -32,7 +32,9 @@
    [io.undertow.websockets.extensions PerMessageDeflateHandshake]
    [java.util.concurrent.locks ReentrantLock]
    [java.util.concurrent.atomic AtomicLong]
+   [java.io IOException]
    [java.nio ByteBuffer]
+   [java.nio.channels ClosedChannelException]
    [org.xnio IoUtils]))
 
 (defn ws-listener
@@ -69,6 +71,18 @@
 
 (defonce ping-pool (delay/make-pool!))
 
+(defn try-send-ping-blocking
+  "Tries to send a ping-message. Ignores closed channel exceptions."
+  [channel]
+  (try
+    (WebSockets/sendPingBlocking
+     (ByteBuffer/allocate 0)
+     channel)
+    (catch ClosedChannelException _)
+    (catch IOException e
+      (when-not (= (.getMessage e) "UT002002: Channel is closed")
+        (throw e)))))
+
 (defn straight-jacket-run-ping-job [^WebSocketChannel channel
                                     ^AtomicLong atomic-last-received-at
                                     idle-timeout-ms]
@@ -79,10 +93,7 @@
       (if (> ms-since-last-message idle-timeout-ms)
         (tracer/with-span! {:name "socket/close-inactive"}
           (IoUtils/safeClose channel))
-        (try (WebSockets/sendPingBlocking
-              (ByteBuffer/allocate 0)
-              channel)
-             (catch java.io.IOException _))))
+        (try-send-ping-blocking channel)))
     (catch Exception e
       (tracer/record-exception-span! e {:name "socket/ping-err"
                                         :escaping? false}))))


### PR DESCRIPTION
We get some IOExceptions, when trying to send a ping to a socket that becomes closed. 

Afaik this can happen due to a race condition: the socket closes while we are running a sendPingBlocking 

[Example trace 1](https://ui.honeycomb.io/instantdb/environments/prod/datasets/instant-server/result/2FA3CtCUCka/trace?source=query&trace_id=1d3131aa8fee0d361069181df4ad87ef)
[Example trace 2](https://ui.honeycomb.io/instantdb/environments/prod/datasets/instant-server/result/2FA3CtCUCka/trace/jbnpdnkjv4A?fields[]=s_name&fields[]=s_serviceName&source=query&span=080bc468fb0979b3)

I say we suppress these errors, as they are expected. Open to other ideas though. 

@dwwoelfel @markyfyi @nezaj 