### PR TITLE
[delete-entity] fix automatic deletes on the value side

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -531,7 +531,6 @@
                                  [:= :idents.etype etype]]}]]
                       [:and
                        ;; Delete ref triples where we're the value
-                       [:= :entity-id id-lookup]
                        :vae
                        [:= :value-md5 [:md5 [:cast [:to_jsonb id] :text]]]
                        [:in


### PR DESCRIPTION
Cam reported a bug, where he was seeing 'stray' entities in instaql results. 

The root cause was the following:

If you have a `boards` namespace, and a `nodes` namespace. If the link was: `[boardId :boards/nodes nodeId]`. 

When a `node` was deleted, the link was not cleaned up. 

Looking into it, I realized there was a stray conditional. 

Added a test, and removed the stray conditional.

Once landed, will write a quick script to delete stray entities 🫡

@dwwoelfel @nezaj 
