### PR TITLE
[Docs] Fix  $users

### DIFF
--- a/client/www/pages/docs/users.md
+++ b/client/www/pages/docs/users.md
@@ -61,7 +61,7 @@ import { i } from "@instantdb/react";
 const graph = i.graph(
   {
     $users: i.entity({
-      email: i.string().unique(),
+      email: i.any().unique().indexed(),
     }),
     profiles: i.entity({
       nickname: i.string(), // We can't add this directly to `$users`


### PR DESCRIPTION
One of users got confused because the cli tool would complain that we were trying to modify `$users` table. Re-pulling the schema fixed it for him, but he noticed that the default `$users` schema did not match what was in the docs.