### PR TITLE
Remove session from store before clearing ephemeral state

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -517,8 +517,8 @@
     (let [app-id (-> (rs/get-auth @store-conn id)
                      :app
                      :id)]
-      (eph/leave-by-session-id! eph-store-atom app-id id)
-      (rs/remove-session! store-conn id))))
+      (rs/remove-session! store-conn id)
+      (eph/leave-by-session-id! eph-store-atom app-id id))))
 
 (defn undertow-config
   [store-conn eph-store-atom receive-q {:keys [id]}]


### PR DESCRIPTION
If a session disconnects just as they join the room, we can end up with data for the session in the ephemeral state that will never go away.

This change removes the session from the store before we remove the ephemeral state.