### PR TITLE
Fix errors in generated d.ts files

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -174,7 +174,7 @@ function init_experimental<
  *  const db = init<Schema>({ appId: "my-app-id" })
  *
  */
-function init<Schema = {}, RoomSchema extends RoomSchemaShape = {}>(
+function init<Schema extends {} = {}, RoomSchema extends RoomSchemaShape = {}>(
   config: Config,
   Storage?: any,
   NetworkListener?: any,

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -127,7 +127,7 @@ type PageInfoResponse<T> = {
  *  adding `Exactly` fixes this, but it does.
  *
  * */
-type Exactly<Parent, Child extends Parent> = Parent & {
+type Exactly<Parent, Child> = Parent & {
   [K in keyof Child]: K extends keyof Parent ? Child[K] : never;
 };
 


### PR DESCRIPTION
Somehow, we're getting type errors in the `.d.ts` files generated in our builds, but not in the source `.ts` files. 😱  I'm still looking into how/why, but shipping a fix in the meantime.