### PR TITLE
Fix json encode error for transact-perms-check

### DIFF
--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -233,7 +233,7 @@
                         :committed? (:committed? result)
                         :check-results
                         (map (fn [r]
-                               (dissoc r :check))
+                               (dissoc r :check :program))
                              (:check-results result))}]
     (response/ok cleaned-result)))
 


### PR DESCRIPTION
We were trying to encode the program as JSON.