### PR TITLE
Quieter logs

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -276,8 +276,9 @@
             :let [squuid-timestamp (squuid-time-millis sess-id)]
             :when (< squuid-timestamp oldest-timestamp)]
       (tracer/with-span! {:name "clean-old-session"
-                          :attributes {:session-id sess-id
-                                       :app-id app-id
+                          :attributes {:app-id app-id
+                                       :room-id room-id
+                                       :session-id sess-id
                                        :squuid-timestamp squuid-timestamp}}
         (remove-session! app-id room-id sess-id)))))
 

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -64,8 +64,7 @@
       ;; every span. This is too noisy for stdout
       (string/starts-with? k "jvm.")
       ;; gauge metrics for a namespace
-      (and (not= :prod (config/get-env))
-           (string/starts-with? k "instant."))))
+      (string/starts-with? k "instant.")))
 
 (defn format-attr-value
   "Formats attr values for logs."


### PR DESCRIPTION
Stops logging the gauge properties. They're adding a lot of extra log volume.