### PR TITLE
Improved error messaging for conflicting link defs in schema.ts

### DIFF
--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -29,16 +29,28 @@ const graph = i.graph(
     },
     postsTags: {
       forward: {
-        on: "posts",
-        has: "many",
-        label: "tags",
-      },
-      reverse: {
         on: "tags",
         has: "many",
         label: "posts",
       },
+      reverse: {
+        on: "posts",
+        has: "many",
+        label: "tags",
+      },
     },
+    // postsTags2: {
+    //   forward: {
+    //     on: "posts",
+    //     has: "many",
+    //     label: "tags",
+    //   },
+    //   reverse: {
+    //     on: "tags",
+    //     has: "many",
+    //     label: "posts",
+    //   },
+    // },
   },
 );
 

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -39,18 +39,6 @@ const graph = i.graph(
         label: "tags",
       },
     },
-    // postsTags2: {
-    //   forward: {
-    //     on: "posts",
-    //     has: "many",
-    //     label: "tags",
-    //   },
-    //   reverse: {
-    //     on: "tags",
-    //     has: "many",
-    //     label: "posts",
-    //   },
-    // },
   },
 );
 

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -8,8 +8,6 @@
             [instant.util.exception :as ex])
   (:import (java.util UUID)))
 
-
-
 (defn map-map [f m]
   (into {} (map (fn [[k v]] [k (f [k v])]) m)))
 
@@ -169,12 +167,12 @@
         current-all-ident-names (->> current-attrs
                                      (mapcat attr-ident-names)
                                      (map vec))
-        steps-ident-names (->>
-                           steps
-                           (mapcat (fn [[op data]]
-                                     (when (= op :add-attr)
-                                       (attr-ident-names data)))))
-        dups (->> (concat current-all-ident-names steps-ident-names)
+        new-ident-names (->>
+                         steps
+                         (mapcat (fn [[op data]]
+                                   (when (= op :add-attr)
+                                     (attr-ident-names data)))))
+        dups (->> (concat current-all-ident-names new-ident-names)
                   (frequencies)
                   (filter (fn [[_ freq]] (> freq 1))))
         errors (map (fn [[[etype label]]]

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -184,7 +184,6 @@
                                   (dup-message etype label)
                                   (backwards-link-message etype label))})
                     dups)]
-    (tool/def-locals!)
     (ex/assert-valid! :schema
                       :steps
                       errors)))

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -8,6 +8,8 @@
             [instant.util.exception :as ex])
   (:import (java.util UUID)))
 
+
+
 (defn map-map [f m]
   (into {} (map (fn [[k v]] [k (f [k v])]) m)))
 
@@ -149,21 +151,40 @@
        ". "
        "Check your schema file for duplicate link definitions."))
 
+(defn backwards-link-message [etype label]
+  (str "Conflicting link found for attribute: "
+       etype
+       "->"
+       label
+       ". "
+       "It's possible that you already have a link with the same label names, but in the reverse direction. "
+       "We cannot automatically swap the direction of the link, so you will need to do this manually. "
+       "Check your schema in https://www.instantdb.com/dash for a link with the same label names. "
+       "If you find one, you can either delete the existing link in the dashboard, or swap the `forward` and `reverse` parameters for this link in your schema file."))
+
 (defn assert-unique-idents! [current-attrs steps]
-  (let [current-ident-names (->> current-attrs
-                                 (mapcat attr-ident-names)
-                                 (map vec))
-        ident-names (->>
-                     steps
-                     (mapcat (fn [[op data]]
-                               (when (= op :add-attr)
-                                 (attr-ident-names data)))))
-        dups (->> (concat current-ident-names ident-names)
+  (let [current-fwd-ident-names (->> current-attrs
+                                     (map attr-model/fwd-ident-name)
+                                     (map vec))
+        current-all-ident-names (->> current-attrs
+                                     (mapcat attr-ident-names)
+                                     (map vec))
+        steps-ident-names (->>
+                           steps
+                           (mapcat (fn [[op data]]
+                                     (when (= op :add-attr)
+                                       (attr-ident-names data)))))
+        dups (->> (concat current-all-ident-names steps-ident-names)
                   (frequencies)
                   (filter (fn [[_ freq]] (> freq 1))))
         errors (map (fn [[[etype label]]]
                       {:in [:schema]
-                       :message (dup-message etype label)}) dups)]
+                       :message (if
+                                 (some #(= % [etype label]) current-fwd-ident-names)
+                                  (dup-message etype label)
+                                  (backwards-link-message etype label))})
+                    dups)]
+    (tool/def-locals!)
     (ex/assert-valid! :schema
                       :steps
                       errors)))


### PR DESCRIPTION
The schema planner doesn't account for a sneaky invariant: what if the user has a link def, but in the _opposite direction_ of one in the database?  As in, the forward and reverse identities are swapped.  Right now, we catch this, but throw a misleading "check your schema file for dupes" error.  In this change, I add some code to check for this case, and throw a (hopefully) more informative error.

To repro - go to `sandbox/cli-nodejs/instant.schema.ts` and swap the `forward` and `reverse` props of one of the links.