### PR TITLE
[perf][1] cache dataForResult

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -549,7 +549,6 @@ export default class Reactor {
     }
     const prev = this._dataForResultCache[hash];
     if (prev) return prev;
-    
   };
 
   /**

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -549,6 +549,7 @@ export default class Reactor {
     }
     const prev = this._dataForResultCache[hash];
     if (prev) return prev;
+    
   };
 
   /**

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -548,7 +548,7 @@ export default class Reactor {
       return { error: errorMessage };
     }
     const prev = this._dataForResultCache[hash];
-    if (prev) return prev;)
+    if (prev) return prev;
   };
 
   /**


### PR DESCRIPTION
We don't cache `dataForResult` right now. This means that when we render in dev, we get: 

1. 1 call for dataForResult from notifyOne
2. 2 calls for `dataForResult`, when running `useQuery`

This is a very light cache for dataForResult; there's still going to be false positives [1]. _But_ this will remove the 2 unnecessary in dev, and 1 in prod. Here's how it looks from a flame graph: 

**Before**
<img width="600" alt="CleanShot 2024-09-18 at 16 56 43@2x" src="https://github.com/user-attachments/assets/19248ef8-125b-41a3-a338-a6d36beeb780">


**After** 
<img width="580" alt="CleanShot 2024-09-18 at 16 57 20@2x" src="https://github.com/user-attachments/assets/bf41f255-4d12-4dcc-8b68-f4388f72b92d">

Lots moar coming! 

@nezaj @dwwoelfel @markyfyi 

[1] Eventually, we should really look into turning a bunch of our objects into observables. It would be _so_ cool if we could quickly derive whether a `dataForResult` is stale or not, based on whether it's dependents have changed.