### PR TITLE
Fix $users invalidation

### DIFF
--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -285,12 +285,12 @@
                   [($users-triple-change-for-attr app_id
                                                   id
                                                   created-at-ms
-                                                  id-attr-id
+                                                  (str id-attr-id)
                                                   id)
                    ($users-triple-change-for-attr app_id
                                                   id
                                                   created-at-ms
-                                                  email-attr-id
+                                                  (str email-attr-id)
                                                   email)]))))
           (filter (fn [c]
                     (and (= (:table c) "app_users")


### PR DESCRIPTION
We were passing attr ids as uuids, which caused the invalidator to fail when it tried to call `UUID/fromString` on them.