### PR TITLE
[reactor] add more logging to send and receive

### DIFF
--- a/client/packages/core/__tests__/src/Reactor.test.js
+++ b/client/packages/core/__tests__/src/Reactor.test.js
@@ -36,7 +36,7 @@ test("querySubs round-trips", async () => {
   });
 
   // Initialize the store
-  reactor._handleReceive({
+  reactor._handleReceive(0, {
     op: "add-query-ok",
     q,
     "processed-tx-id": 0,

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1027,6 +1027,9 @@ export default class Reactor {
     if (this._ws.readyState !== WS_OPEN_STATUS) {
       return;
     }
+    if (!ignoreLogging[msg.op]) {
+      log.info("[send]", this._ws._id, msg.op, msg);
+    }
     this._ws.send(JSON.stringify({ "client-event-id": eventId, ...msg }));
   }
 


### PR DESCRIPTION
Small PR that adds more verbose logging in Reactor. I am doing this to try to better debug the issue that a few of our apps are facing, where queries don't seem to return. 

@dwwoelfel @nezaj 