### PR TITLE
Env app IDs

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -15,16 +15,16 @@ import openInBrowser from "open";
 
 // config
 
-const dev = Boolean(process.env.DEV);
-const verbose = Boolean(process.env.VERBOSE);
+const dev = Boolean(process.env.INSTANT_CLI_DEV);
+const verbose = Boolean(process.env.INSTANT_CLI_VERBOSE);
 
 const instantDashOrigin = dev
   ? "http://localhost:3000"
   : "https://instantdb.com";
 
-const instantBackendOrigin = dev
-  ? "http://localhost:8888"
-  : "https://api.instantdb.com";
+const instantBackendOrigin =
+  process.env.INSTANT_CLI_API_URI ||
+  (dev ? "http://localhost:8888" : "https://api.instantdb.com");
 
 // cli
 

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -78,8 +78,8 @@ program
   .description(
     "Generates an initial instant.schema definition from production state.",
   )
-  .action(() => {
-    pullSchema();
+  .action((appIdOrName) => {
+    pullSchema(appIdOrName);
   });
 
 program
@@ -88,8 +88,8 @@ program
   .description(
     "Generates an initial instant.perms definition from production rules.",
   )
-  .action(() => {
-    pullPerms();
+  .action((appIdOrName) => {
+    pullPerms(appIdOrName);
   });
 
 program

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -929,5 +929,6 @@ export default graph;
 const noAppIdErrorMessage = `
 No app ID found.
 Add \`INSTANT_APP_ID=<ID>\` to your .env file.
+(Or \`NEXT_PUBLIC_INSTANT_APP_ID\`, \`VITE_INSTANT_APP_ID\`)
 Or provide an app ID via the CLI \`instant-cli pull-schema <ID>\`.
 `.trim();

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -722,21 +722,32 @@ function isUUID(uuid) {
 }
 
 async function getAppIdWithErrorLogging(defaultAppIdOrName) {
-  const config = await readInstantConfigFile();
+  if (defaultAppIdOrName) {
+    const config = await readInstantConfigFile();
 
-  const _namedAppId = config?.apps?.[defaultAppIdOrName]?.id;
-  const namedAppId = _namedAppId && isUUID(_namedAppId) ? _namedAppId : null;
-  const uuidAppId =
-    defaultAppIdOrName && isUUID(defaultAppIdOrName)
-      ? defaultAppIdOrName
-      : null;
+    const nameMatch = config?.apps?.[defaultAppIdOrName]?.id;
+    const namedAppId = nameMatch && isUUID(nameMatch) ? nameMatch : null;
+    const uuidAppId =
+      defaultAppIdOrName && isUUID(defaultAppIdOrName)
+        ? defaultAppIdOrName
+        : null;
+
+    if (nameMatch && !namedAppId) {
+      console.error(`App ID for "${defaultAppIdOrName}" is not a valid UUID.`);
+    } else if (!namedAppId && !uuidAppId) {
+      console.error(`The provided app ID is not a valid UUID.`);
+    }
+
+    return (
+      // first, check for a config and whether the provided arg
+      // matched a named ID
+      namedAppId ||
+      // next, check whether there's a provided arg at all
+      uuidAppId
+    );
+  }
 
   const appId =
-    // first, check for a config and whether the provided arg
-    // matched a named ID
-    namedAppId ||
-    // next, check whether there's a provided arg at all
-    uuidAppId ||
     // finally, check .env
     process.env.INSTANT_APP_ID ||
     process.env.NEXT_PUBLIC_INSTANT_APP_ID ||

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -79,8 +79,6 @@ program
     "Generates an initial instant.schema definition from production state.",
   )
   .action((appIdOrName) => {
-    console.log(appIdOrName);
-
     pullSchema(appIdOrName);
   });
 

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -79,6 +79,8 @@ program
     "Generates an initial instant.schema definition from production state.",
   )
   .action((appIdOrName) => {
+    console.log(appIdOrName);
+
     pullSchema(appIdOrName);
   });
 
@@ -734,7 +736,7 @@ async function getAppIdWithErrorLogging(defaultAppIdOrName) {
         ? defaultAppIdOrName
         : null;
 
-    if (nameMatch && !namedAppId) {
+    if (nameMatch != null && !namedAppId) {
       console.error(`App ID for "${defaultAppIdOrName}" is not a valid UUID.`);
     } else if (!namedAppId && !uuidAppId) {
       console.error(`The provided app ID is not a valid UUID.`);

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -729,15 +729,17 @@ async function getAppIdWithErrorLogging(defaultAppIdOrName) {
   if (defaultAppIdOrName) {
     const config = await readInstantConfigFile();
 
-    const nameMatch = config?.apps?.[defaultAppIdOrName]?.id;
-    const namedAppId = nameMatch && isUUID(nameMatch) ? nameMatch : null;
+    const nameMatch = config?.apps?.[defaultAppIdOrName];
+    const namedAppId = nameMatch?.id && isUUID(nameMatch.id) ? nameMatch : null;
     const uuidAppId =
       defaultAppIdOrName && isUUID(defaultAppIdOrName)
         ? defaultAppIdOrName
         : null;
 
-    if (nameMatch != null && !namedAppId) {
-      console.error(`App ID for "${defaultAppIdOrName}" is not a valid UUID.`);
+    if (nameMatch && !namedAppId) {
+      console.error(
+        `App ID for \`${defaultAppIdOrName}\` is not a valid UUID.`,
+      );
     } else if (!namedAppId && !uuidAppId) {
       console.error(`The provided app ID is not a valid UUID.`);
     }

--- a/client/packages/cli/package.json
+++ b/client/packages/cli/package.json
@@ -13,6 +13,7 @@
     "@inquirer/prompts": "^5.3.8",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "dotenv": "^16.3.1",
     "env-paths": "^3.0.0",
     "inquirer": "^10.1.6",
     "open": "^10.1.0",

--- a/client/packages/core/__tests__/src/instaqlInference.test.js
+++ b/client/packages/core/__tests__/src/instaqlInference.test.js
@@ -6,7 +6,6 @@ import { createLinkIndex } from "../../src/utils/linkIndex";
 
 test("many-to-many with inference", () => {
   const schema = i.graph(
-    "",
     {
       posts: i.entity({}),
       tags: i.entity({}),
@@ -84,7 +83,6 @@ test("many-to-many with inference", () => {
 
 test("one-to-one with inference", () => {
   const schema = i.graph(
-    "",
     {
       users: i.entity({}),
       profiles: i.entity({}),

--- a/client/packages/core/__tests__/src/schema.test.ts
+++ b/client/packages/core/__tests__/src/schema.test.ts
@@ -5,7 +5,6 @@ import type { InstaQLQueryResult } from "../../src/queryTypes";
 
 test("runs without exception", () => {
   const graph = i.graph(
-    "123",
     {
       users: i.entity({
         name: i.string(),
@@ -106,7 +105,8 @@ test("runs without exception", () => {
   const queryResult: DemoQueryResult = null as any;
   type DemoQueryResult = InstaQLQueryResult<
     Graph["entities"],
-    typeof demoQuery
+    typeof demoQuery,
+    true
   >;
   queryResult?.users[0].friends[0]._friends[0].bio;
   queryResult?.users[0].posts[0].author?.junk;

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -30,7 +30,6 @@ export {
  * @see https://instantdb.com/docs/schema#defining-entities
  * @example
  *   export default i.graph(
- *     APP_ID,
  *     {
  *       posts: i.entity({
  *         title: i.string(),
@@ -59,9 +58,8 @@ export {
 function graph<
   EntitiesWithoutLinks extends EntitiesDef,
   const Links extends LinksDef<EntitiesWithoutLinks>,
->(appId: string, entities: EntitiesWithoutLinks, links: Links) {
+>(entities: EntitiesWithoutLinks, links: Links) {
   return new InstantGraph(
-    appId,
     enrichEntitiesWithLinks<EntitiesWithoutLinks, Links>(entities, links),
     // (XXX): LinksDef<any> stems from TypeScript’s inability to reconcile the
     // type EntitiesWithLinks<EntitiesWithoutLinks, Links> with
@@ -215,14 +213,12 @@ class InstantGraph<
   RoomSchema extends RoomSchemaShape = {},
 > {
   constructor(
-    public appId: string,
     public entities: Entities,
     public links: Links,
   ) {}
 
   withRoomSchema<_RoomSchema extends RoomSchemaShape>() {
     return new InstantGraph<Entities, Links, _RoomSchema>(
-      this.appId,
       this.entities,
       this.links,
     );

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.4.5
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0
@@ -255,7 +258,7 @@ importers:
         version: 3.3.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.5.4)(typescript@5.5.4)
+        version: 10.9.2(@types/node@22.5.5)(typescript@5.5.4)
     devDependencies:
       '@types/body-parser':
         specifier: ^1.19.5
@@ -7707,8 +7710,8 @@ packages:
     dependencies:
       undici-types: 6.19.8
 
-  /@types/node@22.5.4:
-    resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
+  /@types/node@22.5.5:
+    resolution: {integrity: sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==}
     dependencies:
       undici-types: 6.19.8
     dev: false
@@ -16962,7 +16965,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-node@10.9.2(@types/node@22.5.4)(typescript@5.5.4):
+  /ts-node@10.9.2(@types/node@22.5.5)(typescript@5.5.4):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -16981,7 +16984,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.5.4
+      '@types/node': 22.5.5
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.0

--- a/client/sandbox/admin-sdk-express/src/with-schema.ts
+++ b/client/sandbox/admin-sdk-express/src/with-schema.ts
@@ -9,7 +9,6 @@ import fs from "fs";
 dotenv.config();
 
 const schema = i.graph(
-  process.env.INSTANT_APP_ID!,
   {
     goals: i.entity({
       title: i.string(),

--- a/client/sandbox/cli-nodejs/instant.config.ts
+++ b/client/sandbox/cli-nodejs/instant.config.ts
@@ -1,0 +1,7 @@
+export default {
+  apps: {
+    test: {
+      id: "9af6374d-c0f0-4e6a-aa7a-532a90b1b856",
+    },
+  },
+};

--- a/client/sandbox/cli-nodejs/instant.config.ts
+++ b/client/sandbox/cli-nodejs/instant.config.ts
@@ -1,7 +1,13 @@
 export default {
   apps: {
-    coolApp: {
-      id: "",
+    main: {
+      id: "...",
+    },
+    test: {
+      id: "...",
+    },
+    staging: {
+      id: "...",
     },
   },
 };

--- a/client/sandbox/cli-nodejs/instant.config.ts
+++ b/client/sandbox/cli-nodejs/instant.config.ts
@@ -1,7 +1,7 @@
 export default {
   apps: {
-    test: {
-      id: "9af6374d-c0f0-4e6a-aa7a-532a90b1b856",
+    coolApp: {
+      id: "",
     },
   },
 };

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -4,7 +4,6 @@ import { i } from "@instantdb/core";
 
 // Example entities and links (you can delete these!)
 const graph = i.graph(
-  process.env.INSTANT_APP_ID!,
   {
     posts: i.entity({
       name: i.string(),

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -1,24 +1,21 @@
-import "dotenv/config";
-
 import { i } from "@instantdb/core";
 
-// Example entities and links (you can delete these!)
 const graph = i.graph(
   {
-    posts: i.entity({
-      name: i.string(),
-      content: i.string(),
-    }),
     authors: i.entity({
-      userId: i.string(),
-      name: i.string(),
+      name: i.any(),
+      userId: i.any(),
+    }),
+    posts: i.entity({
+      content: i.any(),
+      name: i.any(),
     }),
     tags: i.entity({
-      label: i.string(),
+      label: i.any(),
     }),
   },
   {
-    authorPosts: {
+    authorsPosts: {
       forward: {
         on: "authors",
         has: "many",

--- a/client/sandbox/react-native-expo/app/play/colors-schema.js
+++ b/client/sandbox/react-native-expo/app/play/colors-schema.js
@@ -4,7 +4,6 @@ import { View, Text, Button, StyleSheet } from "react-native";
 import config from "../config";
 
 const schema = i.graph(
-  config.appId,
   {
     colors: i.entity({
       color: i.string(),

--- a/client/sandbox/react-nextjs/pages/play/color-schema.tsx
+++ b/client/sandbox/react-nextjs/pages/play/color-schema.tsx
@@ -5,7 +5,6 @@ import config from "../../config";
 const db = init_experimental({
   ...config,
   schema: i.graph(
-    "",
     {
       colors: i.entity({
         color: i.string().indexed(),

--- a/client/sandbox/vanilla-js-vite/src/schema.ts
+++ b/client/sandbox/vanilla-js-vite/src/schema.ts
@@ -17,7 +17,6 @@ document.body.appendChild(buttonEl);
 const db = init_experimental({
   appId: APP_ID,
   schema: i.graph(
-    APP_ID,
     {
       todos: i.entity({
         title: i.string(),

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -19,6 +19,10 @@ Instant CLI relies on the presence of two core config files: `instant.schema.ts`
 
 You can learn more about [schemas here](/docs/schema) here and [permissions here](/docs/permissions).
 
+## App ID
+
+The CLI looks for `INSTANT_APP_ID` in `process.env`. As a convenience, it will also check for common prefixes like `NEXT_PUBLIC_INSTANT_APP_ID` and `VITE_PUBLIC_INSTANT_APP_ID`
+
 ## Actions
 
 ### Logging in
@@ -56,10 +60,7 @@ Here's an example `instant.schema.ts` file.
 ```ts
 import { i } from '@instantdb/core';
 
-const INSTANT_APP_ID = 'YOUR_APP_ID_HERE';
-
 const graph = i.graph(
-  INSTANT_APP_ID,
   {
     authors: i.entity({
       userId: i.string(),
@@ -121,9 +122,9 @@ If you already created an app in the dashboard and created some schema and
 permissions, you can run `npx instant-cli pull <APP_ID>` to generate an `instant.schema.ts` and `instant.perms.ts` files based on your production configuration.
 
 ```bash
-npx instant-cli pull-schema <APP_ID>
-npx instant-cli pull-perms [APP_ID] # ID optional if there's already an instant.schema.ts
-npx instant-cli pull <APP_ID> # pulls both schema and perms
+npx instant-cli pull-schema
+npx instant-cli pull-perms
+npx instant-cli pull # pulls both schema and perms
 ```
 
 {% callout type="warning" %}

--- a/client/www/pages/docs/patterns.md
+++ b/client/www/pages/docs/patterns.md
@@ -49,10 +49,7 @@ permissions. Here's an example of limiting a user to creating at most 2 todos.
 // Here we define users, todos, and a link between them.
 import { i } from '@instantdb/core';
 
-const INSTANT_APP_ID = 'YOUR_APP_ID_HERE';
-
 const graph = i.graph(
-  INSTANT_APP_ID,
   {
     users: i.entity({
       email: i.string(),

--- a/client/www/pages/docs/schema.md
+++ b/client/www/pages/docs/schema.md
@@ -13,10 +13,7 @@ The default export of `instant.schema.ts` should always be the result of a call 
 
 import { i } from '@instantdb/core';
 
-const INSTANT_APP_ID = '__APP_ID__';
-
 export default i.graph(
-  INSTANT_APP_ID, // your apps UUID
   entitiesMap, // a map of `i.entity` definitions, see "Defining entities" below
   linksMap // a description of links between your app's entities, see "Defining links" below
 );
@@ -26,7 +23,7 @@ export default graph;
 
 ## Defining entities
 
-The second parameter to `i.graph` is a dictionary of entities, where the key represents the entities name, and the value is a call to `i.entity` with a dictionary of attributes.
+The first parameter to `i.graph` is a dictionary of entities, where the key represents the entities name, and the value is a call to `i.entity` with a dictionary of attributes.
 
 ```typescript
 {
@@ -113,10 +110,7 @@ Make sure to set the graph object as your file's default export to that it can b
 ```typescript
 import { i } from '@instantdb/core';
 
-const INSTANT_APP_ID = 'YOUR_APP_ID_HERE';
-
 const graph = i.graph(
-  INSTANT_APP_ID,
   {
     authors: i.entity({
       userId: i.string(),

--- a/client/www/pages/labs/platform_demo.tsx
+++ b/client/www/pages/labs/platform_demo.tsx
@@ -80,7 +80,6 @@ const exampleSchemaGen = (appId: string) => {
   return `
 import { i } from '@instantdb/core';
 const g = i.graph(
-  appId,
   {
     posts: i.entity({
       title: i.string(),
@@ -110,7 +109,6 @@ JSON.stringify(g, null, 2) // this is the schema you can push!
 };
 const exGraph = (appId: string) => {
   const g = i.graph(
-    appId,
     {
       posts: i.entity({
         title: i.string(),


### PR DESCRIPTION
Change how we do app IDs in CLI/schema.

- Completely decouple schema.ts/`i.graph` from the concept of app IDs.  They're exclusively handled at a higher level in the CLI.
- Since we can no longer read an app ID from the schema, I modified the CLI to look for `process.env.INSTANT_APP_ID`.
- Update docs, examples, and error messages accordingly.
- Also add preliminary support for reading named IDs in `instant.config.ts`.  Users with multiple named apps can specify one in the CLI, e.g. `instant-cli pull dev`, where `dev` is a key in a map of names to IDs. **Note, I'm not documenting/announcing this feature until I get feedback from our core testers.**

Once we land this, I'll announce the breaking changes in Discord.

How to test:

cd into `sandbox/cli-nodejs` and try these out

1. Run a command without a `.env`.  It should give you a helpful error.
1. Run a command with `INSTANT_APP_ID` in `.env`.  It should work.
1. Run a command with a malformed `INSTANT_APP_ID` in `.env`.  It should give a helpful error.
1. Run a command with an app ID as an arg.  It should work.
1. Run a command with a malformed app ID as an arg.  It should give a helpful error.
1. BONUS: Run a command with an `instant.config.ts` file like the example below.  It should work.


```ts
// example config file
export default {
  apps: {
    coolApp: {
      id: "ID_HERE_PLS",
    },
  },
};

```