### PR TITLE
[React Native] Add lookup to rn

### DIFF
--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -18,6 +18,7 @@ import {
   i,
   id,
   tx,
+  lookup,
   type RoomSchemaShape,
   type InstantQuery,
   type InstantQueryResult,
@@ -96,6 +97,7 @@ export {
   init_experimental,
   id,
   tx,
+  lookup,
   i,
 
   // types


### PR DESCRIPTION
[One of our users](https://discord.com/channels/1031957483243188235/1148284450992574535/1289917835321278514) noticed we don't export `lookup` in React Native.

Let's add it in!