### PR TITLE
Fix roomId

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -454,9 +454,9 @@ export default class Reactor {
         const joinedRoom = this._rooms[loadingRoomId];
 
         if (!joinedRoom) {
-          if (this._roomsPendingLeave[roomId]) {
+          if (this._roomsPendingLeave[loadingRoomId]) {
             this._tryLeaveRoom(loadingRoomId);
-            delete this._roomsPendingLeave[roomId];
+            delete this._roomsPendingLeave[loadingRoomId];
           }
 
           break;


### PR DESCRIPTION
I think this was just a copy/paste typo because `roomId` isn't defined at this part of the file. I think the reason we didn't see an error is because of the weird way switches bleed into eachother in js.