### PR TITLE
[client] make sure that auth is finished after awaiting db.auth

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1441,7 +1441,7 @@ export default class Reactor {
       email,
       code,
     });
-    this.changeCurrentUser(res.user);
+    await this.changeCurrentUser(res.user);
     return res;
   }
 
@@ -1451,7 +1451,7 @@ export default class Reactor {
       appId: this.config.appId,
       refreshToken: authToken,
     });
-    this.changeCurrentUser(res.user);
+    await this.changeCurrentUser(res.user);
     return res;
   }
 
@@ -1467,8 +1467,7 @@ export default class Reactor {
         });
       } catch (e) {}
     }
-
-    this.changeCurrentUser(null);
+    await this.changeCurrentUser(null);
   }
 
   /**
@@ -1490,7 +1489,7 @@ export default class Reactor {
       code: code,
       codeVerifier,
     });
-    this.changeCurrentUser(res.user);
+    await this.changeCurrentUser(res.user);
     return res;
   }
 
@@ -1517,7 +1516,7 @@ export default class Reactor {
       nonce,
       refreshToken,
     });
-    this.changeCurrentUser(res.user);
+    await this.changeCurrentUser(res.user);
     return res;
   }
 

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -451,7 +451,7 @@ class Auth {
   };
 
   /**
-   * Sign in a user with a refresh toke
+   * Sign in a user with a refresh token
    *
    * @see https://instantdb.com/docs/backend#frontend-auth-sign-in-with-token
    *

--- a/client/sandbox/react-nextjs/pages/play/authsync.tsx
+++ b/client/sandbox/react-nextjs/pages/play/authsync.tsx
@@ -1,0 +1,52 @@
+// 1. Import Instant
+import { init, tx, id } from "@instantdb/react";
+import config from "../../config";
+import { useEffect, useState } from "react";
+
+// 2. Get your app id
+const db = init(config);
+
+async function getToken() {
+  const res = await fetch("http://localhost:3005/signin", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "stopa@instantdb.com" }),
+  });
+  return await res.json();
+}
+
+function App() {
+  const { isLoading, user } = db.useAuth();
+  const [calledSignIn, setCalledSignIn] = useState(false);
+  const [result, setResult] = useState<any>(null);
+  useEffect(() => {
+    if (calledSignIn && !result) {
+      setResult({ calledSignIn, user });
+    }
+  }, [user, calledSignIn]);
+  return (
+    <div>
+      <button
+        onClick={() => {
+          db.auth.signOut();
+        }}
+      >
+        Sign out
+      </button>
+      <button
+        onClick={async () => {
+          const ret = await getToken();
+          await db.auth.signInWithToken(ret.token);
+          setCalledSignIn(true);
+        }}
+      >
+        Sign in
+      </button>
+      <pre>
+        {JSON.stringify({ isLoading, user, calledSignIn, result }, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export default App;

--- a/client/sandbox/react-nextjs/pages/play/authsync.tsx
+++ b/client/sandbox/react-nextjs/pages/play/authsync.tsx
@@ -26,25 +26,32 @@ function App() {
   }, [user, calledSignIn]);
   return (
     <div>
-      <button
-        onClick={() => {
-          db.auth.signOut();
-        }}
-      >
-        Sign out
-      </button>
-      <button
-        onClick={async () => {
-          const ret = await getToken();
-          await db.auth.signInWithToken(ret.token);
-          setCalledSignIn(true);
-        }}
-      >
-        Sign in
-      </button>
+      <div className="space-x-2 space-y-2">
+        <button
+          onClick={() => {
+            db.auth.signOut();
+          }}
+        >
+          Sign out
+        </button>
+        <button
+          onClick={async () => {
+            const ret = await getToken();
+            await db.auth.signInWithToken(ret.token);
+            setCalledSignIn(true);
+          }}
+        >
+          Sign in
+        </button>
+      </div>
       <pre>
         {JSON.stringify({ isLoading, user, calledSignIn, result }, null, 2)}
       </pre>
+      <div>
+        This playground tests that if `signInWithToken` is finished, `useAuth`
+        _should_ already have the user.
+        <br />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
If you await `db.auth.signIn*`, you would expect that afterwards the system would be logged in. But Clark noticed this was not the case. A basic repro: 

```javascript
function App() {
  const { isLoading, user } = db.useAuth();
  const [calledSignIn, setCalledSignIn] = useState(false);
  const [result, setResult] = useState<any>(null);
  useEffect(() => {
    if (calledSignIn && !result) {
      setResult({ calledSignIn, user }); // Problem: `user` won't exist, when `calledSignIn` is already true
    }
  }, [user, calledSignIn]);
  return (
    <button
      onClick={async () => {
        const ret = await getToken();
        await db.auth.signInWithToken(ret.token);
        setCalledSignIn(true);
      }}
    >
      Sign in
    </button>
  );
}
```

This is because we did not await on `this.changeCurrentUser`. Adding an await fixed the issue 


@dwwoelfel @nezaj 