### PR TITLE
Use a grouped-queue in session

### DIFF
--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -37,17 +37,16 @@
         (process-fn item))
       :group-key
       (let [group-key arg
-            [prev curr] (swap-vals! group-key->subqueue update group-key pop)
-            prev-subqueue (get prev group-key)
-            item (first prev-subqueue)
+            item (first (get @group-key->subqueue group-key))
+            _ (process-fn item)
+            curr (swap! group-key->subqueue update group-key pop)
             curr-subqueue (get curr group-key)]
-        (process-fn item)
         (when (seq curr-subqueue)
           (.put main-queue [:group-key group-key]))))))
 
 (comment
-  (def gq (create :k))
-  (enqueue! gq {:k :a})
+  (def gq (create identity))
+  (enqueue! gq :a)
   (enqueue! gq {:k :a})
   (enqueue! gq {:k :b})
   (enqueue! gq {:not-grouped :c})

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -16,7 +16,7 @@
 (defn size [{:keys [size] :as _grouped-q}]
   (.get size))
 
-(defn add! [{:keys [group-fn main-queue group-key->subqueue size]
+(defn put! [{:keys [group-fn main-queue group-key->subqueue size]
              :as _grouped-q} item]
   (let [group-key (group-fn item)]
     (if (nil? group-key)
@@ -74,9 +74,9 @@
 
 (comment
   (def gq (create {:group-fn :k}))
-  (add! gq {:k :a})
-  (add! gq {:k :a})
-  (add! gq {:k :b})
-  (add! gq {:not-grouped :c})
+  (put! gq {:k :a})
+  (put! gq {:k :a})
+  (put! gq {:k :b})
+  (put! gq {:not-grouped :c})
   (peek gq)
   (process-polling! gq println))

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -1,23 +1,31 @@
 (ns instant.grouped-queue
   (:import
    (java.util.concurrent LinkedBlockingQueue TimeUnit)
+   (java.util.concurrent.atomic AtomicInteger)
    (clojure.lang PersistentQueue)))
 
 (def empty-q PersistentQueue/EMPTY)
 
 (defn create [{:keys [group-fn]}]
-  {:group-fn group-fn
+  {:size (AtomicInteger. 0)
+   :group-fn group-fn
    :group-key->subqueue (atom {})
    :main-queue (LinkedBlockingQueue.)})
 
-(defn enqueue! [{:keys [group-fn main-queue group-key->subqueue]
+(defn size [{:keys [size] :as _grouped-q}]
+  (.get size))
+
+(defn enqueue! [{:keys [group-fn main-queue group-key->subqueue size]
                  :as _grouped-q} item]
   (let [group-key (group-fn item)]
     (if (nil? group-key)
       ;; This item is not to be grouped.
-      (.put main-queue [:item item])
+      (do (.incrementAndGet size)
+          (.put main-queue [:item item]))
+
       ;; This item will be grouped on `group-key` 
-      (let [[prev] (swap-vals! group-key->subqueue
+      (let [_ (.incrementAndGet size)
+            [prev] (swap-vals! group-key->subqueue
                                update
                                group-key
                                (fn [subqueue]
@@ -28,14 +36,25 @@
         (when first-enqueue?
           (.put main-queue [:group-key group-key]))))))
 
-(defn process-polling! [{:keys [main-queue group-key->subqueue] :as _grouped-q}
+(defn peek [{:keys [main-queue group-key->subqueue] :as _grouped-q}]
+  (let [[t arg :as entry] (.peek main-queue)]
+    (cond
+      (nil? entry) nil
+      (= t :item) arg
+      (= t :group-key) (first (get @group-key->subqueue arg)))))
+
+(defn process-polling! [{:keys [main-queue group-key->subqueue size] :as _grouped-q}
                         process-fn]
   (let [[t arg :as entry] (.poll main-queue 1000 TimeUnit/MILLISECONDS)]
     (cond
       (nil? entry) nil
 
       (= t :item)
-      (process-fn arg)
+      (do
+        (process-fn arg)
+        (.decrementAndGet size)
+        true)
+
       (= t :group-key)
       (let [group-key arg
             item (first (get @group-key->subqueue group-key))]
@@ -44,8 +63,10 @@
           (finally
             (let [curr (swap! group-key->subqueue update group-key pop)
                   curr-subqueue (get curr group-key)]
+              (.decrementAndGet size)
               (when (seq curr-subqueue)
-                (.put main-queue [:group-key group-key])))))))))
+                (.put main-queue [:group-key group-key])))))
+        true))))
 
 (comment
   (def gq (create {:group-fn :k}))
@@ -53,4 +74,5 @@
   (enqueue! gq {:k :a})
   (enqueue! gq {:k :b})
   (enqueue! gq {:not-grouped :c})
+  (peek gq)
   (process-polling! gq println))

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -5,7 +5,7 @@
 
 (def empty-q PersistentQueue/EMPTY)
 
-(defn create [group-fn]
+(defn create [{:keys [group-fn]}]
   {:group-fn group-fn
    :group-key->subqueue (atom {})
    :main-queue (LinkedBlockingQueue.)})
@@ -28,8 +28,8 @@
         (when first-enqueue?
           (.put main-queue [:group-key group-key]))))))
 
-(defn process-polling! [{:keys [main-queue group-key->subqueue]
-                         :as _grouped-q} process-fn]
+(defn process-polling! [{:keys [main-queue group-key->subqueue] :as _grouped-q}
+                        process-fn]
   (let [[t arg :as entry] (.poll main-queue 1000 TimeUnit/MILLISECONDS)]
     (cond
       (nil? entry) nil
@@ -48,7 +48,7 @@
                 (.put main-queue [:group-key group-key])))))))))
 
 (comment
-  (def gq (create :k))
+  (def gq (create {:group-fn :k}))
   (enqueue! gq {:k :a})
   (enqueue! gq {:k :a})
   (enqueue! gq {:k :b})

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -1,0 +1,54 @@
+(ns instant.grouped-queue
+  (:import
+   (java.util.concurrent LinkedBlockingQueue)
+   (clojure.lang PersistentQueue)))
+
+(def empty-q PersistentQueue/EMPTY)
+
+(defn create [group-fn]
+  {:group-fn group-fn
+   :group-key->subqueue (atom {})
+   :main-queue (LinkedBlockingQueue.)})
+
+(defn enqueue! [{:keys [group-fn main-queue group-key->subqueue]
+                 :as _grouped-q} item]
+  (let [group-key (group-fn item)]
+    (if (nil? group-key)
+      ;; This item is not to be grouped.
+      (.put main-queue [:item item])
+      ;; This item will be grouped on `group-key` 
+      (let [[prev] (swap-vals! group-key->subqueue
+                               update
+                               group-key
+                               (fn [subqueue]
+                                 (conj (or subqueue empty-q)
+                                       item)))
+            prev-subqueue (get prev group-key)
+            first-enqueue? (empty? prev-subqueue)]
+        (when first-enqueue?
+          (.put main-queue [:group-key group-key]))))))
+
+(defn process! [{:keys [main-queue group-key->subqueue]
+                 :as _grouped-q} process-fn]
+  (let [[t arg] (.take main-queue)]
+    (case t
+      :item
+      (let [item arg]
+        (process-fn item))
+      :group-key
+      (let [group-key arg
+            [prev curr] (swap-vals! group-key->subqueue update group-key pop)
+            prev-subqueue (get prev group-key)
+            item (first prev-subqueue)
+            curr-subqueue (get curr group-key)]
+        (process-fn item)
+        (when (seq curr-subqueue)
+          (.put main-queue [:group-key group-key]))))))
+
+(comment
+  (def gq (create :k))
+  (enqueue! gq {:k :a})
+  (enqueue! gq {:k :a})
+  (enqueue! gq {:k :b})
+  (enqueue! gq {:not-grouped :c})
+  (process! gq println))

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -29,9 +29,8 @@
             [prev] (swap-vals! group-key->subqueue
                                update
                                group-key
-                               (fn [subqueue]
-                                 (conj (or subqueue empty-q)
-                                       item)))
+                               (fnil conj empty-q)
+                               item)
             prev-subqueue (get prev group-key)
             first-enqueue? (empty? prev-subqueue)]
         (when first-enqueue?

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -484,7 +484,7 @@
              (recur)))))))
 
 (defn enqueue->receive-q [receive-q item]
-  (grouped-queue/add!
+  (grouped-queue/put!
    receive-q
    {:item item :put-at (Instant/now)}))
 

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -484,7 +484,7 @@
              (recur)))))))
 
 (defn enqueue->receive-q [receive-q item]
-  (grouped-queue/enqueue!
+  (grouped-queue/add!
    receive-q
    {:item item :put-at (Instant/now)}))
 
@@ -573,6 +573,10 @@
       #{:join-room :leave-room :set-presence :client-broadcast}
       [session-id :eph]
 
+      #{:add-query :remove-query}
+      (let [{:keys [q]} item]
+        [session-id :query q])
+
       nil)))
 
 (comment
@@ -581,7 +585,7 @@
   (group-fn {:item {:session-id 1 :op :add-query}}))
 
 (defn start []
-  (def receive-q (grouped-queue/create {:group-fn group-fn}))
+  (def receive-q (grouped-queue/create {:group-fn #'group-fn}))
   (def receive-q-stop-signal (atom false))
   (def cleanup-gauge (gauges/add-gauge-metrics-fn
                       (fn [] (receive-q-metrics receive-q))))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -563,7 +563,7 @@
 ;; ------
 ;; System
 
-(defn receive-q-metrics [receive-q]
+(defn receive-q-metrics [_receive-q]
   ;; TODO: add metrics
   #_[{:path "instant.reactive.session.receive-q.size"
       :value (.size receive-q)}
@@ -577,6 +577,7 @@
     (condp = op
       :transact
       [session-id op]
+      ;; TODO: do the same for `set-presence` `join-room` `leave-room` (they should all batch together) 
       :else
       nil)))
 

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -556,14 +556,13 @@
 ;; ------
 ;; System
 
-(defn receive-q-metrics [_receive-q]
-  ;; TODO: add metrics
-  #_[{:path "instant.reactive.session.receive-q.size"
-      :value (.size receive-q)}
-     {:path "instant.reactive.session.receive-q.longest-waiting-ms"
-      :value (if-let [{:keys [put-at]} (.peek receive-q)]
-               (.toMillis (Duration/between put-at (Instant/now)))
-               0)}])
+(defn receive-q-metrics [receive-q]
+  [{:path "instant.reactive.session.receive-q.size"
+    :value (grouped-queue/size receive-q)}
+   {:path "instant.reactive.session.receive-q.longest-waiting-ms"
+    :value (if-let [{:keys [put-at]} (grouped-queue/peek receive-q)]
+             (.toMillis (Duration/between put-at (Instant/now)))
+             0)}])
 
 (defn group-fn [{:keys [item] :as _input}]
   (let [{:keys [session-id op]} item]


### PR DESCRIPTION
Reference: https://paper.dropbox.com/doc/Receive-Q-Causal-Order-RAfjwje81o6jWqDT6jLie

### Problem
Since we removed the transaction lock, there’s a race condition: if you send two transactions txA, txB, txB can finish before txA. 

```
    // Client: 
    txA { name = "Alice" }
    txB { name = "Bob" } 
    // Expected result: 
    {name: "Bob"} 
    // Got: 
    {name = "Alice" }
```

### Solution: grouped-queue

Created a `grouped-queue` abstraction, so we can maintain causal order for events, and used it inside session. 

`grouped-queue` takes a `group-fn`. Each enqueued item goes through a `group-fn`. We make sure that only _one_ item can run for a particular group at a time. We also distribute work into the queue more fairly. 

Right now we group the following events:
- (`transact`) by session-id 
- (`set-presence` `join-room` `leave-room` `broadcast`) by session-id
- (`add-query` `remove-query`) by session-id and query

### Future work

Now that we have this abstraction, we can use it in more places: for example, we can use it in invalidator to separate work per app

We can also make smarter batching decisions: 
  - we can treat N refreshes as 1 refresh command. 
  - we can batch `transacts` and `set-presence` together, etc

@dwwoelfel @nezaj