### PR TITLE
[Core] Remove object-hash

### DIFF
--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -31,9 +31,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
-    "@types/object-hash": "^3.0.6",
     "mutative": "^1.0.10",
-    "object-hash": "^3.0.0",
     "uuid": "^9.0.0"
   }
 }

--- a/client/packages/core/src/utils/hash.ts
+++ b/client/packages/core/src/utils/hash.ts
@@ -1,5 +1,0 @@
-import { MD5 } from "object-hash";
-
-const weakHash = MD5;
-
-export default weakHash;

--- a/client/packages/core/src/utils/weakHash.ts
+++ b/client/packages/core/src/utils/weakHash.ts
@@ -1,40 +1,76 @@
 /**
  *
- * Optimized MurmurHash3 implementation (32-bit), where we want consistent,
- * unique hashing and are not concerned with the hash being decoded.
+ * Unique Hashing implementation inspired by djb2/fnv1a algorithms,
+ * where we are not concerned with the hash being decoded.
  * Focuses on speed while maintaining good hash distribution
+ *
+ * Note: We could also use something like Murmurhash instead
+ * https://github.com/jensyt/imurmurhash-js/blob/master/imurmurhash.js
+ *
+ * @param {any} input - Value to hash
+ * @returns {string} - Hash in hex format
  */
-export default function weakHash(input: any) {
-  // Convert input to string if necessary
-  const str = typeof input === 'string'
-    ? input
-    : JSON.stringify(Array.isArray(input) ? input : Object.entries(input).sort());
+export default function weakHash(input: any): string {
+  // Handle primitives without JSON stringify for better performance
+  if (typeof input === 'number') {
+    // Use a larger number space for numeric values
+    return (Math.abs(input * 2654435761) >>> 0).toString(16);
+  }
+  if (typeof input === 'boolean') return input ? '1' : '0';
+  if (input === null) return 'null';
+  if (input === undefined) return 'undefined';
 
-  // MurmurHash3's mixing function
-  let h1 = 0xdeadbeef;
-  const c1 = 0xcc9e2d51;
-  const c2 = 0x1b873593;
-
-  for (let i = 0; i < str.length; i++) {
-    let k1 = str.charCodeAt(i);
-
-    k1 = Math.imul(k1, c1);
-    k1 = (k1 << 15) | (k1 >>> 17);
-    k1 = Math.imul(k1, c2);
-
-    h1 ^= k1;
-    h1 = (h1 << 13) | (h1 >>> 19);
-    h1 = Math.imul(h1, 5) + 0xe6546b64;
+  // For strings, use FNV-1a algorithm
+  if (typeof input === 'string') {
+    let hash = 0x811C9DC5; // FNV offset basis (32 bit)
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i);
+      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+      hash = hash >>> 0; // Convert to unsigned 32-bit after each iteration
+    }
+    return hash.toString(16);
   }
 
-  // Final mixing
-  h1 ^= str.length;
-  h1 ^= h1 >>> 16;
-  h1 = Math.imul(h1, 0x85ebca6b);
-  h1 ^= h1 >>> 13;
-  h1 = Math.imul(h1, 0xc2b2ae35);
-  h1 ^= h1 >>> 16;
+  // For arrays, hash elements directly
+  if (Array.isArray(input)) {
+    let hash = 0x811C9DC5;
+    for (let i = 0; i < input.length; i++) {
+      // Add array position to hash calculation
+      hash ^= (i + 1) * 2654435761;
+      // Recursively hash array elements
+      const elementHash = weakHash(input[i]);
+      // Mix the element hash into the running hash
+      for (let j = 0; j < elementHash.length; j++) {
+        hash ^= elementHash.charCodeAt(j);
+        hash *= 16777619; // FNV prime (32 bit)
+        hash = hash >>> 0;
+      }
+    }
+    return hash.toString(16);
+  }
 
-  // Convert to unsigned 32-bit integer and return as hex
-  return (h1 >>> 0).toString(16);
+  // For objects, hash keys and values
+  if (typeof input === 'object') {
+    let hash = 0x811C9DC5;
+    const keys = Object.keys(input).sort(); // Sort for consistency
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      // Hash the key using string hash
+      const keyHash = weakHash(key);
+      hash ^= parseInt(keyHash, 16);
+      hash *= 16777619;
+      hash = hash >>> 0;
+
+      // Hash the value recursively
+      const valueHash = weakHash(input[key]);
+      hash ^= parseInt(valueHash, 16);
+      hash *= 16777619;
+      hash = hash >>> 0;
+    }
+    return hash.toString(16);
+  }
+
+  // Fallback for other types
+  return weakHash(String(input));
 }

--- a/client/packages/core/src/utils/weakHash.ts
+++ b/client/packages/core/src/utils/weakHash.ts
@@ -1,9 +1,40 @@
 /**
- * Wrapper for a fast hash function, where we want consistent, unique hashing
- * and are not concerned with the hash being decoded
- * */
-import { MD5 } from "object-hash";
+ *
+ * Optimized MurmurHash3 implementation (32-bit), where we want consistent,
+ * unique hashing and are not concerned with the hash being decoded.
+ * Focuses on speed while maintaining good hash distribution
+ */
+export default function weakHash(input: any) {
+  // Convert input to string if necessary
+  const str = typeof input === 'string'
+    ? input
+    : JSON.stringify(Array.isArray(input) ? input : Object.entries(input).sort());
 
-const weakHash = MD5;
+  // MurmurHash3's mixing function
+  let h1 = 0xdeadbeef;
+  const c1 = 0xcc9e2d51;
+  const c2 = 0x1b873593;
 
-export default weakHash;
+  for (let i = 0; i < str.length; i++) {
+    let k1 = str.charCodeAt(i);
+
+    k1 = Math.imul(k1, c1);
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = Math.imul(k1, c2);
+
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >>> 19);
+    h1 = Math.imul(h1, 5) + 0xe6546b64;
+  }
+
+  // Final mixing
+  h1 ^= str.length;
+  h1 ^= h1 >>> 16;
+  h1 = Math.imul(h1, 0x85ebca6b);
+  h1 ^= h1 >>> 13;
+  h1 = Math.imul(h1, 0xc2b2ae35);
+  h1 ^= h1 >>> 16;
+
+  // Convert to unsigned 32-bit integer and return as hex
+  return (h1 >>> 0).toString(16);
+}

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -91,15 +91,9 @@ importers:
 
   packages/core:
     dependencies:
-      '@types/object-hash':
-        specifier: ^3.0.6
-        version: 3.0.6
       mutative:
         specifier: ^1.0.10
         version: 1.0.10
-      object-hash:
-        specifier: ^3.0.0
-        version: 3.0.0
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -687,9 +681,6 @@ importers:
       '@types/node':
         specifier: 17.0.4
         version: 17.0.4
-      '@types/object-hash':
-        specifier: ^3.0.6
-        version: 3.0.6
       '@types/prismjs':
         specifier: ^1.26.0
         version: 1.26.3
@@ -9413,9 +9404,6 @@ packages:
     resolution: {integrity: sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==}
     dependencies:
       undici-types: 6.19.8
-
-  /@types/object-hash@3.0.6:
-    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
 
   /@types/parse5@6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}

--- a/client/www/package.json
+++ b/client/www/package.json
@@ -61,7 +61,6 @@
     "@types/js-cookie": "^3.0.2",
     "@types/lodash": "^4.14.182",
     "@types/node": "17.0.4",
-    "@types/object-hash": "^3.0.6",
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.2.74",
     "@types/react-copy-to-clipboard": "^5.0.4",


### PR DESCRIPTION
`object-hash` has a dependency on `crypto` which has caused folks issues in environments like [[Cloudflare](https://discord.com/channels/1031957483243188235/1280983629270487080/1290051152737472542)]

We only use `object-hash` for creating a unique value for our queries but we can use something else.

I looked into a few hashing alternatives and asked claude to come up with something. Based on the results this seemed like the fastest algo. You can see benchmarks here https://github.com/nezaj/hash-benchmarks