### PR TITLE
Surface advanced features in docs

### DIFF
--- a/client/www/pages/docs/index.md
+++ b/client/www/pages/docs/index.md
@@ -8,7 +8,7 @@ Instant is the Modern Firebase. With Instant you can easily build realtime and c
 
 Curious about what it's all about? Try a {% blank-link href="https://instantdb.com/tutorial" label="demo" /%}. Have questions? {% blank-link href="https://discord.com/invite/VU53p7uQcE" label="Join us on discord!" /%}
 
-And if you're ready, follow the quick start below, to build a live app in less than 5 minutes! 
+And if you're ready, follow the quick start below, to build a live app in less than 5 minutes!
 
 ---
 
@@ -257,3 +257,11 @@ export default App
 Go to `localhost:3000` and follow the final instruction to load the app!
 
 Huzzah 🎉 You've got your first Instant web app running! Check out the [**Explore**](/docs/init) section to learn more about how to use Instant :)
+
+{% callout type="note" %}
+
+**Level up your app!**
+
+Instant also support a [CLI-based workflow](/docs/cli) and [schema-as-code](/docs/schema), plus we're piloting [strictly-typed queries and mutations](/docs/strong-init).
+
+{% /callout %}

--- a/client/www/pages/docs/index.md
+++ b/client/www/pages/docs/index.md
@@ -257,11 +257,3 @@ export default App
 Go to `localhost:3000` and follow the final instruction to load the app!
 
 Huzzah 🎉 You've got your first Instant web app running! Check out the [**Explore**](/docs/init) section to learn more about how to use Instant :)
-
-{% callout type="note" %}
-
-**Level up your app!**
-
-Instant also support a [CLI-based workflow](/docs/cli) and [schema-as-code](/docs/schema), plus we're piloting [strictly-typed queries and mutations](/docs/strong-init).
-
-{% /callout %}

--- a/client/www/pages/docs/init.md
+++ b/client/www/pages/docs/init.md
@@ -41,3 +41,11 @@ const db = init<MyAppSchema>({ appId: APP_ID });
 ```
 
 You'll now be able to use `InstaQL` and `InstalML` throughout your app!
+
+{% callout type="note" %}
+
+**Level up your app!**
+
+Instant also support a [CLI-based workflow](/docs/cli) and [schema-as-code](/docs/schema), plus we're piloting [strictly-typed queries and mutations](/docs/strong-init).
+
+{% /callout %}

--- a/client/www/pages/docs/init.md
+++ b/client/www/pages/docs/init.md
@@ -44,7 +44,7 @@ You'll now be able to use `InstaQL` and `InstalML` throughout your app!
 
 {% callout type="note" %}
 
-**Level up your app!**
+**Schema as code and type safety**
 
 Instant also support a [CLI-based workflow](/docs/cli) and [schema-as-code](/docs/schema), plus we're piloting [strictly-typed queries and mutations](/docs/strong-init).
 

--- a/client/www/pages/docs/init.md
+++ b/client/www/pages/docs/init.md
@@ -44,7 +44,7 @@ You'll now be able to use `InstaQL` and `InstalML` throughout your app!
 
 {% callout type="note" %}
 
-**Schema as code and type safety**
+**Schema-as-code and type safety**
 
 Instant also support a [CLI-based workflow](/docs/cli) and [schema-as-code](/docs/schema), plus we're piloting [strictly-typed queries and mutations](/docs/strong-init).
 


### PR DESCRIPTION
I notice users in Discord still asking about types and schemas.  This patch makes an effort to surface awareness of these features in our onboarding docs.