### PR TITLE
Client Devtool UI polish

### DIFF
--- a/client/packages/core/src/devtool.ts
+++ b/client/packages/core/src/devtool.ts
@@ -84,7 +84,7 @@ function createIframe(src: string) {
 
 function createToggler(onClick) {
   const logoSVG = `
-    <svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="32" height="32" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
       <rect width="512" height="512" fill="black"/>
       <rect x="97.0973" y="91.3297" width="140" height="330" fill="white"/>
     </svg>

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -2,20 +2,13 @@ import { useRouter } from 'next/router';
 import { TokenContext } from '@/lib/contexts';
 import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
 import { DashResponse } from '@/lib/types';
-import config, { setLocal } from '@/lib/config';
+import config from '@/lib/config';
 import { useAuthToken, useTokenFetch } from '@/lib/auth';
 import { Sandbox } from '@/components/dash/Sandbox';
 import { Explorer } from '@/components/dash/explorer/Explorer';
 import { init } from '@instantdb/react';
 import { useEffect, useState } from 'react';
-import {
-  Content,
-  ScreenHeading,
-  SectionHeading,
-  Stack,
-  TabBar,
-  twel,
-} from '@/components/ui';
+import { SectionHeading, Stack, TabBar, twel } from '@/components/ui';
 import Auth from '@/components/dash/Auth';
 
 type InstantReactClient = ReturnType<typeof init>;
@@ -47,9 +40,8 @@ export default function Devtool() {
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       const isToggleShortcut = e.shiftKey && e.ctrlKey && e.key === '0';
-      const isEsc = e.key === 'Escape' || e.key === 'Esc';
 
-      if (isToggleShortcut || isEsc) {
+      if (isToggleShortcut) {
         parent.postMessage(
           {
             type: 'close',
@@ -75,6 +67,7 @@ export default function Devtool() {
         websocketURI: config.websocketURI,
         // @ts-expect-error
         __adminToken: app?.admin_token,
+        devtool: false,
       });
 
       setConnection({ state: 'ready', db });
@@ -114,10 +107,29 @@ export default function Devtool() {
     );
   }
 
+  if (dashResponse.error) {
+    return (
+      <div className="h-full w-full flex flex-col justify-center items-center gap-2">
+        <div>Error loading app</div>
+        <pre className="p-1 bg-gray-100 max-w-sm w-full overflow-x-auto">
+          {JSON.stringify(dashResponse.error, null, '\t')}{' '}
+        </pre>
+      </div>
+    );
+  }
+
+  if (!appId) {
+    return (
+      <div className="h-full w-full flex justify-center items-center">
+        No app ID provided. Are you passing an app ID into <Code>init</Code>?
+      </div>
+    );
+  }
+
   if (!app) {
     return (
       <div className="h-full w-full flex justify-center items-center">
-        Unable to access app
+        Cound not find app. Are you logged in to the correct account?
       </div>
     );
   }
@@ -125,7 +137,7 @@ export default function Devtool() {
   if (connection.state === 'error') {
     return (
       <div className="h-full w-full flex justify-center items-center">
-        Failed to connect
+        Failed to connect to Instant backend.
       </div>
     );
   }
@@ -144,6 +156,22 @@ export default function Devtool() {
         <div className="flex flex-col h-full w-full">
           <div className="px-3 py-1 text-xs font-mono bg-gray-100 border-b">
             Instant Devtools {app?.title ? `• ${app?.title}` : ''}
+          </div>
+          <div className="flex gap-2 px-3 py-1 text-xs font-mono bg-gray-50 border-b">
+            <span>App ID</span>
+            <code
+              className="bg-white rounded border px-2"
+              onClick={(e) => {
+                const node = e.currentTarget;
+                const selection = window.getSelection();
+                const range = document.createRange();
+                range.selectNodeContents(node);
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+              }}
+            >
+              {app.id ?? <>&nbsp;</>}
+            </code>
           </div>
           <TabBar
             className="text-sm"
@@ -196,7 +224,7 @@ function Help() {
       </p>
       <p>
         You can toggle this view with the keyboard shortcut
-        <Code>ctrl + shift + 0</Code>, and close it with <Code>Esc</Code>.
+        <Code>ctrl + shift + 0</Code>.
       </p>
       <p>
         It's is only displayed in development (i.e. when the site's hostname

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -111,9 +111,11 @@ export default function Devtool() {
     return (
       <div className="h-full w-full flex flex-col justify-center items-center gap-2">
         <div>Error loading app</div>
-        <pre className="p-1 bg-gray-100 max-w-sm w-full overflow-x-auto">
-          {JSON.stringify(dashResponse.error, null, '\t')}{' '}
-        </pre>
+        {!isEmptyObj(dashResponse.error) ? (
+          <pre className="p-1 bg-gray-100 max-w-sm w-full overflow-x-auto">
+            {JSON.stringify(dashResponse.error, null, '\t')}{' '}
+          </pre>
+        ) : null}
       </div>
     );
   }
@@ -248,3 +250,7 @@ function Help() {
 }
 
 const Code = twel('code', 'bg-gray-200 px-1 rounded text-xs font-mono');
+
+function isEmptyObj(obj: object) {
+  return Object.keys(obj).length === 0;
+}


### PR DESCRIPTION
- Prominently display the app ID.
- Fixed the improperly-sized focus ring in Devtool toggler widget.
- Removed `Esc`'ing out of Devtool.   Toggle the popup with `ctrl+shift+0`.
- Richer error messages, including displaying the server error when `/dash` fails.