### PR TITLE
Wal2json v2

### DIFF
--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -10,7 +10,6 @@
    [instant.reactive.session :as session]
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]
-   [instant.util.coll :as ucoll]
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [<-json ->json]]
    [instant.util.tracer :as tracer])
@@ -256,7 +255,7 @@
    It's a noop if the app hasn't enabled the users table."
   [app-users-changes users-shims]
 
-  (reduce (fn [acc {:keys [action columns]}]
+  (mapcat (fn [{:keys [columns]}]
             (let [{:strs [app_id id email created_at]} (columns->map columns)
                   {:keys [id-attr-id email-attr-id]} (get users-shims app_id)]
               (when (and app_id id email created_at id-attr-id email-attr-id)
@@ -271,7 +270,6 @@
                                                   created-at-ms
                                                   (str email-attr-id)
                                                   email)]))))
-          []
           app-users-changes))
 
 (defn triple-changes-with-app-users [triple-changes app-user-changes users-shims]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -254,7 +254,6 @@
   "Converts any changes to the app-users table into triples changes.
    It's a noop if the app hasn't enabled the users table."
   [app-users-changes users-shims]
-
   (mapcat (fn [{:keys [columns]}]
             (let [{:strs [app_id id email created_at]} (columns->map columns)
                   {:keys [id-attr-id email-attr-id]} (get users-shims app_id)]

--- a/server/test/instant/reactive/invalidator_test.clj
+++ b/server/test/instant/reactive/invalidator_test.clj
@@ -13,251 +13,278 @@
    [instant.util.json :refer [->json]]
    [instant.util.test :refer [wait-for]]))
 
-(def create-triple-changes
-  '({:kind "insert",
-     :schema "public",
-     :table "triples",
-     :columnnames
-     ["app_id"
-      "entity_id"
-      "attr_id"
-      "value"
-      "value_md5"
-      "ea"
-      "eav"
-      "av"
-      "ave"
-      "vae"],
-     :columntypes
-     ["uuid"
-      "uuid"
-      "uuid"
-      "jsonb"
-      "text"
-      "boolean"
-      "boolean"
-      "boolean"
-      "boolean"
-      "boolean"],
-     :columnvalues
-     ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
-      "7c6b379b-d841-46e1-8970-2da7e0cbc490"
-      "a2f7b8b7-5c6f-4b8c-a7aa-2ba400336acb"
-      "\"New Movie\""
-      "01a892b6f33fa54aa3e8056d49b790db"
-      true
-      false
-      false
-      false
-      false]}
-    {:kind "insert",
-     :schema "public",
-     :table "triples",
-     :columnnames
-     ["app_id"
-      "entity_id"
-      "attr_id"
-      "value"
-      "value_md5"
-      "ea"
-      "eav"
-      "av"
-      "ave"
-      "vae"],
-     :columntypes
-     ["uuid"
-      "uuid"
-      "uuid"
-      "jsonb"
-      "text"
-      "boolean"
-      "boolean"
-      "boolean"
-      "boolean"
-      "boolean"],
-     :columnvalues
-     ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
-      "7c6b379b-d841-46e1-8970-2da7e0cbc490"
-      "6a631008-d315-4bbd-8665-c92aed9abc9c"
-      "1987"
-      "d68a18275455ae3eaa2c291eebb46e6d"
-      true
-      false
-      false
-      false
-      false]}))
+(defn transform-change [{:keys [columnnames columntypes columnvalues] :as v1}]
+  (merge (select-keys v1 [:schema :table])
+         {:action (keyword (:kind v1))
+          :columns (map (fn [name type value]
+                          {:name name
+                           :type type
+                           :value value})
+                        columnnames columntypes columnvalues)}
+         (when-let [{:keys [keynames keytypes keyvalues]} (:oldkeys v1)]
+           {:identity (map (fn [name type value]
+                             {:name name
+                              :type type
+                              :value value})
+                           keynames keytypes keyvalues)})))
 
-(def update-triple-changes
-  '({:kind "update",
-     :schema "public",
-     :table "triples",
-     :columnnames
-     ["app_id"
-      "entity_id"
-      "attr_id"
-      "value"
-      "value_md5"
-      "ea"
-      "eav"
-      "av"
-      "ave"
-      "vae"],
-     :columntypes
-     ["uuid"
-      "uuid"
-      "uuid"
-      "jsonb"
-      "text"
-      "boolean"
-      "boolean"
-      "boolean"
-      "boolean"
-      "boolean"],
-     :columnvalues
-     ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
-      "7c6b379b-d841-46e1-8970-2da7e0cbc490"
-      "a2f7b8b7-5c6f-4b8c-a7aa-2ba400336acb"
-      "\"Updated Movie3\""
-      "26833117de9ecb130a208c6da76eb18b"
-      true
-      false
-      false
-      false
-      false],
-     :oldkeys
-     {:keynames ["app_id" "entity_id" "attr_id" "value_md5"],
-      :keytypes ["uuid" "uuid" "uuid" "text"],
-      :keyvalues
+(defn ->wal2jsonv2 [changes]
+  (map transform-change changes))
+
+(def create-triple-changes
+  (->wal2jsonv2
+   '({:kind "insert",
+      :schema "public",
+      :table "triples",
+      :columnnames
+      ["app_id"
+       "entity_id"
+       "attr_id"
+       "value"
+       "value_md5"
+       "ea"
+       "eav"
+       "av"
+       "ave"
+       "vae"],
+      :columntypes
+      ["uuid"
+       "uuid"
+       "uuid"
+       "jsonb"
+       "text"
+       "boolean"
+       "boolean"
+       "boolean"
+       "boolean"
+       "boolean"],
+      :columnvalues
       ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
        "7c6b379b-d841-46e1-8970-2da7e0cbc490"
        "a2f7b8b7-5c6f-4b8c-a7aa-2ba400336acb"
-       "01a892b6f33fa54aa3e8056d49b790db"]}}))
-
-(def delete-triple-changes
-  '({:kind "delete",
-     :schema "public",
-     :table "triples",
-     :oldkeys
-     {:keynames ["app_id" "entity_id" "attr_id" "value_md5"],
-      :keytypes ["uuid" "uuid" "uuid" "text"],
-      :keyvalues
+       "\"New Movie\""
+       "01a892b6f33fa54aa3e8056d49b790db"
+       true
+       false
+       false
+       false
+       false]}
+     {:kind "insert",
+      :schema "public",
+      :table "triples",
+      :columnnames
+      ["app_id"
+       "entity_id"
+       "attr_id"
+       "value"
+       "value_md5"
+       "ea"
+       "eav"
+       "av"
+       "ave"
+       "vae"],
+      :columntypes
+      ["uuid"
+       "uuid"
+       "uuid"
+       "jsonb"
+       "text"
+       "boolean"
+       "boolean"
+       "boolean"
+       "boolean"
+       "boolean"],
+      :columnvalues
       ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
        "7c6b379b-d841-46e1-8970-2da7e0cbc490"
        "6a631008-d315-4bbd-8665-c92aed9abc9c"
-       "d68a18275455ae3eaa2c291eebb46e6d"]}}
-    {:kind "delete",
-     :schema "public",
-     :table "triples",
-     :oldkeys
-     {:keynames ["app_id" "entity_id" "attr_id" "value_md5"],
-      :keytypes ["uuid" "uuid" "uuid" "text"],
-      :keyvalues
+       "1987"
+       "d68a18275455ae3eaa2c291eebb46e6d"
+       true
+       false
+       false
+       false
+       false]})))
+
+(def update-triple-changes
+  (->wal2jsonv2
+   '({:kind "update",
+      :schema "public",
+      :table "triples",
+      :columnnames
+      ["app_id"
+       "entity_id"
+       "attr_id"
+       "value"
+       "value_md5"
+       "ea"
+       "eav"
+       "av"
+       "ave"
+       "vae"],
+      :columntypes
+      ["uuid"
+       "uuid"
+       "uuid"
+       "jsonb"
+       "text"
+       "boolean"
+       "boolean"
+       "boolean"
+       "boolean"
+       "boolean"],
+      :columnvalues
       ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
        "7c6b379b-d841-46e1-8970-2da7e0cbc490"
        "a2f7b8b7-5c6f-4b8c-a7aa-2ba400336acb"
-       "26833117de9ecb130a208c6da76eb18b"]}}))
+       "\"Updated Movie3\""
+       "26833117de9ecb130a208c6da76eb18b"
+       true
+       false
+       false
+       false
+       false],
+      :oldkeys
+      {:keynames ["app_id" "entity_id" "attr_id" "value_md5"],
+       :keytypes ["uuid" "uuid" "uuid" "text"],
+       :keyvalues
+       ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
+        "7c6b379b-d841-46e1-8970-2da7e0cbc490"
+        "a2f7b8b7-5c6f-4b8c-a7aa-2ba400336acb"
+        "01a892b6f33fa54aa3e8056d49b790db"]}})))
+
+(def delete-triple-changes
+  (->wal2jsonv2
+   '({:kind "delete",
+      :schema "public",
+      :table "triples",
+      :oldkeys
+      {:keynames ["app_id" "entity_id" "attr_id" "value_md5"],
+       :keytypes ["uuid" "uuid" "uuid" "text"],
+       :keyvalues
+       ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
+        "7c6b379b-d841-46e1-8970-2da7e0cbc490"
+        "6a631008-d315-4bbd-8665-c92aed9abc9c"
+        "d68a18275455ae3eaa2c291eebb46e6d"]}}
+     {:kind "delete",
+      :schema "public",
+      :table "triples",
+      :oldkeys
+      {:keynames ["app_id" "entity_id" "attr_id" "value_md5"],
+       :keytypes ["uuid" "uuid" "uuid" "text"],
+       :keyvalues
+       ["7e2d83a2-5018-44b2-84d0-0ebf7134da6d"
+        "7c6b379b-d841-46e1-8970-2da7e0cbc490"
+        "a2f7b8b7-5c6f-4b8c-a7aa-2ba400336acb"
+        "26833117de9ecb130a208c6da76eb18b"]}})))
 
 (def create-ident-changes
-  '({:kind "insert",
-     :schema "public",
-     :table "idents",
-     :columnnames ["id" "app_id" "attr_id" "etype" "label"],
-     :columntypes ["uuid" "uuid" "uuid" "text" "text"],
-     :columnvalues
-     ["d3a14b35-7e3c-4a5d-ae45-bacba24bedc4"
-      "935132de-8426-4972-ac65-ff5b4b79c504"
-      "ea72edf9-036a-413b-9c72-2bf92ec137d3"
-      "counters"
-      "id"]}))
+  (->wal2jsonv2
+   '({:kind "insert",
+      :schema "public",
+      :table "idents",
+      :columnnames ["id" "app_id" "attr_id" "etype" "label"],
+      :columntypes ["uuid" "uuid" "uuid" "text" "text"],
+      :columnvalues
+      ["d3a14b35-7e3c-4a5d-ae45-bacba24bedc4"
+       "935132de-8426-4972-ac65-ff5b4b79c504"
+       "ea72edf9-036a-413b-9c72-2bf92ec137d3"
+       "counters"
+       "id"]})))
 
 (def create-attr-changes
-  '({:kind "insert",
-     :schema "public",
-     :table "attrs",
-     :columnnames
-     ["id"
-      "app_id"
-      "value_type"
-      "cardinality"
-      "is_unique"
-      "is_indexed"
-      "forward_ident"
-      "reverse_ident"],
-     :columntypes
-     ["uuid" "uuid" "text" "text" "boolean" "boolean" "uuid" "uuid"],
-     :columnvalues
-     ["ea72edf9-036a-413b-9c72-2bf92ec137d3"
-      "935132de-8426-4972-ac65-ff5b4b79c504"
-      "blob"
-      "one"
-      false
-      false
-      "d3a14b35-7e3c-4a5d-ae45-bacba24bedc4"
-      nil]}))
+  (->wal2jsonv2
+   '({:kind "insert",
+      :schema "public",
+      :table "attrs",
+      :columnnames
+      ["id"
+       "app_id"
+       "value_type"
+       "cardinality"
+       "is_unique"
+       "is_indexed"
+       "forward_ident"
+       "reverse_ident"],
+      :columntypes
+      ["uuid" "uuid" "text" "text" "boolean" "boolean" "uuid" "uuid"],
+      :columnvalues
+      ["ea72edf9-036a-413b-9c72-2bf92ec137d3"
+       "935132de-8426-4972-ac65-ff5b4b79c504"
+       "blob"
+       "one"
+       false
+       false
+       "d3a14b35-7e3c-4a5d-ae45-bacba24bedc4"
+       nil]})))
 
 (def update-attr-changes
-  '({:kind "update",
-     :schema "public",
-     :table "attrs",
-     :columnnames
-     ["id"
-      "app_id"
-      "value_type"
-      "cardinality"
-      "is_unique"
-      "is_indexed"
-      "forward_ident"
-      "reverse_ident"],
-     :columntypes
-     ["uuid" "uuid" "text" "text" "boolean" "boolean" "uuid" "uuid"],
-     :columnvalues
-     ["a684c2ba-27af-4d54-8c02-68832b4566f0"
-      "935132de-8426-4972-ac65-ff5b4b79c504"
-      "blob"
-      "one"
-      false
-      true
-      "2a6cc86d-2814-4dd7-b3b3-3029bdd335af"
-      nil],
-     :oldkeys
-     {:keynames ["id"],
-      :keytypes ["uuid"],
-      :keyvalues ["a684c2ba-27af-4d54-8c02-68832b4566f0"]}}))
+  (->wal2jsonv2
+   '({:kind "update",
+      :schema "public",
+      :table "attrs",
+      :columnnames
+      ["id"
+       "app_id"
+       "value_type"
+       "cardinality"
+       "is_unique"
+       "is_indexed"
+       "forward_ident"
+       "reverse_ident"],
+      :columntypes
+      ["uuid" "uuid" "text" "text" "boolean" "boolean" "uuid" "uuid"],
+      :columnvalues
+      ["a684c2ba-27af-4d54-8c02-68832b4566f0"
+       "935132de-8426-4972-ac65-ff5b4b79c504"
+       "blob"
+       "one"
+       false
+       true
+       "2a6cc86d-2814-4dd7-b3b3-3029bdd335af"
+       nil],
+      :oldkeys
+      {:keynames ["id"],
+       :keytypes ["uuid"],
+       :keyvalues ["a684c2ba-27af-4d54-8c02-68832b4566f0"]}})))
 
 (def update-ident-changes
-  '({:kind "update",
-     :schema "public",
-     :table "idents",
-     :columnnames ["id" "app_id" "attr_id" "etype" "label"],
-     :columntypes ["uuid" "uuid" "uuid" "text" "text"],
-     :columnvalues
-     ["2a6cc86d-2814-4dd7-b3b3-3029bdd335af"
-      "935132de-8426-4972-ac65-ff5b4b79c504"
-      "a684c2ba-27af-4d54-8c02-68832b4566f0"
-      "counters"
-      "floopy"],
-     :oldkeys
-     {:keynames ["id"],
-      :keytypes ["uuid"],
-      :keyvalues ["2a6cc86d-2814-4dd7-b3b3-3029bdd335af"]}}))
+  (->wal2jsonv2
+   '({:kind "update",
+      :schema "public",
+      :table "idents",
+      :columnnames ["id" "app_id" "attr_id" "etype" "label"],
+      :columntypes ["uuid" "uuid" "uuid" "text" "text"],
+      :columnvalues
+      ["2a6cc86d-2814-4dd7-b3b3-3029bdd335af"
+       "935132de-8426-4972-ac65-ff5b4b79c504"
+       "a684c2ba-27af-4d54-8c02-68832b4566f0"
+       "counters"
+       "floopy"],
+      :oldkeys
+      {:keynames ["id"],
+       :keytypes ["uuid"],
+       :keyvalues ["2a6cc86d-2814-4dd7-b3b3-3029bdd335af"]}})))
 
 (def delete-ident-changes
-  '({:kind "delete",
-     :schema "public",
-     :table "idents",
-     :oldkeys
-     {:keynames ["id"],
-      :keytypes ["uuid"],
-      :keyvalues ["3d9fe1e5-f7cc-4c44-a4f2-0088fe28b119"]}}))
+  (->wal2jsonv2
+   '({:kind "delete",
+      :schema "public",
+      :table "idents",
+      :oldkeys
+      {:keynames ["id"],
+       :keytypes ["uuid"],
+       :keyvalues ["3d9fe1e5-f7cc-4c44-a4f2-0088fe28b119"]}})))
 
 (def delete-attr-changes
-  '({:kind "delete",
-     :schema "public",
-     :table "attrs",
-     :oldkeys
-     {:keynames ["id"],
-      :keytypes ["uuid"],
-      :keyvalues ["48c22b06-ecc8-4459-a3b4-3c0b640780b5"]}}))
+  (->wal2jsonv2
+   '({:kind "delete",
+      :schema "public",
+      :table "attrs",
+      :oldkeys
+      {:keynames ["id"],
+       :keytypes ["uuid"],
+       :keyvalues ["48c22b06-ecc8-4459-a3b4-3c0b640780b5"]}})))
 
 (deftest changes-produce-correct-topics
   (testing "insert triples"
@@ -367,8 +394,8 @@
       crypt-util/str->md5
       crypt-util/bytes->hex-string))
 
-(defn xform-change [{:keys [columnnames columnvalues]}]
-  (zipmap columnnames columnvalues))
+(defn xform-change [{:keys [columns]}]
+  (zipmap (map :name columns) (map :value columns)))
 
 (deftest smoke-test
   (with-zeneca-app


### PR DESCRIPTION
Updates the wal listener to use format_version 2 in wal2json. It produces one JSON object per tuple instead of one per transaction.

This should put less strain on the db connection when there is a very large update.

Before when there was a transaction, we would have something that looked like:

```js
{change: [
  {table: "triples",...},
  {table: "triples",...},
  {table: "transactions", ...}]}
```

Now we'll get a stream of changes for one transaction:
```js
{action: "B"}
{action: "U", table: "triples", ...}
{action: "U", table: "triples", ...}
{action: "U", table: "triples", ...}
{action: "C"}
```

Our `produce` function is now stateful and will collect all of the changes between the "B" and the "C" to collect the set of changes for the invalidator.