### PR TITLE
Auth users ref

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Get changed files
       id: changed-files
       run: |
-        if ${{ github.event_name == 'pull_request' }}; then
+        if ${{ github.event_name == 'pull_request' || github.event.before == '0000000000000000000000000000000000000000' }}; then
             echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
         else
             echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT

--- a/server/README.md
+++ b/server/README.md
@@ -61,5 +61,4 @@ If you want to make any changes to your configuration, update the `resources/con
 
 # Questions?
 
-
 If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/server/README.md
+++ b/server/README.md
@@ -61,4 +61,5 @@ If you want to make any changes to your configuration, update the `resources/con
 
 # Questions?
 
+
 If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/server/src/instant/dash/ephemeral_app.clj
+++ b/server/src/instant/dash/ephemeral_app.clj
@@ -2,6 +2,7 @@
   (:require
    [chime.core :as chime-core]
    [instant.config :as config]
+   [instant.db.model.attr :as attr-model]
    [instant.model.app :as app-model]
    [instant.model.instant-user :as instant-user-model]
    [instant.model.rule :as rule-model]
@@ -48,7 +49,9 @@
   (let [title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         rules-code (get-in req [:body :rules :code])
         _ (when rules-code
-            (ex/assert-valid! :rule rules-code (rule-model/validation-errors rules-code)))
+            (ex/assert-valid! :rule rules-code (rule-model/validation-errors
+                                                (attr-model/wrap-attrs [])
+                                                rules-code)))
         app (create! {:title title})]
     (when rules-code
       (rule-model/put! {:app-id (:id app)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -357,8 +357,9 @@
 
 (defn rules-post [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
-        code (ex/get-param! req [:body :code] w/stringify-keys)]
-    (ex/assert-valid! :rule code (rule-model/validation-errors code))
+        code (ex/get-param! req [:body :code] w/stringify-keys)
+        attrs (attr-model/get-by-app-id aurora/conn-pool app-id)]
+    (ex/assert-valid! :rule code (rule-model/validation-errors attrs code))
     (response/ok {:rules (rule-model/put! {:app-id app-id
                                            :code code})})))
 

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -339,9 +339,16 @@
 ;; but this will do for now.
 (defn collect-ref-uses
   "Returns a set of `path-str` used in `data.ref` calls in the given cel ast,
-   grouped by the object, e.g. {\"data\": #{\"a.b\"}, \"auth\" #{\"c.d\"}}."
+   grouped by the object, e.g. {\"data\": #{\"a.b\"}, \"auth\" #{\"c.d\"}}.
+   Automatically strips `$user` from auth path-str"
   [^CelAbstractSyntaxTree ast]
-  (expr->ref-uses (.getExpr ast)))
+  (-> (expr->ref-uses (.getExpr ast))
+      (update "auth" (fn [x]
+                       (set (map (fn [path-str]
+                                   (clojure-string/replace path-str
+                                                           #"^\$user\."
+                                                           ""))
+                                 x))))))
 
 (defn prefetch-data-refs
   "refs should be a list of:

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -20,6 +20,7 @@
                        CelExpr$CelComprehension
                        CelExpr$ExprKind$Kind
                        Expression$Map$Entry)
+   (dev.cel.common.navigation CelNavigableExpr)
    (dev.cel.common.types CelType ListType MapType SimpleType)
    (dev.cel.compiler CelCompiler CelCompilerFactory CelCompilerLibrary)
    (dev.cel.extensions CelExtensions)
@@ -157,7 +158,7 @@
   ;; behavior -- we'd rather just return null when a key is
   ;; accessed.  To get this behavior, we override `containsKey`, so
   ;; we always return true when checking for key presence.
-  (containsKey [_ k]
+  (containsKey [_ _k]
     true)
 
   (entrySet [_]
@@ -208,7 +209,7 @@
                String
                impl))})
 
-(def custom-fns [ref-fn auth-ref-fn])
+(def custom-fns [ref-fn])
 (def custom-fn-decls (mapv :decl custom-fns))
 (def custom-fn-bindings (mapv :runtime custom-fns))
 
@@ -391,9 +392,9 @@
                  patterns
                  results))))
 
-(defn ^CelAstValidator make-validator [attrs]
+(defn make-validator ^CelAstValidator [attrs]
   (reify CelAstValidator
-    (validate [_this ast cel issues-factory]
+    (validate [_this ast _cel issues-factory]
       (doseq [^CelNavigableExpr node (-> ast
                                          (.getRoot)
                                          (.allNodes)

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -316,25 +316,25 @@
    `path-str`s for each object."
   [^CelExpr expr]
   (condp = (.getKind expr)
-    CelExpr$ExprKind$Kind/NOT_SET {}
-    CelExpr$ExprKind$Kind/CONSTANT {}
+    CelExpr$ExprKind$Kind/NOT_SET #{}
+    CelExpr$ExprKind$Kind/CONSTANT #{}
     ;; An identifier expression. e.g. `request`.
-    CelExpr$ExprKind$Kind/IDENT {}
+    CelExpr$ExprKind$Kind/IDENT #{}
     ;; A field selection expression. e.g. `request.auth`.
-    CelExpr$ExprKind$Kind/SELECT {}
+    CelExpr$ExprKind$Kind/SELECT #{}
     CelExpr$ExprKind$Kind/LIST (reduce (fn [acc item]
                                          (into acc (expr->ref-uses item)))
-                                       {}
+                                       #{}
                                        (.elements (.list expr)))
     ;; Not sure how to make one of these, will ignore for now
     CelExpr$ExprKind$Kind/STRUCT (tracer/with-span! {:name "cel/unknown-struct"
                                                      :attributes {:expr expr}}
-                                   {})
+                                   #{})
     CelExpr$ExprKind$Kind/MAP (reduce (fn [acc ^Expression$Map$Entry entry]
                                         (-> acc
                                             (into (expr->ref-uses (.key entry)))
                                             (into (expr->ref-uses (.value entry)))))
-                                      {}
+                                      #{}
                                       (.entries (.map expr)))
     ;; https://github.com/google/cel-java/blob/10bb524bddc7c32a55101f6b4967eb52cd14fb18/common/src/main/java/dev/cel/common/ast/CelExpr.java#L925
     CelExpr$ExprKind$Kind/COMPREHENSION (compression->ref-uses (.comprehension expr))

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1509,10 +1509,10 @@
   [user-id eid->etype etype->program]
   (let [etype->eid (ucoll/map-invert-key-set eid->etype)]
     (reduce (fn [acc [etype program]]
-              (if-let [refs (-> program
-                                :cel-ast
-                                cel/collect-ref-uses
-                                seq)]
+              (if-let [refs (some-> program
+                                    :cel-ast
+                                    cel/collect-ref-uses
+                                    seq)]
                 (reduce (fn [acc {:keys [obj path]}]
                           (case obj
                             "data" (conj acc {:etype etype

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -10,7 +10,7 @@
             [clojure.string :as string]
             [instant.jdbc.aurora :as aurora]
             [instant.db.model.attr-pat :as attr-pat]
-            [instant.util.json :refer [->json <-json]]
+            [instant.util.json :refer [->json]]
             [instant.data.resolvers :as resolvers]
             [instant.util.tracer :as tracer]
             [instant.util.coll :as ucoll]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1520,7 +1520,9 @@
                                               :eids (get etype->eid etype)})
                             "auth" (conj acc {:etype "$users"
                                               :path-str path
-                                              :eids #{user-id}})
+                                              :eids (if user-id
+                                                      #{user-id}
+                                                      #{})})
 
                             acc))
                         acc

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -120,13 +120,13 @@
                                       :ctx ctx
                                       :etype "$users"}
                                      current-user)
-                      "newData"
-                      (cel/->cel-map {} new-data)
                       "data"
                       (cel/->cel-map {:ctx ctx
                                       :etype etype
                                       :type :data}
-                                     new-data)})))}))
+                                     original)
+                      "newData"
+                      (cel/->cel-map {} new-data)})))}))
 
 (defn object-delete-check [{:keys [rules current-user] :as ctx} etype eid triples]
   (let [original (entity-model/triples->map ctx triples)
@@ -471,10 +471,10 @@
                              (update acc
                                      ["$users" path]
                                      (fn [ref]
-                                       (-> (or ref {:etype "$users"
-                                                    :path-str path
-                                                    :eids #{}})
-                                           (update :eids conj user-id))))
+                                       (cond-> (or ref {:etype "$users"
+                                                        :path-str path
+                                                        :eids #{}})
+                                         user-id (update :eids conj user-id))))
 
                              acc))
                          acc

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -11,7 +11,6 @@
    [instant.model.rule :as rule-model]
    [instant.util.exception :as ex]
    [instant.util.io :as io]
-   [instant.util.json :refer [->json <-json]]
    [instant.util.string :as string-util]
    [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util]

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -2,6 +2,7 @@
   (:require [compojure.core :refer [defroutes POST GET DELETE] :as compojure]
             [ring.util.http-response :as response]
             [clojure.string :as string]
+            [instant.db.model.attr :as attr-model]
             [instant.util.uuid :as uuid-util]
             [instant.model.app :as app-model]
             [instant.model.instant-user :as instant-user-model]
@@ -120,8 +121,9 @@
 
 (defn app-rules-post [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
-        code (ex/get-param! req [:body :code] w/stringify-keys)]
-    (ex/assert-valid! :rule code (rule-model/validation-errors code))
+        code (ex/get-param! req [:body :code] w/stringify-keys)
+        attrs (attr-model/get-by-app-id aurora/conn-pool app-id)]
+    (ex/assert-valid! :rule code (rule-model/validation-errors attrs code))
     (response/ok {:rules (rule-model/put! {:app-id app-id
                                            :code code})})))
 

--- a/server/src/instant/util/date.clj
+++ b/server/src/instant/util/date.clj
@@ -1,13 +1,12 @@
 (ns instant.util.date
   (:import
-   (java.time ZoneId ZonedDateTime LocalDate)
+   (java.time ZoneId ZonedDateTime ZoneRegion LocalDate)
    (java.time.format DateTimeFormatter)
    (java.time.temporal TemporalAdjusters)))
 
-(def est-zone (ZoneId/of "America/New_York"))
+(def ^ZoneRegion est-zone (ZoneId/of "America/New_York"))
 
-(defn est-now
-  []
+(defn est-now ^ZonedDateTime []
   (ZonedDateTime/now est-zone))
 
 (def numeric-date-pattern

--- a/server/src/instant/util/storage.clj
+++ b/server/src/instant/util/storage.clj
@@ -5,7 +5,6 @@
             [instant.model.rule :as rule-model]
             [instant.model.app-user-refresh-token :as app-user-refresh-token-model]
             [instant.db.cel :as cel]
-            [instant.util.json :refer [->json <-json]]
             [instant.storage.s3 :as s3-util]
             [instant.storage.beta :as storage-beta])
 
@@ -55,7 +54,7 @@
                           {"auth" (cel/->cel-map {:type :auth
                                                   :ctx ctx
                                                   :etype "$users"}
-                                                 (<-json (->json current-user)))
+                                                 current-user)
                            "data" (cel/->cel-map {:type :data
                                                   :ctx ctx}
                                                  {"path" filepath})})))))


### PR DESCRIPTION
Adds support for `auth.ref` for querying off of the `$users` namespace in permissions rules.

This will allow for more flexibility in permission rules and make it easier to implement role-based permissions.

If you had a `capabilities` namespace with an `action` attr that linked to `$users`, you would protect the `tasks` ns with something like:

```json
"tasks": {
  "allow": {
    "view": "'view_tasks' in auth.ref('$user.capabilties.action')"
  }
}
```

Also creates a new `CelMap` `deftype` so that we can store metadata like `ctx` and `etype` outside of the data in the map. `->cel-map` takes two arguments, the metadata and the object, then automatically cycles the object through ->json and <-json.


