### PR TITLE
move our sampling to refinery

### DIFF
--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -1,8 +1,8 @@
 RulesVersion: 2
 Samplers:
     __default__:
-        DeterministicSampler:
-            SampleRate: 1
+      DeterministicSampler:
+          SampleRate: 1
     prod:
       RulesBasedSampler:
         Rules:
@@ -11,7 +11,18 @@ Samplers:
             Conditions:
               - Field: error
                 Operator: exists
-
+          - Name: set-presence = 1/100
+            SampleRate: 100 
+            Conditions: 
+              - Field: op
+                Operator: = 
+                Value: ':set-presence' 
+          - Name: client-broadcast = 1/10 
+            SampleRate: 10
+            Conditions:
+              - Field: op 
+                Operator: =
+                Value: ':client-broadcast'
           - Name: default rule
             Sampler:
               EMAThroughputSampler:


### PR DESCRIPTION
Previously, we had an in-house, 'poor-man's' sampler. This led to some child events being lost. Now that we have refinery, we don't need to sample at the event level. Instead, we can use refinery rules and sample at the trace level. 

Moved our current use of sampling into refinery.

@dwwoelfel @nezaj 