### PR TITLE
docs(schema-as-code): fixed syntax error in default export of i.graph

### DIFF
--- a/client/www/pages/docs/schema.md
+++ b/client/www/pages/docs/schema.md
@@ -13,7 +13,7 @@ The default export of `instant.schema.ts` should always be the result of a call 
 
 import { i } from '@instantdb/core';
 
-export default i.graph(
+const graph = i.graph(
   entitiesMap, // a map of `i.entity` definitions, see "Defining entities" below
   linksMap // a description of links between your app's entities, see "Defining links" below
 );


### PR DESCRIPTION
Either do 

```ts
export default i.graph();

# or

const g = i.graph():
export default g;
```


![image](https://github.com/user-attachments/assets/a6b6a43e-68cc-474e-a719-fb087ff16808)
