### PR TITLE
[Admin] Remove id from tx-steps

### DIFF
--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -169,16 +169,20 @@
 (defn expand-delete-attr [_ [id]]
   [[:delete-attr id]])
 
-(defn to-tx-steps [attrs [action & args]]
-  (case action
-    "update" (expand-update attrs args)
-    "merge" (expand-merge attrs args)
-    "link"   (expand-link attrs args)
-    "unlink" (expand-unlink attrs args)
-    "delete" (expand-delete attrs args)
-    "add-attr" (expand-add-attr attrs args)
-    "delete-attr" (expand-delete-attr attrs args)
-    (throw (ex-info (str "unsupported action " action) {}))))
+(defn remove-id-from-step [[op ns eid obj]]
+  [op ns eid (dissoc obj "id")])
+
+(defn to-tx-steps [attrs step]
+  (let [[action & args] (remove-id-from-step step)]
+    (case action
+      "update" (expand-update attrs args)
+      "merge" (expand-merge attrs args)
+      "link"   (expand-link attrs args)
+      "unlink" (expand-unlink attrs args)
+      "delete" (expand-delete attrs args)
+      "add-attr" (expand-add-attr attrs args)
+      "delete-attr" (expand-delete-attr attrs args)
+      (throw (ex-info (str "unsupported action " action) {})))))
 
 (defn create-object-attr
   ([etype label] (create-object-attr etype label nil))


### PR DESCRIPTION
Removes `id` from tx-steps in the admin API

Mulitple users [[1]](https://discord.com/channels/1031957483243188235/1287593736930463856/1288027582473961533) [[2]](https://discord.com/channels/1031957483243188235/1286706771234263163/1286840977796894770) encountered an issue with the admin API where if you include `id` in `update` it will cause a strange state where transactions will succeed but querying the data won't show results. I was able to repro this behavior using this snippet in the  sandbox

```
const itemId = id()
const randomId = id()
if (itemId) {
  const res =await db.transact([
    tx.messages[itemId].update({id: randomId, itemId, randomId }),
  ]);
  console.log(res)
}
```

The transaction will succeed and the row count will increase in the explorer but we won't be able to display the data. If you set `id: itemId` then it will work. Here's a video below with toggling different values for `id`

https://github.com/user-attachments/assets/c6f094ba-d828-4569-94f4-4c5a56a49f21

