### PR TITLE
[sandbox] add a `display-code` variable to `program`

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -444,7 +444,7 @@ export function Sandbox({ app }: { app: InstantApp }) {
                               view
                             </span>
                             <code className="bg-white px-2">
-                              {cr.program?.code ?? (
+                              {cr.program?.['display-code'] ?? (
                                 <span className="text-gray-400">none</span>
                               )}
                             </code>
@@ -522,7 +522,7 @@ export function Sandbox({ app }: { app: InstantApp }) {
                             {cr.action}
                           </span>
                           <code className="bg-white px-2">
-                            {cr.program?.code ?? (
+                            {cr.program?.['display-code'] ?? (
                               <span className="text-gray-400">none</span>
                             )}
                           </code>

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -188,7 +188,7 @@
                                    (dissoc :check)
                                    (update :program
                                            select-keys
-                                           [:etype :action :code])))
+                                           [:etype :action :code :display-code])))
                              (:check-results result))}]
     (response/ok cleaned-result)))
 

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -183,6 +183,7 @@
                         :committed? (:committed? result)
                         :check-results
                         (map (fn [r]
+                               (tool/def-locals!)
                                (-> r
                                    (dissoc :check)
                                    (update :program

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -183,7 +183,6 @@
                         :committed? (:committed? result)
                         :check-results
                         (map (fn [r]
-                               (tool/def-locals!)
                                (-> r
                                    (dissoc :check)
                                    (update :program

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -52,6 +52,9 @@
           (str "cel.bind(" var-name ", " var-body ", " body ")"))
         expr)))
 
+(defn get-expr [rule etype action]
+  (get-in rule [etype "allow" action]))
+
 (defn extract [rule etype action]
   (when-let [expr (get-in rule [etype "allow" action])]
     (with-binds rule etype expr)))
@@ -71,21 +74,25 @@
         {:etype etype
          :action action
          :code code
+         :display-code code
          :cel-ast ast
          :cel-program (cel/->program ast)})
-      (let [ast (cel/->ast "false")]
+      (let [display-code (format "disallow_%s_on_system_tables" action)
+            code "false"
+            ast (cel/->ast code)]
         {:etype etype
          :action action
-         ;; For display purposes
-         :code (format "disallow_%s_on_system_tables" action)
+         :display-code display-code
+         :code code
          :cel-ast ast
          :cel-program (cel/->program ast)}))))
 
 (defn get-program! [rules etype action]
   (or
-   (when-let [code (some-> rules :code (extract etype action))]
+   (when-let [expr (get-expr rules etype action)]
      (try
-       (let [ast (cel/->ast code)]
+       (let [code (with-binds rules etype expr)
+             ast (cel/->ast code)]
          {:etype etype
           :action action
           :code code

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -89,13 +89,14 @@
 
 (defn get-program! [rules etype action]
   (or
-   (when-let [expr (get-expr rules etype action)]
+   (when-let [expr (get-expr (:code rules) etype action)]
      (try
-       (let [code (with-binds rules etype expr)
+       (let [code (with-binds (:code rules) etype expr)
              ast (cel/->ast code)]
          {:etype etype
           :action action
           :code code
+          :display-code expr
           :cel-ast ast
           :cel-program (cel/->program ast)})
        (catch CelValidationException e


### PR DESCRIPTION
daformat noticed that the 'rules' pain in sandbox shows the 'semi-compiled' view of rules:

```cel
cel.bind(...)
```

I added a special `display-code` parameter, which 

- a) shows the version of the code before we add `binds`
- b) shows the pretty-printed code for system tables

@dwwoelfel @nezaj 