### PR TITLE
Fix over-eager queryOnce case

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -24,7 +24,7 @@ const STATUS = {
   ERRORED: "errored",
 };
 
-const QUERY_ONCE_TIMEOUT = 5000;
+const QUERY_ONCE_TIMEOUT = 10_000;
 
 const WS_OPEN_STATUS = 1;
 
@@ -969,6 +969,13 @@ export default class Reactor {
     safeSubs.forEach(({ eventId, q }) => {
       this._trySendAuthed(eventId, { op: "add-query", q });
     });
+
+    Object.values(this.queryOnceDfds)
+      .flat()
+      .forEach(({ eventId, q }) => {
+        this._trySendAuthed(eventId, { op: "add-query", q });
+      });
+
     const muts = this._rewriteMutations(
       this.attrs,
       this.pendingMutations.currentValue,

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -16,6 +16,10 @@ const db = init<{
   };
 }>(config);
 
+db.queryOnce({
+  onceTest: {},
+}).then((r) => console.log("onceTest on init", r));
+
 function _subsCount() {
   return Object.values(db._core._reactor.queryOnceDfds).flat().length;
 }
@@ -88,16 +92,6 @@ const TodoForm: React.FC<FormProps> = ({ addOnce }) => {
 };
 
 function Main() {
-  useEffect(() => {
-    (async () => {
-      const r = await db.queryOnce({
-        onceTest: {},
-      });
-
-      console.log("onceTest on init", r);
-    })();
-  }, []);
-
   const { isLoading, error, data } = db.useQuery({
     onceTest: {},
   });


### PR DESCRIPTION
@stopachka pointed out that `queryOnce` calls that fired before `init-ok` were timing out.  This is because we silently failed sending them over WebSocket (due to the connection not being in an authenticated state) and never tried again once a connection was established.  This change enhances `_flushPendingMessages` to send events for every pending `queryOnce` like we do with subs.