### PR TITLE
Return res (which would include res.user) from signInWithCustomToken

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1452,6 +1452,7 @@ export default class Reactor {
       refreshToken: authToken,
     });
     this.changeCurrentUser(res.user);
+    return res;
   }
 
   async signOut() {


### PR DESCRIPTION
pls 🙏🏾

This would be thus also be returned in `db.auth.signInWithToken` which would be very convenient and helpful 

I noticed that `user` from `db.useAuth` doesn't sync immediately after calling `db.auth.signInWithToken`, causing issues with our React Native navigation that depends on `user` from `db.useAuth`

in any case it seems like an oversight not to return `res`