### PR TITLE
More hazelcast sync workers

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -426,7 +426,8 @@
   (ua/fut-bg (start-refresh-worker rs/store-conn ephemeral-store-atom room-refresh-ch))
   (dotimes [_ 32]
     (ua/vfut-bg (start-refresh-map-worker rs/store-conn refresh-map-ch)))
-  (ua/fut-bg (start-hz-sync hz-ops-ch)))
+  (dotimes [_ 8]
+    (ua/vfut-bg (start-hz-sync hz-ops-ch))))
 
 (defn stop []
   (a/close! room-refresh-ch)


### PR DESCRIPTION
We have a worker that applies updates to the ephemeral store to hazelcast so that the transition from atom -> hazelcast will be smooth.

It can get backed up and throw `too many puts` errors, so this adds some extra workers.

Temporary until hazelcast is the default.