### PR TITLE
Send wal alerts directly to discord

### DIFF
--- a/server/src/instant/discord.clj
+++ b/server/src/instant/discord.clj
@@ -37,5 +37,25 @@
                   "Content-Type" "application/json"}
         :body (->json {:content message})}))))
 
+;; Instructions for finding a user id and formatting it for a mention:
+;; https://chatgpt.com/share/67081219-2e0c-8007-9fe0-4c0f6bacf26c
+(def mention-constants
+  {:dww "<@235826349607092224>"
+   :nezaj "<@149718000281452545>"
+   :stopa "<@150691007019614218>"
+   :instateam "<@&1031959593066172477>"})
+
+(def send-agent (agent nil))
+
+(defn send-async! [channel-id message]
+  (send-off send-agent (fn [_]
+                         (send! channel-id message))))
+
+(defn send-error-async! [message]
+  (send-async! config/discord-errors-channel-id
+               message))
+
 (comment
-  (send! config/discord-debug-channel-id "test"))
+  (send! config/discord-debug-channel-id "test")
+  (send-async! config/discord-debug-channel-id (format "%s testing user mention"
+                                                       (:dww mention-constants))))

--- a/server/src/instant/stripe.clj
+++ b/server/src/instant/stripe.clj
@@ -24,7 +24,8 @@
 (defn ping-js-on-new-customer [user-id]
   (let [{email :email} (instant-user-model/get-by-id {:id user-id})
         message (str "💖 A user subscribed! Say thank you to " "`" email "`")]
-    (discord/send! config/discord-signups-channel-id message)
+    (discord/send! config/discord-signups-channel-id
+                   (str (:instateam discord/mention-constants)) " " message)
     (postmark/send!
      {:from "Instant Assistant <hello@pm.instantdb.com>"
       :to "founders@instantdb.com"
@@ -44,7 +45,8 @@
 (defn ping-js-on-churned-customer [user-id]
   (let [{email :email} (instant-user-model/get-by-id {:id user-id})
         message (str "🪣  Churned customer! " email)]
-    (discord/send! config/discord-signups-channel-id message)
+    (discord/send! config/discord-signups-channel-id
+                   (str (:instateam discord/mention-constants)) " " message)
     (postmark/send!
      {:from "Instant Assistant <hello@pm.instantdb.com>"
       :to "founders@instantdb.com"

--- a/server/src/instant/stripe.clj
+++ b/server/src/instant/stripe.clj
@@ -25,7 +25,7 @@
   (let [{email :email} (instant-user-model/get-by-id {:id user-id})
         message (str "💖 A user subscribed! Say thank you to " "`" email "`")]
     (discord/send! config/discord-signups-channel-id
-                   (str (:instateam discord/mention-constants)) " " message)
+                   (str (:instateam discord/mention-constants) " " message))
     (postmark/send!
      {:from "Instant Assistant <hello@pm.instantdb.com>"
       :to "founders@instantdb.com"
@@ -46,7 +46,7 @@
   (let [{email :email} (instant-user-model/get-by-id {:id user-id})
         message (str "🪣  Churned customer! " email)]
     (discord/send! config/discord-signups-channel-id
-                   (str (:instateam discord/mention-constants)) " " message)
+                   (str (:instateam discord/mention-constants) " " message))
     (postmark/send!
      {:from "Instant Assistant <hello@pm.instantdb.com>"
       :to "founders@instantdb.com"


### PR DESCRIPTION
Sends wal alerts directly to the errors discord channel and `@` instanteam when we send it.

Adds an `agent` to send the messages in the background.

We now have the ability to do mentions in discord messages, so this also adds an `@instanteam` mention for new paying users and churns.

