### PR TITLE
Lower refinery goal throughput

### DIFF
--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -15,7 +15,7 @@ Samplers:
           - Name: default rule
             Sampler:
               EMAThroughputSampler:
-                # With one server, that's about 80MM/month
-                GoalThroughputPerSec: 30
+                # With one server, that's about 65MM/month
+                GoalThroughputPerSec: 25
                 FieldList:
                   - name


### PR DESCRIPTION
We're just over the threshold at the current 30/second rate, lowering it to 25/second may nudge us under.