### PR TITLE
[experiment][strong-init-sandbox] export a `Graph` interface in instant.schema.ts

### DIFF
--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -1,6 +1,6 @@
 import { i } from "@instantdb/react";
 
-const graph = i.graph(
+const _graph = i.graph(
   {
     messages: i.entity({
       content: i.string(),
@@ -25,5 +25,8 @@ const graph = i.graph(
   },
 );
 
+type _Graph = typeof _graph;
 
+export interface Graph extends _Graph {};
+const graph: Graph = _graph;
 export default graph;

--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -25,4 +25,5 @@ const graph = i.graph(
   },
 );
 
+
 export default graph;


### PR DESCRIPTION
**Context:** 

We used a lot of inference to generate the `Schema` type. When you infer types though, they tend to auto-expand in intellisense, so you get these kind of inscrutable types like so: 

**Before** 

<img width="897" alt="CleanShot 2024-11-07 at 15 27 15@2x" src="https://github.com/user-attachments/assets/f035d663-9854-439c-8747-f78fe63005e6">

<img width="897" alt="CleanShot 2024-11-07 at 15 27 15@2x" src="https://github.com/user-attachments/assets/c42a6216-56c4-48e4-999e-26058f7b5f4b">

This is a [known issue](https://github.com/microsoft/TypeScript/issues/45954) in Typescript. 

However, there's a "trick" we can do. Typescript doesn't expand interfaces. So if we 'cast' our graph to an interface, the types look a lot better: 

**After** 

<img width="690" alt="CleanShot 2024-11-07 at 15 29 27@2x" src="https://github.com/user-attachments/assets/16c6bdf5-9d54-4c53-8f99-a17619e9cec8">

<img width="708" alt="CleanShot 2024-11-07 at 15 29 44@2x" src="https://github.com/user-attachments/assets/81547a2a-2578-4504-b172-b13d2b491da4">

**Related Stackoverflow: https://stackoverflow.com/questions/79164542/how-can-i-mask-a-generic-type-for-intellisense**
--- 

Right now, I'm just doing this manually in our strong-init playground. If we end up liking this, I'll make this a part of the instant.schema.ts generation. For now, there's still more parts where the types look off, so I'm going to keep pushing and playing. 


@dwwoelfel @nezaj 