### PR TITLE
De-namespace schema types

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -44,6 +44,10 @@ jobs:
         working-directory: client
         run: pnpm run build-packages
 
+      - name: Build sandbox
+        working-directory: client
+        run: pnpm run build-sandbox
+
       - name: Run tests
         working-directory: client
         run: pnpm run test

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,8 @@
     "test": "turbo run test:ci",
     "format": "prettier --write --config ./.prettierrc \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "publish-packages": "turbo run publish-package --filter=\"./packages/*\"",
-    "build-packages": "turbo run build --filter=\"./packages/*\" --cache-dir=.turbo"
+    "build-packages": "turbo run build --filter=\"./packages/*\" --cache-dir=.turbo",
+    "build-sandbox": "turbo run build --filter=\"./sandbox/*\" --cache-dir=.turbo"
   },
   "devDependencies": {
     "@changesets/cli": "^2.24.1",

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -12,6 +12,7 @@ import {
   type InstaQLQueryParams,
   type Query,
   type QueryResponse,
+  type InstantGraph,
 } from "@instantdb/core";
 
 type DebugCheckResult = {
@@ -133,7 +134,7 @@ function init<Schema = {}>(config: Config) {
 }
 
 function init_experimental<
-  Schema extends i.InstantGraph<any, any, any>,
+  Schema extends InstantGraph<any, any, any>,
   WithCardinalityInference extends boolean = true,
 >(
   config: Config & {
@@ -154,7 +155,7 @@ function init_experimental<
  *  const db = init({ appId: "my-app-id", adminToken: "my-admin-token" })
  */
 class InstantAdmin<
-  Schema extends i.InstantGraph<any, any> | {},
+  Schema extends InstantGraph<any, any> | {},
   WithCardinalityInference extends boolean,
 > {
   config: FilledConfig;
@@ -164,9 +165,7 @@ class InstantAdmin<
 
   public tx =
     txInit<
-      Schema extends i.InstantGraph<any, any>
-        ? Schema
-        : i.InstantGraph<any, any>
+      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
     >();
 
   constructor(_config: Config) {
@@ -210,7 +209,7 @@ class InstantAdmin<
    *  await db.query({ goals: { todos: {} } })
    */
   query = <
-    Q extends Schema extends i.InstantGraph<any, any>
+    Q extends Schema extends InstantGraph<any, any>
       ? InstaQLQueryParams<Schema>
       : Exactly<Query, Q>,
   >(

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -1,6 +1,6 @@
 import { TxChunk } from "./instatx";
 import { RoomSchemaShape } from "./presence";
-import { InstantGraph } from "./schema";
+import type { InstantGraph } from "./schemaTypes";
 
 export interface IDatabase<
   Schema extends InstantGraph<any, any> | {} = {},

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -1,6 +1,10 @@
-import { InstaQLQueryParams, InstaQLQueryResult, Remove$ } from "./queryTypes";
-import { InstantGraph } from "./schemaTypes";
-import { IDatabase } from "./coreTypes";
+import type {
+  InstaQLQueryParams,
+  InstaQLQueryResult,
+  Remove$,
+} from "./queryTypes";
+import type { InstantGraph } from "./schemaTypes";
+import type { IDatabase } from "./coreTypes";
 
 export type InstantQuery<DB extends IDatabase<any, any, any>> =
   DB extends IDatabase<infer Schema, any, any>

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -1,5 +1,5 @@
 import { InstaQLQueryParams, InstaQLQueryResult, Remove$ } from "./queryTypes";
-import { InstantGraph } from "./schema";
+import { InstantGraph } from "./schemaTypes";
 import { IDatabase } from "./coreTypes";
 
 export type InstantQuery<DB extends IDatabase<any, any, any>> =

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -35,6 +35,20 @@ import type {
   InstantQueryResult,
   InstantSchema,
 } from "./helperTypes";
+import type {
+  AttrsDefs,
+  CardinalityKind,
+  DataAttrDef,
+  EntitiesDef,
+  EntitiesWithLinks,
+  EntityDef,
+  InstantGraph,
+  LinkAttrDef,
+  LinkDef,
+  LinksDef,
+  ResolveAttrs,
+  ValueTypes,
+} from "./schemaTypes";
 
 const defaultOpenDevtool = true;
 
@@ -47,7 +61,7 @@ export type Config = {
   devtool?: boolean;
 };
 
-export type ConfigWithSchema<S extends i.InstantGraph<any, any>> = Config & {
+export type ConfigWithSchema<S extends InstantGraph<any, any>> = Config & {
   schema: S;
 };
 
@@ -115,7 +129,7 @@ function initGlobalInstantCoreStore(): Record<
 const globalInstantCoreStore = initGlobalInstantCoreStore();
 
 function init_experimental<
-  Schema extends i.InstantGraph<any, any, any>,
+  Schema extends InstantGraph<any, any, any>,
   WithCardinalityInference extends boolean = true,
 >(
   config: Config & {
@@ -126,14 +140,12 @@ function init_experimental<
   NetworkListener?: any,
 ): InstantCore<
   Schema,
-  Schema extends i.InstantGraph<any, infer RoomSchema, any>
-    ? RoomSchema
-    : never,
+  Schema extends InstantGraph<any, infer RoomSchema, any> ? RoomSchema : never,
   WithCardinalityInference
 > {
   return _init_internal<
     Schema,
-    Schema extends i.InstantGraph<any, infer RoomSchema, any>
+    Schema extends InstantGraph<any, infer RoomSchema, any>
       ? RoomSchema
       : never,
     WithCardinalityInference
@@ -171,7 +183,7 @@ function init<Schema = {}, RoomSchema extends RoomSchemaShape = {}>(
 }
 
 function _init_internal<
-  Schema extends {} | i.InstantGraph<any, any, any>,
+  Schema extends {} | InstantGraph<any, any, any>,
   RoomSchema extends RoomSchemaShape,
   WithCardinalityInference extends boolean = false,
 >(
@@ -221,7 +233,7 @@ function _init_internal<
 }
 
 class InstantCore<
-  Schema extends i.InstantGraph<any, any> | {} = {},
+  Schema extends InstantGraph<any, any> | {} = {},
   RoomSchema extends RoomSchemaShape = {},
   WithCardinalityInference extends boolean = false,
 > implements IDatabase<Schema, RoomSchema, WithCardinalityInference>
@@ -233,9 +245,7 @@ class InstantCore<
 
   public tx =
     txInit<
-      Schema extends i.InstantGraph<any, any>
-        ? Schema
-        : i.InstantGraph<any, any>
+      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
     >();
 
   constructor(reactor: Reactor<RoomSchema>) {
@@ -302,7 +312,7 @@ class InstantCore<
    *  });
    */
   subscribeQuery<
-    Q extends Schema extends i.InstantGraph<any, any>
+    Q extends Schema extends InstantGraph<any, any>
       ? InstaQLQueryParams<Schema>
       : Exactly<Query, Q>,
   >(
@@ -596,7 +606,7 @@ export {
   Auth,
   Storage,
 
-  // types
+  // og types
   type IDatabase,
   type RoomSchemaShape,
   type Query,
@@ -610,11 +620,29 @@ export {
   type TxChunk,
   type SubscriptionState,
   type LifecycleSubscriptionState,
+
+  // presence types
   type PresenceOpts,
   type PresenceSlice,
   type PresenceResponse,
+
+  // new query types
   type InstaQLQueryParams,
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+
+  // schema types
+  type AttrsDefs,
+  type CardinalityKind,
+  type DataAttrDef,
+  type EntitiesDef,
+  type EntitiesWithLinks,
+  type EntityDef,
+  type InstantGraph,
+  type LinkAttrDef,
+  type LinkDef,
+  type LinksDef,
+  type ResolveAttrs,
+  type ValueTypes,
 };

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import weakHash from "./utils/weakHash";
 import id from "./utils/uuid";
 import IndexedDBStorage from "./IndexedDBStorage";
 import WindowNetworkListener from "./WindowNetworkListener";
-import * as i from "./schema";
+import { i } from "./schema";
 import { createDevtool } from "./devtool";
 
 import type {

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -1,4 +1,4 @@
-import { DataAttrDef, InstantGraph, LinkAttrDef } from "./schemaTypes";
+import type { DataAttrDef, InstantGraph, LinkAttrDef } from "./schemaTypes";
 
 type Action = "update" | "link" | "unlink" | "delete" | "merge";
 type EType = string;

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -1,4 +1,4 @@
-import { DataAttrDef, InstantGraph, LinkAttrDef } from "./schema";
+import { DataAttrDef, InstantGraph, LinkAttrDef } from "./schemaTypes";
 
 type Action = "update" | "link" | "unlink" | "delete" | "merge";
 type EType = string;

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -1,7 +1,12 @@
 // Query
 // -----
 
-import { EntitiesDef, InstantGraph, LinkAttrDef, ResolveAttrs } from "./schema";
+import type {
+  EntitiesDef,
+  InstantGraph,
+  LinkAttrDef,
+  ResolveAttrs,
+} from "./schemaTypes";
 
 // NonEmpty disallows {}, so that you must provide at least one field
 type NonEmpty<T> = {

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -1,15 +1,3 @@
-export {
-  // constructs
-  graph,
-  entity,
-  // value types
-  string,
-  number,
-  boolean,
-  json,
-  any,
-};
-
 import {
   EntityDef,
   DataAttrDef,
@@ -155,3 +143,15 @@ type LinksIndex = Record<
   "fwd" | "rev",
   Record<string, Record<string, { entityName: string; cardinality: string }>>
 >;
+
+export const i = {
+  // constructs
+  graph,
+  entity,
+  // value types
+  string,
+  number,
+  boolean,
+  json,
+  any,
+};

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -1,5 +1,3 @@
-import type { RoomSchemaShape } from "./presence";
-
 export {
   // constructs
   graph,
@@ -10,16 +8,22 @@ export {
   boolean,
   json,
   any,
-  // types
-  type InstantGraph,
-  type EntitiesDef,
-  type LinkDef,
-  type LinksDef,
-  type LinkAttrDef,
-  type DataAttrDef,
-  type EntityDef,
-  type ResolveAttrs,
 };
+
+import {
+  AttrsDefs,
+  CardinalityKind,
+  DataAttrDef,
+  EntitiesDef,
+  EntitiesWithLinks,
+  EntityDef,
+  InstantGraph,
+  LinkAttrDef,
+  LinkDef,
+  LinksDef,
+  ResolveAttrs,
+  ValueTypes,
+} from "./schemaTypes";
 
 // ==========
 // API
@@ -110,7 +114,7 @@ function json<T = any>(): DataAttrDef<T, true> {
   return new DataAttrDef("json", true);
 }
 
-function any(): DataAttrDef<JSONValue, true> {
+function any(): DataAttrDef<any, true> {
   return new DataAttrDef("json", true);
 }
 
@@ -152,265 +156,7 @@ function enrichEntitiesWithLinks<
   return enrichedEntities as EnrichedEntities;
 }
 
-class LinkAttrDef<
-  Cardinality extends CardinalityKind,
-  EntityName extends string,
-> {
-  constructor(
-    public entityName: EntityName,
-    public cardinality: Cardinality,
-  ) {}
-}
-
-class DataAttrDef<ValueType, IsRequired extends boolean> {
-  constructor(
-    public valueType: ValueTypes,
-    public required: IsRequired,
-    public config: {
-      indexed: boolean;
-      unique: boolean;
-      // clientValidator?: (value: ValueType) => boolean;
-    } = { indexed: false, unique: false },
-  ) {}
-
-  optional() {
-    return new DataAttrDef<ValueType, false>(this.valueType, false);
-  }
-
-  unique() {
-    return new DataAttrDef<ValueType, IsRequired>(
-      this.valueType,
-      this.required,
-      {
-        ...this.config,
-        unique: true,
-      },
-    );
-  }
-
-  indexed() {
-    return new DataAttrDef<ValueType, IsRequired>(
-      this.valueType,
-      this.required,
-      {
-        ...this.config,
-        indexed: true,
-      },
-    );
-  }
-
-  // clientValidate(clientValidator: (value: ValueType) => boolean) {
-  //   return new DataAttrDef(this.valueType, this.required, {
-  //     ...this.config,
-  //     clientValidator,
-  //   });
-  // }
-}
-
-class InstantGraph<
-  Entities extends EntitiesDef,
-  Links extends LinksDef<Entities>,
-  RoomSchema extends RoomSchemaShape = {},
-> {
-  constructor(
-    public entities: Entities,
-    public links: Links,
-  ) {}
-
-  withRoomSchema<_RoomSchema extends RoomSchemaShape>() {
-    return new InstantGraph<Entities, Links, _RoomSchema>(
-      this.entities,
-      this.links,
-    );
-  }
-}
-
-// ==========
-// base types
-
 type LinksIndex = Record<
   "fwd" | "rev",
   Record<string, Record<string, { entityName: string; cardinality: string }>>
 >;
-
-type ValueTypes = "string" | "number" | "boolean" | "json";
-
-type CardinalityKind = "one" | "many";
-
-type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JSONValue }
-  | JSONValue[];
-
-type AttrsDefs = Record<string, DataAttrDef<any, any>>;
-
-class EntityDef<
-  Attrs extends AttrsDefs,
-  Links extends Record<string, LinkAttrDef<any, any>>,
-  AsType,
-> {
-  constructor(
-    public attrs: Attrs,
-    public links: Links,
-  ) {}
-
-  asType<_AsType>() {
-    return new EntityDef<Attrs, Links, _AsType>(this.attrs, this.links);
-  }
-}
-
-type EntitiesDef = Record<string, EntityDef<any, any, any>>;
-
-type LinksDef<Entities extends EntitiesDef> = Record<
-  string,
-  LinkDef<
-    Entities,
-    keyof Entities,
-    string,
-    CardinalityKind,
-    keyof Entities,
-    string,
-    CardinalityKind
-  >
->;
-
-type LinkDef<
-  Entities extends EntitiesDef,
-  FwdEntity extends keyof Entities,
-  FwdAttr extends string,
-  FwdCardinality extends CardinalityKind,
-  RevEntity extends keyof Entities,
-  RevAttr extends string,
-  RevCardinality extends CardinalityKind,
-> = {
-  forward: {
-    on: FwdEntity;
-    label: FwdAttr;
-    has: FwdCardinality;
-  };
-  reverse: {
-    on: RevEntity;
-    label: RevAttr;
-    has: RevCardinality;
-  };
-};
-
-// ==========
-// derived types
-
-type EntitiesWithLinks<
-  Entities extends EntitiesDef,
-  Links extends LinksDef<Entities>,
-> = {
-  [EntityName in keyof Entities]: EntityDef<
-    Entities[EntityName]["attrs"],
-    EntityForwardLinksMap<EntityName, Entities, Links> &
-      EntityReverseLinksMap<EntityName, Entities, Links>,
-    Entities[EntityName] extends EntityDef<any, any, infer O>
-      ? O extends void
-        ? void
-        : O
-      : void
-  >;
-};
-
-type EntityForwardLinksMap<
-  EntityName extends keyof Entities,
-  Entities extends EntitiesDef,
-  Links extends LinksDef<Entities>,
-  LinkIndexFwd = LinksIndexedByEntity<Entities, Links, "reverse">,
-> = EntityName extends keyof LinkIndexFwd
-  ? {
-      [LinkName in keyof LinkIndexFwd[EntityName]]: LinkIndexFwd[EntityName][LinkName] extends LinkDef<
-        Entities,
-        infer RelatedEntityName,
-        any,
-        any,
-        any,
-        any,
-        infer Cardinality
-      >
-        ? {
-            entityName: RelatedEntityName;
-            cardinality: Cardinality;
-          }
-        : never;
-    }
-  : {};
-
-type EntityReverseLinksMap<
-  EntityName extends keyof Entities,
-  Entities extends EntitiesDef,
-  Links extends LinksDef<Entities>,
-  RevLinkIndex = LinksIndexedByEntity<Entities, Links, "forward">,
-> = EntityName extends keyof RevLinkIndex
-  ? {
-      [LinkName in keyof RevLinkIndex[EntityName]]: RevLinkIndex[EntityName][LinkName] extends LinkDef<
-        Entities,
-        any,
-        any,
-        infer Cardinality,
-        infer RelatedEntityName,
-        any,
-        any
-      >
-        ? {
-            entityName: RelatedEntityName;
-            cardinality: Cardinality;
-          }
-        : never;
-    }
-  : {};
-
-type LinksIndexedByEntity<
-  Entities extends EntitiesDef,
-  Links extends LinksDef<Entities>,
-  Direction extends "forward" | "reverse",
-> = {
-  [FwdEntity in keyof Entities]: {
-    [LinkName in keyof Links as Links[LinkName][Direction]["on"] extends FwdEntity
-      ? Links[LinkName][Direction]["label"]
-      : never]: Links[LinkName] extends LinkDef<
-      Entities,
-      infer FwdEntity,
-      infer FwdAttr,
-      infer FwdCardinality,
-      infer RevEntity,
-      infer RevAttr,
-      infer RevCardinality
-    >
-      ? LinkDef<
-          Entities,
-          FwdEntity,
-          FwdAttr,
-          FwdCardinality,
-          RevEntity,
-          RevAttr,
-          RevCardinality
-        >
-      : never;
-  };
-};
-
-type ResolveAttrs<
-  Entities extends EntitiesDef,
-  EntityName extends keyof Entities,
-  ResolvedAttrs = {
-    [AttrName in keyof Entities[EntityName]["attrs"]]: Entities[EntityName]["attrs"][AttrName] extends DataAttrDef<
-      infer ValueType,
-      infer IsRequired
-    >
-      ? IsRequired extends true
-        ? ValueType
-        : ValueType | undefined
-      : never;
-  },
-> =
-  Entities[EntityName] extends EntityDef<any, any, infer AsType>
-    ? AsType extends void
-      ? ResolvedAttrs
-      : AsType
-    : ResolvedAttrs;

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -11,18 +11,13 @@ export {
 };
 
 import {
-  AttrsDefs,
-  CardinalityKind,
-  DataAttrDef,
-  EntitiesDef,
-  EntitiesWithLinks,
   EntityDef,
+  DataAttrDef,
   InstantGraph,
-  LinkAttrDef,
-  LinkDef,
-  LinksDef,
-  ResolveAttrs,
-  ValueTypes,
+  type EntitiesDef,
+  type AttrsDefs,
+  type EntitiesWithLinks,
+  type LinksDef,
 } from "./schemaTypes";
 
 // ==========

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -1,0 +1,251 @@
+import type { RoomSchemaShape } from "./presence";
+
+export class LinkAttrDef<
+  Cardinality extends CardinalityKind,
+  EntityName extends string,
+> {
+  constructor(
+    public entityName: EntityName,
+    public cardinality: Cardinality,
+  ) {}
+}
+
+export class DataAttrDef<ValueType, IsRequired extends boolean> {
+  constructor(
+    public valueType: ValueTypes,
+    public required: IsRequired,
+    public config: {
+      indexed: boolean;
+      unique: boolean;
+      // clientValidator?: (value: ValueType) => boolean;
+    } = { indexed: false, unique: false },
+  ) {}
+
+  optional() {
+    return new DataAttrDef<ValueType, false>(this.valueType, false);
+  }
+
+  unique() {
+    return new DataAttrDef<ValueType, IsRequired>(
+      this.valueType,
+      this.required,
+      {
+        ...this.config,
+        unique: true,
+      },
+    );
+  }
+
+  indexed() {
+    return new DataAttrDef<ValueType, IsRequired>(
+      this.valueType,
+      this.required,
+      {
+        ...this.config,
+        indexed: true,
+      },
+    );
+  }
+
+  // clientValidate(clientValidator: (value: ValueType) => boolean) {
+  //   return new DataAttrDef(this.valueType, this.required, {
+  //     ...this.config,
+  //     clientValidator,
+  //   });
+  // }
+}
+
+export class InstantGraph<
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  RoomSchema extends RoomSchemaShape = {},
+> {
+  constructor(
+    public entities: Entities,
+    public links: Links,
+  ) {}
+
+  withRoomSchema<_RoomSchema extends RoomSchemaShape>() {
+    return new InstantGraph<Entities, Links, _RoomSchema>(
+      this.entities,
+      this.links,
+    );
+  }
+}
+
+// ==========
+// base types
+
+export type ValueTypes = "string" | "number" | "boolean" | "json";
+
+export type CardinalityKind = "one" | "many";
+
+export type AttrsDefs = Record<string, DataAttrDef<any, any>>;
+
+export class EntityDef<
+  Attrs extends AttrsDefs,
+  Links extends Record<string, LinkAttrDef<any, any>>,
+  AsType,
+> {
+  constructor(
+    public attrs: Attrs,
+    public links: Links,
+  ) {}
+
+  asType<_AsType>() {
+    return new EntityDef<Attrs, Links, _AsType>(this.attrs, this.links);
+  }
+}
+
+export type EntitiesDef = Record<string, EntityDef<any, any, any>>;
+
+export type LinksDef<Entities extends EntitiesDef> = Record<
+  string,
+  LinkDef<
+    Entities,
+    keyof Entities,
+    string,
+    CardinalityKind,
+    keyof Entities,
+    string,
+    CardinalityKind
+  >
+>;
+
+export type LinkDef<
+  Entities extends EntitiesDef,
+  FwdEntity extends keyof Entities,
+  FwdAttr extends string,
+  FwdCardinality extends CardinalityKind,
+  RevEntity extends keyof Entities,
+  RevAttr extends string,
+  RevCardinality extends CardinalityKind,
+> = {
+  forward: {
+    on: FwdEntity;
+    label: FwdAttr;
+    has: FwdCardinality;
+  };
+  reverse: {
+    on: RevEntity;
+    label: RevAttr;
+    has: RevCardinality;
+  };
+};
+
+// ==========
+// derived types
+
+export type EntitiesWithLinks<
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+> = {
+  [EntityName in keyof Entities]: EntityDef<
+    Entities[EntityName]["attrs"],
+    EntityForwardLinksMap<EntityName, Entities, Links> &
+      EntityReverseLinksMap<EntityName, Entities, Links>,
+    Entities[EntityName] extends EntityDef<any, any, infer O>
+      ? O extends void
+        ? void
+        : O
+      : void
+  >;
+};
+
+type EntityForwardLinksMap<
+  EntityName extends keyof Entities,
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  LinkIndexFwd = LinksIndexedByEntity<Entities, Links, "reverse">,
+> = EntityName extends keyof LinkIndexFwd
+  ? {
+      [LinkName in keyof LinkIndexFwd[EntityName]]: LinkIndexFwd[EntityName][LinkName] extends LinkDef<
+        Entities,
+        infer RelatedEntityName,
+        any,
+        any,
+        any,
+        any,
+        infer Cardinality
+      >
+        ? {
+            entityName: RelatedEntityName;
+            cardinality: Cardinality;
+          }
+        : never;
+    }
+  : {};
+
+type EntityReverseLinksMap<
+  EntityName extends keyof Entities,
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  RevLinkIndex = LinksIndexedByEntity<Entities, Links, "forward">,
+> = EntityName extends keyof RevLinkIndex
+  ? {
+      [LinkName in keyof RevLinkIndex[EntityName]]: RevLinkIndex[EntityName][LinkName] extends LinkDef<
+        Entities,
+        any,
+        any,
+        infer Cardinality,
+        infer RelatedEntityName,
+        any,
+        any
+      >
+        ? {
+            entityName: RelatedEntityName;
+            cardinality: Cardinality;
+          }
+        : never;
+    }
+  : {};
+
+type LinksIndexedByEntity<
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  Direction extends "forward" | "reverse",
+> = {
+  [FwdEntity in keyof Entities]: {
+    [LinkName in keyof Links as Links[LinkName][Direction]["on"] extends FwdEntity
+      ? Links[LinkName][Direction]["label"]
+      : never]: Links[LinkName] extends LinkDef<
+      Entities,
+      infer FwdEntity,
+      infer FwdAttr,
+      infer FwdCardinality,
+      infer RevEntity,
+      infer RevAttr,
+      infer RevCardinality
+    >
+      ? LinkDef<
+          Entities,
+          FwdEntity,
+          FwdAttr,
+          FwdCardinality,
+          RevEntity,
+          RevAttr,
+          RevCardinality
+        >
+      : never;
+  };
+};
+
+export type ResolveAttrs<
+  Entities extends EntitiesDef,
+  EntityName extends keyof Entities,
+  ResolvedAttrs = {
+    [AttrName in keyof Entities[EntityName]["attrs"]]: Entities[EntityName]["attrs"][AttrName] extends DataAttrDef<
+      infer ValueType,
+      infer IsRequired
+    >
+      ? IsRequired extends true
+        ? ValueType
+        : ValueType | undefined
+      : never;
+  },
+> =
+  Entities[EntityName] extends EntityDef<any, any, infer AsType>
+    ? AsType extends void
+      ? ResolvedAttrs
+      : AsType
+    : ResolvedAttrs;

--- a/client/packages/core/src/utils/linkIndex.ts
+++ b/client/packages/core/src/utils/linkIndex.ts
@@ -1,4 +1,4 @@
-import { InstantGraph, LinkDef, LinksDef } from "../schema";
+import type { InstantGraph, LinkDef, LinksDef } from "../schemaTypes";
 
 export type LinkIndex = Record<
   string,

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -22,6 +22,20 @@ import {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+
+  // schema types
+  type AttrsDefs,
+  type CardinalityKind,
+  type DataAttrDef,
+  type EntitiesDef,
+  type EntitiesWithLinks,
+  type EntityDef,
+  type InstantGraph,
+  type LinkAttrDef,
+  type LinkDef,
+  type LinksDef,
+  type ResolveAttrs,
+  type ValueTypes,
 } from "@instantdb/core";
 
 /**
@@ -51,7 +65,7 @@ function init<Schema = {}, RoomSchema extends RoomSchemaShape = {}>(
 }
 
 function init_experimental<
-  Schema extends i.InstantGraph<any, any, any>,
+  Schema extends InstantGraph<any, any, any>,
   WithCardinalityInference extends boolean = true,
 >(
   config: Config & {
@@ -61,7 +75,7 @@ function init_experimental<
 ) {
   return new InstantReactNative<
     Schema,
-    Schema extends i.InstantGraph<any, infer RoomSchema, any>
+    Schema extends InstantGraph<any, infer RoomSchema, any>
       ? RoomSchema
       : never,
     WithCardinalityInference
@@ -95,4 +109,18 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+
+  // schema types
+  type AttrsDefs,
+  type CardinalityKind,
+  type DataAttrDef,
+  type EntitiesDef,
+  type EntitiesWithLinks,
+  type EntityDef,
+  type InstantGraph,
+  type LinkAttrDef,
+  type LinkDef,
+  type LinksDef,
+  type ResolveAttrs,
+  type ValueTypes,
 };

--- a/client/packages/react/src/Cursors.tsx
+++ b/client/packages/react/src/Cursors.tsx
@@ -1,12 +1,11 @@
 import {
-  Fragment,
   createElement,
-  ReactNode,
-  MouseEvent,
-  CSSProperties,
+  type ReactNode,
+  type MouseEvent,
+  type CSSProperties,
 } from "react";
-import { InstantReactRoom } from "./InstantReact";
-import { RoomSchemaShape } from "@instantdb/core";
+import type { InstantReactRoom } from "./InstantReact";
+import type { RoomSchemaShape } from "@instantdb/core";
 
 export function Cursors<
   RoomSchema extends RoomSchemaShape,

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -18,6 +18,7 @@ import {
   type InstaQLQueryParams,
   type ConfigWithSchema,
   type IDatabase,
+  type InstantGraph,
 } from "@instantdb/core";
 import {
   KeyboardEvent,
@@ -293,7 +294,7 @@ const defaultAuthState = {
 };
 
 export abstract class InstantReact<
-  Schema extends i.InstantGraph<any, any> | {} = {},
+  Schema extends InstantGraph<any, any> | {} = {},
   RoomSchema extends RoomSchemaShape = {},
   WithCardinalityInference extends boolean = false,
 > implements IDatabase<Schema, RoomSchema, WithCardinalityInference>
@@ -301,9 +302,7 @@ export abstract class InstantReact<
   public withCardinalityInference?: WithCardinalityInference;
   public tx =
     txInit<
-      Schema extends i.InstantGraph<any, any>
-        ? Schema
-        : i.InstantGraph<any, any>
+      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
     >();
 
   public auth: Auth;
@@ -404,7 +403,7 @@ export abstract class InstantReact<
    *  db.useQuery(auth.user ? { goals: {} } : null)
    */
   useQuery = <
-    Q extends Schema extends i.InstantGraph<any, any>
+    Q extends Schema extends InstantGraph<any, any>
       ? InstaQLQueryParams<Schema>
       : Exactly<Query, Q>,
   >(

--- a/client/packages/react/src/InstantReactWeb.ts
+++ b/client/packages/react/src/InstantReactWeb.ts
@@ -1,8 +1,8 @@
-import { i, RoomSchemaShape } from "@instantdb/core";
+import { type InstantGraph, type RoomSchemaShape } from "@instantdb/core";
 import { InstantReact } from "./InstantReact";
 
 export class InstantReactWeb<
-  Schema extends i.InstantGraph<any, any> | {} = {},
+  Schema extends InstantGraph<any, any> | {} = {},
   RoomSchema extends RoomSchemaShape = {},
   WithCardinalityInference extends boolean = false,
 > extends InstantReact<Schema, RoomSchema, WithCardinalityInference> {}

--- a/client/packages/react/src/InstantReactWeb.ts
+++ b/client/packages/react/src/InstantReactWeb.ts
@@ -1,4 +1,4 @@
-import { type InstantGraph, type RoomSchemaShape } from "@instantdb/core";
+import type { InstantGraph, RoomSchemaShape } from "@instantdb/core";
 import { InstantReact } from "./InstantReact";
 
 export class InstantReactWeb<

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -14,6 +14,20 @@ import {
   type AuthState,
   type Query,
   type Config,
+
+  // schema types
+  type AttrsDefs,
+  type CardinalityKind,
+  type DataAttrDef,
+  type EntitiesDef,
+  type EntitiesWithLinks,
+  type EntityDef,
+  type InstantGraph,
+  type LinkAttrDef,
+  type LinkDef,
+  type LinksDef,
+  type ResolveAttrs,
+  type ValueTypes,
 } from "@instantdb/core";
 
 import { InstantReact } from "./InstantReact";
@@ -44,4 +58,18 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+
+  // schema types
+  type AttrsDefs,
+  type CardinalityKind,
+  type DataAttrDef,
+  type EntitiesDef,
+  type EntitiesWithLinks,
+  type EntityDef,
+  type InstantGraph,
+  type LinkAttrDef,
+  type LinkDef,
+  type LinksDef,
+  type ResolveAttrs,
+  type ValueTypes,
 };

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   // types
   Config,
-  type InstantGraph,
-  type RoomSchemaShape,
+  InstantGraph,
+  RoomSchemaShape,
 } from "@instantdb/core";
 import { InstantReactWeb } from "./InstantReactWeb";
 

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -1,8 +1,8 @@
 import {
   // types
   Config,
-  i,
-  RoomSchemaShape,
+  type InstantGraph,
+  type RoomSchemaShape,
 } from "@instantdb/core";
 import { InstantReactWeb } from "./InstantReactWeb";
 
@@ -33,7 +33,7 @@ export function init<Schema = {}, RoomSchema extends RoomSchemaShape = {}>(
 }
 
 export function init_experimental<
-  Schema extends i.InstantGraph<any, any, any>,
+  Schema extends InstantGraph<any, any, any>,
   WithCardinalityInference extends boolean = true,
 >(
   config: Config & {
@@ -43,7 +43,7 @@ export function init_experimental<
 ) {
   return new InstantReactWeb<
     Schema,
-    Schema extends i.InstantGraph<any, any, infer RoomSchema>
+    Schema extends InstantGraph<any, any, infer RoomSchema>
       ? RoomSchema
       : never,
     WithCardinalityInference

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -1,12 +1,12 @@
 import {
   weakHash,
   coerceQuery,
-  Query,
-  Exactly,
-  InstantClient,
-  LifecycleSubscriptionState,
-  InstaQLQueryParams,
-  i,
+  type Query,
+  type Exactly,
+  type InstantClient,
+  type LifecycleSubscriptionState,
+  type InstaQLQueryParams,
+  type InstantGraph,
 } from "@instantdb/core";
 import { useCallback, useRef, useSyncExternalStore } from "react";
 
@@ -28,7 +28,7 @@ function stateForResult(result: any) {
 }
 
 export function useQuery<
-  Q extends Schema extends i.InstantGraph<any, any>
+  Q extends Schema extends InstantGraph<any, any>
     ? InstaQLQueryParams<Schema>
     : Exactly<Query, Q>,
   Schema,

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -5,6 +5,7 @@ import {
   type InstantSchema,
   type InstantQuery,
   type InstantQueryResult,
+  type InstantGraph,
 } from "@instantdb/react";
 import config from "../../config";
 
@@ -14,7 +15,6 @@ interface Data {
 
 const schema = i
   .graph(
-    "",
     {
       discriminatedUnionExample: i
         .entity({ x: i.string(), y: i.number() })
@@ -171,5 +171,5 @@ const deepVal = result.checkins[0].habit?.category?.id;
 
 // types
 type DeepVal = typeof deepVal;
-type Graph = i.InstantGraph<any, any, any>;
+type Graph = InstantGraph<any, any, any>;
 type DBGraph = InstantSchema<typeof db>;


### PR DESCRIPTION
Take all of our schema-related types out of the `i` namespace.  This improves intellisense and autocomplete, and may help us bypass some tricky type resolution errors.