### PR TITLE
[Dash] Enable billing page for admins

### DIFF
--- a/client/www/components/dash/Billing.tsx
+++ b/client/www/components/dash/Billing.tsx
@@ -1,5 +1,5 @@
 import { SectionHeading, Button, Content } from '@/components/ui';
-import { messageFromInstantError, useAuthedFetch } from '@/lib/auth';
+import { messageFromInstantError, friendlyErrorMessage, useAuthedFetch } from '@/lib/auth';
 import config, { stripeKey } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
@@ -53,7 +53,8 @@ async function createCheckoutSession(appId: string, token: string) {
       const message =
         messageFromInstantError(err as InstantError) ||
         'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
-      errorToast(message);
+      const friendlyMessage = friendlyErrorMessage('dash-billing', message);
+      errorToast(friendlyMessage);
       console.error(err);
     });
 }

--- a/client/www/lib/auth.ts
+++ b/client/www/lib/auth.ts
@@ -130,6 +130,7 @@ const friendlyNameFromIn = (inArr: string[]) => {
   return friendlyName(inArr[inArr.length - 1]);
 };
 
+/* Standardize error messages from Instant */
 export const messageFromInstantError = (
   e: InstantError,
 ): string | undefined => {
@@ -154,6 +155,26 @@ export const messageFromInstantError = (
       return body.message;
   }
 };
+
+/**
+  * Friendly error messages to display to our users
+  * We can add more cases as we encounter them
+*/
+export function friendlyErrorMessage(label: string, message: string) {
+  switch (label) {
+    case 'dash-billing':
+      return friendlyBillingError(message);
+    default:
+      return message;
+  }
+}
+
+function friendlyBillingError(message: string) {
+  if (message.includes('Permission denied')) {
+    return 'Billing management is restricted to the app owner.';
+  }
+  return message;
+}
 
 // --------
 // Auth API

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -517,7 +517,7 @@ function Dashboard() {
                     db={connection.db}
                   />
                 ) : tab == 'billing' &&
-                  isMinRole('owner', app.user_app_role) ? (
+                  isMinRole('admin', app.user_app_role) ? (
                   <Billing appId={appId} />
                 ) : null}
               </div>

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -517,7 +517,7 @@ function Dashboard() {
                     db={connection.db}
                   />
                 ) : tab == 'billing' &&
-                  isMinRole('admin', app.user_app_role) ? (
+                  isMinRole('collaborator', app.user_app_role) ? (
                   <Billing appId={appId} />
                 ) : null}
               </div>

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -697,7 +697,7 @@
     (response/ok {:url (.getUrl session)})))
 
 (defn get-billing [req]
-  (let [{{app-id :id} :app {user-id :id} :user} (req->app-and-user! req)
+  (let [{{app-id :id} :app {user-id :id} :user} (req->app-and-user! :admin req)
         {subscription-name :name stripe-subscription-id :stripe_subscription_id}
         (instant-subscription-model/get-by-user-app {:user-id user-id :app-id app-id})
         {total-app-bytes :num_bytes} (app-model/app-usage {:app-id app-id})

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -697,7 +697,7 @@
     (response/ok {:url (.getUrl session)})))
 
 (defn get-billing [req]
-  (let [{{app-id :id} :app {user-id :id} :user} (req->app-and-user! :admin req)
+  (let [{{app-id :id} :app {user-id :id} :user} (req->app-and-user! :collaborator req)
         {subscription-name :name stripe-subscription-id :stripe_subscription_id}
         (instant-subscription-model/get-by-user-app {:user-id user-id :app-id app-id})
         {total-app-bytes :num_bytes} (app-model/app-usage {:app-id app-id})


### PR DESCRIPTION
The [Kosmik](https://discord.com/channels/1031957483243188235/1258878823529844766/1303025195992350856) team mentioned how not being able to see app/storage usage is a schlep for them. Figured we can lower the role requirement for seeing the admin page.

I also felt like we should start adding friendly error messages. 

**Before**
<img width="468" alt="image" src="https://github.com/user-attachments/assets/1612dff7-b951-473d-8ab3-7be4f267b343">

**After**
<img width="475" alt="image" src="https://github.com/user-attachments/assets/91810f4d-52fd-4f03-9c5f-2fa688e6ac5a">
