### PR TITLE
Only evaluate span-opts once

### DIFF
--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -185,13 +185,14 @@
 ;; Going with some manual clojure macros for now.
 (defmacro with-span!
   [span-opts & body]
-  `(cond
-     *skipped* (do ~@body)
-     (> (rand) (:sample-rate ~span-opts 1.0))
-     (binding [*skipped* true]
-       ~@body)
-     :else
-     (with-span!* ~span-opts ~@body)))
+  `(let [span-opts# ~span-opts]
+     (cond
+       *skipped* (do ~@body)
+       (> (rand) (:sample-rate span-opts# 1.0))
+       (binding [*skipped* true]
+         ~@body)
+       :else
+       (with-span!* span-opts# ~@body))))
 
 (comment
   ;; this will always print new-span!


### PR DESCRIPTION
Each time we do `~span-opts`, it will evaluate the form. This change ensures we only evaluate the form once per call to `with-span!`.