### PR TITLE
Remove view check flag

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -42,19 +42,6 @@
                        (get o "appId")))
                    (get result "storage-whitelist")))
 
-        view-check (when-let [view-check-flag (-> (get result "view-checks")
-                                                  first)]
-                     (let [disabled-apps (-> view-check-flag
-                                             (get "disabled-apps")
-                                             set)
-                           enabled-apps (-> view-check-flag
-                                            (get "enabled-apps")
-                                            set)
-                           default-value (get view-check-flag "default-value" false)]
-                       {:disabled-apps disabled-apps
-                        :enabled-apps enabled-apps
-                        :default-value default-value}))
-
         hazelcast (when-let [hz-flag (-> (get result "hazelcast")
                                          first)]
                     (let [disabled-apps (-> hz-flag
@@ -76,7 +63,6 @@
                                      (get result "promo-emails")))]
     {:emails emails
      :storage-enabled-whitelist storage-enabled-whitelist
-     :view-check view-check
      :hazelcast hazelcast
      :promo-code-emails promo-code-emails}))
 
@@ -102,19 +88,6 @@
 (defn storage-enabled? [app-id]
   (let [app-id (str app-id)]
     (contains? (storage-enabled-whitelist) app-id)))
-
-(defn run-view-checks? [app-id]
-  (if-let [view-check (get-in @query-results [query :result :view-check])]
-    (let [{:keys [disabled-apps enabled-apps default-value]} view-check]
-      (cond (contains? disabled-apps (str app-id))
-            false
-
-            (contains? enabled-apps (str app-id))
-            true
-
-            :else default-value))
-    ;; Default false
-    false))
 
 (defn use-hazelcast? [app-id]
   (if-let [hz-flag (get-in @query-results [query :result :hazelcast])]

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -13,7 +13,6 @@
    [instant.db.model.triple :as triple-model]
    [instant.db.permissioned-transaction :as permissioned-tx]
    [instant.db.transaction :as tx]
-   [instant.flags :as flags]
    [instant.fixtures :refer [with-empty-app with-zeneca-app]]
    [instant.jdbc.aurora :as aurora]
    [instant.model.app :as app-model]
@@ -1936,8 +1935,7 @@
         (app-user-model/create! aurora/conn-pool {:app-id app-id
                                                   :id user-id
                                                   :email "test@example.com"})
-        (with-redefs [flags/run-view-checks? (constantly true)]
-          (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps)))
+        (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
         (is (permissioned-tx/transact! (assoc (make-ctx)
                                               :current-user {:id user-id}) tx-steps))))))
 
@@ -1990,8 +1988,7 @@
                        book-creator-attr-id
                        [(resolvers/->uuid r :$users/email) "test@example.com"]]]]
 
-        (with-redefs [flags/run-view-checks? (constantly true)]
-          (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps)))
+        (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
         (permissioned-tx/transact! (assoc (make-ctx)
                                           :current-user {:id user-id}) tx-steps)
         (is (= (pretty-perm-q


### PR DESCRIPTION
There was an error when we tried to report the status of the view check in the trace. We were running it in admin-mode when it was disabled, so it was returning a map. When I flipped the flag to run it for real, it returned a boolean instead.

I think we can push forward with the view check, as it seems to be working as designed.