### PR TITLE
Use mutative instead of immer

### DIFF
--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -33,7 +33,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
-    "immer": "9.0.14",
+    "mutative": "^1.0.10",
     "object-hash": "^3.0.0",
     "uuid": "^9.0.0"
   }

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -1,8 +1,5 @@
-import { produce, enableMapSet } from "immer";
+import { create } from "mutative";
 import { immutableDeepMerge } from "./utils/object";
-
-// Makes immer work with maps and sets
-enableMapSet();
 
 function hasEA(attr) {
   return attr["cardinality"] === "one";
@@ -483,7 +480,7 @@ export function getTriples(store, [e, a, v]) {
 }
 
 export function transact(store, txSteps) {
-  return produce(store, (draft) => {
+  return create(store, (draft) => {
     txSteps.forEach((txStep) => {
       applyTxStep(draft, txStep);
     });

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -112,9 +112,9 @@ importers:
 
   packages/core:
     dependencies:
-      immer:
-        specifier: 9.0.14
-        version: 9.0.14
+      mutative:
+        specifier: ^1.0.10
+        version: 1.0.10
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
@@ -14476,6 +14476,11 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
+
+  /mutative@1.0.10:
+    resolution: {integrity: sha512-YD4MEleW9vJyIVEItz6x71fWdJ9qea3+R8hxtNiei8cQ7BGLM1c9Q6zCJ7SuLzorBhd2PBHN+xUEwEahxMI34w==}
+    engines: {node: '>=14.0'}
     dev: false
 
   /mute-stream@1.0.0:


### PR DESCRIPTION
Immer autofreezes objects. When the object is really large, this gets more and more costly. I switched us to mutative, which does not rely on auto-freeze. [They have a comparison about immer vs mutative here](https://mutative.js.org/docs/extra-topics/comparison-with-immer). 

I made a bunch of transactions in our perf tester. 

**Before** 
[many_tx_immer.json](https://github.com/user-attachments/files/17065226/many_tx_immer.json)

A single transaction ontop of the bench query on immer is about 8ms. As you add more pending transactions, it grows to about 40ms.
![image](https://github.com/user-attachments/assets/5d5239ae-b2e6-479a-b6d1-56b8c86d7a92)

**After** 
[many_tx_mutative.json](https://github.com/user-attachments/files/17065227/many_tx_mutative.json)

Mutative is about 3ms on a single transaction. As I add more pending transactions, the size _seems to stay_ at 3ms! 

<img width="498" alt="CleanShot 2024-09-19 at 12 10 26@2x" src="https://github.com/user-attachments/assets/f2845090-51cb-45b2-9128-0ff744d189d4">

@dwwoelfel @markyfyi @nezaj 
