### PR TITLE
[Docs] Correct vite env name

### DIFF
--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -21,7 +21,7 @@ You can learn more about [schemas here](/docs/schema) here and [permissions here
 
 ## App ID
 
-The CLI looks for `INSTANT_APP_ID` in `process.env`. As a convenience, it will also check for common prefixes like `NEXT_PUBLIC_INSTANT_APP_ID` and `VITE_PUBLIC_INSTANT_APP_ID`
+The CLI looks for `INSTANT_APP_ID` in `process.env`. As a convenience, it will also check for common prefixes like `NEXT_PUBLIC_INSTANT_APP_ID` and `VITE_INSTANT_APP_ID`
 
 ## Specifying an auth token
 


### PR DESCRIPTION
[Felix](https://discord.com/channels/1031957483243188235/1148284450992574535/1287467897660116993) noted we have a typo in the docs about our environment variable name for Vite.

`VITE_PUBLIC_INSTANT_APP_ID` -> `VITE_INSTANT_APP_ID`