### PR TITLE
instant db from schema hepler type

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -19,6 +19,7 @@ import {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantSchemaDatabase,
   type InstantObject,
   type InstantEntity,
 
@@ -665,6 +666,7 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantSchemaDatabase,
   type InstantObject,
   type InstantEntity,
 

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -6,6 +6,7 @@ import type {
 } from "./queryTypes";
 import type { InstantGraph } from "./schemaTypes";
 import type { IDatabase } from "./coreTypes";
+import { RoomSchemaShape } from "./presence";
 
 export type InstantQuery<DB extends IDatabase<any, any, any>> =
   DB extends IDatabase<infer Schema, any, any>
@@ -48,3 +49,9 @@ export type InstantEntity<
         : never
       : never
     : never;
+
+export type InstantSchemaDatabase<
+  Schema extends InstantGraph<any, any>,
+  R extends RoomSchemaShape = {},
+  CI extends boolean = true,
+> = IDatabase<Schema, R, CI>;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -35,6 +35,7 @@ import type {
   InstantQueryResult,
   InstantSchema,
   InstantEntity,
+  InstantSchemaDatabase,
 } from "./helperTypes";
 import type {
   AttrsDefs,
@@ -633,6 +634,7 @@ export {
   type InstantQueryResult,
   type InstantSchema,
   type InstantEntity,
+  type InstantSchemaDatabase,
 
   // schema types
   type AttrsDefs,

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -23,6 +23,7 @@ import {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantSchemaDatabase,
 
   // schema types
   type AttrsDefs,
@@ -112,6 +113,7 @@ export {
   type InstantQuery,
   type InstantQueryResult,
   type InstantSchema,
+  type InstantSchemaDatabase,
   type InstantEntity,
   type RoomSchemaShape,
 

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -11,6 +11,7 @@ import {
   type InstantSchema,
   type InstantObject,
   type InstantEntity,
+  type InstantSchemaDatabase,
   type User,
   type AuthState,
   type Query,
@@ -61,6 +62,7 @@ export {
   type InstantQueryResult,
   type InstantSchema,
   type InstantEntity,
+  type InstantSchemaDatabase,
   type InstaQLQueryParams,
 
   // schema types

--- a/client/sandbox/react-nextjs/pages/play/checkins.tsx
+++ b/client/sandbox/react-nextjs/pages/play/checkins.tsx
@@ -7,6 +7,7 @@ import {
   type InstantQueryResult,
   type InstantGraph,
   type InstantEntity,
+  InstantSchemaDatabase,
 } from "@instantdb/react";
 import config from "../../config";
 
@@ -177,9 +178,10 @@ const deepVal = result.checkins[0].habit?.category?.id;
 type DeepVal = typeof deepVal;
 type Graph = InstantGraph<any, any, any>;
 type DBGraph = InstantSchema<typeof db>;
+type DB2 = InstantSchemaDatabase<typeof schema>;
 
 type Checkin = InstantEntity<
-  DB,
+  DB2,
   "checkins",
   {
     habit: {


### PR DESCRIPTION
Exports a helper for users who require a DB type prior to initialization.  For example, when using a DI framework that defers initialization.

Context: https://discord.com/channels/1031957483243188235/1289204418515832903