### PR TITLE
Extract base tsconfig from client packages

### DIFF
--- a/client/packages/admin/tsconfig.json
+++ b/client/packages/admin/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
+  "extends": "../../tsconfig.base.json"
 }

--- a/client/packages/admin/tsconfig.json
+++ b/client/packages/admin/tsconfig.json
@@ -1,5 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "exclude": ["node_modules", "dist"],
-  "extends": "../../tsconfig.base.json"
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
 }

--- a/client/packages/admin/tsconfig.json
+++ b/client/packages/admin/tsconfig.json
@@ -1,19 +1,3 @@
 {
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"],
-  "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-    "module": "commonjs",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "target": "es2015",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "stripInternal": true,
-    "allowSyntheticDefaultImports": true,
-    "allowJs": true,
-  },
+  "extends": "../../tsconfig.base.json",
 }

--- a/client/packages/core/tsconfig.json
+++ b/client/packages/core/tsconfig.json
@@ -1,8 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
     "checkJs": false
-  },
-  "extends": "../../tsconfig.base.json"
+  }
 }

--- a/client/packages/core/tsconfig.json
+++ b/client/packages/core/tsconfig.json
@@ -1,6 +1,8 @@
 {
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "checkJs": false,
+    "checkJs": false
   },
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json"
 }

--- a/client/packages/core/tsconfig.json
+++ b/client/packages/core/tsconfig.json
@@ -1,21 +1,6 @@
 {
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "checkJs": false,
-    "module": "commonjs",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "inlineSources": true,
-    "target": "es2015",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "stripInternal": true,
-    "allowSyntheticDefaultImports": true,
-    "allowJs": true,
   },
+  "extends": "../../tsconfig.base.json",
 }

--- a/client/packages/react-native/tsconfig.json
+++ b/client/packages/react-native/tsconfig.json
@@ -1,3 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
+  "extends": "../../tsconfig.base.json"
 }

--- a/client/packages/react-native/tsconfig.json
+++ b/client/packages/react-native/tsconfig.json
@@ -1,5 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "exclude": ["node_modules", "dist"],
-  "extends": "../../tsconfig.base.json"
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
 }

--- a/client/packages/react-native/tsconfig.json
+++ b/client/packages/react-native/tsconfig.json
@@ -1,20 +1,3 @@
 {
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"],
-  "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-    "module": "commonjs",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "inlineSources": true,
-    "target": "es2015",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "stripInternal": true,
-    "allowSyntheticDefaultImports": true,
-    "allowJs": true,
-  },
+  "extends": "../../tsconfig.base.json",
 }

--- a/client/packages/react/tsconfig.json
+++ b/client/packages/react/tsconfig.json
@@ -1,21 +1,6 @@
 {
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "declaration": true,
-    "declarationMap": true,
-    "module": "commonjs",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "inlineSources": true,
-    "target": "es2015",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "stripInternal": true,
-    "allowSyntheticDefaultImports": true,
-    "allowJs": true,
   },
+  "extends": "../../tsconfig.base.json",
 }

--- a/client/packages/react/tsconfig.json
+++ b/client/packages/react/tsconfig.json
@@ -1,6 +1,8 @@
 {
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "react-jsx"
   },
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json"
 }

--- a/client/packages/react/tsconfig.json
+++ b/client/packages/react/tsconfig.json
@@ -1,8 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
     "jsx": "react-jsx"
-  },
-  "extends": "../../tsconfig.base.json"
+  }
 }

--- a/client/tsconfig.base.json
+++ b/client/tsconfig.base.json
@@ -3,8 +3,6 @@
     "declaration": true,
     "declarationMap": true,
     "module": "commonjs",
-    "outDir": "dist",
-    "rootDir": "src",
     "sourceMap": true,
     "inlineSources": true,
     "target": "es2015",

--- a/client/tsconfig.base.json
+++ b/client/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "inlineSources": true,
+    "target": "es2015",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "stripInternal": true,
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+  },
+}

--- a/client/tsconfig.base.json
+++ b/client/tsconfig.base.json
@@ -1,6 +1,4 @@
 {
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
@@ -15,6 +13,6 @@
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true,
     "allowSyntheticDefaultImports": true,
-    "allowJs": true,
-  },
+    "allowJs": true
+  }
 }


### PR DESCRIPTION
Utilizes [`extends`](https://www.typescriptlang.org/tsconfig/#extends) to share common config across our core client packages.  I wanted to do `www` and `sandbox` too but they were all pretty different.