### PR TITLE
Fix refinery url

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - BEANSTALK_PORT=80
       - PRODUCTION=true
-      - HONEYCOMB_ENDPOINT=http://refinery:8082
+      - HONEYCOMB_ENDPOINT=http://localhost:8082
     env_file:
       - .env
     network_mode: "host"


### PR DESCRIPTION
The switch to host mode made us unable to resolve `refinery` as an endpoint. Switching it to localhost makes it work.