### PR TITLE
fix: breaking typos in tutorials

### DIFF
--- a/client/www/data/tutorial-snippets/todos-update-delete-instant.tsx
+++ b/client/www/data/tutorial-snippets/todos-update-delete-instant.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 function deleteMessage(setMessages, messageId: string) {
-  db.transact(tx.message[messageId].delete());
+  db.transact(tx.messages[messageId].delete());
 }
 
 function updateMessage(messageId: string, newText: string) {

--- a/client/www/pages/tutorial-examples/2-todos-edit.tsx
+++ b/client/www/pages/tutorial-examples/2-todos-edit.tsx
@@ -22,7 +22,7 @@ function addMessage(text: string) {
 }
 
 function deleteMessage(messageId: string) {
-  db.transact(tx.message[messageId].delete());
+  db.transact(tx.messages[messageId].delete());
 }
 
 function updateMessage(messageId: string, newText: string) {

--- a/client/www/pages/tutorial-examples/3-todos-attributes.tsx
+++ b/client/www/pages/tutorial-examples/3-todos-attributes.tsx
@@ -22,7 +22,7 @@ function addMessage(text: string) {
 }
 
 function deleteMessage(messageId: string) {
-  db.transact(tx.message[messageId].delete());
+  db.transact(tx.messages[messageId].delete());
 }
 
 function updateMessage(messageId: string, newText: string) {


### PR DESCRIPTION
Just noticed tutorial's delete cases are broken because of typo `tx.message` instead of `tx.messages`

reproduction video and details: https://discord.com/channels/1031957483243188235/1148284450992574535/1291236006921637930