### PR TITLE
Merge EntityDef::asType with attrs

### DIFF
--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -92,7 +92,18 @@ export class EntityDef<
     public links: Links,
   ) {}
 
-  asType<_AsType>() {
+  asType<
+    _AsType extends Partial<{
+      [AttrName in keyof Attrs]: Attrs[AttrName] extends DataAttrDef<
+        infer ValueType,
+        infer IsRequired
+      >
+        ? IsRequired extends true
+          ? ValueType
+          : ValueType | undefined
+        : never;
+    }>,
+  >() {
     return new EntityDef<Attrs, Links, _AsType>(this.attrs, this.links);
   }
 }

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -247,5 +247,5 @@ export type ResolveAttrs<
   Entities[EntityName] extends EntityDef<any, any, infer AsType>
     ? AsType extends void
       ? ResolvedAttrs
-      : AsType
+      : Omit<ResolvedAttrs, keyof AsType> & AsType
     : ResolvedAttrs;

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -18,7 +18,7 @@ const schema = i
     {
       discriminatedUnionExample: i
         .entity({ x: i.string(), y: i.number(), z: i.number() })
-        .asType<{ x: "foo"; y: 1 } | { x: "bar"; y: 2 }>(),
+        .asType<{ x: "foo"; y: 1 } | { x: "bar" }>(),
       habits: i.entity({
         name: i.string(),
         enum: i.string<"a" | "b">(),

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -17,7 +17,7 @@ const schema = i
   .graph(
     {
       discriminatedUnionExample: i
-        .entity({ x: i.string(), y: i.number() })
+        .entity({ x: i.string(), y: i.number(), z: i.number() })
         .asType<{ x: "foo"; y: 1 } | { x: "bar"; y: 2 }>(),
       habits: i.entity({
         name: i.string(),
@@ -90,8 +90,9 @@ export default function Main() {
   if (error) return <div>Error: {error.message}</div>;
 
   const du = data.discriminatedUnionExample.at(0);
+
   if (du?.x === "foo") {
-    // this should be constrained to 1
+    // y should be constrained to 1
     du.y;
   }
 


### PR DESCRIPTION
When resolving an entity extended with `.asType`, we ignore the attr defs.   This is annoying because it forces the user to define types in two spots.  This change modifies `.asType` to merge the provided generic with the entity's original attr def.