### PR TITLE
Improve dataForResult cache

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -90,7 +90,7 @@ export default class Reactor {
   _broadcastSubs = {};
   _currentUserCached = { isLoading: true, error: undefined, user: undefined };
   _beforeUnloadCbs = [];
-  _dataForResultCache = {};
+  _dataForQueryCache = {};
 
   constructor(
     config,
@@ -692,10 +692,10 @@ export default class Reactor {
     const pendingMutationsVersion = this.pendingMutations.version();
     const pendingMutations = this.pendingMutations.currentValue;
 
-    const { q, result } = this.querySubs.currentValue[hash] || {};
+    const { q, result } = querySubs[hash] || {};
     if (!result) return;
 
-    const cached = this._dataForResultCache[hash];
+    const cached = this._dataForQueryCache[hash];
     if (
       cached &&
       querySubVersion === cached.querySubVersion &&
@@ -714,7 +714,7 @@ export default class Reactor {
     const newStore = s.transact(store, txSteps);
     const resp = instaql({ store: newStore, pageInfo, aggregate }, q);
 
-    this._dataForResultCache[hash] = {
+    this._dataForQueryCache[hash] = {
       querySubVersion,
       pendingMutationsVersion,
       data: resp,
@@ -727,7 +727,7 @@ export default class Reactor {
   notifyOne = (hash) => {
     const cbs = this.queryCbs[hash] || [];
     if (!cbs) return;
-    const prevData = this._dataForResultCache[hash]?.data;
+    const prevData = this._dataForQueryCache[hash]?.data;
     const data = this.dataForQuery(hash);
     if (!data) return;
     if (areObjectsDeepEqual(data, prevData)) return;

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -687,6 +687,8 @@ export default class Reactor {
     if (errorMessage) {
       return { error: errorMessage };
     }
+    if (!this.querySubs) return;
+    if (!this.pendingMutations) return;
     const querySubVersion = this.querySubs.version();
     const querySubs = this.querySubs.currentValue;
     const pendingMutationsVersion = this.pendingMutations.version();

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -543,12 +543,7 @@ export default class Reactor {
 
   getPreviousResult = (q) => {
     const hash = weakHash(q);
-    const errorMessage = this._errorMessage;
-    if (errorMessage) {
-      return { error: errorMessage };
-    }
-    const prev = this._dataForResultCache[hash];
-    if (prev) return prev;
+    return this.dataForQuery(hash);
   };
 
   /**
@@ -687,15 +682,44 @@ export default class Reactor {
   }
 
   /** Runs instaql on a query and a store */
-  dataForResult(q, { store, pageInfo, aggregate }) {
+  dataForQuery(hash) {
+    const errorMessage = this._errorMessage;
+    if (errorMessage) {
+      return { error: errorMessage };
+    }
+    const querySubVersion = this.querySubs.version();
+    const querySubs = this.querySubs.currentValue;
+    const pendingMutationsVersion = this.pendingMutations.version();
+    const pendingMutations = this.pendingMutations.currentValue;
+
+    const { q, result } = this.querySubs.currentValue[hash] || {};
+    if (!result) return;
+
+    const cached = this._dataForResultCache[hash];
+    if (
+      cached &&
+      querySubVersion === cached.querySubVersion &&
+      pendingMutationsVersion === cached.pendingMutationsVersion
+    ) {
+      return cached.data;
+    }
+
+    const { store, pageInfo, aggregate } = result;
     const muts = this._rewriteMutations(
       store.attrs,
-      this.pendingMutations.currentValue,
+      pendingMutations
     );
+
     const txSteps = [...muts.values()].flatMap((x) => x["tx-steps"]);
     const newStore = s.transact(store, txSteps);
     const resp = instaql({ store: newStore, pageInfo, aggregate }, q);
-    this._dataForResultCache[weakHash(q)] = resp;
+
+    this._dataForResultCache[hash] = {
+      querySubVersion,
+      pendingMutationsVersion,
+      data: resp,
+    };
+
     return resp;
   }
 
@@ -703,19 +727,11 @@ export default class Reactor {
   notifyOne = (hash) => {
     const cbs = this.queryCbs[hash] || [];
     if (!cbs) return;
-    const errorMessage = this._errorMessage;
-    if (errorMessage) {
-      cbs.forEach((cb) => cb({ error: errorMessage }));
-      return;
-    }
-
-    const { q, result } = this.querySubs.currentValue[hash] || {};
-    if (!result) return; // No store data, no need to notify
-
-    const resp = this.dataForResult(q, result);
-    const prev = this._dataForResultCache[hash];
-    if (areObjectsDeepEqual(resp.data, prev)) return; // No change, no need to notify
-    cbs.forEach((cb) => cb(resp));
+    const prevData = this._dataForResultCache[hash]?.data;
+    const data = this.dataForQuery(hash);
+    if (!data) return;
+    if (areObjectsDeepEqual(data, prevData)) return;
+    cbs.forEach((cb) => cb(data));
   };
 
   notifyQueryError = (hash, msg) => {
@@ -1228,7 +1244,7 @@ export default class Reactor {
           appId: this.config.appId,
           refreshToken,
         });
-      } catch (e) {}
+      } catch (e) { }
     }
 
     this.changeCurrentUser(null);

--- a/client/packages/core/src/utils/PersistedObject.js
+++ b/client/packages/core/src/utils/PersistedObject.js
@@ -38,6 +38,7 @@ export class PersistedObject {
     this.fromJSON = fromJSON;
     this._saveThrottleMs = saveThrottleMs;
     this._pendingSaveCbs = [];
+    this._version = 0; 
 
     this._load();
   }
@@ -64,6 +65,10 @@ export class PersistedObject {
 
   isLoading() {
     return this._isLoading;
+  }
+  
+  version() { 
+    return this._version;
   }
 
   async waitForSync() {
@@ -106,6 +111,7 @@ export class PersistedObject {
   }
 
   set(f, cb) {
+    this._version++;
     this.currentValue = f(this.currentValue);
     if (this._isLoading) {
       this._loadedCbs.push(() => this._enqueuePersist(cb));

--- a/client/packages/core/tsconfig.json
+++ b/client/packages/core/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,
+    "inlineSources": true,
     "target": "es2015",
     "esModuleInterop": true,
     "moduleResolution": "node",

--- a/client/packages/react-native/tsconfig.json
+++ b/client/packages/react-native/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,
+    "inlineSources": true,
     "target": "es2015",
     "esModuleInterop": true,
     "moduleResolution": "node",

--- a/client/packages/react/tsconfig.json
+++ b/client/packages/react/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,
+    "inlineSources": true,
     "target": "es2015",
     "esModuleInterop": true,
     "moduleResolution": "node",


### PR DESCRIPTION
In our previous perf improvement, we lost one advantage: 

Consider the following scenario: 
1. We load everything from storage
2. Afterwards, we get a `useQuery`

In this scenario, there would be no data for `getPreviousResult`, since 1. would not have done a `notifyOne`. 

I circumvented this problem by making the cache a bit smarter. Now, we run the `dataForQuery` in _both_ `notifyOne` _and_ `getPreviousResult`. If those calls run on the same 'version' of querySubs and pendingMutations, they return from the cache.

**Before**
![image](https://github.com/user-attachments/assets/6dcdc426-46ab-44b7-a838-53c40aec20b8)

**After** 
(No change)
<img width="832" alt="CleanShot 2024-09-19 at 11 08 22@2x" src="https://github.com/user-attachments/assets/e3d32077-ba66-429d-9204-1fbdb9e9454c">

@nezaj @dwwoelfel @markyfyi 