### PR TITLE
[Dev tool] Add clear app to devtool

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -101,7 +101,7 @@ const tabs: Tab[] = [
 
 const tabIndex = new Map(tabs.map((t) => [t.id, t]));
 
-function isMinRole(minRole: Role, role: Role) {
+export function isMinRole(minRole: Role, role: Role) {
   return roleOrder.indexOf(role) >= roleOrder.indexOf(minRole);
 }
 


### PR DESCRIPTION
[Cam](https://discord.com/channels/1031957483243188235/1288277649805938729/1289306430880350240) mentioned that having clear app in the devtool would be the most useful place. So this PR stubs an Admin section in the devtool

Not all the Admin actions in the dashboard makes sense here, for example, you probably don't want to delete the app in the devtool.

It would probably be better to have the Admin page more configurable so you could select which pieces you want. That feels like a bigger lift right now, and if more admin features are requested in the dev tool, I think we can take on a more elegant solution then.

**Authorized View**

<img width="465" alt="image" src="https://github.com/user-attachments/assets/968dc07b-52f0-4651-a9e8-b1ff77b950ea">

**Insufficent Role View**

<img width="484" alt="image" src="https://github.com/user-attachments/assets/adea6ed4-aa89-41b5-b97c-643d16bcca43">
