### PR TITLE
[Blog] Add conj video

### DIFF
--- a/client/www/_posts/conj.md
+++ b/client/www/_posts/conj.md
@@ -1,7 +1,7 @@
 ---
 title: 'Building a Sync Engine in Clojure [Video]'
 date: '2024-10-24'
-author: stopachka
+author: nezaj
 ---
 
 [!video](https://www.youtube.com/watch?v=6FikTQf8qho "Building a Sync Engine in Clojure")

--- a/client/www/_posts/conj.md
+++ b/client/www/_posts/conj.md
@@ -1,0 +1,15 @@
+---
+title: 'Building a Sync Engine in Clojure [Video]'
+date: '2024-10-24'
+author: stopachka
+---
+
+[!video](https://www.youtube.com/watch?v=6FikTQf8qho "Building a Sync Engine in Clojure")
+
+Following up from [A Graph-Based
+Firebase](https://www.instantdb.com/essays/next_firebase), Stopa (CTO of
+Instant), gave a talk about building Instant at Clojure Conj 2024! In this talk
+he discusses the common schleps developers face when building apps, and how
+Instant compresses them.
+
+Give this a watch if you’re interested in learning more about how Instant works under the hood!

--- a/client/www/lib/posts.js
+++ b/client/www/lib/posts.js
@@ -5,6 +5,7 @@ import * as ReactDOMServer from 'react-dom/server';
 import { marked } from 'marked';
 import { Fence } from '../components/ui';
 import footnotes from './footnotes';
+import videos from './videos';
 
 marked.use({
   renderer: {
@@ -14,6 +15,7 @@ marked.use({
       );
     },
     ...footnotes,
+    ...videos,
   },
 });
 

--- a/client/www/lib/videos.js
+++ b/client/www/lib/videos.js
@@ -26,7 +26,6 @@ const videoTemplate = {
         width="100%"
         src="https://www.youtube.com/embed/${id}?${youtubeParams}"
         title="${title}"
-        frameborder="0"
         allow="autoplay; picture-in-picture"
         allowfullscreen>
       </iframe>
@@ -38,7 +37,6 @@ const videoTemplate = {
         width="100%"
         src="https://stream.mux.com/${id}"
         title="${title}"
-        frameborder="0"
         allowfullscreen>
       </iframe>
     </div>`

--- a/client/www/lib/videos.js
+++ b/client/www/lib/videos.js
@@ -1,0 +1,67 @@
+/**
+ * Video extension for marked.js
+ *
+ * Usage:
+ * [!video](https://www.youtube.com/watch?v=video-id "Video Title")
+ * [!video](https://stream.mux.com/video-id "Video Title")
+ */
+import { marked } from 'marked';
+
+const containerClass = 'md-video-container';
+const youtubePattern = /(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+const muxPattern = /stream\.mux\.com\/([A-Za-z0-9]+)/;
+
+const youtubeParams = [
+  'rel=0',            // Don't show related videos
+  'modestbranding=1', // Reduce YouTube branding
+  'playsinline=1',    // Play inline on mobile
+  'autoplay=0',       // Don't autoplay
+  'cc_load_policy=1'  // Show closed captions if available
+].join('&');
+
+const videoTemplate = {
+  youtube: (id, title) => `
+    <div class=${containerClass}>
+      <iframe
+        width="100%"
+        src="https://www.youtube.com/embed/${id}?${youtubeParams}"
+        title="${title}"
+        frameborder="0"
+        allow="autoplay; picture-in-picture"
+        allowfullscreen>
+      </iframe>
+    </div>`,
+
+  mux: (id, title) => `
+    <div class=${containerClass}>
+      <iframe
+        width="100%"
+        src="https://stream.mux.com/${id}"
+        title="${title}"
+        frameborder="0"
+        allowfullscreen>
+      </iframe>
+    </div>`
+};
+
+const videos = {
+  link(href, title, text) {
+    if (text !== '!video') {
+      return marked.Renderer.prototype.link.call(this, href, title, text);
+    }
+
+    const youtubeMatch = href.match(youtubePattern);
+    if (youtubeMatch) {
+      return videoTemplate.youtube(youtubeMatch[1], title);
+    }
+
+    const muxMatch = href.match(muxPattern);
+    if (muxMatch) {
+      return videoTemplate.mux(muxMatch[1], title);
+    }
+
+    return marked.Renderer.prototype.link.call(this, href, title, text);
+  }
+};
+
+export default videos;

--- a/client/www/styles/globals.css
+++ b/client/www/styles/globals.css
@@ -186,6 +186,7 @@ input#docsearch-input {
 /* ----------- */
 .md-video-container {
   position: relative;
+  border: 1px solid #f8f9fa;
   width: 100%;
   padding-bottom: 56.25%;
   /* 16:9 aspect ratio */

--- a/client/www/styles/globals.css
+++ b/client/www/styles/globals.css
@@ -181,3 +181,20 @@ input#docsearch-input {
 .DocSearch-Footer {
   flex-direction: row !important;
 }
+
+/* Markdown video styles */
+/* ----------- */
+.md-video-container {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  /* 16:9 aspect ratio */
+}
+
+.md-video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Adds Stopa's conj talk to our essays page. Added a video extension to our markdown parser to make this work

<img width="815" alt="image" src="https://github.com/user-attachments/assets/1038229c-407c-4406-95ce-0bb260f3db51">
