### PR TITLE
Clear the token on the dashboard if we get unauthorized

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -72,7 +72,8 @@
 
 (defn req->auth-user! [req]
   (let [refresh-token (http-util/req->bearer-token! req)]
-    (instant-user-model/get-by-refresh-token! {:refresh-token refresh-token})))
+    (instant-user-model/get-by-refresh-token! {:refresh-token refresh-token
+                                               :auth? true})))
 
 (defn assert-valid-member-role! [role]
   (ex/assert-valid! :role role (when-not (member-role->idx (keyword role)) ["Invalid role"])))

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -102,8 +102,11 @@
               bad-request (when instant-ex
                             (instant-ex->bad-request instant-ex))]
           (cond
-            bad-request (do (tracer/record-exception-span! e {:name "instant-ex/bad-request"})
-                            (response/bad-request bad-request))
+            bad-request (if (-> bad-request :hint :args first :auth?)
+                          (do (tracer/record-exception-span! e {:name "instant-ex/unauthorized"})
+                              (response/unauthorized bad-request))
+                          (do (tracer/record-exception-span! e {:name "instant-ex/bad-request"})
+                              (response/bad-request bad-request)))
 
             instant-ex (do (tracer/add-exception! instant-ex {:escaping? false})
                            (response/internal-server-error


### PR DESCRIPTION
Logs the user out if the token is bad instead of showing "Record not found: instant-user".

I don't think we hit this much in production, but if we did, the user would have to figure out that they needed to clear localStorage to reset the auth state. 

Useful when switching between databases in development.