### PR TITLE
Query Once

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -881,13 +881,15 @@ export default class Reactor {
     const prevData = this._dataForQueryCache[hash]?.data;
     const data = this.dataForQuery(hash)?.value;
     if (!data) return;
-    if (areObjectsDeepEqual(data, prevData)) return;
+    const haveChanged = !areObjectsDeepEqual(data, prevData);
     rs.forEach((r) => {
       if (r.once) {
         this._unsubQuery(r.q, hash, r.cb);
       }
 
-      r.cb(data);
+      if (haveChanged || r.once) {
+        r.cb(data);
+      }
     });
   };
 

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -599,7 +599,7 @@ export default class Reactor {
 
   getPreviousResult = (q) => {
     const hash = weakHash(q);
-    return this.dataForQuery(hash);
+    return this.dataForQuery(hash)?.value;
   };
 
   /**
@@ -619,7 +619,6 @@ export default class Reactor {
   _subscribeQuery(q, cb, once) {
     const eventId = uuid();
     const hash = weakHash(q);
-
     if (!once) {
       const prevResult = this.getPreviousResult(q);
       if (prevResult) {
@@ -660,12 +659,14 @@ export default class Reactor {
     return authdPromise;
   }
 
+  _assertOnline() {
+    if (this._isOnline) return;
+
+    throw new Error("Error: device is offline");
+  }
+
   async queryOnce(q) {
-    if (!this._isOnline) {
-      throw new Error(
-        "Offline: Cannot execute query because the device is offline.",
-      );
-    }
+    this._assertOnline();
 
     // If `queryOnce` is called on app startup, it's very likely that we haven't received `init-ok` yet.
     // In this case, we want to wait until we're authenticated (with a timeout) before we proceed.
@@ -679,7 +680,15 @@ export default class Reactor {
       }
     }
 
-    const result = await new Promise((resolve, reject) => {
+    // If we're online and authenticated,
+    // and if we have a ackd value from the server,
+    // we don't need to subscribe at all.
+    const qData = this.dataForQuery(weakHash(q));
+    if (qData?.fresh) {
+      return Promise.resolve(qData.value);
+    }
+
+    return new Promise((resolve, reject) => {
       let done = false;
 
       const unsub = this._subscribeQuery(
@@ -700,12 +709,11 @@ export default class Reactor {
       setTimeout(() => {
         if (done) return;
         done = true;
+
         reject(new Error("Query timed out"));
         unsub();
       }, QUERY_ONCE_TIMEOUT);
     });
-
-    return result;
   }
 
   _unsubQuery(q, hash, cb) {
@@ -829,7 +837,7 @@ export default class Reactor {
   dataForQuery(hash) {
     const errorMessage = this._errorMessage;
     if (errorMessage) {
-      return { error: errorMessage };
+      return { value: { error: errorMessage } };
     }
     if (!this.querySubs) return;
     if (!this.pendingMutations) return;
@@ -847,7 +855,7 @@ export default class Reactor {
       querySubVersion === cached.querySubVersion &&
       pendingMutationsVersion === cached.pendingMutationsVersion
     ) {
-      return cached.data;
+      return { fresh: true, value: cached.data };
     }
 
     const { store, pageInfo, aggregate } = result;
@@ -863,7 +871,7 @@ export default class Reactor {
       data: resp,
     };
 
-    return resp;
+    return { fresh: false, value: resp };
   }
 
   /** Re-run instaql and call all callbacks with new data */
@@ -871,7 +879,7 @@ export default class Reactor {
     const rs = this.queryCbs[hash] || [];
     if (!rs) return;
     const prevData = this._dataForQueryCache[hash]?.data;
-    const data = this.dataForQuery(hash);
+    const data = this.dataForQuery(hash)?.value;
     if (!data) return;
     if (areObjectsDeepEqual(data, prevData)) return;
     rs.forEach((r) => {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -24,7 +24,7 @@ const STATUS = {
   ERRORED: "errored",
 };
 
-const QUERY_ONCE_TIMEOUT = 3000;
+const QUERY_ONCE_TIMEOUT = 5000;
 
 const WS_OPEN_STATUS = 1;
 

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -626,8 +626,8 @@ export default class Reactor {
     }
 
     const hash = weakHash(q);
-
     const dfd = new Deferred();
+
     this.queryOnceDfds[hash] = this.queryOnceDfds[hash] ?? [];
     this.queryOnceDfds[hash].push({ q, dfd });
 

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -620,17 +620,11 @@ export default class Reactor {
     const eventId = uuid();
     const hash = weakHash(q);
 
-    const prevResult = this.getPreviousResult(q);
-    if (prevResult) {
-      cb(prevResult);
-    }
-
-    // If it's only once and we have a cached value,
-    // we don't need to subscribe at all
-    const isOneAndDone = once && prevResult;
-    if (isOneAndDone) {
-      // no-op!
-      return () => {};
+    if (!once) {
+      const prevResult = this.getPreviousResult(q);
+      if (prevResult) {
+        cb(prevResult);
+      }
     }
 
     this.queryCbs[hash] = this.queryCbs[hash] || [];

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -241,30 +241,6 @@ export default class Reactor {
   _setStatus(status, err) {
     this.status = status;
     this._errorMessage = err;
-    this._notifyStatus();
-  }
-
-  _notifyStatus() {
-    this.statusCbs.forEach((r) => {
-      if (r.once) {
-        this._unsubStatus(r.cb);
-      }
-
-      r.cb(this.status);
-    });
-  }
-
-  _subscribeStatus(cb, once) {
-    this.statusCbs.push({ cb, once: Boolean(once) });
-    cb(this.status);
-
-    return () => {
-      this._unsubStatus(cb);
-    };
-  }
-
-  _unsubStatus(cb) {
-    this.statusCbs = this.statusCbs.filter((r) => r.cb !== cb);
   }
 
   /**
@@ -642,26 +618,6 @@ export default class Reactor {
     return () => {
       this._unsubQuery(q, hash, cb);
     };
-  }
-
-  _waitForAuthd(timeout) {
-    const timeoutPromise = sleep(timeout, false);
-
-    const statusOncePromise = new Promise((resolve) => {
-      let done = false;
-      const unsub = this._subscribeStatus((status) => {
-        if (done) return;
-        if (status !== STATUS.AUTHENTICATED) return;
-
-        done = true;
-        resolve(true);
-        setTimeout(() => unsub(), 0);
-      }, true);
-    });
-
-    const authdPromise = Promise.race([timeoutPromise, statusOncePromise]);
-
-    return authdPromise;
   }
 
   async queryOnce(q) {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -503,8 +503,6 @@ export default class Reactor {
   }
 
   _handleReceiveError(msg) {
-    console.log(msg);
-
     const eventId = msg["client-event-id"];
     const prevMutation = this.pendingMutations.currentValue.get(eventId);
     if (prevMutation) {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -829,9 +829,11 @@ export default class Reactor {
   notifyOneQueryOnce = (hash) => {
     const rs = this.queryCbs[hash] ?? [];
     const data = this.dataForQuery(hash);
-    if (!data) return;
 
-    rs.filter((r) => r.once).forEach((r) => r.cb(data));
+    rs.filter((r) => r.once).forEach((r) => {
+      this._unsubQuery(r.q, hash, r.cb);
+      r.cb(data);
+    });
   };
 
   notifyQueryError = (hash, msg) => {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -503,6 +503,8 @@ export default class Reactor {
   }
 
   _handleReceiveError(msg) {
+    console.log(msg);
+
     const eventId = msg["client-event-id"];
     const prevMutation = this.pendingMutations.currentValue.get(eventId);
     if (prevMutation) {
@@ -842,12 +844,6 @@ export default class Reactor {
   notifyQueryError = (hash, error) => {
     const cbs = this.queryCbs[hash] || [];
     cbs.forEach((r) => r.cb({ error }));
-
-    const dfds = this.queryOnceDfds[hash] ?? [];
-    dfds.forEach((r) => {
-      this._completeQueryOnce(r.q, hash, r.dfd);
-      r.dfd.reject(error);
-    });
   };
 
   /** Re-compute all subscriptions */

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1677,7 +1677,3 @@ export default class Reactor {
     return result;
   }
 }
-
-function sleep(ms, value) {
-  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
-}

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -385,6 +385,19 @@ class InstantCore<
     delete globalInstantCoreStore[this._reactor.config.appId];
     this._reactor.shutdown();
   }
+
+  queryOnce<
+    Q extends Schema extends InstantGraph<any, any>
+      ? InstaQLQueryParams<Schema>
+      : Exactly<Query, Q>,
+  >(
+    query: Q,
+  ): Promise<{
+    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    pageInfo: PageInfoResponse<Q>;
+  }> {
+    return this._reactor.queryOnce(query);
+  }
 }
 
 /**
@@ -611,6 +624,7 @@ export {
   type RoomSchemaShape,
   type Query,
   type QueryResponse,
+  type PageInfoResponse,
   type InstantObject,
   type Exactly,
   type TransactionChunk,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -386,6 +386,19 @@ class InstantCore<
     this._reactor.shutdown();
   }
 
+  /**
+   * Use this for one-off queries.
+   * Returens local data if available, otherwise fetches from the server.
+   * Because we want to avoid stale data, this method will throw an error
+   * if the user is offline or there is no active connection to the server.
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *
+   *  const resp = await db.queryOnce({ goals: {} });
+   *  console.log(resp.data.goals)
+   */
   queryOnce<
     Q extends Schema extends InstantGraph<any, any>
       ? InstaQLQueryParams<Schema>

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -388,7 +388,7 @@ class InstantCore<
 
   /**
    * Use this for one-off queries.
-   * Returens local data if available, otherwise fetches from the server.
+   * Returns local data if available, otherwise fetches from the server.
    * Because we want to avoid stale data, this method will throw an error
    * if the user is offline or there is no active connection to the server.
    *

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -19,6 +19,8 @@ import {
   type ConfigWithSchema,
   type IDatabase,
   type InstantGraph,
+  type QueryResponse,
+  type PageInfoResponse,
 } from "@instantdb/core";
 import {
   KeyboardEvent,
@@ -462,5 +464,18 @@ export abstract class InstantReact<
       () => defaultAuthState,
     );
     return state;
+  };
+
+  queryOnce = <
+    Q extends Schema extends InstantGraph<any, any>
+      ? InstaQLQueryParams<Schema>
+      : Exactly<Query, Q>,
+  >(
+    query: Q,
+  ): Promise<{
+    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    pageInfo: PageInfoResponse<Q>;
+  }> => {
+    return this._core.queryOnce(query);
   };
 }

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -468,7 +468,7 @@ export abstract class InstantReact<
 
   /**
    * Use this for one-off queries.
-   * Returens local data if available, otherwise fetches from the server.
+   * Returns local data if available, otherwise fetches from the server.
    * Because we want to avoid stale data, this method will throw an error
    * if the user is offline or there is no active connection to the server.
    *

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -466,6 +466,19 @@ export abstract class InstantReact<
     return state;
   };
 
+  /**
+   * Use this for one-off queries.
+   * Returens local data if available, otherwise fetches from the server.
+   * Because we want to avoid stale data, this method will throw an error
+   * if the user is offline or there is no active connection to the server.
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *
+   *  const resp = await db.queryOnce({ goals: {} });
+   *  console.log(resp.data.goals)
+   */
   queryOnce = <
     Q extends Schema extends InstantGraph<any, any>
       ? InstaQLQueryParams<Schema>

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -60,16 +60,6 @@ interface FormProps {
   addOnce: (value: string) => void;
 }
 const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
-  useEffect(() => {
-    (async () => {
-      const r = await db.queryOnce({
-        onceTest: {},
-      });
-
-      console.log("onceTest on init", r);
-    })();
-  });
-
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const input = e.currentTarget.elements.namedItem(
@@ -98,11 +88,23 @@ const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
 };
 
 function Main() {
+  useEffect(() => {
+    (async () => {
+      const r = await db.queryOnce({
+        onceTest: {},
+      });
+
+      console.log("onceTest on init", r);
+    })();
+  }, []);
+
   const { isLoading, error, data } = db.useQuery({
     onceTest: {},
   });
+
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;
+
   return (
     <div className="p-2">
       <div className="flex space-x-2 py-2">

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -30,7 +30,7 @@ async function queryOnceDemo(newItem: string) {
   });
 
   console.log("res", res);
-  console.log("existingQueryRes", existingQueryRes);
+  console.log("existing onceTest", existingQueryRes);
 
   return res.data.onceTest.length > 0;
 }
@@ -47,6 +47,12 @@ interface FormProps {
   addOnce: (value: string) => void;
 }
 const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
+  useEffect(() => {
+    db.queryOnce({
+      onceTest: {},
+    }).then((r) => console.log("initial onceTest", r));
+  });
+
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const input = e.currentTarget.elements.namedItem(

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -19,15 +19,15 @@ const db = init<{
 async function queryOnceDemo(newItem: string) {
   console.log("newItem", newItem);
   const res = await db.queryOnce({
-    onceTest: { $: { where: { 'text': newItem } } },
+    onceTest: { $: { where: { text: newItem } } },
   });
+  console.log(res);
+
   return res.data.onceTest.length > 0;
 }
 
 function addOnce(text: string) {
-  db.transact(
-    tx.onceTest[id()].update({ text, }),
-  );
+  db.transact(tx.onceTest[id()].update({ text }));
 }
 
 function deleteAll(items: any) {
@@ -40,13 +40,15 @@ interface FormProps {
 const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const input = e.currentTarget.elements.namedItem('todoInput') as HTMLInputElement;
+    const input = e.currentTarget.elements.namedItem(
+      "todoInput",
+    ) as HTMLInputElement;
     if (input && input.value.trim()) {
       if (await queryOnceDemo(input.value)) {
-        alert('Item already exists');
+        alert("Item already exists");
       } else {
         addOnce(input.value);
-        input.value = '';
+        input.value = "";
       }
     }
   };
@@ -73,14 +75,19 @@ function Main() {
     <div className="p-2">
       <div className="flex space-x-2 py-2">
         <div>Query Once test</div>
-        <button className="border px-4 border-black" onClick={() => deleteAll(data.onceTest)}>Delete All</button>
+        <button
+          className="border px-4 border-black"
+          onClick={() => deleteAll(data.onceTest)}
+        >
+          Delete All
+        </button>
       </div>
       <TodoForm addOnce={addOnce} />
       {data.onceTest.map((todo: any) => (
         <div key={todo.id}>{todo.text}</div>
       ))}
     </div>
-  )
+  );
 }
 
 function Page() {

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -1,0 +1,27 @@
+import { init } from "@instantdb/react";
+import { useEffect } from "react";
+import config from "../../config";
+
+const db = init<{
+  habits: {
+    name: string;
+  };
+}>(config);
+
+async function queryOnceDemo() {
+  const res = await db.queryOnce({
+    habits: {
+      $: { limit: 1 },
+    },
+  });
+
+  console.log(res.data.habits);
+}
+
+export default function () {
+  useEffect(() => {
+    queryOnceDemo();
+  }, []);
+
+  return null;
+}

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -19,15 +19,15 @@ const db = init<{
 async function queryOnceDemo(newItem: string) {
   console.log("newItem", newItem);
   const res = await db.queryOnce({
-    onceTest: { $: { where: { text: newItem } } },
+    onceTest: { $: { where: { 'text': newItem } } },
   });
-  console.log(res);
-
   return res.data.onceTest.length > 0;
 }
 
 function addOnce(text: string) {
-  db.transact(tx.onceTest[id()].update({ text }));
+  db.transact(
+    tx.onceTest[id()].update({ text, }),
+  );
 }
 
 function deleteAll(items: any) {
@@ -40,15 +40,13 @@ interface FormProps {
 const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const input = e.currentTarget.elements.namedItem(
-      "todoInput",
-    ) as HTMLInputElement;
+    const input = e.currentTarget.elements.namedItem('todoInput') as HTMLInputElement;
     if (input && input.value.trim()) {
       if (await queryOnceDemo(input.value)) {
-        alert("Item already exists");
+        alert('Item already exists');
       } else {
         addOnce(input.value);
-        input.value = "";
+        input.value = '';
       }
     }
   };
@@ -75,19 +73,14 @@ function Main() {
     <div className="p-2">
       <div className="flex space-x-2 py-2">
         <div>Query Once test</div>
-        <button
-          className="border px-4 border-black"
-          onClick={() => deleteAll(data.onceTest)}
-        >
-          Delete All
-        </button>
+        <button className="border px-4 border-black" onClick={() => deleteAll(data.onceTest)}>Delete All</button>
       </div>
       <TodoForm addOnce={addOnce} />
       {data.onceTest.map((todo: any) => (
         <div key={todo.id}>{todo.text}</div>
       ))}
     </div>
-  );
+  )
 }
 
 function Page() {

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -18,16 +18,20 @@ const db = init<{
 
 async function queryOnceDemo(newItem: string) {
   console.log("newItem", newItem);
-  const res = await db.queryOnce({
-    onceTest: { $: { where: { 'text': newItem } } },
+  const existingQUeryRes = await db.queryOnce({
+    onceTest: {},
   });
+  const res = await db.queryOnce({
+    onceTest: { $: { where: { text: newItem } } },
+  });
+  console.log("res", res);
+  console.log("existingQUeryRes", existingQUeryRes);
+
   return res.data.onceTest.length > 0;
 }
 
 function addOnce(text: string) {
-  db.transact(
-    tx.onceTest[id()].update({ text, }),
-  );
+  db.transact(tx.onceTest[id()].update({ text }));
 }
 
 function deleteAll(items: any) {
@@ -40,13 +44,15 @@ interface FormProps {
 const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const input = e.currentTarget.elements.namedItem('todoInput') as HTMLInputElement;
+    const input = e.currentTarget.elements.namedItem(
+      "todoInput",
+    ) as HTMLInputElement;
     if (input && input.value.trim()) {
       if (await queryOnceDemo(input.value)) {
-        alert('Item already exists');
+        alert("Item already exists");
       } else {
         addOnce(input.value);
-        input.value = '';
+        input.value = "";
       }
     }
   };
@@ -73,14 +79,19 @@ function Main() {
     <div className="p-2">
       <div className="flex space-x-2 py-2">
         <div>Query Once test</div>
-        <button className="border px-4 border-black" onClick={() => deleteAll(data.onceTest)}>Delete All</button>
+        <button
+          className="border px-4 border-black"
+          onClick={() => deleteAll(data.onceTest)}
+        >
+          Delete All
+        </button>
       </div>
       <TodoForm addOnce={addOnce} />
       {data.onceTest.map((todo: any) => (
         <div key={todo.id}>{todo.text}</div>
       ))}
     </div>
-  )
+  );
 }
 
 function Page() {

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -18,14 +18,19 @@ const db = init<{
 
 async function queryOnceDemo(newItem: string) {
   console.log("newItem", newItem);
-  const existingQUeryRes = await db.queryOnce({
+
+  // since we have an existing subscription to this query
+  // this will result in an `add-query-exists`
+  const existingQueryRes = await db.queryOnce({
     onceTest: {},
   });
+
   const res = await db.queryOnce({
     onceTest: { $: { where: { text: newItem } } },
   });
+
   console.log("res", res);
-  console.log("existingQUeryRes", existingQUeryRes);
+  console.log("existingQueryRes", existingQueryRes);
 
   return res.data.onceTest.length > 0;
 }

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -17,11 +17,11 @@ const db = init<{
 }>(config);
 
 function _subsCount() {
-  return Object.values(db._core._reactor.queryCbs).flat().length;
+  return Object.values(db._core._reactor.queryOnceDfds).flat().length;
 }
 
 async function queryOnceDemo(newItem: string) {
-  console.log("subs count before:", _subsCount());
+  console.log("dfs count before:", _subsCount());
   console.log("newItem", newItem);
 
   // since we have an existing subscription to this query
@@ -34,7 +34,7 @@ async function queryOnceDemo(newItem: string) {
     onceTest: { $: { where: { text: newItem } } },
   });
 
-  console.log("subs count whenm pending:", _subsCount());
+  console.log("dfs count when pending:", _subsCount());
 
   const [checkRes, existingQueryRes] = await Promise.all([
     checkP,
@@ -43,7 +43,7 @@ async function queryOnceDemo(newItem: string) {
 
   console.log("res", checkRes);
   console.log("existing onceTest", existingQueryRes);
-  console.log("subs count after:", _subsCount());
+  console.log("dfs count after:", _subsCount());
 
   return checkRes.data.onceTest.length > 0;
 }

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -1,27 +1,101 @@
-import { init } from "@instantdb/react";
-import { useEffect } from "react";
+/*
+ * Query Once example
+ * The goal here is to show how we can use queryOnce to fetch data
+ * without subscribing to updates but still get data from the server
+ * to validate if the item already exists.
+ * */
+
+import { init, id, tx } from "@instantdb/react";
+import Head from "next/head";
+import { useEffect, FormEvent } from "react";
 import config from "../../config";
 
 const db = init<{
-  habits: {
-    name: string;
+  onceTest: {
+    text: string;
   };
 }>(config);
 
-async function queryOnceDemo() {
+async function queryOnceDemo(newItem: string) {
+  console.log("newItem", newItem);
   const res = await db.queryOnce({
-    habits: {
-      $: { limit: 1 },
-    },
+    onceTest: { $: { where: { 'text': newItem } } },
   });
-
-  console.log(res.data.habits);
+  return res.data.onceTest.length > 0;
 }
 
-export default function () {
-  useEffect(() => {
-    queryOnceDemo();
-  }, []);
-
-  return null;
+function addOnce(text: string) {
+  db.transact(
+    tx.onceTest[id()].update({ text, }),
+  );
 }
+
+function deleteAll(items: any) {
+  db.transact(items.map((item: any) => tx.onceTest[item.id].delete()));
+}
+
+interface FormProps {
+  addOnce: (value: string) => void;
+}
+const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const input = e.currentTarget.elements.namedItem('todoInput') as HTMLInputElement;
+    if (input && input.value.trim()) {
+      if (await queryOnceDemo(input.value)) {
+        alert('Item already exists');
+      } else {
+        addOnce(input.value);
+        input.value = '';
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        name="todoInput"
+        autoFocus
+        placeholder="What needs to be done?"
+        type="text"
+      />
+    </form>
+  );
+};
+
+function Main() {
+  const { isLoading, error, data } = db.useQuery({
+    onceTest: {},
+  });
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  return (
+    <div className="p-2">
+      <div className="flex space-x-2 py-2">
+        <div>Query Once test</div>
+        <button className="border px-4 border-black" onClick={() => deleteAll(data.onceTest)}>Delete All</button>
+      </div>
+      <TodoForm addOnce={addOnce} />
+      {data.onceTest.map((todo: any) => (
+        <div key={todo.id}>{todo.text}</div>
+      ))}
+    </div>
+  )
+}
+
+function Page() {
+  return (
+    <div>
+      <Head>
+        <title>Instant Example App: Query Once</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <Main />
+    </div>
+  );
+}
+
+export default Page;

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -9,8 +9,8 @@ Instant uses a declarative syntax for querying. It's like GraphQL without the co
 One of the simplest queries you can write is to simply get all entities of a namespace.
 
 ```javascript
-const query = { goals: {} }
-const { isLoading, error, data } = db.useQuery(query)
+const query = { goals: {} };
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 Inspecting `data`, we'll see:
@@ -34,7 +34,7 @@ console.log(data)
 For comparison, the SQL equivalent of this would be something like:
 
 ```javascript
-const data = { goals: doSQL('SELECT * FROM goals') }
+const data = { goals: doSQL('SELECT * FROM goals') };
 ```
 
 ## Fetch multiple namespaces
@@ -42,8 +42,8 @@ const data = { goals: doSQL('SELECT * FROM goals') }
 You can fetch multiple namespaces at once:
 
 ```javascript
-const query = { goals: {}, todos: {} }
-const { isLoading, error, data } = db.useQuery(query)
+const query = { goals: {}, todos: {} };
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 We will now see data for both namespaces.
@@ -72,7 +72,7 @@ The equivalent of this in SQL would be to write two separate queries.
 const data = {
   goals: doSQL('SELECT * from goals'),
   todos: doSQL('SELECT * from todos'),
-}
+};
 ```
 
 ## Fetch a specific entity
@@ -88,8 +88,8 @@ const query = {
       },
     },
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 ```javascript
@@ -107,7 +107,7 @@ console.log(data)
 The SQL equivalent would be:
 
 ```javascript
-const data = { goals: doSQL("SELECT * FROM goals WHERE id = 'healthId'") }
+const data = { goals: doSQL("SELECT * FROM goals WHERE id = 'healthId'") };
 ```
 
 ## Fetch associations
@@ -119,8 +119,8 @@ const query = {
   goals: {
     todos: {},
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 `goals` would now include nested `todos`
@@ -178,8 +178,8 @@ const query = {
   goals: {
     todos: {},
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 Modern applications often need to render nested relations, `InstaQL` really starts to shine for these use cases.
@@ -200,8 +200,8 @@ const query = {
     },
     todos: {},
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 Which returns
@@ -246,8 +246,8 @@ const query = {
     },
     todos: {},
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 Returns
@@ -293,8 +293,8 @@ const query = {
       },
     },
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 This will return goals and filtered todos
@@ -344,8 +344,8 @@ const query = {
   todos: {
     goals: {},
   },
-}
-const { isLoading, error, data } = db.useQuery(query)
+};
+const { isLoading, error, data } = db.useQuery(query);
 ```
 
 ```javascript
@@ -595,10 +595,7 @@ const query = {
   todos: {
     $: {
       where: {
-        or: [
-          { title: 'Code a bunch' },
-          { title: 'Review PRs' }
-        ],
+        or: [{ title: 'Code a bunch' }, { title: 'Review PRs' }],
       },
     },
   },
@@ -654,4 +651,20 @@ console.log(data)
     },
   ]
 }
+```
+
+## Querying once
+
+Sometimes, you only need to fetch data once and don't need to subscribe to changes. For example, you might want to fetch data before rendering a page or when the user clicks a button.
+
+In these cases, you can use `queryOnce` instead of `useQuery`. `queryOnce` returns a promise that resolves with the data once the query is complete.
+
+Unlike `useQuery`, `queryOnce` will throw an error if the user is offline. This is because `queryOnce` is intended for use cases where you need the most up-to-date data.
+
+```javascript
+const query = {
+  todos: {},
+};
+
+const { error, data } = await db.queryOnce(query);
 ```

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -666,5 +666,5 @@ const query = {
   todos: {},
 };
 
-const { error, data } = await db.queryOnce(query);
+const { data } = await db.queryOnce(query);
 ```


### PR DESCRIPTION
Adds `queryOnce` to our suite of client SDKs.  `queryOnce` is basically `useQuery`, but returns a promise instead of registering a subscription.

- `queryOnce` is a hack on top of `subscribeQuery`/`add-query`.
- Along the way, I implemented "true" un-subscription, i.e. sending the `remove-query` op to the server when we no longer need to listen to a query.  I updated the current `subscribeQuery` flow with this, too.  Credit to @stopachka for the idea.

I added an example (`/play/query-once`) to demonstrate various cases:
- `queryOnce` in `useEffect` on init
- `queryOnce` on an existing live subscription (the `add-query-exists` case)
- `queryOnce` with a new query

I'll add docs/docstrings once we're happy with the implementation!