### PR TITLE
[Admin SDK] Encode getUser for admin sdk

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -471,7 +471,10 @@ class Auth {
   getUser = async (
     params: { email: string } | { id: string } | { refresh_token: string },
   ): Promise<User> => {
-    const qs = Object.entries(params).map(([k, v]) => `${k}=${v}`);
+    const qs = Object.entries(params)
+      .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+      .join('&');
+
     const response: { user: User } = await jsonFetch(
       `${this.config.apiURI}/admin/users?${qs}`,
       {

--- a/client/sandbox/admin-sdk-express/src/with-schema.ts
+++ b/client/sandbox/admin-sdk-express/src/with-schema.ts
@@ -133,7 +133,7 @@ async function testSignOut() {
 }
 
 async function testFetchUser() {
-  const email = "stopa@instantdb.com";
+  const email = "stopa+123@instantdb.com";
   const user = await db.auth.getUser({ email });
   console.log("user", user);
 }


### PR DESCRIPTION
One of our users reported `getUser` borks when there's a `+` in email. This is due to us not encoding the query string [[SO]](https://stackoverflow.com/a/6855723)