### PR TITLE
Fix view checks, make them warn-only for now

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -60,4 +60,4 @@ If you want to make any changes to your configuration, update the `resources/con
 
 # Questions?
 
-If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE)
+If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -313,7 +313,7 @@
 (defn attr-update-check [{:keys [admin?] :as _ctx} _aid]
   {:scope :attr
    :etype :attrs
-   :type :update
+   :action :update
    :check (fn [_ctx]
             admin?)})
 

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -148,23 +148,24 @@
   [{:keys [rules current-user] :as ctx} etype eid triples]
   (let [original (entity-model/triples->map ctx triples)
         program (rule-model/get-program! rules etype "view")]
-    {:scope :object
-     :etype (keyword etype)
-     :action :view
-     :eid eid
-     :program program
-     :check (fn [ctx]
-              (if-not program
-                true
-                (cel/eval-program!
-                 program
-                 {"auth"
-                  (cel/->cel-map (<-json (->json current-user)))
-                  "data"
-                  (cel/->cel-map
-                   (assoc  (<-json (->json original))
-                           "_ctx" ctx
-                           "_etype" etype))})))}))
+    (when (seq original)
+      {:scope :object
+       :etype (keyword etype)
+       :action :view
+       :eid eid
+       :program program
+       :check (fn [ctx]
+                (if-not program
+                  true
+                  (cel/eval-program!
+                   program
+                   {"auth"
+                    (cel/->cel-map (<-json (->json current-user)))
+                    "data"
+                    (cel/->cel-map
+                     (assoc  (<-json (->json original))
+                             "_ctx" ctx
+                             "_etype" etype))})))})))
 
 (defn object-check [ctx etype eid action tx-steps triples]
   (condp = action
@@ -298,9 +299,9 @@
 
    With this, we can generate a grouped `check` command for each `eid+etype`."
   [ctx preloaded-triples]
-  (mapv (fn [[{:keys [eid etype action]} {:keys [triples tx-steps]}]]
-          (object-check ctx etype eid action tx-steps triples))
-        preloaded-triples))
+  (vec (keep (fn [[{:keys [eid etype action]} {:keys [triples tx-steps]}]]
+               (object-check ctx etype eid action tx-steps triples))
+             preloaded-triples)))
 
 (defn attr-delete-check [{:keys [admin?] :as _ctx} _aid]
   {:scope :attr
@@ -544,16 +545,46 @@
                    ;; resolve etypes for older version of delete-entity
                    preloaded-triples))
 
-                {create-checks true update-delete-checks false}
-                (group-by create-check? check-commands)
+                {create-checks :create
+                 view-checks :view
+                 update-checks :update
+                 delete-checks :delete}
+                (group-by :action check-commands)
 
-                preloaded-update-delete-refs (preload-refs ctx update-delete-checks)
+                update-delete-checks (concat update-checks delete-checks)
+
+                preloaded-update-delete-refs (preload-refs ctx (concat update-delete-checks
+                                                                       view-checks))
 
                 update-delete-checks-results
                 (io/warn-io :run-check-commands!
                   (run-check-commands! (assoc ctx
                                               :preloaded-refs preloaded-update-delete-refs)
                                        update-delete-checks))
+
+                view-check-results
+                (io/warn-io :run-check-commands!
+                  (run-check-commands!
+                   (assoc ctx
+                          :preloaded-refs preloaded-update-delete-refs
+                          ;; We just want to warn on view checks while
+                          ;; we check on the impact to existing apps
+                          ;; TODO (users-table): remove after validating
+                          ;;                     in production
+                          :admin-check? true)
+                   view-checks))
+
+                _ (tracer/add-data! {:attributes
+                                     {:view-check-results
+                                      (mapv #(select-keys % [:scope
+                                                             :etype
+                                                             :eid
+                                                             :check-result
+                                                             :check-pass?])
+                                            view-check-results)
+                                      :view-check-failed?
+                                      (boolean (some (comp false? :check-pass?)
+                                                     view-check-results))}})
 
                 tx-data (tx/transact-without-tx-conn! tx-conn
                                                       (:attrs ctx)

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -1888,10 +1888,10 @@
         (app-user-model/create! aurora/conn-pool {:app-id app-id
                                                   :id user-id
                                                   :email "test@example.com"})
-        (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
-        ;; XXX: Need to get some feedback on whether this is the right thing to do
-        (permissioned-tx/transact! (assoc (make-ctx)
-                                          :current-user {:id user-id}) tx-steps)))))
+        ;; TODO (users-table): uncomment once view check is live
+        ;;(perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
+        (is (permissioned-tx/transact! (assoc (make-ctx)
+                                              :current-user {:id user-id}) tx-steps))))))
 
 (deftest perms-accepts-writes-to-reverse-links-to-users-table-with-lookups
   (with-empty-app

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -1942,7 +1942,8 @@
                        book-creator-attr-id
                        [(resolvers/->uuid r :$users/email) "test@example.com"]]]]
 
-        (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
+        ;; TODO (users-table): uncomment after view rule checks out
+        ;; (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
         (permissioned-tx/transact! (assoc (make-ctx)
                                           :current-user {:id user-id}) tx-steps)
         (is (= (pretty-perm-q


### PR DESCRIPTION
Fix for view checks that were causing problems for some users.

The problem happened when an object was created and linked in the same transaction. We would try to run the `view` check on an empty object, which would fail.

Now we'll only run the `view` check if the object already exists, counting on the `create` check to reject the transaction if the user isn't allowed to create it.

To prevent more problems for users, we just log the results of the `view` check for now. Once we have some confidence that everything looks ok, we can turn it on.