### PR TITLE
Handle hazelcast shutdown on our own

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -144,7 +144,9 @@
                                (tracer/with-span! {:name "stop-server"}
                                  (stop))
                                (tracer/with-span! {:name "stop-invalidator"}
-                                 (inv/stop-global))))))
+                                 (inv/stop-global))
+                               (tracer/with-span! {:name "stop-ephemeral"}
+                                 (eph/stop))))))
 
 (defn -main [& _args]
   (let [{:keys [aead-keyset]} (config/init)]

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -50,6 +50,7 @@
         (a/put! ch room-key)))))
 
 (defn init-hz []
+  (System/setProperty "hazelcast.shutdownhook.enabled" "false")
   (let [config (Config.)
         network-config (.getNetworkConfig config)
         join-config (.getJoin network-config)


### PR DESCRIPTION
Hazelcast is shutting down on its own when it sees the sigterm signal, but that happens before we're finished shutting down the server. It leaves a trail of errors as the sessions close and can't update hazelcast. 

After this change, we'll wait to gracefully shutdown hazelcast until after the undertow server shuts down.