### PR TITLE
[spacing] change up the spacing on the admin page

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -31,10 +31,10 @@ export const Stack = twel('div', 'flex flex-col gap-2');
 export const Group = twel('div', 'flex flex-col gap-2 md:flex-row');
 
 export const Content = twel('div', 'prose');
-export const ScreenHeading = twel('div', 'text-2xl font-mono');
-export const SectionHeading = twel('div', 'text-xl font-mono');
-export const SubsectionHeading = twel('div', 'text-lg font-bold font-mono');
-export const BlockHeading = twel('div', 'text-md font-bold font-mono');
+export const ScreenHeading = twel('div', 'text-2xl font-bold');
+export const SectionHeading = twel('div', 'text-xl font-bold');
+export const SubsectionHeading = twel('div', 'text-lg');
+export const BlockHeading = twel('div', 'text-md font-bold');
 
 export const Hint = twel('div', 'text-sm text-gray-400');
 export const Label = twel('div', 'text-sm font-bold text-gray-700');
@@ -188,7 +188,7 @@ export function TextInput({
   }, []);
 
   return (
-    <label className="flex flex-col gap-1">
+    <label className="flex flex-col gap-2">
       {label ? <Label>{label}</Label> : null}
       <input
         disabled={disabled}

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -1302,7 +1302,7 @@ function Admin({
       </Content>
       <Copyable label="Secret" value={app.admin_token} />
       {isMinRole('collaborator', app.user_app_role) ? (
-        <div>
+        <div className="space-y-2">
           <SectionHeading>Experimental</SectionHeading>
           <SubsectionHeading>Users namespace</SubsectionHeading>
           <Content>
@@ -1421,7 +1421,7 @@ function Admin({
       ) : null}
       {isMinRole('owner', app.user_app_role) ? (
         // mt-auto pushes the danger zone to the bottom of the page
-        <div className="mt-auto space-y-2">
+        <div className="mt-auto space-y-2 pb-4">
           <SectionHeading>Danger zone</SectionHeading>
           <Content>
             These are destructive actions and will irreversibly delete


### PR DESCRIPTION
I noticed a few spacing issues on the admin page. 
- Labels and inputs felt too tight. Changed gap-1 to gap-2 
- The subheading font size felt bigger than the heading. The monospace also felt jarring. Changed them to be sans, and same sizes. 
- There was not bottom padding in danger zone. Added it. 

**Before** 
<img width="1726" alt="CleanShot 2024-10-02 at 16 21 18@2x" src="https://github.com/user-attachments/assets/d126b42e-8b92-4206-9a48-7a60e4c071b0">

**After**

<img width="1728" alt="CleanShot 2024-10-02 at 16 21 33@2x" src="https://github.com/user-attachments/assets/80bae7e8-3ce8-4bcc-9d58-92f7d5fa8829">

@nezaj @dwwoelfel @markyfyi