### PR TITLE
Add app-id in the oauth state param

### DIFF
--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -431,16 +431,18 @@
                         state
                         (return-error "Missing state param in OAuth redirect."))
 
-          [app-id state] (let [[app-id state] (case (count state-param)
-                                                ;; TODO(dww): Remove this case once all
-                                                ;;   of the oauth redirects have cycled
-                                                36 [nil (uuid-util/coerce state-param)]
-                                                72 [(uuid-util/coerce (subs state-param 0 36))
-                                                    (uuid-util/coerce (subs state-param 36))]
-                                                [])]
-                           (if state
-                             [app-id state]
-                             (return-error "Invalid state param in OAuth redirect.")))
+          ;; _app-id unused for now, but will be used when we have
+          ;; app_oauth_redirects in triples
+          [_app-id state] (let [[app-id state] (case (count state-param)
+                                                 ;; TODO(dww): Remove this case once all
+                                                 ;;   of the oauth redirects have cycled
+                                                 36 [nil (uuid-util/coerce state-param)]
+                                                 72 [(uuid-util/coerce (subs state-param 0 36))
+                                                     (uuid-util/coerce (subs state-param 36))]
+                                                 [])]
+                            (if state
+                              [app-id state]
+                              (return-error "Invalid state param in OAuth redirect.")))
 
           cookie (if-let [cookie (-> req
                                      (get-in [:cookies oauth-cookie-name :value])

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -33,7 +33,8 @@
             [lambdaisland.uri :as uri]
             [next.jdbc :as next-jdbc]
             [ring.middleware.cookies :refer [wrap-cookies]]
-            [ring.util.http-response :as response]))
+            [ring.util.http-response :as response])
+  (:import (java.util UUID)))
 
 ;; ----
 ;; ws


### PR DESCRIPTION
We put the app-id in the state param. When we move the `app_oauth_redirects` in the `triples` table, we'll need to know which app to fetch the redirect from. This lets us figure out which app to use.

Two other small changes:
1. Replaces `(UUID/randomUUID)` with `(random-uuid)` in the route ns
2. Changes our cookie-handling logic a bit to add a prefix to the cookie value. On localhost, clerk was overwriting the `__session` key. In order to know which cookie is ours, we now add a `instantdb_` prefix to the value. 