### PR TITLE
[instant-cli] Update version command

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -18,10 +18,6 @@ import openInBrowser from "open";
 dotenv.config();
 
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const version = JSON.parse(
-  readFileSync(join(__dirname, 'package.json'), 'utf8')
-).version;
 const dev = Boolean(process.env.INSTANT_CLI_DEV);
 const verbose = Boolean(process.env.INSTANT_CLI_VERBOSE);
 
@@ -49,6 +45,10 @@ program
   .option("-t --token <TOKEN>", "auth token override")
   .option("-y", "skip confirmation prompt")
   .option("-v --version", "output the version number", () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const version = JSON.parse(
+      readFileSync(join(__dirname, 'package.json'), 'utf8')
+    ).version;
     console.log(version);
     process.exit(0);
   })

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -2,9 +2,9 @@
 
 import { readFileSync } from "fs";
 import { mkdir, writeFile, readFile, stat } from "fs/promises";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from 'url';
 import { randomUUID } from "crypto";
-
 import dotenv from "dotenv";
 import chalk from "chalk";
 import { program } from "commander";
@@ -17,8 +17,10 @@ import openInBrowser from "open";
 // config
 dotenv.config();
 
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const version = JSON.parse(
-  readFileSync(join(import.meta.dirname, "package.json"), "utf8"),
+  readFileSync(join(__dirname, 'package.json'), 'utf8')
 ).version;
 const dev = Boolean(process.env.INSTANT_CLI_DEV);
 const verbose = Boolean(process.env.INSTANT_CLI_VERBOSE);
@@ -46,7 +48,10 @@ program
   .description(instantCLIDescription)
   .option("-t --token <TOKEN>", "auth token override")
   .option("-y", "skip confirmation prompt")
-  .version(version);
+  .option("-v --version", "output the version number", () => {
+    console.log(version);
+    process.exit(0);
+  })
 
 program
   .command("login")


### PR DESCRIPTION
Provides a fix for #250.

I also thought it would be nice to let `-v` work for version. (previously you would have to use uppercase V, which was not consistent with our other options)