### PR TITLE
[bugfix] clear dataForQuery cache when changing users

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1413,6 +1413,7 @@ export default class Reactor {
   updateUser(newUser) {
     const newV = { error: undefined, user: newUser };
     this._currentUserCached = { isLoading: false, ...newV };
+    this._dataForQueryCache = {};
     this.querySubs.set((prev) => {
       Object.keys(prev).forEach((k) => {
         delete prev[k].result;


### PR DESCRIPTION
In our authhello example, I noticed a time where a query gets stuck in a loading state. 

Without refreshing the page: 

1. Log in 
2. Log out
3. Log back in 

This happened because:
- In `notifyOne`, we exit early whenever we see a result that has already been in our cache
- But logging in and out, we never cleared our cache

I am not 100% sure this is the root cause. There may be other situations where our cache backfires and prevents us from notifying a cb. This is a clearly broken case, so first fixing it.

@dwwoelfel @nezaj 

