### PR TITLE
Custom serializer for hazelcast room keys

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -57,8 +57,9 @@
         network-config (.getNetworkConfig config)
         join-config (.getJoin network-config)
         tcp-ip-config (.getTcpIpConfig join-config)
-        aws-config (.getAwsConfig join-config)]
-    (.setInstanceName config "instant-hz")
+        aws-config (.getAwsConfig join-config)
+        serialization-config (.getSerializationConfig config)]
+    (.setInstanceName config "instant-hz-v2")
     (.setEnabled (.getMulticastConfig join-config) false)
     (if (= :prod (config/get-env))
       (let [ip (aws-util/get-instance-ip)]
@@ -74,8 +75,11 @@
 
     (.setClusterName config "instant-server")
 
-    (.setSerializerConfigs (.getSerializationConfig config)
+    (.setSerializerConfigs serialization-config
                            hz-util/serializer-configs)
+
+    (.setGlobalSerializerConfig serialization-config
+                                hz-util/global-serializer-config)
 
     (let [hz (Hazelcast/getOrCreateHazelcastInstance config)
           hz-rooms-map (.getMap hz "rooms-v2")

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -78,7 +78,7 @@
                            hz-util/serializer-configs)
 
     (let [hz (Hazelcast/getOrCreateHazelcastInstance config)
-          hz-rooms-map (.getMap hz "rooms")
+          hz-rooms-map (.getMap hz "rooms-v2")
           listener-id (.addEntryListener hz-rooms-map
                                          (reify
                                            EntryAddedListener

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -203,7 +203,7 @@
         (recur (a/<!! ch))))))
 
 (defn get-room-data [app-id room-id]
-  (.get (get-hz-rooms-map) {:app-id app-id :room-id room-id}))
+  (.get (get-hz-rooms-map) (hz-util/room-key app-id room-id)))
 
 (defn push-hz-sync-op [f]
   (try
@@ -216,7 +216,7 @@
   "Registers that the session is following the room and starts a channel
    for the room if one doesn't already exist."
   [app-id room-id sess-id]
-  (let [room-key {:app-id app-id :room-id room-id}
+  (let [room-key (hz-util/room-key app-id room-id)
         chan (a/chan (a/sliding-buffer 1))
         res (swap!
              room-maps
@@ -245,7 +245,7 @@
           (recur))))))
 
 (defn remove-session! [app-id room-id sess-id]
-  (let [room-key {:app-id app-id :room-id room-id}
+  (let [room-key (hz-util/room-key app-id room-id)
 
         [old-val new-val]
         (swap-vals! room-maps
@@ -335,7 +335,7 @@
   (let [hz-op (fn []
                 (register-session! app-id room-id sess-id)
                 (hz-util/join-room! (get-hz-rooms-map)
-                                    {:app-id app-id :room-id room-id}
+                                    (hz-util/room-key app-id room-id)
                                     sess-id
                                     (:id current-user)))
         regular-op
@@ -356,7 +356,7 @@
 (defn set-presence! [store-atom app-id sess-id room-id data]
   (let [hz-op (fn []
                 (hz-util/set-presence! (get-hz-rooms-map)
-                                       {:app-id app-id :room-id room-id}
+                                       (hz-util/room-key app-id room-id)
                                        sess-id
                                        data))
         regular-op (fn []

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -28,6 +28,43 @@
       (.setTypeClass protocol)
       (.setImplementation serializer)))
 
+;; --------
+;; Room key
+
+(defrecord RoomKeyV1 [^UUID app-id ^String room-id])
+
+(def ^ByteArraySerializer room-key-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 4)
+    (write ^bytes [_ obj]
+      (let [uuid-bytes (uuid-util/->bytes (:app-id obj))
+            ^String room-id (:room-id obj)
+            room-id-bytes (.getBytes room-id)
+            byte-buffer (ByteBuffer/allocate (+ (count uuid-bytes)
+                                                (count room-id-bytes)))]
+        (tool/def-locals)
+        (.put byte-buffer uuid-bytes)
+        (.put byte-buffer room-id-bytes)
+        (.array byte-buffer)))
+    (read [_ ^bytes in]
+      (let [buf (ByteBuffer/wrap in)
+            app-id (UUID. (.getLong buf)
+                          (.getLong buf))
+            room-id-bytes (byte-array (.remaining buf))
+            _ (.get buf room-id-bytes)
+            room-id (String. room-id-bytes)]
+        (tool/def-locals)
+        (->RoomKeyV1 app-id room-id)))
+    (destroy [_])))
+
+(def room-key-config
+  (make-serializer-config RoomKeyV1
+                          room-key-serializer))
+
+(defn room-key [^UUID app-id ^String room-id]
+  (->RoomKeyV1 app-id room-id))
+
 ;; --------------
 ;; Remove session
 
@@ -42,7 +79,7 @@
         nil
         res))))
 
-(defn remove-session! [^IMap hz-map room-key session-id]
+(defn remove-session! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id]
   (.merge hz-map
           room-key
           ;; If the current value of the key is null, then the new value
@@ -81,7 +118,7 @@
              :user (when user-id
                      {:id user-id})})))
 
-(defn join-room! [^IMap hz-map room-key ^UUID session-id ^UUID user-id]
+(defn join-room! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id ^UUID user-id]
   (.merge hz-map
           room-key
           {session-id {:peer-id session-id
@@ -130,7 +167,7 @@
                      :data
                      data)))
 
-(defn set-presence! [^IMap hz-map room-key ^UUID session-id data]
+(defn set-presence! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id data]
   (.merge hz-map
           room-key
           ;; if current value is nil, then we're not in the room, so we
@@ -157,4 +194,5 @@
 (def serializer-configs
   [remove-session-config
    join-room-config
-   set-presence-config])
+   set-presence-config
+   room-key-config])

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -2,7 +2,7 @@
   (:require [instant.util.uuid :as uuid-util]
             [medley.core :refer [update-existing]]
             [taoensso.nippy :as nippy])
-  (:import (com.hazelcast.config SerializerConfig)
+  (:import (com.hazelcast.config GlobalSerializerConfig SerializerConfig)
            (com.hazelcast.map IMap)
            (com.hazelcast.nio.serialization ByteArraySerializer)
            (java.nio ByteBuffer)
@@ -188,6 +188,25 @@
 (def set-presence-config
   (make-serializer-config SetPresenceMergeV1
                           set-presence-serializer))
+
+;; -----------------
+;; Global serializer
+
+(def ^ByteArraySerializer global-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 5)
+    (write ^bytes [_ obj]
+      (tool/def-locals)
+      (nippy/fast-freeze obj))
+    (read [_ ^bytes in]
+      (tool/def-locals)
+      (nippy/fast-thaw in))
+    (destroy [_])))
+
+(def global-serializer-config (-> (GlobalSerializerConfig.)
+                                  (.setImplementation global-serializer)
+                                  (.setOverrideJavaSerialization true)))
 
 (def serializer-configs
   [remove-session-config

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -197,10 +197,8 @@
     ;; Must be unique within the project
     (getTypeId [_] 5)
     (write ^bytes [_ obj]
-      (tool/def-locals)
       (nippy/fast-freeze obj))
     (read [_ ^bytes in]
-      (tool/def-locals)
       (nippy/fast-thaw in))
     (destroy [_])))
 

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -43,7 +43,6 @@
             room-id-bytes (.getBytes room-id)
             byte-buffer (ByteBuffer/allocate (+ (count uuid-bytes)
                                                 (count room-id-bytes)))]
-        (tool/def-locals)
         (.put byte-buffer uuid-bytes)
         (.put byte-buffer room-id-bytes)
         (.array byte-buffer)))
@@ -54,7 +53,6 @@
             room-id-bytes (byte-array (.remaining buf))
             _ (.get buf room-id-bytes)
             room-id (String. room-id-bytes)]
-        (tool/def-locals)
         (->RoomKeyV1 app-id room-id)))
     (destroy [_])))
 

--- a/server/src/instant/util/uuid.clj
+++ b/server/src/instant/util/uuid.clj
@@ -12,7 +12,7 @@
 
 (defn ->bytes
   "Converts a java.util.UUID into a byte array"
-  [^UUID uuid]
+  ^bytes [^UUID uuid]
   (let [byte-buffer (ByteBuffer/allocate 16)]
     (.putLong byte-buffer (.getMostSignificantBits uuid))
     (.putLong byte-buffer (.getLeastSignificantBits uuid))

--- a/server/test/instant/util/hazelcast_test.clj
+++ b/server/test/instant/util/hazelcast_test.clj
@@ -2,6 +2,12 @@
   (:require [instant.util.hazelcast :as h]
             [clojure.test :refer [deftest is testing]]))
 
+(deftest room-key-roundtrips
+  (let [start (h/->RoomKeyV1 (random-uuid) "room-id")
+        serializer h/room-key-serializer]
+    (is (= start (->> (.write serializer start)
+                      (.read serializer))))))
+
 (deftest remove-session-roundtrips
   (let [start (h/->RemoveSessionMergeV1 (random-uuid))
         serializer h/remove-session-serializer]


### PR DESCRIPTION
Seeing a weird issue in prod where sessions aren't being removed because the key isn't recognized as being in the map. I haven't been able to replicate it locally, but it's possible that there is some inconsistency in how the map key is serialized. 

This PR writes our own serializer/deserializer for the room-map keys. Hopefully that will make hazelcast recognize the key.