### PR TITLE
[CEL] Add strings extensions

### DIFF
--- a/client/www/pages/docs/storage.md
+++ b/client/www/pages/docs/storage.md
@@ -188,7 +188,7 @@ Authenticated users may only upload and view files from their own subdirectory:
       "view": "isOwner",
       "create": "isOwner"
     },
-    "bind": ["isOwner", "data.path.startsWith(auth.id)"]
+    "bind": ["isOwner", "data.path.startsWith(auth.id + '/')"]
   }
 }
 ```

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -220,11 +220,12 @@
       (.addVar "newData" type-obj)
       (.addFunctionDeclarations (ucoll/array-of CelFunctionDecl custom-fn-decls))
       (.setStandardMacros (CelStandardMacro/STANDARD_MACROS))
-      (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings)]))
+      (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings) (CelExtensions/strings)]))
       (.build)))
 
 (def ^:private ^CelRuntime cel-runtime
   (-> (CelRuntimeFactory/standardCelRuntimeBuilder)
+      (.addLibraries [(CelExtensions/strings)])
       (.addFunctionBindings (ucoll/array-of CelRuntime$CelFunctionBinding custom-fn-bindings))
       (.build)))
 


### PR DESCRIPTION
A user pointed out that we should include a trailing slash for our storage permission rule. This PR updates the docs and also adds the string extensions for CEL

Note: The string extension is not needed for this example, but I thought it might be useful to add this in since it's part of our current version of CEL. Separately I notice we're currently on `0.5.2` of cel-java but the latest is [0.8.0](https://github.com/google/cel-java/tags) which includes some improvements / additional extensions. May be good to upgrade/test in a separate PR