### PR TITLE
[Dash] Make sandbox transact return more similar

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -103,7 +103,7 @@ export function Sandbox({ app }: { app: InstantApp }) {
 
           out('transaction', { response, rules });
 
-          return response['tx-id'];
+          return { 'tx-id': response['tx-id'] };
         } catch (error) {
           out('error', { message: JSON.stringify(error, null, '  ') });
           throw error;


### PR DESCRIPTION
[[One of our users]](https://discord.com/channels/1031957483243188235/1287593736930463856/1287926659915452476) was using the sandbox to debug and was confused by the return of `transact.` In the sandbox we extract out the `tx-id` but in actual instaml we don't.

This change makes the sandbox `transact` return match more closely to the real `transact`