### PR TITLE
[Client] Add button for Hide/Show App ID on Copyable component

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -20,6 +20,8 @@ import {
   CheckCircleIcon,
   ClipboardCopyIcon,
   XIcon,
+  EyeIcon,
+  EyeOffIcon,
 } from '@heroicons/react/solid';
 import { errorToast, successToast } from '@/lib/toast';
 import CopyToClipboard from 'react-copy-to-clipboard';
@@ -620,6 +622,7 @@ export function Copyable({
   label: string;
   size?: 'normal' | 'large';
 }) {
+  const [showLabel, setShowLabel] = useState<boolean>(false);
   const [copyLabel, setCopyLabel] = useState('Copy');
   const sizeToStyle = {
     normal: { main: 'text-sm', copy: 'text-xs' },
@@ -644,9 +647,28 @@ export function Copyable({
           selection.selectAllChildren(el);
         }}
       >
-        {value}
+        {showLabel ? value : '********-****-****-****-************'}
       </pre>
-      <div className="px-4">
+      <div className="flex gap-1 px-1">
+        <button
+          onClick={() => setShowLabel(!showLabel)}
+          className={cn(
+            'flex items-center gap-x-1 rounded-sm bg-white px-2 py-1 ring-1 ring-inset ring-gray-300 hover:bg-gray-50',
+            { 'text-xs': size === 'normal', 'text-sm': size === 'large' },
+          )}
+        >
+          {showLabel ? (
+            <>
+            <EyeOffIcon className="-ml-0.5 h-4 w-4" aria-hidden="true" />
+            Hide
+            </>
+          ) : (
+            <>
+            <EyeIcon className="-ml-0.5 h-4 w-4" aria-hidden="true" />
+            Show
+            </>
+          )}
+        </button>
         <CopyToClipboard text={value}>
           <button
             onClick={() => {


### PR DESCRIPTION
Hello!

I started using Instantdb today, and I find it great! The only problem I found is that when I use it, my App ID is always visible, so if I want to share a screen or screens, it is impossible.

Because of this, I decided to make a small modification to the client so that it always appears hidden and can be shown if necessary.

![Captura de pantalla 2024-10-16 a la(s) 4 38 31 p  m](https://github.com/user-attachments/assets/6e8e6fa3-2a7a-436f-bac1-0ed5f52b8dcc)
