### PR TITLE
Instant Entity helper type

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -20,6 +20,7 @@ import {
   type InstantQueryResult,
   type InstantSchema,
   type InstantObject,
+  type InstantEntity,
 
   // schema types
   type AttrsDefs,
@@ -665,6 +666,7 @@ export {
   type InstantQueryResult,
   type InstantSchema,
   type InstantObject,
+  type InstantEntity,
 
   // schema types
   type AttrsDefs,

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -1,4 +1,5 @@
 import type {
+  InstaQLQueryEntityResult,
   InstaQLQueryParams,
   InstaQLQueryResult,
   Remove$,
@@ -22,3 +23,28 @@ export type InstantQueryResult<DB extends IDatabase<any, any, any>, Q> =
 
 export type InstantSchema<DB extends IDatabase<any, any, any>> =
   DB extends IDatabase<infer Schema, any, any> ? Schema : never;
+
+export type InstantEntity<
+  DB extends IDatabase<any, any, any>,
+  EntityName extends DB extends IDatabase<infer Schema, any, any>
+    ? Schema extends InstantGraph<infer Entities, any>
+      ? keyof Entities
+      : never
+    : never,
+  Query extends
+    | (DB extends IDatabase<infer Schema, any, any>
+        ? Schema extends InstantGraph<infer Entities, any>
+          ? {
+              [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
+            }
+          : never
+        : never)
+    | {} = {},
+> =
+  DB extends IDatabase<infer Schema, any, any>
+    ? Schema extends InstantGraph<infer Entities, any>
+      ? EntityName extends keyof Entities
+        ? InstaQLQueryEntityResult<Entities, EntityName, Query, true>
+        : never
+      : never
+    : never;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -34,6 +34,7 @@ import type {
   InstantQuery,
   InstantQueryResult,
   InstantSchema,
+  InstantEntity,
 } from "./helperTypes";
 import type {
   AttrsDefs,
@@ -631,6 +632,7 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantEntity,
 
   // schema types
   type AttrsDefs,

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -1,6 +1,7 @@
 // Query
 // -----
 
+import { IDatabase } from "./coreTypes";
 import type {
   EntitiesDef,
   InstantGraph,
@@ -231,5 +232,6 @@ export {
   Remove$,
   InstaQLQueryResult,
   InstaQLQueryParams,
+  InstaQLQueryEntityResult,
   Cursor,
 };

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -36,6 +36,7 @@ import {
   type LinksDef,
   type ResolveAttrs,
   type ValueTypes,
+  type InstantEntity,
 } from "@instantdb/core";
 
 /**
@@ -109,6 +110,7 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantEntity,
   type RoomSchemaShape,
 
   // schema types

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -10,6 +10,7 @@ import {
   type InstantQueryResult,
   type InstantSchema,
   type InstantObject,
+  type InstantEntity,
   type User,
   type AuthState,
   type Query,
@@ -59,6 +60,7 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantEntity,
   type InstaQLQueryParams,
 
   // schema types

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -6,6 +6,7 @@ import {
   type InstantQuery,
   type InstantQueryResult,
   type InstantGraph,
+  type InstantEntity,
 } from "@instantdb/react";
 import config from "../../config";
 
@@ -71,6 +72,8 @@ const db = init_experimental({
   ...config,
   schema,
 });
+
+type DB = typeof db;
 
 export default function Main() {
   db.room("demo", "demo").useSyncPresence({
@@ -174,3 +177,13 @@ const deepVal = result.checkins[0].habit?.category?.id;
 type DeepVal = typeof deepVal;
 type Graph = InstantGraph<any, any, any>;
 type DBGraph = InstantSchema<typeof db>;
+
+type Checkin = InstantEntity<
+  DB,
+  "checkins",
+  {
+    habit: {
+      category: {};
+    };
+  }
+>;


### PR DESCRIPTION
Users wanted a way to quickly pluck a single entity's type from their schema, so I made `InstantEntity`. 💥

```ts
type Checkin = InstantEntity<
  DB,
  "checkins"
>;
```

But it's easy to imagine many cases where you want the entity with some links, so `InstantEntity` accepts an optional 3rd param specifying a "subslice" of InstaQL links relative to the entity. 🎉 ✨ 

```ts
type Checkin = InstantEntity<
  DB,
  "checkins",
  {
    habit: {
      category: {};
    };
  }
>;
```