### PR TITLE
Handle simultaneous add-attr

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -61,5 +61,4 @@ If you want to make any changes to your configuration, update the `resources/con
 
 # Questions?
 
-
 If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/server/README.md
+++ b/server/README.md
@@ -61,4 +61,5 @@ If you want to make any changes to your configuration, update the `resources/con
 
 # Questions?
 
+
 If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -292,9 +292,9 @@
                                                    [:raise_exception_message
                                                     [:||
                                                      "The attribute with id "
-                                                     [:cast [:to_json :EXCLUDED] :text]
+                                                     [:cast :EXCLUDED.id :text]
                                                      " conflicts with an existing attribute with id "
-                                                     [:cast [:to_json :attrs] :text] "."]]
+                                                     [:cast :attrs.id :text] "."]]
                                                    :text]]}
                :returning [:id]}]]
       :union-all

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -230,6 +230,9 @@
                                                       (qualify-col :ident-values col)
                                                       (qualify-col :idents col)])
                                                    ident-table-cols))}]]}]
+               ;; This can still conflict on (app_id, etype, label),
+               ;; but you can only handle a single constraint.
+               ;; MERGE in postgres > 15 may fix this issue
                :on-conflict {:on-constraint :idents_pkey}
                :do-update-set {:etype [:case
                                        (list* :and

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -230,6 +230,25 @@
                                                       (qualify-col :ident-values col)
                                                       (qualify-col :idents col)])
                                                    ident-table-cols))}]]}]
+               :on-conflict {:on-constraint :idents_pkey}
+               :do-update-set {:etype [:case
+                                       (list* :and
+                                              (map (fn [col]
+                                                     [:=
+                                                      (qualify-col :idents col)
+                                                      (qualify-col :EXCLUDED col)])
+                                                   ident-table-cols))
+                                       :EXCLUDED.etype
+                                       ;; raise_exception_message is typed to return
+                                       ;; a boolean, so we cast it to text so that it
+                                       ;; can throw its exception
+                                       :else [:cast
+                                              [:raise_exception_message
+                                               [:||
+                                                "Another attribute for "
+                                                :EXCLUDED.etype  "." :EXCLUDED.label
+                                                " exists with different properties."]]
+                                              :text]]}
                :returning [:id]}]
              [:ident-ids
               {:union-all
@@ -255,6 +274,28 @@
                                                    attr-table-cols))}]]
                  :join [:ident-ids
                         [:= :attr-values.forward-ident :ident-ids.id]]}]
+               :on-conflict {:on-constraint :attrs_pkey}
+               :do-update-set {:value_type [:case
+                                            (list* :and
+                                                   (map (fn [col]
+                                                          ;; Some fields can be null, so we need to
+                                                          ;; use "distinct from" instead of "="
+                                                          [:raw [[:inline (qualify-col :attrs col)]
+                                                                 " is not distinct from "
+                                                                 [:inline (qualify-col :EXCLUDED col)]]])
+                                                        attr-table-cols))
+                                            :EXCLUDED.value_type
+                                            ;; raise_exception_message is typed to return
+                                            ;; a boolean, so we cast it to text so that it
+                                            ;; can throw its exception
+                                            :else [:cast
+                                                   [:raise_exception_message
+                                                    [:||
+                                                     "The attribute with id "
+                                                     [:cast [:to_json :EXCLUDED] :text]
+                                                     " conflicts with an existing attribute with id "
+                                                     [:cast [:to_json :attrs] :text] "."]]
+                                                   :text]]}
                :returning [:id]}]]
       :union-all
       [{:select :id :from :ident-inserts}


### PR DESCRIPTION
Handles simultaneous add-attr transactions that create the same attributes.

If we have multiple database transactions that are adding the same attrs, one of the transactions can fail with "Record not unique ident".

With this change, we'll do an upsert on the `id` and only throw if one of the fields on the ident or attr is different.