### PR TITLE
Add newsletter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ dump.sql
 
 # metrics
 server/resources/metrics/*-usage.png
+
+# emails
+server/resources/emails/*

--- a/client/Makefile
+++ b/client/Makefile
@@ -16,3 +16,15 @@ publish:
 publish-experimental:
 	@echo "(Experimental Build) Building + Publishing Packages..."
 	./scripts/publish_packages.clj experimental
+
+build-email:
+	$(MAKE) text-email
+	$(MAKE) html-email
+
+text-email:
+	echo "Generating text verison of email..."
+	sed -e 's/!\[[^]]*\]([^)]*)//g' www/_emails/markdown/$(slug).md | sed '/^$$/N;/^\n$$/D' > www/_emails/txt/$(slug).txt
+
+html-email:
+	echo "Generating HTML version email..."
+	pandoc -f markdown -t html www/_emails/markdown/$(slug).md -o www/_emails/html/$(slug).html

--- a/client/www/_emails/html/oct2024.html
+++ b/client/www/_emails/html/oct2024.html
@@ -1,0 +1,78 @@
+<p><img
+src="https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730238267270_instant_header.png" /></p>
+<p>Hello and welcome to Instant’s first newsletter! We’re going to start
+sending you updates every month to keep you in the loop with what’s new
+:)</p>
+<p>Two months ago we launched on Hacker News and open sourced Instant.
+Since then we’ve announced our fundraising, set up an office in San
+Francisco, and are actively hiring! More info below :)</p>
+<p><strong>Open Source</strong></p>
+<p><img
+src="https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1729122912083_image.png" /></p>
+<p>We were heads down for two years before we finally open sourced at
+the end of August. The same day we announced on Hacker News and had one
+of the <a href="https://news.ycombinator.com/item?id=41322281">biggest
+show HNs</a> for any YC company, amassing over 1k points. Since then
+we’ve gotten over <a href="https://github.com/instantdb/instant">6k
+Github stars</a> and over 1k of you are now in <a
+href="https://discord.com/invite/VU53p7uQcE">the discord</a>. It’s
+energizing to hear your feedback and we’re excited to grow with you!</p>
+<p><strong>Fundraising Announcement</strong></p>
+<p><img
+src="https://paper-attachments.dropboxusercontent.com/s_B8A06116D3803694CDA0C13F9F97E92EA0220D4E377317F0F00D7831E3E41E9E_1727988124731_image.png" /></p>
+<p>A month after open sourcing we announced <a
+href="https://techcrunch.com/2024/10/02/instant-harkens-back-to-a-pre-google-firebase/">our
+fundraising on Techcrunch</a>. We’re honored to be backed by these
+fantastic technical angels. We now have an office in San Francisco and
+are actively hiring engineers. If you or someone you know are interested
+in building infrastructure to power applications of the future, check
+out our <a href="https://instantdb.com/hiring">hiring page</a>.</p>
+<p><strong>Clojure Conj 2024</strong></p>
+<p><img
+src="https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1729123513053_image.png" /></p>
+<p>Our very own Stopa (CTO of Instant), gave a talk about building
+Instant at <a href="https://2024.clojure-conj.org/">Clojure Conj</a>
+last week! This is the oldest gathering of the Clojure community, which
+is the language Instant uses on the backend! During this talk Stopa
+discusses how Instant works under the hood. If you enjoyed reading <a
+href="https://www.instantdb.com/essays/next_firebase">A Graph-Based
+Firebase</a>, you’ll love watching this talk. Will follow-up next month
+when the video is ready!</p>
+<p><strong>Announcing $users table!</strong></p>
+<p><img
+src="https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730244149277_users_table.png" /></p>
+<p>With Instant, whether it’s magic codes, Google OAuth, or the Clerk
+integration, you can set up auth in a few minutes. But where did those
+users live? What if you wanted to query your users, or link them to
+objects?</p>
+<p>Well now you get a nifty <code>$users</code> table in the explorer to
+manage your users. You can query, create links, and and even reference
+<code>$users</code> with permissions. These improvements make it much
+easier to build role-based apps with security! To learn more, <a
+href="https://www.instantdb.com/docs/users">check out our $users
+docs</a>.</p>
+<p><strong>Announcing queryOnce!</strong></p>
+<p><img
+src="https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730244001267_image.png" /></p>
+<p><code>useQuery</code> is great, but sometimes you just want to get a
+query…once. Well now you can via <code>queryOnce</code></p>
+<p>This has been one of the most requested functions on Instant. It’s
+really useful when you want to fetch data outside of components, or when
+you want to warm up the cache for route transitions. We had it live for
+the last few weeks, and were watching it to fix bugs. Starting today
+consider <code>queryOnce</code> out of beta!</p>
+<p><strong>What’s next?</strong></p>
+<p>We’re focused on making the core Instant experience great. Since open
+sourcing we’ve launched a few beta features, our goal for this next
+month is to get them across the finish line. Next month you can expect
+to see improvements for storage, strong init, the instant-cli tool, and
+instaql!</p>
+<p>Stay tuned :)</p>
+<p><strong>We are hiring founding engineers!</strong></p>
+<p>We’re a team of 3 right now hacking away in our new San Francisco
+office and we’re looking to grow! If you’re interested in working on
+some of the hardest problems for modern app development drop us a line
+at founders@instantdb.com with a resume and a side project you’ve worked
+on (including a Github is a huge plus!)</p>
+<p><img
+src="https://pbs.twimg.com/media/GZd_xO0akAETvju?format=jpg&amp;name=large" /></p>

--- a/client/www/_emails/markdown/oct2024.md
+++ b/client/www/_emails/markdown/oct2024.md
@@ -1,7 +1,5 @@
 ![](https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730238267270_instant_header.png)
 
-I am a little teapot. Short and stout
-
 Hello and welcome to Instant’s first newsletter! We’re going to start sending you updates every month to keep you in the loop with what’s new :)
 
 Two months ago we launched on Hacker News and open sourced Instant. Since then we’ve announced our fundraising, set up an office in San Francisco, and are actively hiring! More info below :)

--- a/client/www/_emails/markdown/oct2024.md
+++ b/client/www/_emails/markdown/oct2024.md
@@ -1,0 +1,59 @@
+![](https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730238267270_instant_header.png)
+
+I am a little teapot. Short and stout
+
+Hello and welcome to Instant’s first newsletter! We’re going to start sending you updates every month to keep you in the loop with what’s new :)
+
+Two months ago we launched on Hacker News and open sourced Instant. Since then we’ve announced our fundraising, set up an office in San Francisco, and are actively hiring! More info below :)
+
+**Open Source**
+
+![](https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1729122912083_image.png)
+
+
+We were heads down for two years before we finally open sourced at the end of August. The same day we announced on Hacker News and had one of the [biggest show HNs](https://news.ycombinator.com/item?id=41322281) for any YC company, amassing over 1k points. Since then we’ve gotten over [6k Github stars](https://github.com/instantdb/instant) and over 1k of you are now in [the discord](https://discord.com/invite/VU53p7uQcE). It’s energizing to hear your feedback and we’re excited to grow with you!
+
+**Fundraising Announcement**
+
+![](https://paper-attachments.dropboxusercontent.com/s_B8A06116D3803694CDA0C13F9F97E92EA0220D4E377317F0F00D7831E3E41E9E_1727988124731_image.png)
+
+
+A month after open sourcing we announced [our fundraising on Techcrunch](https://techcrunch.com/2024/10/02/instant-harkens-back-to-a-pre-google-firebase/). We’re honored to be backed by these fantastic technical angels. We now have an office in San Francisco and are actively hiring engineers. If you or someone you know are interested in building infrastructure to power applications of the future, check out our [hiring page](https://instantdb.com/hiring).
+
+**Clojure Conj 2024**
+
+![](https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1729123513053_image.png)
+
+
+Our very own Stopa (CTO of Instant), gave a talk about building Instant at [Clojure Conj](https://2024.clojure-conj.org/) last week! This is the oldest gathering of the Clojure community, which is the language Instant uses on the backend! During this talk Stopa discusses how Instant works under the hood. If you enjoyed reading [A Graph-Based Firebase](https://www.instantdb.com/essays/next_firebase), you’ll love watching this talk. Will follow-up next month when the video is ready!
+
+**Announcing $users table!**
+
+![](https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730244149277_users_table.png)
+
+With Instant, whether it’s magic codes, Google OAuth, or the Clerk integration, you can set up auth in a few minutes. But where did those users live? What if you wanted to query your users, or link them to objects?
+
+Well now you get a nifty `$users` table in the explorer to manage your users. You can query, create links, and and even reference `$users` with permissions. These improvements make it much easier to build role-based apps with security! To learn more, [check out our $users docs](https://www.instantdb.com/docs/users).
+
+**Announcing queryOnce!**
+
+![](https://paper-attachments.dropboxusercontent.com/s_DF8F10A9009F2A236BC7D07C4EC05DDA50E4FB82F40AA98593D3B98A1A7EA3DC_1730244001267_image.png)
+
+
+`useQuery` is great, but sometimes you just want to get a query…once. Well now you can via `queryOnce`
+
+This has been one of the most requested functions on Instant. It’s really useful when you want to fetch data outside of components, or when you want to warm up the cache for route transitions. We had it live for the last few weeks, and were watching it to fix bugs. Starting today consider `queryOnce` out of beta!
+
+**What’s next?**
+
+We’re focused on making the core Instant experience great. Since open sourcing we’ve launched a few beta features, our goal for this next month is to get them across the finish line. Next month you can expect to see improvements for storage, strong init, the instant-cli tool, and instaql!
+
+Stay tuned :)
+
+**We are hiring founding engineers!**
+
+We’re a team of 3 right now hacking away in our new San Francisco office and we’re looking to grow! If you’re interested in working on some of the hardest problems for modern app development drop us a line at founders@instantdb.com with a resume and a side project you’ve worked on (including a Github is a huge plus!)
+
+![](https://pbs.twimg.com/media/GZd_xO0akAETvju?format=jpg&name=large)
+
+

--- a/client/www/_emails/txt/oct2024.txt
+++ b/client/www/_emails/txt/oct2024.txt
@@ -1,0 +1,38 @@
+
+Hello and welcome to Instant’s first newsletter! We’re going to start sending you updates every month to keep you in the loop with what’s new :)
+
+Two months ago we launched on Hacker News and open sourced Instant. Since then we’ve announced our fundraising, set up an office in San Francisco, and are actively hiring! More info below :)
+
+**Open Source**
+
+We were heads down for two years before we finally open sourced at the end of August. The same day we announced on Hacker News and had one of the [biggest show HNs](https://news.ycombinator.com/item?id=41322281) for any YC company, amassing over 1k points. Since then we’ve gotten over [6k Github stars](https://github.com/instantdb/instant) and over 1k of you are now in [the discord](https://discord.com/invite/VU53p7uQcE). It’s energizing to hear your feedback and we’re excited to grow with you!
+
+**Fundraising Announcement**
+
+A month after open sourcing we announced [our fundraising on Techcrunch](https://techcrunch.com/2024/10/02/instant-harkens-back-to-a-pre-google-firebase/). We’re honored to be backed by these fantastic technical angels. We now have an office in San Francisco and are actively hiring engineers. If you or someone you know are interested in building infrastructure to power applications of the future, check out our [hiring page](https://instantdb.com/hiring).
+
+**Clojure Conj 2024**
+
+Our very own Stopa (CTO of Instant), gave a talk about building Instant at [Clojure Conj](https://2024.clojure-conj.org/) last week! This is the oldest gathering of the Clojure community, which is the language Instant uses on the backend! During this talk Stopa discusses how Instant works under the hood. If you enjoyed reading [A Graph-Based Firebase](https://www.instantdb.com/essays/next_firebase), you’ll love watching this talk. Will follow-up next month when the video is ready!
+
+**Announcing $users table!**
+
+With Instant, whether it’s magic codes, Google OAuth, or the Clerk integration, you can set up auth in a few minutes. But where did those users live? What if you wanted to query your users, or link them to objects?
+
+Well now you get a nifty `$users` table in the explorer to manage your users. You can query, create links, and and even reference `$users` with permissions. These improvements make it much easier to build role-based apps with security! To learn more, [check out our $users docs](https://www.instantdb.com/docs/users).
+
+**Announcing queryOnce!**
+
+`useQuery` is great, but sometimes you just want to get a query…once. Well now you can via `queryOnce`
+
+This has been one of the most requested functions on Instant. It’s really useful when you want to fetch data outside of components, or when you want to warm up the cache for route transitions. We had it live for the last few weeks, and were watching it to fix bugs. Starting today consider `queryOnce` out of beta!
+
+**What’s next?**
+
+We’re focused on making the core Instant experience great. Since open sourcing we’ve launched a few beta features, our goal for this next month is to get them across the finish line. Next month you can expect to see improvements for storage, strong init, the instant-cli tool, and instaql!
+
+Stay tuned :)
+
+**We are hiring founding engineers!**
+
+We’re a team of 3 right now hacking away in our new San Francisco office and we’re looking to grow! If you’re interested in working on some of the hardest problems for modern app development drop us a line at founders@instantdb.com with a resume and a side project you’ve worked on (including a Github is a huge plus!)

--- a/client/www/lib/emails.js
+++ b/client/www/lib/emails.js
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import matter from 'gray-matter';
+import _ from 'lodash';
+import * as ReactDOMServer from 'react-dom/server';
+import { marked } from 'marked';
+import { Fence } from '../components/ui';
+import footnotes from './footnotes';
+
+function removeMdExtension(str) {
+  return str.replace(/\.md$/, '');
+}
+
+marked.use({
+  renderer: {
+    code(code, language) {
+      return ReactDOMServer.renderToString(
+        <Fence code={code} language={language}></Fence>
+      );
+    },
+    ...footnotes,
+  },
+});
+
+export function getHTML(slug) {
+  try {
+    const file = fs.readFileSync(`./_emails/markdown/${slug}.md`, 'utf-8');
+    const { content } = matter(file);
+    return marked(content);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function getText(slug) {
+  try {
+    const file = fs.readFileSync(`./_emails/txt/${slug}.txt`, 'utf-8');
+    return file;
+  } catch (e) {
+    return null;
+  }
+}
+
+export function getAllSlugs() {
+  const dir = fs.readdirSync(`./_emails/markdown`);
+  return dir.filter(f => f.endsWith('.md')).map((mdName) => removeMdExtension(mdName));
+}

--- a/client/www/pages/intern/emails/[slug].tsx
+++ b/client/www/pages/intern/emails/[slug].tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import { getAllSlugs, getHTML, getText } from '../../../lib/emails';
+
+const TextView = ({ textBody }: { textBody: string }) => {
+  return (
+    <>
+      <Head>
+        <title>Instant Email Previewer</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <div className="email-container">
+        <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+          {textBody}
+        </pre>
+      </div>
+      <style>{`
+    .email-container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 80px 10px;
+    }
+    `}
+      </style>
+    </>
+  );
+}
+
+
+const HTMLView = ({ htmlBody }: { htmlBody: String }) => {
+  return (
+    <>
+      <Head>
+        <title>Instant Email Previewer</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <div className="email-container">
+        <div className="content desktop-padding" dangerouslySetInnerHTML={{ __html: htmlBody }}></div>
+      </div>
+      <style>{`
+   body, html {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      font: 16px/1.5 sans-serif;
+      word-wrap: break-word;
+    }
+
+    .email-container {
+      width: 100%;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    .content {
+      padding: 40px 30px;
+    }
+
+    img {
+      max-width: 100%;
+      display: block;
+      margin: 0 auto;
+    }
+
+    p {
+      margin: 1em 0;
+      line-height: 1.5;
+    }
+
+    p code {
+      background-color: #eee;
+      padding: 0.05em 0.2em;
+      border: 1px solid #ccc;
+    }
+
+    a {
+      color: #ff6000;
+      text-decoration: none;
+    }
+
+    a:hover, a:focus, a:active {
+      text-decoration: underline;
+    }
+      `}</style>
+    </>
+  );
+};
+
+const Email = ({ htmlBody, textBody }: { htmlBody: string, textBody: string }) => {
+  const [viewMode, setViewMode] = useState('html');
+
+  const toggleViewMode = () => {
+    setViewMode(viewMode === 'text' ? 'html' : 'text');
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Instant Email Previewer</title>
+        <meta name="description" content="Relational Database, on the client." />
+      </Head>
+
+      {!htmlBody && <h1>Could not find html for this page, check the `_emails` folder!</h1>}
+      {htmlBody && (
+        <div className="email-wrapper">
+          {textBody && (
+            <button
+              className="view-toggle-button"
+              onClick={toggleViewMode}
+            >
+              Switch to {viewMode === 'text' ? 'HTML' : 'Text'} View
+            </button>
+          )}
+
+          {viewMode === 'text' && textBody ? (
+            <TextView textBody={textBody} />
+          ) : (
+            <HTMLView htmlBody={htmlBody} />
+          )}
+
+          <style jsx global>{`
+            .email-wrapper {
+              position: relative;
+              width: 100%;
+              max-width: 800px;
+              margin: 0 auto;
+            }
+            .view-toggle-button {
+              position: fixed;
+              top: 20px;
+              right: 20px;
+              z-index: 1000;
+              padding: 5px 10px;
+              background-color: #ff6000;
+              color: white;
+              border: none;
+              border-radius: 5px;
+              cursor: pointer;
+              font-size: 16px;
+              transition: background-color 0.3s;
+            }
+            .view-toggle-button:hover {
+              background-color: #e55a2b;
+            }
+          `}</style>
+        </div>
+      )}
+    </>
+  );
+};
+
+export async function getStaticPaths() {
+  return {
+    paths: getAllSlugs().map((slug) => `/intern/emails/${slug}`),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({
+  params: { slug },
+}: {
+  params: { slug: string };
+}) {
+  return {
+    props: {
+      htmlBody: getHTML(slug),
+      textBody: getText(slug),
+    },
+  };
+}
+
+export default Email;

--- a/client/www/pages/intern/emails/index.tsx
+++ b/client/www/pages/intern/emails/index.tsx
@@ -1,0 +1,18 @@
+import { getAllSlugs } from '../../../lib/emails';
+
+export async function getStaticProps() {
+  return {
+    props: { slugs: getAllSlugs() },
+  };
+}
+
+export default function Page({ slugs }: { slugs: String[] }) {
+  return (
+    <div className="p-2 space-y-2">
+      <p className="font-bold">Slugs</p>
+      <div className="flex-col space-y-2">
+        {slugs.map(e => <div><a href={`/intern/emails/${e}`}>{e}</a></div>)}
+      </div>
+    </div>
+  );
+}

--- a/server/src/instant/scripts/newsletter.clj
+++ b/server/src/instant/scripts/newsletter.clj
@@ -43,12 +43,8 @@
 (defn read-file
   "Reads a file relative to a base path"
   [base-path file-path]
-  (try
-    (let [full-path (io/file base-path file-path)]
-      (slurp full-path))
-    (catch Exception _
-      (println "Error reading file:" file-path)
-      nil)))
+  (let [full-path (io/file base-path file-path)]
+    (slurp full-path)))
 
 (comment
   (read-file base-path (html-path "oct2024"))

--- a/server/src/instant/scripts/newsletter.clj
+++ b/server/src/instant/scripts/newsletter.clj
@@ -127,7 +127,7 @@
 
 (comment
   ;; 1. Set your params
-  (def params {:title "Instant News - Oct 2024" :slug "oct2024"})
+  (def params {:title "Instant News - Oct 2024" :slug "UPDATE ME"})
 
   ;; 2. Send test email to yourself, verify looks good
   (let [htmlBody (read-file base-path (html-path (:slug params)))

--- a/server/src/instant/scripts/newsletter.clj
+++ b/server/src/instant/scripts/newsletter.clj
@@ -1,0 +1,148 @@
+(ns instant.scripts.newsletter
+  "Send newsletters to our users
+
+  Usage: First run through these steps to prepare the email content
+    1. Create email content in Dropbox. Get sign off on the copy.
+    2. Export content as markdown and save to `www/intern/_emails/[slug].md`
+    3. Preview the styled markdown at `localhost:3000/intern/emails/[slug]`
+    4. Once preview looks good, generate html and text versions of the email
+       from `client/Makefile` via `make build-email`
+       Note: we want both html and text to maximize delivery
+    5. Refresh the page at `localhost:3000/intern/emails/[slug]`
+       and verify text version looks good via the text view button
+
+    And now go through the comment block at the bottom of this file to send
+    out the newsletter. Huzzah!
+  "
+
+  (:require
+   [instant.config :as config]
+   [clj-http.client :as clj-http]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [instant.util.json :refer [->json]]
+   [instant.util.tracer :as tracer]
+   [clojure.tools.logging :as log]))
+
+(def base-path (io/file (.getParent (io/file *file*)) "../../../../"))
+(def emails-path "server/resources/emails/emails.txt")
+(defn html-path [slug] (str "client/www/_emails/html/" slug ".html"))
+(defn txt-path [slug] (str "client/www/_emails/txt/" slug ".txt"))
+
+(defonce once (atom false))
+(defonce errors (atom []))
+(comment
+  (reset! once false)
+  (reset! errors []))
+
+(defn read-file
+  "Reads a file relative to a base path"
+  [base-path file-path]
+  (try
+    (let [full-path (io/file base-path file-path)]
+      (slurp full-path))
+    (catch Exception _
+      (println "Error reading file:" file-path)
+      nil)))
+
+(comment
+  (read-file base-path (html-path "oct2024"))
+  (read-file base-path (txt-path "oct2024")))
+
+(defn inactive-recipient? [e]
+  (= 406 (-> e ex-data :body :ErrorCode)))
+
+(defn add-error! [email error-type message]
+  (let [timestamp (java.time.LocalDateTime/now)
+        error-entry {:timestamp timestamp
+                     :email email
+                     :error-type error-type
+                     :message message}]
+    (swap! errors conj error-entry)))
+
+(defn handle-email-error! [e to]
+  (if (inactive-recipient? e)
+    (add-error! to "INACTIVE_RECIPIENT" "This email address has been marked inactive.")
+    (add-error! to "ERROR" (.getMessage e)))
+  nil)
+
+(defn send! [{:keys [to title textBody htmlBody
+                     from alias reply-to]
+              :or {from "js@hey.instantdb.com"
+                   alias "instant-news"
+                   reply-to "founders@instantdb.com"}}]
+  (let [model {:title title
+               :textBody textBody
+               :htmlBody htmlBody}
+        body {:From from
+              :To to
+              :ReplyTo reply-to
+              :TemplateAlias alias
+              :TemplateModel model
+              :MessageStream "broadcast"
+              :TrackOpens true
+              :TrackLinks "HtmlAndText"
+              :InlineCss true}]
+    (if-not (config/postmark-send-enabled?)
+      (tracer/with-span! {:name "postmark/send-disabled"
+                          :attributes body}
+        (tracer/record-info!
+         {:name "postmark-disabled"
+          :attributes
+          {:msg
+           "Postmark is disabled, add postmark-token to config to enable"}}))
+      (tracer/with-span! {:name "postmark/send"
+                          :attributes body}
+        (try
+          (clj-http/post
+           "https://api.postmarkapp.com/email/withTemplate"
+           {:coerce :always
+            :as :json
+            :headers {"X-Postmark-Server-Token" (config/postmark-token)
+                      "Content-Type" "application/json"}
+            :body (->json body)})
+          (catch Exception e
+            (handle-email-error! e to)))))))
+
+(defn send-newsletter! [{:keys [title slug live?]}]
+  (let [emails (str/split-lines (read-file base-path emails-path))]
+    (if-not live?
+      (doseq [email emails]
+        (log/info "Simulating sending newsletter to" email))
+      (if @once
+        (throw (Exception. "Already sent newsletter! Set once atom to false to send again."))
+        (do
+          (reset! once true)
+          (doseq [email emails]
+            (let [htmlBody (read-file base-path (html-path slug))
+                  textBody (read-file base-path (txt-path slug))]
+              (send! {:to email
+                      :title title
+                      :htmlBody htmlBody
+                      :textBody textBody}))))))))
+
+(comment
+  ;; 1. Set your params
+  (def params {:title "Instant News - Oct 2024" :slug "oct2024"})
+
+  ;; 2. Send test email to yourself, verify looks good
+  (let [htmlBody (read-file base-path (html-path (:slug params)))
+        textBody (read-file base-path (txt-path (:slug params)))]
+    (send! (assoc params
+                  :to "joeaverbukh@gmail.com"
+                  :htmlBody htmlBody
+                  :textBody textBody)))
+
+  ;; 3. Add emails to server/resources/emails/emails.txt
+  ;; make sure each email is on a new line, with no trailing commas. e.g.
+  ;; joeaverbukh@gmail.com
+  ;; stepan.p@gmail.com
+  ;;
+  ;; Run this to preview email list looks good
+  (send-newsletter! (assoc params :live? false))
+
+  ;; 4. Send newsletter!
+  (send-newsletter! (assoc params :live? true))
+
+  ;; 5. Check for errors
+  (identity @errors))

--- a/server/src/instant/scripts/newsletter.clj
+++ b/server/src/instant/scripts/newsletter.clj
@@ -3,11 +3,16 @@
 
   Usage: First run through these steps to prepare the email content
     1. Create email content in Dropbox. Get sign off on the copy.
-    2. Export content as markdown and save to `www/intern/_emails/[slug].md`
+    2. Export content as markdown and save to `www/intern/_emails/markdown/[slug].md`
     3. Preview the styled markdown at `localhost:3000/intern/emails/[slug]`
     4. Once preview looks good, generate html and text versions of the email
        from `client/Makefile` via `make build-email`
-       Note: we want both html and text to maximize delivery
+       Notes:
+        * We want both html and text to maximize delivery
+        * We use pandoc to convert markdown to html. If you don't have it,
+          you can install it via `brew install pandoc`
+        * If need be, you can edit the ouputs in`client/www/_emails/html/[slug].html`
+          and `client/www/_emails/txt/[slug].txt`
     5. Refresh the page at `localhost:3000/intern/emails/[slug]`
        and verify text version looks good via the text view button
 

--- a/server/src/instant/scripts/newsletter.clj
+++ b/server/src/instant/scripts/newsletter.clj
@@ -72,9 +72,12 @@
   nil)
 
 (defn send! [{:keys [to title textBody htmlBody
-                     from alias reply-to]
-              :or {from "js@hey.instantdb.com"
-                   alias "instant-news"
+                     ;; alias refers to the email template identifer in postmark
+                     ;; In general you shouldn't need to provide any of these
+                     ;; optional params unless you're sending a custom email
+                     alias from reply-to]
+              :or {alias "instant-news"
+                   from "js@hey.instantdb.com"
                    reply-to "founders@instantdb.com"}}]
   (let [model {:title title
                :textBody textBody

--- a/server/src/instant/scripts/newsletter.clj
+++ b/server/src/instant/scripts/newsletter.clj
@@ -34,10 +34,10 @@
 (defn html-path [slug] (str "client/www/_emails/html/" slug ".html"))
 (defn txt-path [slug] (str "client/www/_emails/txt/" slug ".txt"))
 
-(defonce once (atom false))
+(defonce sent-already? (atom false))
 (defonce errors (atom []))
 (comment
-  (reset! once false)
+  (reset! sent-already? false)
   (reset! errors []))
 
 (defn read-file
@@ -113,10 +113,10 @@
     (if-not live?
       (doseq [email emails]
         (log/info "Simulating sending newsletter to" email))
-      (if @once
-        (throw (Exception. "Already sent newsletter! Set once atom to false to send again."))
+      (if @sent-already?
+        (throw (Exception. "Already sent newsletter! Set sent-already? to false to send again."))
         (do
-          (reset! once true)
+          (reset! sent-already? true)
           (doseq [email emails]
             (let [htmlBody (read-file base-path (html-path slug))
                   textBody (read-file base-path (txt-path slug))]


### PR DESCRIPTION
Adds tooling for sending out broadcast emails!

This PR contains three things

1. Preview tool for emails located at `intern/emails`
2. Adds content for the october newsletter
3. Adds a server scripts `newsletter.clj` with instructions on how to send out newsletters

<img width="382" alt="image" src="https://github.com/user-attachments/assets/7f67464c-ac82-4183-a6da-9af6a9c2c267">
