### PR TITLE
Add validation to check for duplicate attrs

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -380,7 +380,7 @@ async function pushSchema(appIdOrName) {
     },
   });
 
-  if (!planRes.ok) return false;
+  if (!planRes.ok) return;
 
   if (!planRes.data.steps.length) {
     console.log("No schema changes detected.  Exiting.");
@@ -423,9 +423,11 @@ async function pushSchema(appIdOrName) {
     },
   });
 
-  if (!applyRes.ok) return false;
+  if (!applyRes.ok) return;
 
   console.log(chalk.green("Schema updated!"));
+
+  return true;
 }
 
 async function pushPerms(appIdOrName) {
@@ -456,6 +458,8 @@ async function pushPerms(appIdOrName) {
   if (!permsRes.ok) return;
 
   console.log(chalk.green("Permissions updated!"));
+
+  return true;
 }
 
 async function waitForAuthToken({ secret }) {

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -63,13 +63,17 @@ program
   .command("push-schema")
   .argument("[ID]")
   .description("Pushes local instant.schema definition to production.")
-  .action(pushSchema);
+  .action(() => {
+    pushSchema();
+  });
 
 program
   .command("push-perms")
   .argument("[ID]")
   .description("Pushes local instant.perms rules to production.")
-  .action(pushPerms);
+  .action(() => {
+    pushPerms();
+  });
 
 program
   .command("push")
@@ -112,7 +116,9 @@ program.parse(process.argv);
 // command actions
 
 async function pushAll(appIdOrName) {
-  await pushSchema(appIdOrName);
+  const ok = await pushSchema(appIdOrName);
+  if (!ok) return;
+
   await pushPerms(appIdOrName);
 }
 
@@ -374,7 +380,7 @@ async function pushSchema(appIdOrName) {
     },
   });
 
-  if (!planRes.ok) return;
+  if (!planRes.ok) return false;
 
   if (!planRes.data.steps.length) {
     console.log("No schema changes detected.  Exiting.");
@@ -417,7 +423,7 @@ async function pushSchema(appIdOrName) {
     },
   });
 
-  if (!applyRes.ok) return;
+  if (!applyRes.ok) return false;
 
   console.log(chalk.green("Schema updated!"));
 }
@@ -540,7 +546,9 @@ async function fetchJson({
 
         if (Array.isArray(errData?.hint?.errors)) {
           for (const error of errData.hint.errors) {
-            console.error(`${error.in.join("->")}: ${error.message}`);
+            console.error(
+              `${error.in ? error.in.join("->") + ": " : ""}${error.message}`,
+            );
           }
         }
       }

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -39,6 +39,18 @@ const graph = i.graph(
         label: "posts",
       },
     },
+    postsTagsDupe: {
+      forward: {
+        on: "tags",
+        has: "many",
+        label: "posts",
+      },
+      reverse: {
+        on: "posts",
+        has: "many",
+        label: "tags",
+      },
+    },
   },
 );
 

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -39,18 +39,6 @@ const graph = i.graph(
         label: "posts",
       },
     },
-    postsTagsDupe: {
-      forward: {
-        on: "tags",
-        has: "many",
-        label: "posts",
-      },
-      reverse: {
-        on: "posts",
-        has: "many",
-        label: "tags",
-      },
-    },
   },
 );
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1005,7 +1005,7 @@
   (def counters-app-id  #uuid "137ace7a-efdd-490f-b0dc-a3c73a14f892")
   (def u (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))
   (def r (instant-user-refresh-token-model/create! {:id (UUID/randomUUID) :user-id (:id u)}))
-  (schema-model/schemas->ops!
+  (schema-model/schemas->ops
    {:refs {}
     :blobs {}}
    {:refs {["posts" "comments" "comments" "post"] {:unique? false :cardinality "many"}}

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -978,12 +978,12 @@
 (defn schema-push-plan-post [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         client-defs (-> req :body :schema)]
-    (response/ok (schema-model/plan app-id client-defs))))
+    (response/ok (schema-model/plan! app-id client-defs))))
 
 (defn schema-push-apply-post [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         client-defs (-> req :body :schema)
-        r (schema-model/plan app-id client-defs)]
+        r (schema-model/plan! app-id client-defs)]
     (schema-model/apply-plan! app-id r)
     (response/ok r)))
 
@@ -1005,7 +1005,7 @@
   (def counters-app-id  #uuid "137ace7a-efdd-490f-b0dc-a3c73a14f892")
   (def u (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))
   (def r (instant-user-refresh-token-model/create! {:id (UUID/randomUUID) :user-id (:id u)}))
-  (schema-model/schemas->ops
+  (schema-model/schemas->ops!
    {:refs {}
     :blobs {}}
    {:refs {["posts" "comments" "comments" "post"] {:unique? false :cardinality "many"}}

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -189,5 +189,3 @@
              :rules (rule-model/get-by-app-id aurora/conn-pool
                                               {:app-id app-id})}]
     (permissioned-tx/transact! ctx steps)))
-
-*e

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -12,7 +12,7 @@
   (into {} (map (fn [[k v]] [k (f [k v])]) m)))
 
 (defn attr-ident-names [attr]
-  (keep identity [(attr-model/fwd-ident-name attr) (attr-model/rev-ident-name attr)]))
+  (keep seq [(attr-model/fwd-ident-name attr) (attr-model/rev-ident-name attr)]))
 
 (defn schemas->ops [current-schema new-schema]
   (let [{new-blobs :blobs new-refs :refs} new-schema
@@ -151,7 +151,6 @@
 
 (defn assert-unique-idents! [current-attrs steps]
   (let [current-ident-names (->> current-attrs
-                                 (filter (comp #{:ref} :value-type))
                                  (mapcat attr-ident-names)
                                  (map vec))
         ident-names (->>
@@ -185,6 +184,13 @@
      :steps steps}))
 
 (comment
+  (attr-ident-names {:id #uuid "",
+                     :value-type :blob,
+                     :cardinality :one,
+                     :forward-identity [#uuid "" "tags" "x"],
+                     :unique? false,
+                     :index? false,
+                     :inferred-types nil})
   (schemas->ops
    {:refs {}
     :blobs {:ns {:a {:unique? "one"}}}}

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -14,7 +14,7 @@
 (defn attr-ident-names [attr]
   (keep identity [(attr-model/fwd-ident-name attr) (attr-model/rev-ident-name attr)]))
 
-(defn schemas->ops! [current-schema new-schema]
+(defn schemas->ops [current-schema new-schema]
   (let [{new-blobs :blobs new-refs :refs} new-schema
         eid-ops (map (fn [[ns-name _]] (if (get-in current-schema [:blobs ns-name])
                                          nil
@@ -84,20 +84,8 @@
                  new-refs)
         steps  (->> (concat eid-ops blob-ops ref-ops)
                     (filter some?)
-                    vec)
-        dups (->>
-              steps
-              (mapcat (fn [[op data]]
-                        (when (= op :add-attr)
-                          (attr-ident-names data))))
-              (frequencies)
-              (filter (fn [[_ v]] (> v 1))))]
-    (when (seq dups)
-      (ex/assert-valid! :schema
-                        :steps
-                        (map (fn [[[etype label]]]
-                               {:in [:schema]
-                                :message (str "Duplicate entry found for attribute: " etype "->" label ". Check your schema file for duplicate link definitions.")}) dups)))
+                    vec)]
+
     steps))
 
 (defn attrs->schema [attrs]
@@ -153,6 +141,34 @@
                                entities)]
     {:refs refs-indexed :blobs blobs-indexed}))
 
+(defn dup-message [etype label]
+  (str "Duplicate entry found for attribute: "
+       etype
+       "->"
+       label
+       ". "
+       "Check your schema file for duplicate link definitions."))
+
+(defn assert-unique-idents! [current-attrs steps]
+  (let [current-ident-names (->> current-attrs
+                                 (filter (comp #{:ref} :value-type))
+                                 (mapcat attr-ident-names)
+                                 (map vec))
+        ident-names (->>
+                     steps
+                     (mapcat (fn [[op data]]
+                               (when (= op :add-attr)
+                                 (attr-ident-names data)))))
+        dups (->> (concat current-ident-names ident-names)
+                  (frequencies)
+                  (filter (fn [[_ freq]] (> freq 1))))
+        errors (map (fn [[[etype label]]]
+                      {:in [:schema]
+                       :message (dup-message etype label)}) dups)]
+    (ex/assert-valid! :schema
+                      :steps
+                      errors)))
+
 ;; ---- 
 ;; API
 
@@ -161,20 +177,21 @@
   (let [new-schema (defs->schema client-defs)
         current-attrs (attr-model/get-by-app-id aurora/conn-pool app-id)
         current-schema (attrs->schema current-attrs)
-        steps (schemas->ops! current-schema new-schema)]
+        steps (schemas->ops current-schema new-schema)]
+    (assert-unique-idents! current-attrs steps)
     {:new-schema new-schema
      :current-schema current-schema
      :current-attrs current-attrs
      :steps steps}))
 
 (comment
-  (schemas->ops!
+  (schemas->ops
    {:refs {}
     :blobs {:ns {:a {:unique? "one"}}}}
    {:refs {["comments" "post" "posts" "x"] {:unique? true :cardinality "one"}
            ["comments" "post" "posts" "comments"] {:unique? true :cardinality "one"}}
     :blobs {:ns {:a {:cardinality "many"} :b {:cardinality  "many"}}}})
-  (schemas->ops!
+  (schemas->ops
    {:refs {}
     :blobs {:ns {:a {:unique? "one"}}}}
    {:refs {["comments" "post" "posts" "comments"] {:unique? true :cardinality "one"}}

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -102,7 +102,7 @@
                         :steps
                         (map (fn [[[ns attr]]]
                                {:in [:schema]
-                                :message (str "Duplicate entry found for attribute: " ns "->" attr ". Check your schema file for diplicate link definitions.")}) dups)))
+                                :message (str "Duplicate entry found for attribute: " ns "->" attr ". Check your schema file for duplicate link definitions.")}) dups)))
     steps))
 
 (defn attrs->schema [attrs]

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -131,12 +131,12 @@
 (defn app-schema-plan-post [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
         client-defs (-> req :body :schema)]
-    (response/ok (schema-model/plan app-id client-defs))))
+    (response/ok (schema-model/plan! app-id client-defs))))
 
 (defn app-schema-apply-post [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
         client-defs (-> req :body :schema)
-        plan (schema-model/plan app-id client-defs)]
+        plan (schema-model/plan! app-id client-defs)]
     (schema-model/apply-plan! app-id plan)
     (response/ok plan)))
 


### PR DESCRIPTION
Adds some logic to our schema change planner to bail when a user defines a link twice.

```
~/instant/client/sandbox/cli-nodejs λ INSTANT_CLI_DEV=1 px instant-cli push -y 
Planning...
Failed to update schema.
Validation failed for schema
schema: Duplicate entry found for attribute: tags->posts. Check your schema file for duplicate link definitions.
schema: Duplicate entry found for attribute: posts->tags. Check your schema file for duplicate link definitions.
```

Also fixes a bug where we weren't bailing `push perms` when `push schema` failed.