### PR TITLE
[CLI] Add .env file if it doesn't exist

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -276,6 +276,26 @@ async function pullSchema(appIdOrName) {
 
   if (!pullRes.ok) return;
 
+  const hasEnvFile = await pathExists(join(pkgDir, ".env"));
+  if (!hasEnvFile) {
+    const ok = await promptOk(
+      "No .env file detected, would you like to create one so you can push updates to schema and perms?",
+    );
+
+    if (ok) {
+      await writeFile(
+        join(pkgDir, ".env"),
+        `INSTANT_APP_ID=${appId}`,
+        "utf-8",
+      );
+      console.log(
+        `Created .env file with INSTANT_APP_ID=${appId} in ${pkgDir}`,
+      );
+    } else {
+      console.log("No .env file created. If you plan to push updates, please create one.");
+    }
+  }
+
   if (
     !countEntities(pullRes.data.schema.refs) &&
     !countEntities(pullRes.data.schema.blobs)


### PR DESCRIPTION
I notice when starting a new project it may be easy to `npx instant-cli pull <APP_ID>`, edit some schema, and then be surprised that `npx instant-cli push` doesn't work, This is because you also need to create a `.env` file for `push` to know the app id, which I kind of expected the cli would handle for me if I already pulled earlier.

Figured we can just prompt the user if they want to create a `.env` file