### PR TITLE
[client] Make sure we ignore id key in instaml

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -26,6 +26,22 @@ test("simple update transform", () => {
   }
 });
 
+test("ignores id attrs", () => {
+  const testId = uuid();
+
+  const ops = instatx.tx.books[testId].update({ title: "New Title", id: 'ploop' });
+  const result = instaml.transform(zenecaAttrs, ops);
+
+  const expected = [
+    ["add-triple", testId, zenecaAttrToId["books/title"], "New Title"],
+    ["add-triple", testId, zenecaAttrToId["books/id"], testId],
+  ];
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
 test("optimistically adds attrs if they don't exist", () => {
   const testId = uuid();
 
@@ -677,3 +693,4 @@ test("it doesn't create duplicate ref attrs", () => {
     expect(result).toContainEqual(item);
   }
 });
+

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -208,12 +208,13 @@ function expandDeepMerge(attrs, [etype, eid, obj]) {
   return [idTuple].concat(attrTuples);
 }
 function removeIdFromArgs(step) { 
-  const newStep = [...step];
-  const lastIdx = newStep.length - 1;
-  const lastArg = {...newStep[lastIdx]};
-  delete lastArg.id;
-  newStep[lastIdx] = lastArg;
-  return newStep;
+  const [op, etype, eid, obj] = step;
+  if (!obj) {
+    return step;
+  }
+  const newObj = {...obj};
+  delete newObj.id
+  return [op, etype, eid, newObj]
 }
 
 function toTxSteps(attrs, step) {

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -207,8 +207,17 @@ function expandDeepMerge(attrs, [etype, eid, obj]) {
   // id first so that we don't clobber updates on the lookup field
   return [idTuple].concat(attrTuples);
 }
+function removeIdFromArgs(step) { 
+  const newStep = [...step];
+  const lastIdx = newStep.length - 1;
+  const lastArg = {...newStep[lastIdx]};
+  delete lastArg.id;
+  newStep[lastIdx] = lastArg;
+  return newStep;
+}
 
-function toTxSteps(attrs, [action, ...args]) {
+function toTxSteps(attrs, step) {
+  const [action, ...args] = removeIdFromArgs(step);
   switch (action) {
     case "merge":
       return expandDeepMerge(attrs, args);


### PR DESCRIPTION
On the backend, we already ignored the `id` inside a tx-step arg: 

https://github.com/instantdb/instant/blob/main/server/src/instant/admin/model.clj#L180-L181

We did not do the same on the frontend. This meant that if a user did something like: 

```javascript
tx.posts[idA].update({id: idB})
```

This would lead erroneous results. 

Fixing at least from the client, so it's not possible to send data like this

@dwwoelfel @nezaj 
