### PR TITLE
Health page for the wal

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -13,6 +13,7 @@
    [instant.flags :as flags]
    [instant.flags-impl :as flags-impl]
    [instant.gauges :as gauges]
+   [instant.health :as health]
    [instant.honeycomb-api :as honeycomb-api]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
@@ -83,7 +84,8 @@
                admin-routes/routes
                superadmin-routes/routes
                storage-routes/routes
-               generic-webhook-routes)
+               generic-webhook-routes
+               health/routes)
        http-util/tracer-record-attrs
        wrap-keyword-params
        wrap-params

--- a/server/src/instant/health.clj
+++ b/server/src/instant/health.clj
@@ -1,0 +1,46 @@
+(ns instant.health
+  (:require [compojure.core :refer [defroutes GET] :as compojure]
+            [instant.config :as config]
+            [instant.jdbc.aurora :as aurora]
+            [instant.jdbc.sql :as sql]
+            [instant.util.json :refer [->json]]
+            [honey.sql :as hsql]
+            [ring.util.http-response :as response])
+  (:import [java.time Instant]))
+
+(def send-agent (agent nil))
+
+(defn mark-wal-unhealthy []
+  (sql/execute!
+   aurora/conn-pool
+   (hsql/format
+    {:insert-into :config
+     :values [{:k "wal-errors"
+               :v [:cast (->json {@config/process-id (str (Instant/now))}) :json]}]
+     :on-conflict :k
+     :do-update-set {:v [:|| [:cast :config.v :jsonb] [:cast :excluded.v :jsonb]]}})))
+
+(defn mark-wal-healthy []
+  (sql/execute!
+   aurora/conn-pool
+   (hsql/format
+    {:update :config
+     :set {:v [:- [:cast :v :jsonb] [:cast @config/process-id :text]]}
+     :where [:= :k "wal-errors"]})))
+
+(defn mark-wal-unhealthy-async []
+  (send-off send-agent (fn [_]
+                         (mark-wal-unhealthy))))
+
+(defn mark-wal-healthy-async []
+  (send-off send-agent (fn [_]
+                         (mark-wal-healthy))))
+
+(defn health-get [_req]
+  (let [wal-errors (sql/select-one aurora/conn-pool ["select v from config where k = 'wal-errors'"])]
+    (if (some-> wal-errors :v seq)
+      (response/internal-server-error {:wal :error})
+      (response/ok {:wal :ok}))))
+
+(defroutes routes
+  (GET "/health/system" [] health-get))


### PR DESCRIPTION
Adds a page that will return a 500 if the wal unexpectedly restarts and isn't able to recover.

Each time the wal is interrupted, we'll set a flag in config for the machine to indicate that the wal is unhealthy. If we're able to restart, then we'll remove the flag. But if we restart a few times, then we'll stop removing the flag and leave it as unhealthy. In that case, someone will have to manually reset the config flag.

A new page at `/health/system` will return a 500 whenever the config flag is tripped.