### PR TITLE
Build uberjar as part of actions

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -108,6 +108,43 @@ jobs:
       with:
         report_paths: '**/server/target/test-results/*.xml'
 
+  clj-build-check:
+    runs-on: ubuntu-latest
+    needs: [ detect_clj ]
+    if: needs.detect_clj.outputs.did_change == 'True'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Prepare java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'corretto'
+        java-version: '22'
+
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@10.2
+      with:
+        cli: 1.11.3.1463
+
+    - name: Cache Clojure Dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.deps.clj
+        key: cljdeps-${{ hashFiles('server/deps.edn') }}
+        restore-keys: cljdeps
+
+    - name: Install Clojure dependencies
+      working-directory: server
+      run: clojure -P
+
+    - name: Build uberjar
+      working-directory: server
+      run: clojure -T:build uber
+
   lint:
     runs-on: ubuntu-latest
     needs: [ detect_clj ]

--- a/server/README.md
+++ b/server/README.md
@@ -60,4 +60,4 @@ If you want to make any changes to your configuration, update the `resources/con
 
 # Questions?
 
-If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE)
+If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).


### PR DESCRIPTION
Builds an uberjar in CI so that we don't get surprised by a failure after merging to main.