### PR TITLE
[admin] order admin responses

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -750,6 +750,7 @@
                            (:children child))]
             (add-children
              (make-node {:k (:k form)
+                         :option-map (:option-map form)
                          :datalog-query (:datalog-query child)
                          :datalog-result (:result child)})
              nodes)))
@@ -1557,23 +1558,23 @@
                        {:program p
                         :result
                         (let [em (io/warn-io :instaql/entity-map
-                                   (entity-map ctx
-                                               query-cache
-                                               etype
-                                               eid))
+                                             (entity-map ctx
+                                                         query-cache
+                                                         etype
+                                                         eid))
                               ctx (assoc ctx
                                          :preloaded-refs preloaded-refs)]
                           (io/warn-io :instaql/eval-program
-                            (cel/eval-program!
-                             p
-                             {"auth" (cel/->cel-map {:ctx ctx
-                                                     :type :auth
-                                                     :etype "$users"}
-                                                    current-user)
-                              "data" (cel/->cel-map {:ctx ctx
-                                                     :etype etype
-                                                     :type :data}
-                                                    em)})))})])))
+                                      (cel/eval-program!
+                                       p
+                                       {"auth" (cel/->cel-map {:ctx ctx
+                                                               :type :auth
+                                                               :etype "$users"}
+                                                              current-user)
+                                        "data" (cel/->cel-map {:ctx ctx
+                                                               :etype etype
+                                                               :type :data}
+                                                              em)})))})])))
 
            (into {})))))
 

--- a/server/src/instant/util/instaql.clj
+++ b/server/src/instant/util/instaql.clj
@@ -48,8 +48,7 @@
         compare-fn (if (and (= k "serverCreatedAt")
                             (= direction :desc))
                      reverse-compare
-                     compare)
-        _ (tool/def-locals!)]
+                     compare)]
     (->> entries
          (sort-by (fn [{:strs [$serverCreatedAt] :as _entry}]
                     $serverCreatedAt)

--- a/server/src/instant/util/instaql.clj
+++ b/server/src/instant/util/instaql.clj
@@ -22,7 +22,10 @@
 
 (defn obj-node [ctx etype node]
   (let [datalog-result (-> node :data :datalog-result)
-        blob-entries (entity-model/datalog-result->map ctx datalog-result)
+        blob-entries (entity-model/datalog-result->map (assoc ctx
+                                                              :include-server-created-at? true)
+
+                                                       datalog-result)
         ref-entries (some->> node
                              :child-nodes
                              (map (partial enrich-node ctx etype))
@@ -34,11 +37,32 @@
     (= :one (-> data :attr :cardinality))
     (-> data :attr :unique?)))
 
+;; We will need to update this when we support more than serverCreatedAt 
+;; as the sort key
+
+(defn reverse-compare [a b]
+  (compare b a))
+
+(defn sort-entries [option-map entries]
+  (let [{:keys [k direction]} (:order option-map)
+        compare-fn (if (and (= k "serverCreatedAt")
+                            (= direction :desc))
+                     reverse-compare
+                     compare)
+        _ (tool/def-locals!)]
+    (->> entries
+         (sort-by (fn [{:strs [$serverCreatedAt] :as _entry}]
+                    $serverCreatedAt)
+                  compare-fn)
+         (map #(dissoc % "$serverCreatedAt")))))
+
 (defn instaql-ref-nodes->object-tree [ctx nodes]
   (reduce
    (fn [acc node]
      (let [{:keys [child-nodes data]} node
-           entries (map (partial obj-node ctx (-> data :etype)) child-nodes)
+           {:keys [option-map]} data
+           _entries (map (partial obj-node ctx (-> data :etype)) child-nodes)
+           entries (sort-entries option-map _entries)
            singular? (and (:inference? ctx) (singular-entry? data))
            entry-or-entries (if singular? (first entries) entries)]
        (assoc acc (:k data) entry-or-entries)))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -471,6 +471,70 @@
                                  :after alex-cursor
                                  :order {:serverCreatedAt "desc"}}))))))))
 
+(deftest obj-tree-order
+  (with-empty-app
+    (fn [{app-id :id :as _app}]
+      (let [get-handles-ordered (fn [pagination-params]
+                                  (as-> (instaql-nodes->object-tree
+                                         {:db {:conn-pool aurora/conn-pool}
+                                          :app-id app-id
+                                          :attrs (attr-model/get-by-app-id app-id)}
+                                         (iq/query
+                                          {:db {:conn-pool aurora/conn-pool}
+                                           :app-id app-id
+                                           :attrs (attr-model/get-by-app-id app-id)}
+                                          {:users {:$ pagination-params}})) %
+                                    (get % "users")
+                                    (map #(get % "handle") %)
+                                    (vec %)))
+            uid-attr-id (random-uuid)
+            handle-attr-id (random-uuid)
+            joe-eid (random-uuid)
+            stopa-eid (random-uuid)
+            daniel-eid (random-uuid)
+            _ (tx/transact! aurora/conn-pool
+                            (attr-model/get-by-app-id app-id)
+                            app-id
+                            [[:add-attr {:id uid-attr-id
+                                         :forward-identity [(random-uuid) "users" "id"]
+                                         :unique? true
+                                         :index? true
+                                         :value-type :blob
+                                         :cardinality :one}]
+                             [:add-attr {:id handle-attr-id
+                                         :forward-identity [(random-uuid) "users" "handle"]
+                                         :unique? true
+                                         :index? true
+                                         :value-type :blob
+                                         :cardinality :one}]])
+
+            _ (tx/transact! aurora/conn-pool
+                            (attr-model/get-by-app-id app-id)
+                            app-id
+                            [[:add-triple joe-eid uid-attr-id (str joe-eid)]
+                             [:add-triple joe-eid handle-attr-id "joe"]])
+
+            _ (tx/transact! aurora/conn-pool
+                            (attr-model/get-by-app-id app-id)
+                            app-id
+                            [[:add-triple stopa-eid uid-attr-id (str stopa-eid)]
+                             [:add-triple stopa-eid handle-attr-id "stopa"]])
+
+            _ (tx/transact! aurora/conn-pool
+                            (attr-model/get-by-app-id app-id)
+                            app-id
+                            [[:add-triple daniel-eid uid-attr-id (str daniel-eid)]
+                             [:add-triple daniel-eid handle-attr-id "daniel"]])]
+
+        (testing "default is serverCreatedAt asc"
+          (is (= ["joe" "stopa" "daniel"]
+                 (get-handles-ordered {})))
+          (is (= ["joe" "stopa" "daniel"]
+                 (get-handles-ordered {:order {:serverCreatedAt "asc"}}))))
+        (testing "reverse works"
+          (is (= ["daniel" "stopa" "joe"]
+                 (get-handles-ordered {:order {:serverCreatedAt "desc"}}))))))))
+
 (deftest flat-where-byop
   (testing "plain scan"
     (with-zeneca-byop
@@ -1407,8 +1471,7 @@
                       [[:add-triple shared-id user-id-attr shared-id]
                        [:add-triple shared-id user-handle-attr "handle"]
                        [:add-triple shared-id book-id-attr shared-id]
-                       [:add-triple shared-id book-title-attr "title"]
-                       ])
+                       [:add-triple shared-id book-title-attr "title"]])
         (is-pretty-eq?
          (query-pretty ctx r {:users {:$ {:where {:id shared-id}}}})
          [{:topics
@@ -1648,7 +1711,6 @@
         :triples #{}
         :aggregate [{:count 4}
                     {:count 392}]}))))
-
 
 ;; -----------
 ;; Users table

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -533,7 +533,14 @@
                  (get-handles-ordered {:order {:serverCreatedAt "asc"}}))))
         (testing "reverse works"
           (is (= ["daniel" "stopa" "joe"]
-                 (get-handles-ordered {:order {:serverCreatedAt "desc"}}))))))))
+                 (get-handles-ordered {:order {:serverCreatedAt "desc"}}))))
+        ;; This is a sentinel, to remind us to make sure admin queries work with other orders
+        (is (= '{:expected valid-order?
+                 :in ["users" :$ :order "random-field"],
+                 :message
+                 "We currently only support \"serverCreatedAt\" as the sort key in the `order` clause. Got \"random-field\"."}
+               (validation-err {:users
+                                {:$ {:order {:random-field "desc"}}}})))))))
 
 (deftest flat-where-byop
   (testing "plain scan"


### PR DESCRIPTION
A user pointed out that responses in admin were not coming in serverCreatedAt order. 

This makes it happen. 

Note: 

Right now we assume that we only order by serverCreatedAt. Eventually, this will either become unnecessary due to our instaql CTE update. But in case it's not, we'll need to update the logic when we allow for ordering by other keys. 


@dwwoelfel @nezaj 