### PR TITLE
Expose peerId in presence user and peers objects

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1340,7 +1340,7 @@ export default class Reactor {
     if (!room || !presence || !presence.result) return null;
 
     return {
-      ...buildPresenceSlice(presence.result, opts),
+      ...buildPresenceSlice(presence.result, opts, this._sessionId),
       isLoading: !room.isConnected,
       error: room.error,
     };

--- a/client/packages/core/src/presence.ts
+++ b/client/packages/core/src/presence.ts
@@ -18,10 +18,17 @@ export type PresenceOpts<PresenceShape, Keys extends keyof PresenceShape> = {
   keys?: Keys[];
 };
 
+type PresencePeer<PresenceShape, Keys extends keyof PresenceShape> = Pick<
+  PresenceShape,
+  Keys
+> & {
+  peerId: string;
+};
+
 export type PresenceSlice<PresenceShape, Keys extends keyof PresenceShape> = {
-  user?: Pick<PresenceShape, Keys> & { peerId: string };
+  user?: PresencePeer<PresenceShape, Keys>;
   peers: {
-    [peerId: string]: Pick<PresenceShape, Keys> & { peerId: string };
+    [peerId: string]: PresencePeer<PresenceShape, Keys>;
   };
 };
 
@@ -43,7 +50,7 @@ export function buildPresenceSlice<
   },
   opts: PresenceOpts<PresenceShape, Keys>,
   userPeerId: string,
-) {
+): PresenceSlice<PresenceShape, Keys> {
   const slice: PresenceSlice<PresenceShape, Keys> = {
     peers: {},
   };

--- a/client/packages/core/src/presence.ts
+++ b/client/packages/core/src/presence.ts
@@ -19,9 +19,9 @@ export type PresenceOpts<PresenceShape, Keys extends keyof PresenceShape> = {
 };
 
 export type PresenceSlice<PresenceShape, Keys extends keyof PresenceShape> = {
-  user?: Pick<PresenceShape, Keys>;
+  user?: Pick<PresenceShape, Keys> & { peerId: string };
   peers: {
-    [peerId: string]: Pick<PresenceShape, Keys>;
+    [peerId: string]: Pick<PresenceShape, Keys> & { peerId: string };
   };
 };
 
@@ -42,6 +42,7 @@ export function buildPresenceSlice<
     peers: Record<string, PresenceShape>;
   },
   opts: PresenceOpts<PresenceShape, Keys>,
+  userPeerId: string,
 ) {
   const slice: PresenceSlice<PresenceShape, Keys> = {
     peers: {},
@@ -51,7 +52,7 @@ export function buildPresenceSlice<
 
   if (includeUser) {
     const user = pick(data.user ?? {}, opts?.keys);
-    slice.user = user;
+    slice.user = { ...user, peerId: userPeerId };
   }
 
   for (const id of Object.keys(data.peers ?? {})) {
@@ -61,7 +62,7 @@ export function buildPresenceSlice<
 
     if (shouldIncludeAllPeers || isPeerIncluded) {
       const peer = pick(data.peers[id], opts?.keys);
-      slice.peers[id] = peer;
+      slice.peers[id] = { ...peer, peerId: id };
     }
   }
 


### PR DESCRIPTION
https://discord.com/channels/1031957483243188235/1281153699179135027

```
Right now we only get peer ids for other users, which forces us to maintain our own user.peerId  to be able to properly do multiplayer.
This is because the same user can be connected with more than one client, so we can't rely on the user.id  for that matter.
Exposing the current user's peerId would allow to uniquely identify users no matter what
```