### PR TITLE
[Dashboard] Set boolean default to false

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -269,8 +269,8 @@ export function EditRowDialog({
                     tabIndex={tabIndex}
                     value={value}
                     options={[
-                      { value: 'true', label: 'true' },
                       { value: 'false', label: 'false' },
+                      { value: 'true', label: 'true' },
                     ]}
                     onChange={(option) =>
                       handleUpdateFieldValue(attr.name, option!.value)


### PR DESCRIPTION
[Two users](https://discord.com/channels/1031957483243188235/1148284450992574535/1286330010818576486) noted that when you use the schema editor we set booleans to true by default. We should actually set it to false by default so users don't accidentally turn it on when editing the row.