### PR TITLE
Make cursors work with touch on mobile

### DIFF
--- a/client/packages/react/src/Cursors.tsx
+++ b/client/packages/react/src/Cursors.tsx
@@ -45,14 +45,9 @@ export function Cursors<
 
   const fullPresence = room._core._reactor.getPresence(room.type, room.id);
 
-  function onMouseMove(e: MouseEvent) {
-    if (!propagate) {
-      e.stopPropagation();
-    }
-
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX;
-    const y = e.clientY;
+  function publishCursor(rect: DOMRect, touch: MouseEvent | Touch) {
+    const x = touch.clientX;
+    const y = touch.clientY;
     const xPercent = ((x - rect.left) / rect.width) * 100;
     const yPercent = ((y - rect.top) / rect.height) * 100;
     cursorsPresence.publishPresence({
@@ -66,7 +61,38 @@ export function Cursors<
     } as RoomSchema[RoomType]["presence"]);
   }
 
+  function onMouseMove(e: MouseEvent) {
+    if (!propagate) {
+      e.stopPropagation();
+    }
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    publishCursor(rect, e);
+  }
+
   function onMouseOut(e: MouseEvent) {
+    cursorsPresence.publishPresence({
+      [spaceId]: undefined,
+    } as RoomSchema[RoomType]["presence"]);
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (e.touches.length !== 1) {
+      return;
+    }
+
+    const touch = e.touches[0];
+
+    if (touch.target instanceof Element) {
+      if (!propagate) {
+        e.stopPropagation();
+      }
+      const rect = touch.target.getBoundingClientRect();
+      publishCursor(rect, touch);
+    }
+  }
+
+  function onTouchEnd(e: TouchEvent) {
     cursorsPresence.publishPresence({
       [spaceId]: undefined,
     } as RoomSchema[RoomType]["presence"]);
@@ -77,6 +103,8 @@ export function Cursors<
     {
       onMouseMove,
       onMouseOut,
+      onTouchMove,
+      onTouchEnd,
       className,
       style: {
         position: "relative",

--- a/client/packages/react/src/Cursors.tsx
+++ b/client/packages/react/src/Cursors.tsx
@@ -2,6 +2,7 @@ import {
   createElement,
   type ReactNode,
   type MouseEvent,
+  type TouchEvent,
   type CSSProperties,
 } from "react";
 import type { InstantReactRoom } from "./InstantReact";
@@ -45,7 +46,10 @@ export function Cursors<
 
   const fullPresence = room._core._reactor.getPresence(room.type, room.id);
 
-  function publishCursor(rect: DOMRect, touch: MouseEvent | Touch) {
+  function publishCursor(
+    rect: DOMRect,
+    touch: { clientX: number; clientY: number },
+  ) {
     const x = touch.clientX;
     const y = touch.clientY;
     const xPercent = ((x - rect.left) / rect.width) * 100;

--- a/client/www/pages/examples.tsx
+++ b/client/www/pages/examples.tsx
@@ -113,7 +113,7 @@ function Main({ files }: { files: File[] }) {
         undefined,
         {
           shallow: true,
-        }
+        },
       );
     }
   }
@@ -219,7 +219,7 @@ function Main({ files }: { files: File[] }) {
             </div>
           </div>
 
-          {files.map((file) => {
+          {files.map((file, i) => {
             return (
               <Example
                 key={file.pathName}
@@ -232,6 +232,7 @@ function Main({ files }: { files: File[] }) {
 
                   setSelectedExample(file.pathName);
                 }}
+                lazy={i > 0}
               />
             );
           })}
@@ -246,10 +247,12 @@ function Example({
   file,
   appId,
   onViewChange,
+  lazy,
 }: {
   file: File;
   appId: string | undefined;
   onViewChange: (inView: boolean) => void;
+  lazy: boolean;
 }) {
   const [numViews, setNumViews] = useState(2);
 
@@ -323,6 +326,7 @@ function Example({
                     <iframe
                       className="flex-1"
                       src={'/examples/' + file.pathName + '?__appId=' + appId}
+                      loading={lazy ? 'lazy' : undefined}
                     />
                   ) : (
                     <div className="flex-1 animate-slow-pulse bg-gray-300"></div>

--- a/client/www/pages/examples/3-cursors.tsx
+++ b/client/www/pages/examples/3-cursors.tsx
@@ -28,4 +28,4 @@ export default function InstantCursors() {
 const randomDarkColor = '#' + [0, 0, 0].map(() => Math.floor(Math.random() * 200).toString(16).padStart(2, '0')).join('');
 
 const cursorsClassNames =
-  'flex h-screen w-screen items-center justify-center overflow-hidden font-mono text-sm text-gray-800';
+  'flex h-screen w-screen items-center justify-center overflow-hidden font-mono text-sm text-gray-800 touch-none';


### PR DESCRIPTION
Adds ontouch handlers to `<Cursors>` so that they work on mobile.

When people look at the examples page on their phones, the cursors examples don't do anything.

Also tells the browser to load the iframes lazily, which should help shorten the delay for page interactivity. Lighthouse gave the old page a 68 in performance and the new a 75, so there's some evidence it helps.

Try it on your phone: https://instant-www-js-touch-jsv.vercel.app/examples?app=61daa7fa-fc4c-40a6-a9e4-6f1569a9f252#3-cursors