### PR TITLE
Send display-code to frontend for queries

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1617,6 +1617,7 @@
                                               (get (:eid->etype perm-helpers) id)
                                               id)
                           :program (select-keys program [:code
+                                                         :display-code
                                                          :etype
                                                          :action])
                           :check result})


### PR DESCRIPTION
Pulls out `:display-code` from permissioned-node in the query