### PR TITLE
[perf] improve local query perf 2.7x

### DIFF
--- a/client/packages/core/__tests__/src/data/zeneca/attrs.json
+++ b/client/packages/core/__tests__/src/data/zeneca/attrs.json
@@ -18,7 +18,7 @@
   },
   {
     "id": "1fcc2b72-02be-405b-918c-8e441f75dcab",
-    "value-type": "ref",
+    "value-type": "blob",
     "cardinality": "one",
     "forward-identity": [
       "a09d83c4-c587-41fd-b660-bd02a2269dfa",
@@ -35,7 +35,7 @@
   },
   {
     "id": "6eebf15a-ed3c-4442-8869-a44a7c85a1be",
-    "value-type": "ref",
+    "value-type": "blob",
     "cardinality": "one",
     "forward-identity": ["4ceb593d-8953-4441-81c4-21cc521ef6dd", "books", "id"],
     "unique?": true,
@@ -44,7 +44,7 @@
   },
   {
     "id": "5a4f5a6d-ba83-4bf0-ae78-27a863300224",
-    "value-type": "ref",
+    "value-type": "blob",
     "cardinality": "one",
     "forward-identity": ["ce6155ef-e683-4084-bb5e-18757d30b79f", "users", "id"],
     "unique?": true,

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -46,9 +46,7 @@ function isClient() {
 }
 
 function querySubsFromJSON(str) {
-  const start1 = Date.now();
   const parsed = JSON.parse(str);
-  const end1 = Date.now(); 
   for (const key in parsed) {
     const v = parsed[key];
     if (v?.result?.store) {
@@ -66,7 +64,7 @@ function querySubsToJSON(querySubs) {
     if (sub.result?.store) {
       jsonSub.result = {
         ...sub.result,
-        store: s.toJSON(sub.result.store)
+        store: s.toJSON(sub.result.store),
       };
     }
     jsonSubs[key] = jsonSub;
@@ -184,7 +182,7 @@ export default class Reactor {
       {},
       this._onMergeQuerySubs,
       querySubsToJSON,
-      querySubsFromJSON
+      querySubsFromJSON,
     );
     this.pendingMutations = new PersistedObject(
       this._persister,
@@ -735,10 +733,7 @@ export default class Reactor {
     }
 
     const { store, pageInfo, aggregate } = result;
-    const muts = this._rewriteMutations(
-      store.attrs,
-      pendingMutations
-    );
+    const muts = this._rewriteMutations(store.attrs, pendingMutations);
 
     const txSteps = [...muts.values()].flatMap((x) => x["tx-steps"]);
     const newStore = s.transact(store, txSteps);
@@ -1274,7 +1269,7 @@ export default class Reactor {
           appId: this.config.appId,
           refreshToken,
         });
-      } catch (e) { }
+      } catch (e) {}
     }
 
     this.changeCurrentUser(null);

--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -1,6 +1,7 @@
 import { query as datalogQuery } from "./datalog";
 import { uuidCompare } from "./utils/uuid";
 import { getAttrByFwdIdentName, getAttrByReverseIdentName } from "./instaml";
+import * as s from "./store"; 
 
 // Pattern variables
 // -----------------
@@ -46,10 +47,7 @@ function idAttr(store, ns) {
 }
 
 function defaultWhere(makeVar, store, etype, level) {
-  return [
-    eidWhere(makeVar, store, etype, level),
-    attrWhere(makeVar, etype, level),
-  ];
+  return [eidWhere(makeVar, store, etype, level)];
 }
 
 function eidWhere(makeVar, store, etype, level) {
@@ -57,15 +55,6 @@ function eidWhere(makeVar, store, etype, level) {
     makeVar(etype, level),
     idAttr(store, etype).id,
     makeVar(etype, level),
-    wildcard("time"),
-  ];
-}
-
-function attrWhere(makeVar, etype, level) {
-  return [
-    makeVar(etype, level),
-    makeVar("attr", level),
-    makeVar("val", level),
     makeVar("time", level),
   ];
 }
@@ -92,17 +81,17 @@ function refAttrPat(makeVar, store, etype, level, label) {
   const nextLevel = level + 1;
   const attrPat = fwdAttr
     ? [
-        makeVar(fwdEtype, level),
-        attr.id,
-        makeVar(revEtype, nextLevel),
-        wildcard("time"),
-      ]
+      makeVar(fwdEtype, level),
+      attr.id,
+      makeVar(revEtype, nextLevel),
+      wildcard("time"),
+    ]
     : [
-        makeVar(fwdEtype, nextLevel),
-        attr.id,
-        makeVar(revEtype, level),
-        wildcard("time"),
-      ];
+      makeVar(fwdEtype, nextLevel),
+      attr.id,
+      makeVar(revEtype, level),
+      wildcard("time"),
+    ];
 
   const nextEtype = fwdAttr ? revEtype : fwdEtype;
 
@@ -229,12 +218,7 @@ function makeWhere(store, etype, level, where) {
 // -----------------
 
 function makeFind(makeVar, etype, level) {
-  return [
-    makeVar(etype, level),
-    makeVar("attr", level),
-    makeVar("val", level),
-    makeVar("time", level),
-  ];
+  return [makeVar(etype, level), makeVar("time", level)];
 }
 
 // extendObjects
@@ -261,7 +245,7 @@ function extendObjects(makeVar, store, { etype, level, form }, objects) {
     const childResults = children.map((label) => {
       const isSingular = Boolean(
         store.cardinalityInference &&
-          store.linkIndex?.[etype]?.[label]?.isSingular,
+        store.linkIndex?.[etype]?.[label]?.isSingular,
       );
 
       try {
@@ -324,7 +308,7 @@ function cursorCompare(direction, typ) {
   }
 }
 
-function isBefore(startCursor, direction, [e, a, _v, t]) {
+function isBefore(startCursor, direction, [e, _a, _v, t]) {
   return (
     cursorCompare(direction, "number")(t, startCursor[3]) ||
     (t === startCursor[3] &&
@@ -333,43 +317,29 @@ function isBefore(startCursor, direction, [e, a, _v, t]) {
 }
 
 function runDataloadAndReturnObjects(store, etype, direction, pageInfo, dq) {
-  const startCursor = pageInfo?.["start-cursor"];
-  const toRemove = [];
-  const res = datalogQuery(store, dq)
-    .sort((tripleA, tripleB) => {
-      const tsA = tripleA[3];
-      const tsB = tripleB[3];
+  const aid = idAttr(store, etype).id;
+  const idVecs = datalogQuery(store, dq)
+    .sort(([_, tsA], [__, tsB]) => {
       return direction === "desc" ? tsB - tsA : tsA - tsB;
-    })
-    .reduce((res, triple) => {
-      const [e, a, v] = triple;
-      if (shouldIgnoreAttr(store.attrs, a)) {
-        return res;
-      }
-      const attr = store.attrs[a];
-      const [_, attrEtype, label] = attr["forward-identity"];
-      if (attrEtype !== etype) {
-        return res;
-      }
+    });
 
-      if (
-        startCursor &&
-        a === startCursor[1] &&
-        isBefore(startCursor, direction, triple)
-      ) {
-        toRemove.push(e);
-      }
-
-      res[e] = res[e] || {};
-      res[e][label] = v;
-      return res;
-    }, {});
-
-  // remove anything before our start cursor
-  for (const e of toRemove) {
-    delete res[e];
+  let objects = {}
+  const startCursor = pageInfo?.["start-cursor"];
+  const blobAttrs = s.blobAttrs(store, etype);
+  for (const [id, time] of idVecs) {
+    if (
+      startCursor &&
+      aid === startCursor[1] &&
+      isBefore(startCursor, direction, [id, aid, id, time])
+    ) {
+      continue;
+    }
+    const obj = s.getAsObject(store, blobAttrs, id);
+    if (obj) {
+      objects[id] = obj;
+    }
   }
-  return res;
+  return objects;
 }
 
 function determineOrder(form) {


### PR DESCRIPTION
**This PR makes queries ~2.7x faster** 

## Main Change: datalog query _only_ for ids

Say we had a query like `{ posts: {} }`. This would produce a datalog query like:

```clojure
[[?id :posts/id] 
 [?id ?attr ?v]]
```

datalog would end up taking up to 25ms to finish this query. Likely this is because our join algo needs more tuning. Instead, I changed it so: 

1. datalog _only_ queries for eids. 
2. Once we have eids, we 'generate' the object manually

**Before**
<img width="627" alt="CleanShot 2024-09-19 at 16 24 01@2x" src="https://github.com/user-attachments/assets/06988a27-867f-46c7-b184-bbfd8e7710e7">

**After**
<img width="564" alt="CleanShot 2024-09-19 at 16 23 02@2x" src="https://github.com/user-attachments/assets/02e62eab-d5a8-4417-a28d-6121e93cb1c9">

**Note:** In both instances `query` is a bit contaminated by a react update. Afaik react starts rendering when we run `cb()`, and for some reason the profiler counts it as part of `query`. I am not sure why. For this demo I just made React return null, so we saw the results closer to what `query` is actually doing 

## Total impact so far: 

https://paper.dropbox.com/doc/Perf-Impact--CXK5lkdqoXPXTiH7WurEs1kyAg-DEYYXdPeU5ZrP1CnCqsNO

[5200_before.json](https://github.com/user-attachments/files/17068121/5200_before.json)

[5200_after.json](https://github.com/user-attachments/files/17068126/5200_after.json)


@nezaj @dwwoelfel @markyfyi 