### PR TITLE
Fix Typo in Clerk Auth Docs

### DIFF
--- a/client/www/pages/docs/auth/clerk.md
+++ b/client/www/pages/docs/auth/clerk.md
@@ -47,7 +47,7 @@ import {
   SignInButton,
   SignedIn,
   SignedOut,
-} from '@clerk/next';
+} from '@clerk/nextjs';
 import { init } from '@instantdb/react';
 import { useEffect } from 'react';
 


### PR DESCRIPTION
The package name is `@clerk/nextjs` and not `@clerk/next`