### PR TITLE
Update docs for users table, make it easier to edit view rule

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -1303,19 +1303,18 @@ function Admin({
       <Copyable label="Secret" value={app.admin_token} />
       {isMinRole('collaborator', app.user_app_role) ? (
         <div className="space-y-2">
-          <SectionHeading>Experimental</SectionHeading>
-          <SubsectionHeading>Users namespace</SubsectionHeading>
+          <SectionHeading>Users namespace</SectionHeading>
           <Content>
             The users namespace is a psuedo-namespace named <code>$users</code>.
-            It provides a read-only view into your users on Instant. When
-            enabled, you can view your users from the Explorer and link to the{' '}
+            It provides a read-only view into your users on Instant. It allows
+            you to view your users from the Explorer and link to the{' '}
             <code>$users</code> namespace from other namespaces.
           </Content>
           <Content>
-            When enabling, we add default rules that only allow the
-            authenticated user to view their row in the users namespace. The{' '}
-            <code>view</code> rule can be modified from the{' '}
-            <code>Permissions</code> page.
+            It comes with a default <code>view</code> rule (
+            <code>auth.id == data.id</code>) that allows the the authenticated
+            user to view their row in the users namespace. The <code>view</code>{' '}
+            rule can be modified from the <code>Permissions</code> page.
           </Content>
 
           {usersAttrs?.length ? (

--- a/client/www/pages/docs/users.md
+++ b/client/www/pages/docs/users.md
@@ -5,9 +5,9 @@ title: Managing users
 ## See users in your app
 
 You can manage users in your app using the `$users` namespace. This namespace is
-automatically created when you enable it from the `Admin` tab.
+automatically created when you create an app.
 
-Once enabled, you'll see the `$users` namespace in the `Explorer` tab with all
+You'll see the `$users` namespace in the `Explorer` tab with all
 the users in your app!
 
 ## Querying users
@@ -18,15 +18,15 @@ data.
 
 ```javascript
 export default {
-  "$users": {
-    "allow": {
-      "view": "auth.id == data.id",
-      "create": "false",
-      "delete": "false",
-      "update": "false"
-    }
+  $users: {
+    allow: {
+      view: 'auth.id == data.id',
+      create: 'false',
+      delete: 'false',
+      update: 'false',
+    },
   },
-}
+};
 ```
 
 Right now `$users` is a read-only namespace. You can override the `view`
@@ -127,9 +127,11 @@ You can then create links between users on the client side like so:
 const addTodo = (newTodo, currentUser) => {
   const newId = id();
   db.transact(
-    tx.todos[newId].update({ text: newTodo, userId: currentUser.id, completed: false })
+    tx.todos[newId]
+      .update({ text: newTodo, userId: currentUser.id, completed: false })
       // Link the todo to the user with the `owner` label we defined in the schema
-      .link({ owner: currentUser.id }));
+      .link({ owner: currentUser.id }),
+  );
 };
 
 // Creates or updates a user profile with a nickname and links it to the
@@ -137,11 +139,12 @@ const addTodo = (newTodo, currentUser) => {
 const updateNick = (newNick, currentUser) => {
   const profileId = lookup('email', currentUser.email);
   db.transact([
-    tx.profiles[profileId].update({ userId: currentUser.id, nickname: newNick })
+    tx.profiles[profileId]
+      .update({ userId: currentUser.id, nickname: newNick })
       // Link the profile to the user with the `user` label we defined in the schema
       .link({ user: currentUser.id }),
   ]);
-}
+};
 ```
 
 If attr creation on the client [is enabled](/docs/permissions#attrs),
@@ -176,12 +179,12 @@ todos like so:
 ```javascript
 export default {
   // users perms...
-  "todos": {
-    "allow": {
+  todos: {
+    allow: {
       // owner is the label from the todos namespace to the $users namespace
-      "update": "auth.id in data.ref('owner.id')",
-    }
-  }
+      update: "auth.id in data.ref('owner.id')",
+    },
+  },
 };
 ```
 
@@ -192,12 +195,12 @@ equivalent rule to the one above using `auth.ref`:
 ```javascript
 export default {
   // users perms...
-  "todos": {
-    "allow": {
+  todos: {
+    allow: {
       // We traverse the users links directly from the auth object
-      "update": "data.id in auth.ref('$user.todos.id')",
-    }
-  }
+      update: "data.id in auth.ref('$user.todos.id')",
+    },
+  },
 };
 ```
 
@@ -219,3 +222,4 @@ export default {
   }
 };
 
+```

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -106,8 +106,9 @@
   [rules action]
   (case action
     ("create" "update" "delete")
-    (when (not= (get-in rules ["$users" "allow" action])
-                "false")
+    (when (and (not (nil? (get-in rules ["$users" "allow" action])))
+               (not= (get-in rules ["$users" "allow" action])
+                     "false"))
       [["$users"
         action
         (format "The $users namespace is read-only. Set `$users.allow.%s` to `\"false\"`."


### PR DESCRIPTION
<img width="561" alt="image" src="https://github.com/user-attachments/assets/0bbe465a-8c6d-4f2d-8004-96edf2e9fab1">

<img width="643" alt="image" src="https://github.com/user-attachments/assets/326ae0f4-813d-4e0f-a06f-6c7f47b6a7d3">

Also makes it easier to edit the view rule for users. If you don't provide a `create`, `update`, or `delete` rule, we won't throw an error. We'll only throw an error if you set it to something that isn't `"false"`.