### PR TITLE
[query-once] finish line

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -48,6 +48,14 @@ localStorage.setItem("devBackend", true);
 
 Now all requests will go to your local backend at [localhost:8888](http://localhost:8888). If you haven't set up a local backend, follow the [server README](../server/README.md)
 
+### Show client logs
+
+The instant client can show development logs. You can turn this on by writing: 
+
+```
+localStorage.setItem("__instantLogging", true);
+```
+
 ### Running a local app
 You can create local apps by following these steps
 

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -43,7 +43,7 @@ let _wsId = 0;
 function createWebSocket(uri) {
   const ws = new WebSocket(uri);
   // @ts-ignore
-  ws.id = _wsId++;
+  ws._id = _wsId++;
   return ws;
 }
 
@@ -1027,7 +1027,7 @@ export default class Reactor {
     if (this._ws !== targetWs) {
       log.info(
         "[socket][open]",
-        targetWs.id,
+        targetWs._id,
         "skip; this is no longer the current ws",
       );
       return;
@@ -1055,7 +1055,7 @@ export default class Reactor {
     if (this._ws !== targetWs) {
       log.info(
         "[socket][message]",
-        targetWs.id,
+        targetWs._id,
         m,
         "skip; this is no longer the current ws",
       );
@@ -1069,12 +1069,12 @@ export default class Reactor {
     if (this._ws !== targetWs) {
       log.info(
         "[socket][error]",
-        targetWs.id,
+        targetWs._id,
         "skip; this is no longer the current ws",
       );
       return;
     }
-    log.error("[socket][error]", targetWs.id, e);
+    log.error("[socket][error]", targetWs._id, e);
   };
 
   _wsOnClose = (e) => {
@@ -1082,7 +1082,7 @@ export default class Reactor {
     if (this._ws !== targetWs) {
       log.info(
         "[socket][close]",
-        targetWs.id,
+        targetWs._id,
         "skip; this is no longer the current ws",
       );
       return;
@@ -1097,14 +1097,14 @@ export default class Reactor {
     if (this._isShutdown) {
       log.info(
         "[socket][close]",
-        targetWs.id,
+        targetWs._id,
         "Reactor has been shut down and will not reconnect",
       );
       return;
     }
     log.info(
       "[socket][close]",
-      targetWs.id,
+      targetWs._id,
       "schedule reconnect, ms =",
       this._reconnectTimeoutMs,
     );
@@ -1116,7 +1116,7 @@ export default class Reactor {
       if (!this._isOnline) {
         log.info(
           "[socket][close]",
-          targetWs.id,
+          targetWs._id,
           "we are offline, no need to start socket",
         );
         return;
@@ -1132,7 +1132,7 @@ export default class Reactor {
       // effectively fresh.
       log.info(
         "[socket][start]",
-        this._ws.id,
+        this._ws._id,
         "maintained as current ws, we were still in a connecting state",
       );
       return;
@@ -1155,7 +1155,7 @@ export default class Reactor {
       //
       // This means that we have to make sure to kill the previous one ourselves.
       // c.f https://issues.chromium.org/issues/41343684
-      log.info("[socket][start]", this._ws.id, "close previous ws id = ", prevWs.id)
+      log.info("[socket][start]", this._ws._id, "close previous ws id = ", prevWs.id)
       prevWs.close();
     }
   }

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1082,9 +1082,9 @@ export default class Reactor {
     const targetWs = e.target;
     if (this._ws !== targetWs) {
       log.info(
-        "[socket]",
+        "[socket][close]",
         targetWs.id,
-        "skip close; this is no longer the current ws",
+        "skip; this is no longer the current ws",
       );
       return;
     }
@@ -1097,23 +1097,16 @@ export default class Reactor {
 
     if (this._isShutdown) {
       log.info(
-        "[socket-close] Reactor has been shut down and will not reconnect",
-      );
-      return;
-    }
-    if (this._isManualClose) {
-      this._isManualClose = false;
-      log.info(
-        "[socket-close] manual close, will not reconnect, id =",
+        "[socket][close]",
         targetWs.id,
+        "Reactor has been shut down and will not reconnect",
       );
       return;
     }
-
     log.info(
-      "[socket-close] scheduling reconnect id =",
+      "[socket][close]",
       targetWs.id,
-      "ms = ",
+      "schedule reconnect, ms =",
       this._reconnectTimeoutMs,
     );
     setTimeout(() => {
@@ -1123,8 +1116,9 @@ export default class Reactor {
       );
       if (!this._isOnline) {
         log.info(
-          "[socket-close] we are offline, no need to start socket, id =",
+          "[socket][close]",
           targetWs.id,
+          "we are offline, no need to start socket",
         );
         return;
       }

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1032,7 +1032,7 @@ export default class Reactor {
       );
       return;
     }
-    log.info("[socket][open]", this._ws.id);
+    log.info("[socket][open]", this._ws._id);
     this._setStatus(STATUS.OPENED);
     this.getCurrentUser().then((resp) => {
       this._trySend(uuid(), {
@@ -1145,7 +1145,7 @@ export default class Reactor {
     this._ws.onmessage = this._wsOnMessage;
     this._ws.onclose = this._wsOnClose;
     this._ws.onerror = this._wsOnError;
-    log.info("[socket][start]", this._ws.id);
+    log.info("[socket][start]", this._ws._id);
     if (prevWs?.readyState === WS_OPEN_STATUS) {
       // When the network dies, it doesn't always mean that our
       // socket connection will fire a close event.
@@ -1155,7 +1155,7 @@ export default class Reactor {
       //
       // This means that we have to make sure to kill the previous one ourselves.
       // c.f https://issues.chromium.org/issues/41343684
-      log.info("[socket][start]", this._ws._id, "close previous ws id = ", prevWs.id)
+      log.info("[socket][start]", this._ws._id, "close previous ws id = ", prevWs._id)
       prevWs.close();
     }
   }

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -24,7 +24,7 @@ const STATUS = {
   ERRORED: "errored",
 };
 
-const QUERY_ONCE_TIMEOUT = 10_000;
+const QUERY_ONCE_TIMEOUT = 30_000;
 
 const WS_OPEN_STATUS = 1;
 

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -26,6 +26,7 @@ const STATUS = {
 
 const QUERY_ONCE_TIMEOUT = 30_000;
 
+const WS_CONNECTING_STATUS = 0;
 const WS_OPEN_STATUS = 1;
 
 const defaultConfig = {
@@ -37,6 +38,14 @@ const defaultConfig = {
 const OAUTH_REDIRECT_PARAM = "_instant_oauth_redirect";
 
 const currentUserKey = `currentUser`;
+
+let _wsId = 0;
+function createWebSocket(uri) {
+  const ws = new WebSocket(uri);
+  // @ts-ignore
+  ws.id = _wsId++;
+  return ws;
+}
 
 function isClient() {
   const hasWindow = typeof window !== "undefined";
@@ -166,6 +175,7 @@ export default class Reactor {
         if (isOnline === this._isOnline) {
           return;
         }
+        log.info("[network] online =", isOnline);
         this._isOnline = isOnline;
         if (this._isOnline) {
           this._startSocket();
@@ -1001,8 +1011,17 @@ export default class Reactor {
     this._ws.send(JSON.stringify({ "client-event-id": eventId, ...msg }));
   }
 
-  _wsOnOpen = () => {
-    log.info("[socket] connected");
+  _wsOnOpen = (e) => {
+    const targetWs = e.target;
+    if (this._ws !== targetWs) {
+      log.info(
+        "[socket]",
+        targetWs.id,
+        "skipping open event; this is no longer the current ws",
+      );
+      return;
+    }
+    log.info("[socket]", this._ws.id, "opened");
     this._setStatus(STATUS.OPENED);
     this.getCurrentUser().then((resp) => {
       this._trySend(uuid(), {
@@ -1020,14 +1039,45 @@ export default class Reactor {
   };
 
   _wsOnMessage = (e) => {
+    const targetWs = e.target;
+    const m = JSON.parse(e.data.toString());
+    if (this._ws !== targetWs) {
+      log.info(
+        "[socket]",
+        targetWs.id,
+        "skip message",
+        m,
+        "this is no longer the current ws",
+      );
+      return;
+    }
     this._handleReceive(JSON.parse(e.data.toString()));
   };
 
   _wsOnError = (e) => {
-    log.error("[socket] error: ", e);
+    const targetWs = e.target;
+    if (this._ws !== targetWs) {
+      log.info(
+        "[socket]",
+        targetWs.id,
+        "skipping error; this is no longer the current ws",
+      );
+      return;
+    }
+    log.error("[socket]", targetWs.id, "error event =", e);
   };
 
-  _wsOnClose = () => {
+  _wsOnClose = (e) => {
+    const targetWs = e.target;
+    if (this._ws !== targetWs) {
+      log.info(
+        "[socket]",
+        targetWs.id,
+        "skip close; this is no longer the current ws",
+      );
+      return;
+    }
+
     this._setStatus(STATUS.CLOSED);
 
     for (const room of Object.values(this._rooms)) {
@@ -1036,45 +1086,72 @@ export default class Reactor {
 
     if (this._isShutdown) {
       log.info(
-        "[socket-close] socket has been shut down and will not reconnect",
+        "[socket-close] Reactor has been shut down and will not reconnect",
       );
       return;
     }
     if (this._isManualClose) {
       this._isManualClose = false;
-      log.info("[socket-close] manual close, will not reconnect");
+      log.info(
+        "[socket-close] manual close, will not reconnect, id =",
+        targetWs.id,
+      );
       return;
     }
 
-    log.info("[socket-close] scheduling reconnect", this._reconnectTimeoutMs);
+    log.info(
+      "[socket-close] scheduling reconnect id =",
+      targetWs.id,
+      "ms = ",
+      this._reconnectTimeoutMs,
+    );
     setTimeout(() => {
       this._reconnectTimeoutMs = Math.min(
         this._reconnectTimeoutMs + 1000,
         10000,
       );
       if (!this._isOnline) {
-        log.info("[socket-close] we are offline, no need to start socket");
+        log.info(
+          "[socket-close] we are offline, no need to start socket, id =",
+          targetWs.id,
+        );
         return;
       }
       this._startSocket();
     }, this._reconnectTimeoutMs);
   };
 
-  _ensurePreviousSocketClosed() {
-    if (this._ws && this._ws.readyState === WS_OPEN_STATUS) {
-      this._isManualClose = true;
-      this._ws.close();
-    }
-  }
-
   _startSocket() {
-    this._ensurePreviousSocketClosed();
-    this._ws = new WebSocket(
+    if (this._ws && this._ws.readyState == WS_CONNECTING_STATUS) {
+      // Our current websocket is in a 'connecting' state.
+      // There's no need to start another one, as the socket is
+      // effectively fresh.
+      log.info(
+        "[socket]",
+        this._ws.id,
+        "maintained as current ws, we were still in a connecting state",
+      );
+      return;
+    }
+    const prevWs = this._ws;
+    this._ws = createWebSocket(
       `${this.config.websocketURI}?app_id=${this.config.appId}`,
     );
     this._ws.onopen = this._wsOnOpen;
     this._ws.onmessage = this._wsOnMessage;
     this._ws.onclose = this._wsOnClose;
+    this._ws.onerror = this._wsOnError;
+    if (prevWs?.readyState === WS_OPEN_STATUS) {
+      // When the network dies, it doesn't always mean that our
+      // socket connection will fire a close event.
+      //
+      // We _could_ re-use the old socket, if the network drop was a
+      // few seconds. But, to be safe right now we always create a new socket.
+      //
+      // This means that we have to make sure to kill the previous one ourselves.
+      // c.f https://issues.chromium.org/issues/41343684
+      prevWs.close();
+    }
   }
 
   /**

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1026,13 +1026,13 @@ export default class Reactor {
     const targetWs = e.target;
     if (this._ws !== targetWs) {
       log.info(
-        "[socket]",
+        "[socket][open]",
         targetWs.id,
-        "skipping open event; this is no longer the current ws",
+        "skip; this is no longer the current ws",
       );
       return;
     }
-    log.info("[socket]", this._ws.id, "opened");
+    log.info("[socket][open]", this._ws.id);
     this._setStatus(STATUS.OPENED);
     this.getCurrentUser().then((resp) => {
       this._trySend(uuid(), {
@@ -1054,11 +1054,10 @@ export default class Reactor {
     const m = JSON.parse(e.data.toString());
     if (this._ws !== targetWs) {
       log.info(
-        "[socket]",
+        "[socket][message]",
         targetWs.id,
-        "skip message",
         m,
-        "this is no longer the current ws",
+        "skip; this is no longer the current ws",
       );
       return;
     }
@@ -1069,13 +1068,13 @@ export default class Reactor {
     const targetWs = e.target;
     if (this._ws !== targetWs) {
       log.info(
-        "[socket]",
+        "[socket][error]",
         targetWs.id,
-        "skipping error; this is no longer the current ws",
+        "skip; this is no longer the current ws",
       );
       return;
     }
-    log.error("[socket]", targetWs.id, "error event =", e);
+    log.error("[socket][error]", targetWs.id, e);
   };
 
   _wsOnClose = (e) => {
@@ -1132,7 +1131,7 @@ export default class Reactor {
       // There's no need to start another one, as the socket is
       // effectively fresh.
       log.info(
-        "[socket]",
+        "[socket][start]",
         this._ws.id,
         "maintained as current ws, we were still in a connecting state",
       );
@@ -1146,6 +1145,7 @@ export default class Reactor {
     this._ws.onmessage = this._wsOnMessage;
     this._ws.onclose = this._wsOnClose;
     this._ws.onerror = this._wsOnError;
+    log.info("[socket][start]", this._ws.id);
     if (prevWs?.readyState === WS_OPEN_STATUS) {
       // When the network dies, it doesn't always mean that our
       // socket connection will fire a close event.
@@ -1155,6 +1155,7 @@ export default class Reactor {
       //
       // This means that we have to make sure to kill the previous one ourselves.
       // c.f https://issues.chromium.org/issues/41343684
+      log.info("[socket][start]", this._ws.id, "close previous ws id = ", prevWs.id)
       prevWs.close();
     }
   }

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -636,15 +636,26 @@ export default class Reactor {
     };
   }
 
-  async queryOnce(q) {
+  queryOnce(q) {
+    const dfd = new Deferred();
+
     if (!this._isOnline) {
-      throw new Error(
-        "Offline: Cannot execute query because the device is offline.",
+      dfd.reject(
+        new Error("We can't run `queryOnce`, because the device is offline."),
       );
+      return dfd.promise;
+    }
+
+    if (!this.querySubs) {
+      dfd.reject(
+        new Error(
+          "We can't run `queryOnce` on the backend. Use adminAPI.query instead: https://www.instantdb.com/docs/backend#query",
+        ),
+      );
+      return dfd.promise;
     }
 
     const hash = weakHash(q);
-    const dfd = new Deferred();
 
     const eventId = this._startQuerySub(q, hash);
 

--- a/client/packages/core/src/utils/log.ts
+++ b/client/packages/core/src/utils/log.ts
@@ -3,7 +3,9 @@ if (
   typeof window !== "undefined" &&
   typeof window.localStorage !== "undefined"
 ) {
-  isEnabled = !!window.localStorage.getItem("__instantLogging");
+  isEnabled =
+    !!window.localStorage.getItem("devBackend") ||
+    !!window.localStorage.getItem("__instantLogging");
 }
 
 const log = {

--- a/client/packages/core/src/utils/log.ts
+++ b/client/packages/core/src/utils/log.ts
@@ -1,24 +1,15 @@
-const log = (() => {
-  let isEnabled = false;
-  if (
-    typeof window !== "undefined" &&
-    typeof window.localStorage !== "undefined"
-  ) {
-    isEnabled = !!window.localStorage.getItem("loggingEnabled");
-  } else {
-    isEnabled = false;
-  }
-  function makeLogger(fnName: "info" | "debug" | "error") {
-    return (...args: any[]) => {
-      if (!isEnabled) return;
-      console[fnName](...args);
-    };
-  }
-  return {
-    info: makeLogger("info"),
-    debug: makeLogger("debug"),
-    error: makeLogger("error"),
-  };
-})();
+let isEnabled = false;
+if (
+  typeof window !== "undefined" &&
+  typeof window.localStorage !== "undefined"
+) {
+  isEnabled = !!window.localStorage.getItem("__instantLogging");
+}
+
+const log = {
+  info: isEnabled ? console.info.bind(console) : () => {},
+  debug: isEnabled ? console.debug.bind(console) : () => {},
+  error: isEnabled ? console.error.bind(console) : () => {},
+};
 
 export default log;

--- a/client/sandbox/react-nextjs/pages/play/query-once-toggle.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once-toggle.tsx
@@ -1,0 +1,79 @@
+/*
+ * There was a bug where if we toggled connections on and off, 
+ * we could enter a state where multiple _ws instances were active. 
+ * 
+ * This led to a weird bug where queryOnce would hang. Use this 
+ * playground if you ever want to reproduce the bug. 
+ * 
+ * 
+*/
+
+import { init, id, tx } from "@instantdb/react";
+import Head from "next/head";
+import { useEffect, FormEvent, useRef, useState } from "react";
+import config from "../../config";
+
+const db = init<{
+  onceTest: {
+    text: string;
+  };
+}>({
+  ...config,
+});
+
+function useEffectOnce(cb: () => void) {
+  const r = useRef(false);
+  useEffect(() => {
+    if (r.current) return;
+    r.current = true;
+    cb();
+  }, []);
+}
+
+function Main() {
+  const [result, setResult] = useState<any>({ isLoading: true });
+  useEffectOnce(() => {
+    setTimeout(() => {
+      const p1 = db.queryOnce({ posts: {} });
+      window.dispatchEvent(new Event("offline"));
+      const p2 = db.queryOnce({ posts: {} }).catch(e => console.log('expected fail, we are offline'));
+      window.dispatchEvent(new Event("online"));
+      window.dispatchEvent(new Event("offline"));
+      window.dispatchEvent(new Event("online"));
+      const p3 = db.queryOnce({ posts: {} });
+      Promise.all([p1, p3]).then(
+        (succ) => {
+          console.log('Check inspector; how many active ws connections do you see?')
+          setResult({ succ });
+        },
+        (err) => {
+          console.error('Uh oh, we should definitely have gotten a response here');
+          setResult({ err });
+        },
+      );
+    }, 3000);
+  });
+  return (
+    <div>
+      <h1>Query Once Toggle</h1>
+      <pre>{JSON.stringify(result, null, 2)}</pre>
+    </div>
+  );
+}
+
+function Page() {
+  return (
+    <div>
+      <Head>
+        <title>Instant Example App: Query Once Toggle</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <Main />
+    </div>
+  );
+}
+
+export default Page;

--- a/client/sandbox/react-nextjs/pages/play/query-once.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-once.tsx
@@ -16,10 +16,6 @@ const db = init<{
   };
 }>(config);
 
-db.queryOnce({
-  onceTest: {},
-}).then((r) => console.log("onceTest on init", r));
-
 function _subsCount() {
   return Object.values(db._core._reactor.queryOnceDfds).flat().length;
 }


### PR DESCRIPTION
Made a series of different changes, to help us get queryOnce over the finish line. Some were quality-of-life fixes, some small bugs, and one bigger change. 

I could have separated this as separate PRs, but thought they were reasonable to have in one holistic PR. Here are the changes:

### Quality of Life Improvements

**1) Remove wrapping around our `log` util**

We had a nifty `log` util, which we used sparingly in Reactor. One problem with it was that when you used it, you would not get the correct line numbers. 

This was because we wrapped `console.log`, so all the invocations would report `'log.js'`. 

Instead of _wrapping_ console.log, I now expose it directly. This maintains the correct line numbers. 

I also updated our flag from `loggingEnabled` to `__instantLogging`. This is mainly because `loggingEnabled` was too general.

**2) Add an `id` to the websocket, and add more logs in the Reactor**

Once we had a better `log` function, I also started to add more logs in the reactor. I added an `id` field to our websocket too. This is purely for helping us see the flow of actions in logs. We can still use the WebSocket for reference equality

### Small Bugfixes

**3) Increase `queryOnce` timeout to 30s**

I noticed our queryOnce timeout was 10 seconds. I think this is a bit too short, given that the normal `fetch` timeout on Chrome is 300 seconds. Afaik for firefox it's 90 seconds. I went a bit more conservative, at 30 seconds. 

**4) Make sure we report an error if `queryOnce` was called during SSR**

Before, `queryOnce` would throw a random error if you called it from the backend (It would say `this.querySubs is not defined`). This is because Reactor is not initialized on the backend. Instead I updated the code to give a more helpful error, and say to use the admin API instead.

## Main bugfix: Make sure we have only one socket active

Previously, it was possible to get into states where we had _multiple_ sockets up at the same time. 

One way this could have happened: 

1. socket 1 is in a 'connecting' state 
2. we go offline and back online
3. socket 2 starts. We try to 'close' the previous socket; [but we only checked for the 'connected' state ](https://github.com/instantdb/instant/blob/main/client/packages/core/src/Reactor.js#L1064)

In general, we wrote code like `ws.close(); ws.open()`, assuming these would happen synchronously. If they did not, we would get into weird states. 

I refactored the code to make sure that we only have 1 socket active. **To do this, I made it so our websocket callbacks _only_ work on the current socket.**

I also made an optimization: If we are trying to start a socket, and we already have one in a 'connecting' state, we re-use it.

@dwwoelfel @nezaj 