### PR TITLE
Better error for invalid lookup

### DIFF
--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -38,7 +38,7 @@
   (let [[_ eid & json-parts] (.split k "__")]
     (try
       [eid (<-json (string/join "__" json-parts))]
-      (catch JsonParseException e
+      (catch JsonParseException _e
         (ex/throw-validation-err!
          :lookup
          k

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -692,6 +692,13 @@
     (is (= {:message "test.isbn is not a valid lookup attribute."}
            (tx-validation-err
             attrs [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))
+    (is (= {:message "lookup value is invalid", :hint {:attribute "linkOn"
+                                                       :value "undefined"}}
+           (tx-validation-err
+            attrs [["link"
+                    "spans"
+                    "6fd7b6eb-6fa2-4943-b5a3-2d73c8bd6904"
+                    {:parentSpan "lookup__linkOn__undefined"}]])))
     (is (= {:message "test.isbn is not a unique attribute on books"}
            (tx-validation-err
             (conj attrs {:id (random-uuid)


### PR DESCRIPTION
Returns a nicer error when we can't parse the lookup value.

We were throwing 500s when someone encoded `undefined` in the lookup value. Now we'll throw a validation error.