### PR TITLE
[docs] show npx instead of npm i for isntant-cli

### DIFF
--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -8,7 +8,7 @@ The CLI is currently optimized for starting new projects that are managed
 entirely from code. See the [migration guide below](#migrating-from-the-dashboard) if you have an existing app.
 
 ```sh
-npm install -D instant-cli
+npx instant-cli login
 ```
 
 You can view all commands and flags with `npx instant-cli -h`.


### PR DESCRIPTION
In our docs page, we explictly wrote: `npm i -D instant-cli`. This will end up pinning a specific version of the cli to this app. 

However, we don't really want this to be the default experience. The default experience should be to use npx instant-cli. 

The downside of this is that we will have to worry more about backwards compatibility, but it is a better experience for the user. 

@dwwoelfel @nezaj 