### PR TITLE
Use one map for all rooms in Hazelcast

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -23,6 +23,7 @@
         incanter/incanter {:mvn/version "1.9.3"
                            :exclusions [bouncycastle/bctsp-jdk14
                                         postgresql/postgresql]}
+        com.taoensso/nippy {:mvn/version "3.4.2"}
 
         nrepl/nrepl {:mvn/version "0.9.0"}
         jarohen/chime {:mvn/version "0.3.3"}

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -308,7 +308,7 @@
         " The wal handler threw an exception. Check if it restart automatically."
         " If it didn't, redeploy the server.\n\nIf you're quick enough you can "
         "peek at the transaction that caused the error:\n\n"
-        (format "```\nselect data from pg_logical_slot_peek_changes('%s', null, null);```"
+        (format "```\nselect data from pg_logical_slot_peek_changes('%s', null, null, 'format-version', '2', 'include-lsn', 'true');```"
                 slot-name))))
 
 (defn start-worker

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -259,9 +259,9 @@
       ;; The last session left the room, so we should close out the go loop.
       (a/close! chan-before))
 
-    (.merge! (hz-util/->RemoveSessionMergeV1 sess-id)
-             (get-hz-rooms-map)
-             room-key)))
+    (hz-util/merge! (hz-util/->RemoveSessionMergeV1 sess-id)
+                    (get-hz-rooms-map)
+                    room-key)))
 
 (defn clean-old-sessions []
   (let [oldest-timestamp (aws-util/oldest-instance-timestamp)
@@ -330,9 +330,9 @@
 (defn join-room! [store-atom app-id sess-id current-user room-id]
   (let [hz-op (fn []
                 (register-session! app-id room-id sess-id)
-                (.merge! (hz-util/->JoinRoomMergeV1 sess-id (:id current-user))
-                         (get-hz-rooms-map)
-                         {:app-id app-id :room-id room-id}))
+                (hz-util/merge! (hz-util/->JoinRoomMergeV1 sess-id (:id current-user))
+                                (get-hz-rooms-map)
+                                {:app-id app-id :room-id room-id}))
         regular-op
         (fn []
           (when-not (contains? (get-room-session-ids @store-atom app-id room-id)

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -11,16 +11,18 @@
    [instant.util.async :as ua]
    [instant.util.aws :as aws-util]
    [instant.util.exception :as ex]
+   [instant.util.hazelcast :as hz-util]
    [instant.util.tracer :as tracer]
    [medley.core :refer [dissoc-in]])
   (:import
-   (com.hazelcast.config Config)
+   (com.hazelcast.config Config SerializerConfig)
    (com.hazelcast.core Hazelcast HazelcastInstance)
    (com.hazelcast.map IMap)
+   (com.hazelcast.map.impl DataAwareEntryEvent)
    (com.hazelcast.map.listener EntryAddedListener
                                EntryRemovedListener
                                EntryUpdatedListener)
-   (java.util.function BiFunction)))
+   (java.util AbstractMap$SimpleImmutableEntry)))
 
 ;; ------
 ;; Setup
@@ -33,6 +35,20 @@
 (defonce hz-ops-ch (a/chan))
 
 (def refresh-timeout-ms 500)
+
+;; room-maps keeps track of the rooms each session is in (for easy removal
+;; on session close) and some info about the rooms we're subscribed to on
+;; this machine
+;; {:sessions {<session-id>: #{<room-id>}}
+;;  :rooms {<{app-id: app-id, room-id: room-id}> {:session-ids #{<sess-id>}
+;;                                                :chan async/chan}}}
+(defonce room-maps (atom {}))
+
+(defn handle-event [^DataAwareEntryEvent event]
+  (let [{:keys [app-id] :as room-key} (.getKey event)]
+    (when (flags/use-hazelcast? app-id)
+      (when-let [ch (get-in @room-maps [:rooms room-key :chan])]
+        (a/put! ch room-key)))))
 
 (defn init-hz []
   (let [config (Config.)
@@ -55,11 +71,39 @@
         (.setMembers tcp-ip-config (list "127.0.0.1"))))
 
     (.setClusterName config "instant-server")
-    (Hazelcast/getOrCreateHazelcastInstance config)))
+
+    (.setSerializerConfigs (.getSerializationConfig config)
+                           hz-util/serializer-configs)
+
+    (let [hz (Hazelcast/getOrCreateHazelcastInstance config)
+          hz-rooms-map (.getMap hz "rooms")
+          listener-id (.addEntryListener hz-rooms-map
+                                         (reify
+                                           EntryAddedListener
+                                           (entryAdded [_ event]
+                                             (handle-event event))
+
+                                           EntryRemovedListener
+                                           (entryRemoved [_ event]
+                                             (handle-event event))
+
+                                           EntryUpdatedListener
+                                           (entryUpdated [_ event]
+                                             (handle-event event)))
+                                         ;; Don't send value, since we may not be
+                                         ;; interested in this change
+                                         false)]
+      {:hz hz
+       :hz-rooms-map hz-rooms-map
+       :listener-id listener-id})))
 
 (defonce hz (delay (init-hz)))
+
 (defn get-hz ^HazelcastInstance []
-  @hz)
+  (:hz @hz))
+
+(defn get-hz-rooms-map ^IMap []
+  (:hz-rooms-map @hz))
 
 (defn start-hz-sync
   "Temporary function that syncs apps not using hazelcast
@@ -124,27 +168,20 @@
 ;; ---------
 ;; Hazelcast
 
-(defonce room-maps (atom {}))
-
-(defn map-snapshot [hz-map]
-  ;; This is significantly faster than (into {} hz-map)
-  ;; There may be more optimizations available
-  (into {} (.entrySet hz-map)))
-
-(defn handle-refresh-event [store-conn hz-map room-id]
-  (let [snapshot (map-snapshot hz-map)
+(defn handle-refresh-event [store-conn room-key room-id]
+  (let [room-data (.get (get-hz-rooms-map) room-key)
         session-ids (filter (fn [sess-id]
                               (rs/get-session @store-conn sess-id))
-                            (keys snapshot))]
+                            (keys room-data))]
     (rs/try-broadcast-event! store-conn session-ids {:op :refresh-presence
                                                      :room-id room-id
-                                                     :data snapshot})))
+                                                     :data room-data})))
 
 (defn straight-jacket-refresh-event!
-  [store-conn {:keys [hz-map room-id on-sent]}]
+  [store-conn {:keys [room-key room-id on-sent]}]
   (try
     (let [fut (ua/vfuture (handle-refresh-event store-conn
-                                                hz-map
+                                                room-key
                                                 room-id))
           ret (deref fut refresh-timeout-ms :timeout)]
       (when (= :timeout ret)
@@ -162,77 +199,8 @@
         (straight-jacket-refresh-event! store-conn event)
         (recur (a/<!! ch))))))
 
-(defn add-map-listener
-  "Creates a listener on the map that will publish messages to the refresh-map-ch
-   on changes.
-   Returns a cleanup function."
-  [m app-id room-id]
-  (let [ch (a/chan (a/sliding-buffer 1))
-        listener (reify
-                   EntryAddedListener
-                   (entryAdded [_ event]
-                     (a/put! ch event))
-                   EntryRemovedListener
-                   (entryRemoved [_ event]
-                     (a/put! ch event))
-                   EntryUpdatedListener
-                   (entryUpdated [_ event]
-                     (a/put! ch event)))]
-
-    ;; Background process that moves events from the listener
-    ;; to the channel that will broadcast the updates
-    (ua/vfuture (loop [event (a/<!! ch)]
-                  (when event
-                    (when (flags/use-hazelcast? app-id)
-                      (let [complete-ch (a/chan)]
-                        (a/>!! refresh-map-ch
-                               {:hz-map m
-                                :room-id room-id
-                                :on-sent (fn [] (a/close! complete-ch))})
-                        ;; Prevent overwhelming the refresh channel.
-                        ;; We'll wait until this event has been
-                        ;; broadcast before broadcasting the next event,
-                        ;; dropping all but the latest update.
-                        (a/<!! complete-ch)))
-                    (recur (a/<!! ch)))))
-
-    (let [listener-id (.addEntryListener m listener true)]
-      (fn []
-        (.removeEntryListener m listener-id)
-        (a/close! ch)))))
-
-(defn register-room-map [^IMap m app-id room-id sess-id]
-  (let [map-name (.getName m)]
-    ;; Use locking to ensure that we only create one listener
-    ;; for the app and that we don't get a race condition when
-    ;; we destroy the map after the last person leaves.
-    (locking m
-      (let [listener (when (not (get-in @room-maps [:maps map-name :listener]))
-                       (add-map-listener m app-id room-id))]
-        (swap! room-maps
-               (fn [maps]
-                 (cond-> maps
-                   true (update-in [:sessions sess-id] (fnil conj #{}) m)
-
-                   listener
-                   (assoc-in [:maps map-name :listener] listener))))))))
-
-(defn reset-room-listeners!
-  "Debug function if you change the definition of add-map-listener and want to
-   update maps to use the new function. Useful in dev."
-  []
-  (doseq [[k {:keys [listener]}] (:maps @room-maps)]
-    ;; cleanup old listener
-    (listener)
-    (let [m (.getMap (get-hz) k)
-          {:keys [app-id room-id]} (edn/read-string (.getName m))]
-      (swap! room-maps
-             assoc-in
-             [:maps k :listener]
-             (add-map-listener m app-id room-id)))))
-
-(defn get-hz-map ^IMap [app-id room-id]
-  (.getMap (get-hz) (pr-str {:app-id app-id :room-id room-id})))
+(defn get-room-data [app-id room-id]
+  (.get (get-hz-rooms-map) {:app-id app-id :room-id room-id}))
 
 (defn push-hz-sync-op [f]
   (try
@@ -240,38 +208,79 @@
     (catch Throwable e
       (tracer/record-exception-span! e {:name "ephemeral/push-hz-sync-op-err"}))))
 
-(defn remove-session [^IMap hz-map sess-id]
-  (swap! room-maps disj-in [:sessions sess-id] hz-map)
-  (.remove hz-map sess-id)
-  ;; We add the locking to prevent a race condition on registering the map
-  ;; while it's being destroyed. This may still be a race with other machines,
-  ;; but I wasn't able to trigger one locally.
-  (locking hz-map
-    (when (.isEmpty hz-map)
-      (.destroy hz-map)
-      (when-let [cleanup (get-in @room-maps [:maps (.getName hz-map) :listener])]
-        (cleanup)
-        (swap! room-maps dissoc-in [:maps (.getName hz-map)])))))
+(defn register-session!
+  "Registers that the session is following the room and starts a channel
+   for the room if one doesn't already exist."
+  [app-id room-id sess-id]
+  (let [room-key {:app-id app-id :room-id room-id}
+        chan (a/chan (a/sliding-buffer 1))
+        res (swap!
+             room-maps
+             (fn [m]
+               (-> m
+                   (update-in [:sessions sess-id] (fnil conj #{}) room-id)
+                   ;; Keep track of which sessions are interested in the room
+                   ;; so we can close our channel when the last session leaves
+                   (update-in [:rooms room-key :session-ids]
+                              (fnil conj #{}) sess-id)
+                   (update-in [:rooms room-key :chan]
+                              #(or % chan)))))]
+    (when (= chan (get-in res [:rooms room-key :chan]))
+      ;; We set the chan, so we should create the go block that will
+      ;; shuttle messages from the map listener to the channel that
+      ;; broadcasts the room updates.
+      (a/go-loop []
+        (when-let [room-key (a/<! chan)]
+          (let [complete-chan (a/chan)]
+            (a/>! refresh-map-ch {:room-key room-key
+                                  :room-id room-id
+                                  :on-sent (fn [] (a/close! complete-chan))})
+            ;; Wait until we've finished broadcasting before publishing a new
+            ;; message. Helps to prevent the broadcaster getting overwhelmed.
+            (a/<! complete-chan))
+          (recur))))))
+
+(defn remove-session! [app-id room-id sess-id]
+  (let [room-key {:app-id app-id :room-id room-id}
+
+        [old-val new-val]
+        (swap-vals! room-maps
+                    (fn [m]
+                      (let [session-ids (-> m
+                                            (get-in [:rooms room-key :session-ids])
+                                            (disj sess-id))]
+                        (cond-> m
+                          true (disj-in [:sessions sess-id] room-id)
+                          (empty? session-ids) (dissoc-in [:rooms room-key])
+                          (seq session-ids) (assoc-in [:rooms room-key :session-ids]
+                                                      session-ids)))))
+        chan-before (get-in old-val [:rooms room-key :chan])
+        chan-after (get-in new-val [:rooms room-key :chan])]
+    (when (and chan-before (not= chan-before chan-after))
+      ;; The last session left the room, so we should close out the go loop.
+      (a/close! chan-before))
+
+    (.merge! (hz-util/->RemoveSessionMergeV1 sess-id)
+             (get-hz-rooms-map)
+             room-key)))
 
 (defn clean-old-sessions []
-  (let [oldest-timestamp (aws-util/oldest-instance-timestamp)]
+  (let [oldest-timestamp (aws-util/oldest-instance-timestamp)
+        hz-map (get-hz-rooms-map)]
     (when-not oldest-timestamp
       (throw (Exception. "Could not determine oldest instance timestamp")))
-    (doseq [^IMap obj (.getDistributedObjects ^HazelcastInstance @hz)
-            :when (instance? IMap obj)
-            :let [{:keys [app-id room-id]} (try (edn/read-string (.getName obj))
-                                                (catch Throwable _t nil))]
+    (doseq [^AbstractMap$SimpleImmutableEntry entry (.entrySet hz-map)
+            :let [{:keys [app-id room-id]} (.getKey entry)
+                  v (.getValue entry)]
             :when (and app-id room-id)
-            sess-id (.keySet obj)
+            sess-id (keys v)
             :let [squuid-timestamp (squuid-time-millis sess-id)]
             :when (< squuid-timestamp oldest-timestamp)]
       (tracer/with-span! {:name "clean-old-session"
                           :attributes {:session-id sess-id
                                        :app-id app-id
                                        :squuid-timestamp squuid-timestamp}}
-        (remove-session obj sess-id)))))
-
-
+        (remove-session! app-id room-id sess-id)))))
 
 ;; ----------
 ;; Public API
@@ -301,7 +310,7 @@
   "Returns whether a session is part of a room."
   [store-v app-id room-id sess-id]
   (if (flags/use-hazelcast? app-id)
-    (.containsKey (get-hz-map app-id room-id) sess-id)
+    (contains? (get-room-data app-id room-id) sess-id)
     (contains? (get-room-session-ids store-v app-id room-id) sess-id)))
 
 (defn run-op [app-id hz-op regular-op]
@@ -321,12 +330,10 @@
 
 (defn join-room! [store-atom app-id sess-id current-user room-id]
   (let [hz-op (fn []
-                (let [hz-map (get-hz-map app-id room-id)]
-                  (register-room-map hz-map app-id room-id sess-id)
-                  (.putIfAbsent hz-map sess-id {:peer-id sess-id
-                                                :user (when current-user
-                                                        {:id (:id current-user)})
-                                                :data {}})))
+                (register-session! app-id room-id sess-id)
+                (.merge! (hz-util/->JoinRoomMergeV1 sess-id (:id current-user))
+                         (get-hz-rooms-map)
+                         {:app-id app-id :room-id room-id}))
         regular-op
         (fn []
           (when-not (contains? (get-room-session-ids @store-atom app-id room-id)
@@ -337,28 +344,24 @@
 
 (defn leave-room! [store-atom app-id sess-id room-id]
   (let [hz-op (fn []
-                (let [hz-map (get-hz-map app-id room-id)]
-                  (remove-session hz-map sess-id)))
+                (remove-session! app-id room-id sess-id))
         regular-op (fn []
                      (swap! store-atom leave-room app-id sess-id room-id))]
     (run-op app-id hz-op regular-op)))
 
 (defn set-presence! [store-atom app-id sess-id room-id data]
   (let [hz-op (fn []
-                (.merge (get-hz-map app-id room-id)
-                        sess-id
-                        {:data data}
-                        (reify BiFunction
-                          (apply [_ x y]
-                            (merge x y)))))
+                (hz-util/merge! (hz-util/->SetPresenceMergeV1 sess-id data)
+                                (get-hz-rooms-map)
+                                {:app-id app-id :room-id room-id}))
         regular-op (fn []
                      (swap! store-atom set-presence app-id sess-id room-id data))]
     (run-op app-id hz-op regular-op)))
 
 (defn leave-by-session-id! [store-atom app-id sess-id]
   (let [hz-op (fn []
-                (doseq [hz-map (get-in @room-maps [:sessions sess-id])]
-                  (remove-session hz-map sess-id)))
+                (doseq [room-id (get-in @room-maps [:sessions sess-id])]
+                  (remove-session! app-id room-id sess-id)))
         regular-op (fn []
                      (swap! store-atom leave-by-session-id app-id sess-id))]
     (run-op app-id hz-op regular-op)))
@@ -432,7 +435,10 @@
 (defn stop []
   (a/close! room-refresh-ch)
   (a/close! refresh-map-ch)
-  (a/close! hz-ops-ch))
+  (a/close! hz-ops-ch)
+  (when-let [^HazelcastInstance hz (try (get-hz) (catch Exception _e nil))]
+    (.shutdown hz)
+    (def hz (delay (init-hz)))))
 
 (defn restart []
   (stop)

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -2,7 +2,6 @@
   "Handles our ephemeral data apis for a session (presence, cursors)"
   (:require
    [clojure.core.async :as a]
-   [clojure.edn :as edn]
    [clojure.set :as set]
    [datascript.core :refer [squuid-time-millis]]
    [instant.config :as config]

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -15,7 +15,7 @@
    [instant.util.tracer :as tracer]
    [medley.core :refer [dissoc-in]])
   (:import
-   (com.hazelcast.config Config SerializerConfig)
+   (com.hazelcast.config Config)
    (com.hazelcast.core Hazelcast HazelcastInstance)
    (com.hazelcast.map IMap)
    (com.hazelcast.map.impl DataAwareEntryEvent)

--- a/server/src/instant/util/aws.clj
+++ b/server/src/instant/util/aws.clj
@@ -44,13 +44,16 @@
          {:headers {"X-aws-ec2-metadata-token" token}})
         :body)))
 
-(defn oldest-instance-timestamp []
-  (some->> (ec2/describe-instances
-            {:filters [{:Name (str "tag:" environment-tag-name)
-                        :Values [(get-environment-tag)]}]})
-           :reservations
-           (mapcat :instances)
-           (map :launch-time)
-           sort
-           first
-           (.getMillis)))
+(defn oldest-instance-timestamp
+  ([]
+   (oldest-instance-timestamp (get-environment-tag)))
+  ([env-tag-value]
+   (some->> (ec2/describe-instances
+             {:filters [{:Name (str "tag:" environment-tag-name)
+                         :Values [env-tag-value]}]})
+            :reservations
+            (mapcat :instances)
+            (map :launch-time)
+            sort
+            first
+            (.getMillis))))

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -1,0 +1,168 @@
+(ns instant.util.hazelcast
+  (:require [instant.util.uuid :as uuid-util]
+            [medley.core :refer [update-existing]]
+            [taoensso.nippy :as nippy])
+  (:import (com.hazelcast.config SerializerConfig)
+           (com.hazelcast.map IMap)
+           (com.hazelcast.nio.serialization StreamSerializer ByteArraySerializer)
+           (java.nio ByteBuffer)
+           (java.util UUID)
+           (java.util.function BiFunction)))
+
+;; Be careful when you update the records and serializers in this
+;; namespace. Hazelcast shares them across the fleet, so they must be
+;; updated in a backwards compatible way. The old versions have to
+;; work while the new and old versions are simultaneously deployed.
+
+;; To make breaking changes, follow these steps:
+;; 1. Create a new version of the record, e.g. JoinRoomMergeV2
+;; 2. Create a serializer for the new record (make sure getTypeId is unique!)
+;; 3. Create a new config and add it to serializer-configs at the bottom of the file
+;; 4. Deploy the change with the , but don't use the new record yet (or put it behind a feature flag)
+;; 5. Wait for all instance to update to the new version
+;; 6. Start using the new version and stop using the old version
+;; 7. Now it is safe to remove the old version
+
+(defn make-serializer-config [protocol serializer]
+  (-> (SerializerConfig.)
+      (.setTypeClass protocol)
+      (.setImplementation serializer)))
+
+(defprotocol MergeHelper
+  ;; Defines a helper for merging, since the behavior of IMap.merge can be
+  ;; surprising.
+  ;; https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/ConcurrentMap.html#merge(K,V,java.util.function.BiFunction)
+  (merge! [this ^IMap m room-key]))
+
+
+;; --------------
+;; Remove session
+
+;; Helper to remove a session from the room in the hazelcast map
+(defrecord RemoveSessionMergeV1 [^UUID session-id]
+  MergeHelper
+  (merge! [this m room-key]
+    (.merge ^IMap m
+            room-key
+            ;; If the current value of the key is null, then the new value
+            ;; should just be an empty map. We'd like to put nil here to
+            ;; remove the entry (like we do in the bifunction), but that's
+            ;; not allowed.
+            {}
+            this))
+
+  BiFunction
+  (apply [_ room-data _]
+    (let [res (dissoc room-data session-id)]
+      ;; Return null if we're the last so that the entry can be removed
+      ;; from the map instead of holding an empty map
+      (if (empty? res)
+        nil
+        res))))
+
+(def ^ByteArraySerializer remove-session-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 1)
+    (write ^bytes [_ obj]
+      (uuid-util/->bytes (:session-id obj)))
+    (read [_ ^bytes in]
+      (let [session-id (uuid-util/<-bytes in)]
+        (->RemoveSessionMergeV1 session-id)))
+    (destroy [_])))
+
+(def remove-session-config
+  (make-serializer-config RemoveSessionMergeV1
+                          remove-session-serializer))
+
+;; ---------
+;; Join room
+
+;; Helper to add a session to the room in the hazelcast map
+(defrecord JoinRoomMergeV1 [^UUID session-id ^UUID user-id]
+  MergeHelper
+  (merge! [this m room-key]
+    (.merge ^IMap m
+            room-key
+            {session-id {:peer-id session-id
+                         :user (when user-id
+                                 {:id user-id})
+                         :data {}}}
+            this))
+  BiFunction
+  (apply [_ room-data _]
+    (update room-data
+            session-id
+            (fnil merge {:data {}})
+            {:peer-id session-id
+             :user (when user-id
+                     {:id user-id})})))
+
+
+(def ^ByteArraySerializer join-room-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 2)
+    (write ^bytes [_ obj]
+      (let [{:keys [^UUID session-id ^UUID user-id]} obj
+            byte-buffer (ByteBuffer/allocate (if user-id 32 16))]
+        (.putLong byte-buffer (.getMostSignificantBits session-id))
+        (.putLong byte-buffer (.getLeastSignificantBits session-id))
+        (when user-id
+          (.putLong byte-buffer (.getMostSignificantBits user-id))
+          (.putLong byte-buffer (.getLeastSignificantBits user-id)))
+        (.array byte-buffer)))
+    (read [_ ^bytes in]
+      (let [buf (ByteBuffer/wrap in)]
+        (let [session-id (UUID. (.getLong buf)
+                                (.getLong buf))
+              user-id (when (.hasRemaining buf)
+                        (UUID. (.getLong buf)
+                               (.getLong buf)))]
+          (->JoinRoomMergeV1 session-id user-id))))
+    (destroy [_])))
+
+(def join-room-config
+  (make-serializer-config JoinRoomMergeV1
+                          join-room-serializer))
+
+;; ------------
+;; Set presence
+
+(defrecord SetPresenceMergeV1 [^UUID session-id data]
+  MergeHelper
+  (merge! [this m room-key]
+    (.merge ^IMap m
+            room-key
+            ;; if current value is nil, then we're not in the room, so we
+            ;; shouldn't set presence
+            {}
+            this))
+  BiFunction
+  (apply [_ room-data _]
+    (update-existing room-data
+                     session-id
+                     assoc
+                     :data
+                     data)))
+
+(def ^ByteArraySerializer set-presence-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 3)
+    (write ^bytes [_ obj]
+      (let [{:keys [^UUID session-id data]} obj]
+        (nippy/fast-freeze [session-id data])))
+    (read [_ ^bytes in]
+      (let [[session-id data] (nippy/fast-thaw in)]
+        (->SetPresenceMergeV1 session-id data)))
+    (destroy [_])))
+
+(def set-presence-config
+  (make-serializer-config SetPresenceMergeV1
+                          set-presence-serializer))
+
+(def serializer-configs
+  [remove-session-config
+   join-room-config
+   set-presence-config])

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -18,7 +18,7 @@
 ;; 1. Create a new version of the record, e.g. JoinRoomMergeV2
 ;; 2. Create a serializer for the new record (make sure getTypeId is unique!)
 ;; 3. Create a new config and add it to serializer-configs at the bottom of the file
-;; 4. Deploy the change with the , but don't use the new record yet (or put it behind a feature flag)
+;; 4. Deploy the change, but don't use the new record yet (or put it behind a feature flag)
 ;; 5. Wait for all instance to update to the new version
 ;; 6. Start using the new version and stop using the old version
 ;; 7. Now it is safe to remove the old version

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -4,7 +4,7 @@
             [taoensso.nippy :as nippy])
   (:import (com.hazelcast.config SerializerConfig)
            (com.hazelcast.map IMap)
-           (com.hazelcast.nio.serialization StreamSerializer ByteArraySerializer)
+           (com.hazelcast.nio.serialization ByteArraySerializer)
            (java.nio ByteBuffer)
            (java.util UUID)
            (java.util.function BiFunction)))
@@ -113,13 +113,13 @@
           (.putLong byte-buffer (.getLeastSignificantBits user-id)))
         (.array byte-buffer)))
     (read [_ ^bytes in]
-      (let [buf (ByteBuffer/wrap in)]
-        (let [session-id (UUID. (.getLong buf)
-                                (.getLong buf))
-              user-id (when (.hasRemaining buf)
-                        (UUID. (.getLong buf)
-                               (.getLong buf)))]
-          (->JoinRoomMergeV1 session-id user-id))))
+      (let [buf (ByteBuffer/wrap in)
+            session-id (UUID. (.getLong buf)
+                              (.getLong buf))
+            user-id (when (.hasRemaining buf)
+                      (UUID. (.getLong buf)
+                             (.getLong buf)))]
+        (->JoinRoomMergeV1 session-id user-id)))
     (destroy [_])))
 
 (def join-room-config

--- a/server/src/instant/util/uuid.clj
+++ b/server/src/instant/util/uuid.clj
@@ -17,3 +17,9 @@
     (.putLong byte-buffer (.getMostSignificantBits uuid))
     (.putLong byte-buffer (.getLeastSignificantBits uuid))
     (.array byte-buffer)))
+
+(defn <-bytes
+  "Converts a byte array into a java.util.UUID"
+  [^bytes bytes]
+  (let [buf (ByteBuffer/wrap bytes)]
+    (UUID. (.getLong buf) (.getLong buf))))

--- a/server/test/instant/util/hazelcast_test.clj
+++ b/server/test/instant/util/hazelcast_test.clj
@@ -1,0 +1,27 @@
+(ns instant.util.hazelcast-test
+  (:require [instant.util.hazelcast :as h]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest remove-session-roundtrips
+  (let [start (h/->RemoveSessionMergeV1 (random-uuid))
+        serializer h/remove-session-serializer]
+    (is (= start (->> (.write serializer start)
+                      (.read serializer))))))
+
+(deftest join-room-roundtrips
+  (testing "with user"
+    (let [start (h/->JoinRoomMergeV1 (random-uuid) (random-uuid))
+          serializer h/join-room-serializer]
+      (is (= start (->> (.write serializer start)
+                        (.read serializer))))))
+  (testing "without user"
+    (let [start (h/->JoinRoomMergeV1 (random-uuid) nil)
+          serializer h/join-room-serializer]
+      (is (= start (->> (.write serializer start)
+                        (.read serializer)))))))
+
+(deftest set-presence-roundtrips
+  (let [start (h/->SetPresenceMergeV1 (random-uuid) {:some :data})
+        serializer h/set-presence-serializer]
+    (is (= start (->> (.write serializer start)
+                      (.read serializer))))))


### PR DESCRIPTION
Uses a single map in hazelcast for all of the rooms.

In the previous PR https://github.com/instantdb/instant/pull/333, I mentioned that I wasn't sure if one big map or a map per room was best. Now that we've had it in production for a bit, I think one big map will be better. It turns out that creating the listeners on the map is expensive and can cause the virtual thread to park. If we do one big map, then we only have to create listeners once for the big map instead of every time a new room is joined.

The downside is that our listener fires for every change to any room, even if our instance doesn't have any sessions subscribed to the room. To reduce the impact, we don't ask for values in our listener, just the keys, so less data is transferred.

To make the updates efficient, we use merge functions that hazelcast can serialize and send to the instance that is holding the map.  For example, to remove a session, we call merge with our new `RemoveSessionMerge` class with the session id. Our `remove-session-serializer` sends just the session-id to the instance that holds that key and applies the change. Then the listener will distribute that change to all of the connected sessions.
