### PR TITLE
[Dash] Add clear app to admin

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -1023,7 +1023,9 @@ function Admin({
 }) {
   const token = useContext(TokenContext);
   const [deleteAppOk, updateDeleteAppOk] = useState(false);
+  const [clearAppOk, updateClearAppOk] = useState(false);
   const [editMember, setEditMember] = useState<InstantMember | null>();
+  const clearDialog = useDialog();
   const deleteDialog = useDialog();
   const inviteDialog = useDialog();
 
@@ -1288,21 +1290,56 @@ function Admin({
       </Content>
       <Copyable label="Secret" value={app.admin_token} />
       {isMinRole('owner', app.user_app_role) ? (
-        <>
+        <div className="space-y-2">
           <SectionHeading>Danger zone</SectionHeading>
+          <Content>
+            These are destructive actions and will irreversibly delete associated data.
+          </Content>
           <div>
-            <div className="flex flex-col md:flex-row justify-between gap-2 md:gap-8">
-              <div>
-                <SubsectionHeading>Delete app</SubsectionHeading>
-                <Content>Once you delete this app, you can’t undo it.</Content>
-              </div>
-              <div>
-                <Button variant="destructive" onClick={deleteDialog.onOpen}>
-                  <TrashIcon height={'1rem'} /> Delete app
-                </Button>
-              </div>
+            <div className="flex flex-col space-y-6">
+              <Button variant="destructive" onClick={clearDialog.onOpen}>
+                <TrashIcon height={'1rem'} /> Clear app
+              </Button>
+              <Button variant="destructive" onClick={deleteDialog.onOpen}>
+                <TrashIcon height={'1rem'} /> Delete app
+              </Button>
             </div>
           </div>
+          <Dialog {...clearDialog}>
+            <div className="flex flex-col gap-2">
+              <SubsectionHeading className="text-red-600">
+                Clear app
+              </SubsectionHeading>
+              <Content className="space-y-2">
+                <p>Clearing an app will irreversibly delete all namespaces, triples, and permissions.</p>
+                <p>All other data like app id, admin token, users, billing, team members, etc. will remain.</p>
+                <p>This is equivalent to deleting all your namespaces in the explorer and clearing your permissions.</p>
+              </Content>
+              <Checkbox
+                checked={clearAppOk}
+                onChange={(c) => updateClearAppOk(c)}
+                label="I understand and want to clear this app."
+              />
+              <Button
+                disabled={!clearAppOk}
+                variant="destructive"
+                onClick={async () => {
+                  await jsonFetch(`${config.apiURI}/dash/apps/${app.id}/clear`, {
+                    method: 'POST',
+                    headers: {
+                      authorization: `Bearer ${token}`,
+                      'content-type': 'application/json',
+                    },
+                  });
+
+                  clearDialog.onClose();
+                  window.location.reload();
+                }}
+              >
+                Clear and Reload
+              </Button>
+            </div>
+          </Dialog>
           <Dialog {...deleteDialog}>
             <div className="flex flex-col gap-2">
               <SubsectionHeading className="text-red-600">
@@ -1335,7 +1372,7 @@ function Admin({
               </Button>
             </div>
           </Dialog>
-        </>
+        </div>
       ) : null}
     </TabContent>
   );

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -1333,7 +1333,8 @@ function Admin({
                   });
 
                   clearDialog.onClose();
-                  window.location.reload();
+                  dashResponse.mutate();
+                  successToast('App cleared!');
                 }}
               >
                 Clear and Reload

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -1337,7 +1337,7 @@ function Admin({
                   successToast('App cleared!');
                 }}
               >
-                Clear and Reload
+                Clear data
               </Button>
             </div>
           </Dialog>

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -340,6 +340,11 @@
     (app-model/delete-by-id! {:id app-id})
     (response/ok {:ok true})))
 
+(defn apps-clear [req]
+  (let [{{app-id :id} :app} (req->app-and-user! req)]
+    (app-model/clear-by-id! {:id app-id})
+    (response/ok {:ok true})))
+
 (defn admin-tokens-regenerate [req]
   (let [{{app-id :id} :app} (req->app-and-user! req)
         admin-token (ex/get-param! req [:body :admin-token] uuid-util/coerce)]
@@ -1109,6 +1114,7 @@
   (POST "/dash/apps" [] apps-post)
   (POST "/dash/profiles" [] profiles-post)
   (DELETE "/dash/apps/:app_id" [] apps-delete)
+  (POST "/dash/apps/:app_id/clear" [] apps-clear)
   (POST "/dash/apps/:app_id/rules" [] rules-post)
   (POST "/dash/apps/:app_id/tokens" [] admin-tokens-regenerate)
 

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -118,7 +118,7 @@
   [conn app-id]
   (sql/do-execute!
    conn
-   ["DELETE FROM attrs WHERE attrs.app_id = ?" app-id]))
+   ["DELETE FROM attrs WHERE attrs.app_id = ?::uuid" app-id]))
 
 ;; ------
 ;; insert-multi!

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -7,7 +7,9 @@
             [instant.model.app-admin-token :as app-admin-token-model]
             [instant.util.crypt :as crypt-util]
             [instant.util.exception :as ex]
-            [instant.util.uuid :as uuid-util])
+            [instant.util.uuid :as uuid-util]
+            [instant.db.model.attr :as attr-model]
+            [instant.model.rule :as rule-model])
   (:import
    (java.util UUID)))
 
@@ -272,6 +274,17 @@
                             SET creator_id = ?::uuid
                             WHERE a.id = ?::uuid"
                            new-creator-id id])))
+
+(defn clear-by-id!
+  "Deletes attrs, rules, and triples for the specified app_id"
+  ([params] (clear-by-id! aurora/conn-pool params))
+  ([conn {:keys [id]}]
+   (next-jdbc/with-transaction [tx-conn conn]
+     (attr-model/delete-by-app-id! tx-conn id)
+     (rule-model/delete-by-app-id! tx-conn {:app-id id}))))
+
+(comment
+  (clear-by-id! {:id "9a6d8f38-991d-4264-9801-4a05d8b1eab1"}))
 
 (defn delete-by-ids!
   ([params] (delete-by-ids! aurora/conn-pool params))

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -9,7 +9,8 @@
             [instant.util.exception :as ex]
             [instant.util.uuid :as uuid-util]
             [instant.db.model.attr :as attr-model]
-            [instant.model.rule :as rule-model])
+            [instant.model.rule :as rule-model]
+            [instant.db.model.transaction :as transaction-model])
   (:import
    (java.util UUID)))
 
@@ -281,7 +282,8 @@
   ([conn {:keys [id]}]
    (next-jdbc/with-transaction [tx-conn conn]
      (attr-model/delete-by-app-id! tx-conn id)
-     (rule-model/delete-by-app-id! tx-conn {:app-id id}))))
+     (rule-model/delete-by-app-id! tx-conn {:app-id id})
+     (transaction-model/create! tx-conn {:app-id id}))))
 
 (comment
   (clear-by-id! {:id "9a6d8f38-991d-4264-9801-4a05d8b1eab1"}))

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -22,6 +22,13 @@
   ([conn {:keys [app-id]}]
    (sql/select-one conn ["SELECT * FROM rules WHERE app_id = ?::uuid" app-id])))
 
+(defn delete-by-app-id!
+  ([params] (delete-by-app-id! aurora/conn-pool params))
+  ([conn {:keys [app-id]}]
+   (sql/do-execute!
+    conn
+    ["DELETE FROM rules WHERE app_id = ?::uuid" app-id])))
+
 (defn with-binds [rule etype expr]
   (->> (get-in rule [etype "bind"])
        (partition-all 2)


### PR DESCRIPTION
[One of our users](https://discord.com/channels/1031957483243188235/1148286343638687786/1288277649805938729) asked if we could make it easy to clear apps. This is especially useful if someone is prototyping on a paid app, since it's not easy for them to re-create an app from scratch.

One thing that was strange was that the explorer would be stale after clearing the data. I get around this by doing a reload, but I'd be open to a better solution, just wasn't sure how.

It might also be nice to offer some more checkboxes / configuration for what things you want to clear, but I figured this is decent solution for now and if folks need something more customizable they will let us know.

I also held off on adding this to the cli-helper, just wanted to make sure this actually meets his needs for now before increasing the surface area of other packages

https://github.com/user-attachments/assets/b2982671-b975-4035-8ccf-e6d7321a06b5

