### PR TITLE
Optimistic attrs for lookups in the link value position

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -115,6 +115,286 @@ test("lookup creates unique attrs for custom lookups", () => {
   }
 });
 
+test("lookup creates unique attrs for lookups in link values", () => {
+  const uid = uuid();
+  const ops = instatx.tx.users[uid]
+    .update({})
+    .link({ posts: instatx.lookup("slug", "life-is-good") });
+
+  const result = instaml.transform({}, ops);
+
+  expect(result).toEqual([
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "posts"],
+        "reverse-identity": [expect.any(String), "posts", "users"],
+        "value-type": "ref",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "posts", "slug"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "life-is-good"],
+    ],
+  ]);
+});
+
+test("lookup creates unique attrs for lookups in link values with arrays", () => {
+  const uid = uuid();
+  const ops = instatx.tx.users[uid].update({}).link({
+    posts: [
+      instatx.lookup("slug", "life-is-good"),
+      instatx.lookup("slug", "check-this-out"),
+    ],
+  });
+
+  const result = instaml.transform({}, ops);
+
+  const expected = [
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "posts"],
+        "reverse-identity": [expect.any(String), "posts", "users"],
+        "value-type": "ref",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "posts", "slug"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "life-is-good"],
+    ],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "check-this-out"],
+    ],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("lookup creates unique attrs for lookups in link values when fwd-ident exists", () => {
+  const uid = uuid();
+  const ops = instatx.tx.users[uid]
+    .update({})
+    .link({ posts: instatx.lookup("slug", "life-is-good") });
+
+  const attrId = uuid();
+  const existingRefAttr = {
+    id: attrId,
+    "forward-identity": [uuid(), "users", "posts"],
+    "reverse-identity": [uuid(), "posts", "users"],
+    "value-type": "ref",
+    cardinality: "one",
+    "unique?": true,
+    "index?": true,
+  };
+
+  const result = instaml.transform({ attrId: existingRefAttr }, ops);
+
+  expect(result).toEqual([
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "posts", "slug"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "life-is-good"],
+    ],
+  ]);
+});
+
+test("lookup creates unique attrs for lookups in link values when rev-ident exists", () => {
+  const uid = uuid();
+  const ops = instatx.tx.users[uid]
+    .update({})
+    .link({ posts: instatx.lookup("slug", "life-is-good") });
+
+  const attrId = uuid();
+  const existingRefAttr = {
+    id: attrId,
+    "forward-identity": [uuid(), "posts", "users"],
+    "reverse-identity": [uuid(), "users", "posts"],
+    "value-type": "ref",
+    cardinality: "one",
+    "unique?": true,
+    "index?": true,
+  };
+
+  const result = instaml.transform({ attrId: existingRefAttr }, ops);
+
+  expect(result).toEqual([
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "posts", "slug"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    [
+      "add-triple",
+      [expect.any(String), "life-is-good"],
+      expect.any(String),
+      uid,
+    ],
+  ]);
+});
+
+test("lookup doesn't override attrs for lookups in link values", () => {
+  const uid = uuid();
+  const ops = instatx.tx.users[uid]
+    .update({})
+    .link({ posts: instatx.lookup("slug", "life-is-good") });
+
+  const refAttrId = uuid();
+  const userIdAttrId = uuid();
+  const postsSlugAttrId = uuid();
+
+  const attrs = {
+    [refAttrId]: {
+      id: refAttrId,
+      "forward-identity": [uuid(), "users", "posts"],
+      "reverse-identity": [uuid(), "posts", "users"],
+      "value-type": "ref",
+      cardinality: "one",
+      "unique?": true,
+      "index?": true,
+    },
+    [userIdAttrId]: {
+      id: userIdAttrId,
+      "forward-identity": [uuid(), "users", "id"],
+      "value-type": "blob",
+      cardinality: "one",
+      "unique?": true,
+      "index?": false,
+    },
+    [postsSlugAttrId]: {
+      id: postsSlugAttrId,
+      "forward-identity": [uuid(), "posts", "slug"],
+      "value-type": "blob",
+      cardinality: "one",
+      "unique?": true,
+      "index?": true,
+    },
+  };
+
+  const result = instaml.transform(attrs, ops);
+
+  expect(result).toEqual([
+    ["add-triple", uid, userIdAttrId, uid],
+    ["add-triple", uid, refAttrId, [postsSlugAttrId, "life-is-good"]],
+  ]);
+});
+
 test("lookup creates unique ref attrs for ref lookup", () => {
   const uid = uuid();
   const ops = [
@@ -137,7 +417,7 @@ test("lookup creates unique ref attrs for ref lookup", () => {
         "forward-identity": [expect.any(String), "users", "id"],
         "value-type": "blob",
         cardinality: "one",
-        "unique?": false,
+        "unique?": true,
         "index?": false,
         isUnsynced: true,
       },
@@ -149,7 +429,7 @@ test("lookup creates unique ref attrs for ref lookup", () => {
         "forward-identity": [expect.any(String), "user_prefs", "id"],
         "value-type": "blob",
         cardinality: "one",
-        "unique?": false,
+        "unique?": true,
         "index?": false,
         isUnsynced: true,
       },
@@ -169,6 +449,58 @@ test("lookup creates unique ref attrs for ref lookup", () => {
     ],
     ["add-triple", uid, expect.any(String), uid],
     ["add-triple", lookup, expect.any(String), lookup],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("lookup creates unique ref attrs for ref lookup in link value", () => {
+  const uid = uuid();
+  const ops = [
+    instatx.tx.users[uid]
+      .update({})
+      .link({ user_prefs: instatx.lookup("users.id", uid) }),
+  ];
+
+  const lookup = [
+    // The attr is going to be created, so we don't know its value yet
+    expect.any(String),
+    uid,
+  ];
+
+  const result = instaml.transform({}, ops);
+
+  const expected = [
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "user_prefs"],
+        "reverse-identity": [expect.any(String), "user_prefs", "users"],
+        "value-type": "ref",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    ["add-triple", uid, expect.any(String), lookup],
   ];
 
   expect(result).toHaveLength(expected.length);
@@ -207,7 +539,7 @@ test("it doesn't throw if you have a period in your attr", () => {
       id: iid,
       cardinality: "one",
       "forward-identity": [uuid(), "users", "id"],
-      "index?": false,
+      "index?": true,
       "unique?": false,
       "value-type": "blob",
     },
@@ -253,7 +585,7 @@ test("it doesn't create duplicate ref attrs", () => {
         id: expect.any(String),
         "index?": false,
         isUnsynced: true,
-        "unique?": false,
+        "unique?": true,
         "value-type": "blob",
       },
     ],
@@ -265,7 +597,7 @@ test("it doesn't create duplicate ref attrs", () => {
         id: expect.any(String),
         "index?": false,
         isUnsynced: true,
-        "unique?": false,
+        "unique?": true,
         "value-type": "blob",
       },
     ],

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -307,23 +307,6 @@ function lookupPairsOfOp(attrs, op) {
   return res;
 }
 
-function getLinkEtype(etype, attrCandidates) {
-  for (const attr of attrCandidates) {
-    if (
-      attr["forward-identity"]?.[1] === etype &&
-      attr["reverse-identity"]?.[1]
-    ) {
-      return attr["reverse-identity"][1];
-    }
-    if (
-      attr["reverse-identity"]?.[1] === etype &&
-      attr["forward-identity"]?.[1]
-    ) {
-      return attr["forward-identity"][1];
-    }
-  }
-}
-
 function createMissingAttrs(existingAttrs, ops) {
   const [addedIds, attrs, addOps] = [new Set(), { ...existingAttrs }, []];
   function addAttr(attr) {
@@ -358,7 +341,11 @@ function createMissingAttrs(existingAttrs, ops) {
       // We got a link eid that's a lookup, linkLabel is the label of the ident,
       // e.g. `posts` in `link({posts: postIds})`
       if (linkLabel) {
+        // Add our ref attr, e.g. users.posts
         addForRef(etype, linkLabel);
+
+        // Figure out the link etype so we can make sure we have the attrs
+        // for the link lookup
         const fwdAttr = getAttrByFwdIdentName(attrs, etype, linkLabel);
         const revAttr = getAttrByReverseIdentName(attrs, etype, linkLabel);
         addUnsynced(fwdAttr);

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -278,7 +278,7 @@ const SUPPORTS_LOOKUP_ACTIONS = new Set([
 const lookupProps = { "unique?": true, "index?": true };
 const refLookupProps = { ...lookupProps, cardinality: "one" };
 
-function lookupPairsOfOp(attrs, op) {
+function lookupPairsOfOp(op) {
   const res = [];
   const [action, etype, eid, obj] = op;
   if (!SUPPORTS_LOOKUP_ACTIONS.has(action)) {
@@ -336,7 +336,7 @@ function createMissingAttrs(existingAttrs, ops) {
   // Do these first because otherwise we might add a non-unique attr
   // before we get to it
   for (const op of ops) {
-    for (const { etype, lookupPair, linkLabel } of lookupPairsOfOp(attrs, op)) {
+    for (const { etype, lookupPair, linkLabel } of lookupPairsOfOp(op)) {
       const identName = lookupPair[0];
       // We got a link eid that's a lookup, linkLabel is the label of the ident,
       // e.g. `posts` in `link({posts: postIds})`

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -87,7 +87,9 @@ function lookupIdentToAttr(attrs, etype, identName) {
 
   const fwdName = extractRefLookupFwdName(identName);
 
-  const refAttr = getAttrByFwdIdentName(attrs, etype, fwdName);
+  const refAttr =
+    getAttrByFwdIdentName(attrs, etype, fwdName) ||
+    getAttrByReverseIdentName(attrs, etype, fwdName);
   if (refAttr && refAttr["value-type"] !== "ref") {
     throw new Error(`${identName} does not reference a valid link attribute.`);
   }
@@ -276,6 +278,52 @@ const SUPPORTS_LOOKUP_ACTIONS = new Set([
 const lookupProps = { "unique?": true, "index?": true };
 const refLookupProps = { ...lookupProps, cardinality: "one" };
 
+function lookupPairsOfOp(attrs, op) {
+  const res = [];
+  const [action, etype, eid, obj] = op;
+  if (!SUPPORTS_LOOKUP_ACTIONS.has(action)) {
+    return res;
+  }
+
+  const eidLookupPair = lookupPairOfEid(eid);
+  if (eidLookupPair) {
+    res.push({ etype: etype, lookupPair: eidLookupPair });
+  }
+  if (action === "link") {
+    for (const [label, eidOrEids] of Object.entries(obj)) {
+      const eids = Array.isArray(eidOrEids) ? eidOrEids : [eidOrEids];
+      for (const linkEid of eids) {
+        const linkEidLookupPair = lookupPairOfEid(linkEid);
+        if (linkEidLookupPair) {
+          res.push({
+            etype: etype,
+            lookupPair: linkEidLookupPair,
+            linkLabel: label,
+          });
+        }
+      }
+    }
+  }
+  return res;
+}
+
+function getLinkEtype(etype, attrCandidates) {
+  for (const attr of attrCandidates) {
+    if (
+      attr["forward-identity"]?.[1] === etype &&
+      attr["reverse-identity"]?.[1]
+    ) {
+      return attr["reverse-identity"][1];
+    }
+    if (
+      attr["reverse-identity"]?.[1] === etype &&
+      attr["forward-identity"]?.[1]
+    ) {
+      return attr["forward-identity"][1];
+    }
+  }
+}
+
 function createMissingAttrs(existingAttrs, ops) {
   const [addedIds, attrs, addOps] = [new Set(), { ...existingAttrs }, []];
   function addAttr(attr) {
@@ -290,31 +338,52 @@ function createMissingAttrs(existingAttrs, ops) {
     }
   }
 
+  // Adds attrs needed for a ref lookup
+  function addForRef(etype, label) {
+    const fwdAttr = getAttrByFwdIdentName(attrs, etype, label);
+    const revAttr = getAttrByReverseIdentName(attrs, etype, label);
+    addUnsynced(fwdAttr);
+    addUnsynced(revAttr);
+    if (!fwdAttr && !revAttr) {
+      addAttr(createRefAttr(etype, label, refLookupProps));
+    }
+  }
+
   // Create attrs for lookups if we need to
   // Do these first because otherwise we might add a non-unique attr
   // before we get to it
   for (const op of ops) {
-    const [action, etype, eid, obj] = op;
-    if (SUPPORTS_LOOKUP_ACTIONS.has(action)) {
-      const lookupPair = lookupPairOfEid(eid);
-      if (lookupPair) {
-        const identName = lookupPair[0];
-        if (isRefLookupIdent(attrs, etype, identName)) {
-          const label = extractRefLookupFwdName(identName);
-          const fwdAttr = getAttrByFwdIdentName(attrs, etype, label);
-          const revAttr = getAttrByReverseIdentName(attrs, etype, label);
-          if (!fwdAttr && !revAttr) {
-            addAttr(createRefAttr(etype, label, refLookupProps));
-          }
-          addUnsynced(fwdAttr);
-          addUnsynced(revAttr);
+    for (const { etype, lookupPair, linkLabel } of lookupPairsOfOp(attrs, op)) {
+      const identName = lookupPair[0];
+      // We got a link eid that's a lookup, linkLabel is the label of the ident,
+      // e.g. `posts` in `link({posts: postIds})`
+      if (linkLabel) {
+        addForRef(etype, linkLabel);
+        const fwdAttr = getAttrByFwdIdentName(attrs, etype, linkLabel);
+        const revAttr = getAttrByReverseIdentName(attrs, etype, linkLabel);
+        addUnsynced(fwdAttr);
+        addUnsynced(revAttr);
+        const linkEtype =
+          fwdAttr?.["reverse-identity"]?.[1] ||
+          revAttr?.["forward-identity"]?.[1] ||
+          linkLabel;
+        if (isRefLookupIdent(attrs, linkEtype, identName)) {
+          addForRef(linkEtype, extractRefLookupFwdName(identName));
         } else {
-          const attr = getAttrByFwdIdentName(attrs, etype, identName);
+          const attr = getAttrByFwdIdentName(attrs, linkEtype, identName);
           if (!attr) {
-            addAttr(createObjectAttr(etype, identName, lookupProps));
+            addAttr(createObjectAttr(linkEtype, identName, lookupProps));
           }
           addUnsynced(attr);
         }
+      } else if (isRefLookupIdent(attrs, etype, identName)) {
+        addForRef(etype, extractRefLookupFwdName(identName));
+      } else {
+        const attr = getAttrByFwdIdentName(attrs, etype, identName);
+        if (!attr) {
+          addAttr(createObjectAttr(etype, identName, lookupProps));
+        }
+        addUnsynced(attr);
       }
     }
   }
@@ -330,7 +399,13 @@ function createMissingAttrs(existingAttrs, ops) {
         addUnsynced(fwdAttr);
         if (UPDATE_ACTIONS.has(action)) {
           if (!fwdAttr) {
-            addAttr(createObjectAttr(etype, label));
+            addAttr(
+              createObjectAttr(
+                etype,
+                label,
+                label === "id" ? { "unique?": true } : null,
+              ),
+            );
           }
         }
         if (REF_ACTIONS.has(action)) {

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -282,7 +282,7 @@
                        link-label)]
     (add-attrs-for-lookup acc lookup link-etype)))
 
-(defn op->lookups [attrs [action etype eid obj]]
+(defn op->lookups [[action etype eid obj]]
   (when (contains? supports-lookup-actions action)
     (concat (when-let [lookup-pair (eid->lookup-pair eid)]
               [{:etype etype :lookup-pair lookup-pair}])
@@ -295,15 +295,14 @@
 
 (defn create-lookup-attrs [acc ops]
   (reduce (fn [acc op]
-            (let [[action etype eid _obj] op]
-              (reduce (fn [acc {:keys [etype lookup-pair link-label]}]
-                        (if link-label
-                          (-> acc
-                              (add-attrs-for-ref-lookup link-label etype)
-                              (add-attrs-for-link-lookup lookup-pair link-label etype))
-                          (add-attrs-for-lookup acc lookup-pair etype)))
-                      acc
-                      (op->lookups (:attrs acc) op))))
+            (reduce (fn [acc {:keys [etype lookup-pair link-label]}]
+                      (if link-label
+                        (-> acc
+                            (add-attrs-for-ref-lookup link-label etype)
+                            (add-attrs-for-link-lookup lookup-pair link-label etype))
+                        (add-attrs-for-lookup acc lookup-pair etype)))
+                    acc
+                    (op->lookups op)))
           acc
           ops))
 

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -297,7 +297,6 @@
   (reduce (fn [acc op]
             (let [[action etype eid _obj] op]
               (reduce (fn [acc {:keys [etype lookup-pair link-label]}]
-                        (tool/def-locals)
                         (if link-label
                           (-> acc
                               (add-attrs-for-ref-lookup link-label etype)

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -235,7 +235,10 @@
                                (attr-model/seek-by-rev-ident-name [etype label] attrs))]
                 (cond (and (contains? update-actions action)
                            (not fwd-attr))
-                      (add-attr acc (create-object-attr etype label))
+                      (add-attr acc (create-object-attr etype
+                                                        label
+                                                        (when (= label "id")
+                                                          {:unique? true})))
 
                       (and (contains? ref-actions action)
                            (not fwd-attr)

--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -246,18 +246,21 @@
             acc
             labels)))
 
+(defn add-attrs-for-ref-lookup [{:keys [attrs] :as acc} label etype]
+  (let [fwd-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)
+        rev-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]
+    (if (and (not fwd-attr) (not rev-attr))
+      (add-attr acc (create-ref-attr etype
+                                     label
+                                     {:unique? true
+                                      :index? true
+                                      :cardinality :one}))
+      acc)))
+
 (defn add-attrs-for-lookup [{:keys [attrs] :as acc} lookup etype]
   (if (ref-lookup? attrs etype lookup)
-    (let [label (extract-ref-lookup-fwd-name lookup)
-          fwd-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)
-          rev-attr (attr-model/seek-by-fwd-ident-name [etype label] attrs)]
-      (if (and (not fwd-attr) (not rev-attr))
-        (add-attr acc (create-ref-attr etype
-                                       label
-                                       {:unique? true
-                                        :index? true
-                                        :cardinality :one}))
-        acc))
+    (let [label (extract-ref-lookup-fwd-name lookup)]
+      (add-attrs-for-ref-lookup acc label etype))
     (let [[label _value] lookup]
       (if (attr-model/seek-by-fwd-ident-name [etype label]
                                              attrs)
@@ -267,13 +270,41 @@
                                           {:unique? true
                                            :index? true}))))))
 
+(defn add-attrs-for-link-lookup [{:keys [attrs] :as acc} lookup link-label etype]
+  (let [fwd-attr (attr-model/seek-by-fwd-ident-name [etype link-label] attrs)
+        rev-attr (attr-model/seek-by-fwd-ident-name [etype link-label] attrs)
+        link-etype (or (some-> fwd-attr
+                               :reverse-identity
+                               second)
+                       (some-> rev-attr
+                               :forward-identity
+                               second)
+                       link-label)]
+    (add-attrs-for-lookup acc lookup link-etype)))
+
+(defn op->lookups [attrs [action etype eid obj]]
+  (when (contains? supports-lookup-actions action)
+    (concat (when-let [lookup-pair (eid->lookup-pair eid)]
+              [{:etype etype :lookup-pair lookup-pair}])
+            (when (= "link" action)
+              (for [[label eid-or-eids] obj
+                    eid (if (coll? eid-or-eids) eid-or-eids [eid-or-eids])
+                    :let [lookup-pair (eid->lookup-pair eid)]
+                    :when lookup-pair]
+                {:etype etype :lookup-pair lookup-pair :link-label label})))))
+
 (defn create-lookup-attrs [acc ops]
   (reduce (fn [acc op]
             (let [[action etype eid _obj] op]
-              (if-let [lookup (when (contains? supports-lookup-actions action)
-                                (eid->lookup-pair eid))]
-                (add-attrs-for-lookup acc lookup etype)
-                acc)))
+              (reduce (fn [acc {:keys [etype lookup-pair link-label]}]
+                        (tool/def-locals)
+                        (if link-label
+                          (-> acc
+                              (add-attrs-for-ref-lookup link-label etype)
+                              (add-attrs-for-link-lookup lookup-pair link-label etype))
+                          (add-attrs-for-lookup acc lookup-pair etype)))
+                      acc
+                      (op->lookups (:attrs acc) op))))
           acc
           ops))
 


### PR DESCRIPTION
This handles adding optimistic attrs when a lookup is used in the link position.

If you use a lookup in a link before the attrs are loaded:

```
tx.users[userId].link({posts: lookup('number', 10)})
```

Then the request will fail with an attribute is not unique error.