### PR TITLE
Add test that the invalidator is working

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -48,11 +48,7 @@ jobs:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
           POSTGRES_DB: test_db
-        options: >-
-          -c wal_level=logical
-          -c max_replication_slots=4
-          -c max_wal_senders=4
-
+          POSTGRES_INITDB_ARGS: "--wal_level=logical --max_replication_slots=4 --max_wal_senders=4"
 
     steps:
     - name: Checkout

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -41,13 +41,22 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: public.ecr.aws/z9j8u5b3/instant-public:postgres-13
         ports:
           - 5432:5432
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
           POSTGRES_DB: test_db
+        command:
+          - "postgres"
+          - "-c"
+          - "wal_level=logical"
+          - "-c"
+          - "max_replication_slots=4"
+          - "-c"
+          - "max_wal_senders=4"
+
 
     steps:
     - name: Checkout

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -48,7 +48,6 @@ jobs:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
           POSTGRES_DB: test_db
-          POSTGRES_INITDB_ARGS: "--wal_level=logical --max_replication_slots=4 --max_wal_senders=4"
 
     steps:
     - name: Checkout

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -48,14 +48,10 @@ jobs:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
           POSTGRES_DB: test_db
-        command:
-          - "postgres"
-          - "-c"
-          - "wal_level=logical"
-          - "-c"
-          - "max_replication_slots=4"
-          - "-c"
-          - "max_wal_senders=4"
+        options: >-
+          -c wal_level=logical
+          -c max_replication_slots=4
+          -c max_wal_senders=4
 
 
     steps:

--- a/server/README.md
+++ b/server/README.md
@@ -54,6 +54,7 @@ make dev
 
 The instant server will run at [localhost:8888](http://localhost:8888) and you can connect to nrepl on port 6005.
 
+
 ### Config
 
 If you want to make any changes to your configuration, update the `resources/config/override.edn` file that was created when you ran `make docker-compose` or `make bootstrap-oss`. `src/config_edn.clj` has a spec that describes the data for the file, or you can look at `resources/config/dev.edn` for an example.

--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ This houses Instant's backend. Let’s get you started!
 
 ## Docker Compose
 
-The easiest way to get started is run `make docker-compose`. That command will use docker compose to set up a new postgres database and start the server. The instant server will be available at http://localhost:8888 and you can connect to nrepl on port `6005`.
+The easiest way to get started is to run `make docker-compose`. That command will use docker compose to set up a new postgres database and start the server. The instant server will be available at http://localhost:8888 and you can connect to nrepl on port `6005`.
 
 ## Without Docker Compose
 

--- a/server/README.md
+++ b/server/README.md
@@ -52,7 +52,7 @@ And start the server:
 make dev
 ```
 
-The instant server will run at localhost:8888 and you can connect to nrepl on port 6005.
+The instant server will run at [localhost:8888](http://localhost:8888) and you can connect to nrepl on port 6005.
 
 ### Config
 

--- a/server/README.md
+++ b/server/README.md
@@ -54,7 +54,6 @@ make dev
 
 The instant server will run at [localhost:8888](http://localhost:8888) and you can connect to nrepl on port 6005.
 
-
 ### Config
 
 If you want to make any changes to your configuration, update the `resources/config/override.edn` file that was created when you ran `make docker-compose` or `make bootstrap-oss`. `src/config_edn.clj` has a spec that describes the data for the file, or you can look at `resources/config/dev.edn` for an example.

--- a/server/dev-postgres/Dockerfile
+++ b/server/dev-postgres/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean
 
-CMD ["postgres"]
+CMD ["postgres" "-c" "wal_level=logical" "-c" "max_replication_slots=4" "-c" "max_wal_senders=4"]

--- a/server/dev-postgres/Dockerfile
+++ b/server/dev-postgres/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean
 
-CMD ["postgres" "-c" "wal_level=logical" "-c" "max_replication_slots=4" "-c" "max_wal_senders=4"]
+CMD ["postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=4", "-c", "max_wal_senders=4"]

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -115,15 +115,7 @@
                                (tracer/with-span! {:name "stop-server"}
                                  (stop))
                                (tracer/with-span! {:name "stop-invalidator"}
-                                 ;; Hack to get the invalidator to shut down in
-                                 ;; dev. Otherwise the stream takes forever to close.
-                                 (when (= :dev (config/get-env))
-                                   (future
-                                     (loop []
-                                       (wal/kick-wal aurora/conn-pool)
-                                       (Thread/sleep 100)
-                                       (recur))))
-                                 (inv/stop))))))
+                                 (inv/stop-global))))))
 
 (defn -main [& _args]
   (let [{:keys [aead-keyset]} (config/init)]
@@ -149,7 +141,7 @@
   (eph/start)
   (stripe/init)
   (session/start)
-  (inv/start)
+  (inv/start-global)
   (wal/init-cleanup aurora/conn-pool)
   (ephemeral-app/start)
   (session-counter/start)

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -348,4 +348,4 @@
   "A hacky way to trigger the stream reader so that it will close faster.
    Useful to speed up exit in dev where there isn't much activity on the wal."
   [conn]
-  (sql/execute! conn ["select pg_notify('random-channel', 'payload')"]))
+  (sql/execute! conn ["insert into config (k, v) values ('kick-wal', to_jsonb(now())) on conflict (k) do update set v = excluded.v"]))

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -5,7 +5,8 @@
             [instant.db.model.attr :as attr-model]
             [instant.jdbc.aurora :as aurora]
             [instant.util.exception :as ex]
-            [instant.db.datalog :as d]))
+            [instant.db.datalog :as d])
+  (:import [java.time Duration Instant]))
 
 (defmacro instant-ex-data [& body]
   `(try
@@ -27,3 +28,13 @@
         :datalog-query-fn d/query
         :current-user current-user}
        q)))))
+
+(defn wait-for [wait-fn wait-ms]
+  (let [start (Instant/now)]
+    (loop [res (wait-fn)]
+      (when-not res
+        (if (< wait-ms (.toMillis (Duration/between start (Instant/now))))
+          (throw (Exception. "Timed out in wait-for"))
+          (do
+            (Thread/sleep 100)
+            (recur (wait-fn))))))))


### PR DESCRIPTION
Adds an integration test to make sure that the invalidator picks up changes to the triples table.

Inspired by this small bug that I luckily caught before deploying the users table pr: https://github.com/instantdb/instant/pull/280/commits/a27e2497c6c2345053910d9f3b37d331056a0d1a. It would have broken invalidation.

Makes a couple of small changes to the invalidator:

1. You can start and stop it without setting global state. There's a `start-global` and `stop-global` we now use in `instant.core` that keeps the previous behavior.
2. The `kick-wal` helper writes to the `config` table, which is more effective than `pg_notify`. 