### PR TITLE
[in-progress] strong-init upgrades

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -159,14 +159,12 @@ function init<Schema extends {} = {}>(config: Config) {
 
 function init_experimental<
   Schema extends InstantGraph<any, any, any>,
-  WithCardinalityInference extends boolean = true,
 >(
   config: Config & {
     schema: Schema;
-    cardinalityInference?: WithCardinalityInference;
   },
 ) {
-  return new InstantAdminExperimental<Schema, WithCardinalityInference>(config);
+  return new InstantAdminExperimental<Schema>(config);
 }
 
 /**
@@ -675,8 +673,8 @@ class Storage {
  *  const db = init({ appId: "my-app-id", adminToken: "my-admin-token" })
  */
 class InstantAdminExperimental<
-  Schema extends InstantGraph<any, any> | {},
-  WithCardinalityInference extends boolean,
+  // XXX is this {} necessary?
+  Schema extends InstantGraph<any, any> | {}
 > {
   config: FilledConfig;
   auth: Auth;
@@ -733,19 +731,14 @@ class InstantAdminExperimental<
   >(
     query: Q,
   ): Promise<
-    QueryResponseExperimental<Q, Schema, WithCardinalityInference>
+    QueryResponseExperimental<Q, Schema>
   > => {
-    const withInference =
-      "cardinalityInference" in this.config
-        ? Boolean(this.config.cardinalityInference)
-        : true;
-
     return jsonFetch(`${this.config.apiURI}/admin/query`, {
       method: "POST",
       headers: authorizedHeaders(this.config, this.impersonationOpts),
       body: JSON.stringify({
         query: query,
-        "inference?": withInference,
+        "inference?": true,
       }),
     });
   };
@@ -810,7 +803,7 @@ class InstantAdminExperimental<
     query: Exactly<Query, Q>,
     opts?: { rules: any },
   ): Promise<{
-    result: QueryResponseExperimental<Q, Schema, WithCardinalityInference>;
+    result: QueryResponseExperimental<Q, Schema>;
     checkResults: DebugCheckResult[];
   }> => {
     const response = await jsonFetch(

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -157,9 +157,7 @@ function init<Schema extends {} = {}>(config: Config) {
   return new InstantAdmin<Schema>(config);
 }
 
-function init_experimental<
-  Schema extends InstantGraph<any, any, any>,
->(
+function init_experimental<Schema extends InstantGraph<any, any, any>>(
   config: Config & {
     schema: Schema;
   },
@@ -202,9 +200,7 @@ class InstantAdmin<Schema extends InstantGraph<any, any> | {}> {
    * @example
    *  await db.asUser({email: "stopa@instantdb.com"}).query({ goals: {} })
    */
-  asUser = (
-    opts: ImpersonationOpts,
-  ): InstantAdmin<Schema> => {
+  asUser = (opts: ImpersonationOpts): InstantAdmin<Schema> => {
     const newClient = new InstantAdmin<Schema>({
       ...this.config,
     });
@@ -672,19 +668,13 @@ class Storage {
  * @example
  *  const db = init({ appId: "my-app-id", adminToken: "my-admin-token" })
  */
-class InstantAdminExperimental<
-  // XXX is this {} necessary?
-  Schema extends InstantGraph<any, any> | {}
-> {
+class InstantAdminExperimental<Schema extends InstantGraph<any, any>> {
   config: FilledConfig;
   auth: Auth;
   storage: Storage;
   impersonationOpts?: ImpersonationOpts;
 
-  public tx =
-    txInit<
-      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
-    >();
+  public tx = txInit<Schema>();
 
   constructor(_config: Config) {
     this.config = configWithDefaults(_config);
@@ -724,15 +714,9 @@ class InstantAdminExperimental<
    *  // all goals, _alongside_ their todos
    *  await db.query({ goals: { todos: {} } })
    */
-  query = <
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
-  >(
+  query = <Q extends InstaQLQueryParams<Schema>>(
     query: Q,
-  ): Promise<
-    QueryResponseExperimental<Q, Schema>
-  > => {
+  ): Promise<QueryResponseExperimental<Q, Schema>> => {
     return jsonFetch(`${this.config.apiURI}/admin/query`, {
       method: "POST",
       headers: authorizedHeaders(this.config, this.impersonationOpts),
@@ -799,8 +783,8 @@ class InstantAdminExperimental<
    *    { rules: { goals: { allow: { read: "auth.id != null" } } }
    *  )
    */
-  debugQuery = async <Q extends Query>(
-    query: Exactly<Query, Q>,
+  debugQuery = async <Q extends InstaQLQueryParams<Schema>>(
+    query: Q,
     opts?: { rules: any },
   ): Promise<{
     result: QueryResponseExperimental<Q, Schema>;

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -174,16 +174,13 @@ function init_experimental<Schema extends InstantGraph<any, any, any>>(
  * @example
  *  const db = init({ appId: "my-app-id", adminToken: "my-admin-token" })
  */
-class InstantAdmin<Schema extends InstantGraph<any, any> | {}> {
+class InstantAdmin<Schema extends {}> {
   config: FilledConfig;
   auth: Auth;
   storage: Storage;
   impersonationOpts?: ImpersonationOpts;
 
-  public tx =
-    txInit<
-      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
-    >();
+  public tx = txInit<InstantGraph<any, any>>();
 
   constructor(_config: Config) {
     this.config = configWithDefaults(_config);
@@ -223,17 +220,10 @@ class InstantAdmin<Schema extends InstantGraph<any, any> | {}> {
    *  // all goals, _alongside_ their todos
    *  await db.query({ goals: { todos: {} } })
    */
-  query = <
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
-  >(
+  query = <Q extends Exactly<Query, Q>>(
     query: Q,
   ): Promise<QueryResponse<Q, Schema>> => {
-    const withInference =
-      "cardinalityInference" in this.config
-        ? Boolean(this.config.cardinalityInference)
-        : true;
+    const withInference = false;
 
     return jsonFetch(`${this.config.apiURI}/admin/query`, {
       method: "POST",

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1560,14 +1560,7 @@ export default class Reactor {
   // --------
   // Presence
 
-  /**
-   * @template {keyof RoomSchema} RoomType
-   * @template {keyof RoomSchema[RoomType]['presence']} Keys
-   * @param {RoomType} roomType
-   * @param {string | number} roomId
-   * @param {import('./presence').PresenceOpts<RoomSchema[RoomType]['presence'], Keys>} opts
-   * @returns {import('./presence').PresenceResponse<RoomSchema[RoomType]['presence'], Keys>}
-   */
+  // XXX-TODO: type getPresence
   getPresence(roomType, roomId, opts = {}) {
     const room = this._rooms[roomId];
     const presence = this._presence[roomId];
@@ -1580,12 +1573,7 @@ export default class Reactor {
     };
   }
 
-  /**
-   * @template {keyof RoomSchema} RoomType
-   * @param {RoomType} roomType
-   * @param {string | number} roomId
-   * @param {Partial<RoomSchema[RoomType]['presence']>} partialData
-   */
+  // XXX: todo type publishPresence
   publishPresence(roomType, roomId, partialData) {
     const room = this._rooms[roomId];
     const presence = this._presence[roomId];
@@ -1627,15 +1615,7 @@ export default class Reactor {
     this._trySendAuthed(uuid(), { op: "leave-room", "room-id": roomId });
   }
 
-  /**
-   * @template {keyof RoomSchema} RoomType
-   * @template {keyof RoomSchema[RoomType]['presence']} Keys
-   * @param {RoomType} roomType
-   * @param {string | number} roomId
-   * @param {import('./presence').PresenceOpts<RoomSchema[RoomType]['presence'], Keys>} opts
-   * @param {(slice: import('./presence').PresenceResponse<RoomSchema[RoomType]['presence'], Keys>) => void} cb
-   * @returns {() => void}
-   */
+  // XXX-TODO: type subscribePresence
   subscribePresence(roomType, roomId, opts, cb) {
     const leaveRoom = this.joinRoom(roomId);
 

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -14,9 +14,7 @@ export interface IDatabase<
 // ----------------
 // XXX-EXPERIMENTAL
 export interface IDatabaseExperimental<
-  // TODO: does this need to extend to {} ? 
-  Schema extends InstantGraph<any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {}
+  Schema extends InstantGraph<any, any> | undefined = undefined,
 > {
   tx: TxChunk<
     Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -14,13 +14,11 @@ export interface IDatabase<
 // ----------------
 // XXX-EXPERIMENTAL
 export interface IDatabaseExperimental<
+  // TODO: does this need to extend to {} ? 
   Schema extends InstantGraph<any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
+  RoomSchema extends RoomSchemaShape = {}
 > {
   tx: TxChunk<
     Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
   >;
-
-  withCardinalityInference?: WithCardinalityInference;
 }

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -6,17 +6,13 @@ export interface IDatabase<
   Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
 > {
-  tx: TxChunk<
-    InstantGraph<any, any>
-  >;
+  tx: TxChunk<InstantGraph<any, any>>;
 }
 
 // ----------------
 // XXX-EXPERIMENTAL
 export interface IDatabaseExperimental<
-  Schema extends InstantGraph<any, any> | undefined = undefined,
+  Schema extends InstantGraph<any, any, any>,
 > {
-  tx: TxChunk<
-    Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
-  >;
+  tx: TxChunk<Schema>;
 }

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -3,15 +3,12 @@ import { RoomSchemaShape } from "./presence";
 import type { InstantGraph } from "./schemaTypes";
 
 export interface IDatabase<
-  Schema extends InstantGraph<any, any> | {} = {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
 > {
   tx: TxChunk<
-    Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
+    InstantGraph<any, any>
   >;
-
-  withCardinalityInference?: WithCardinalityInference;
 }
 
 // ----------------

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -13,3 +13,17 @@ export interface IDatabase<
 
   withCardinalityInference?: WithCardinalityInference;
 }
+
+// ----------------
+// XXX-EXPERIMENTAL
+export interface IDatabaseExperimental<
+  Schema extends InstantGraph<any, any> | {} = {},
+  RoomSchema extends RoomSchemaShape = {},
+  WithCardinalityInference extends boolean = false,
+> {
+  tx: TxChunk<
+    Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
+  >;
+
+  withCardinalityInference?: WithCardinalityInference;
+}

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -8,32 +8,32 @@ import type { InstantGraph } from "./schemaTypes";
 import type { IDatabaseExperimental } from "./coreTypes";
 import { RoomSchemaShape } from "./presence";
 
-export type InstantQuery<DB extends IDatabaseExperimental<any, any>> =
-  DB extends IDatabaseExperimental<infer Schema, any>
+export type InstantQuery<DB extends IDatabaseExperimental<any>> =
+  DB extends IDatabaseExperimental<infer Schema>
     ? Schema extends InstantGraph<any, any, any>
       ? InstaQLQueryParams<Schema>
       : never
     : never;
 
-export type InstantQueryResult<DB extends IDatabaseExperimental<any, any>, Q> =
-  DB extends IDatabaseExperimental<infer Schema, any>
+export type InstantQueryResult<DB extends IDatabaseExperimental<any>, Q> =
+  DB extends IDatabaseExperimental<infer Schema>
     ? Schema extends InstantGraph<infer E, any>
       ? InstaQLQueryResult<E, Remove$<Q>>
       : never
     : never;
 
-export type InstantSchema<DB extends IDatabaseExperimental<any, any>> =
-  DB extends IDatabaseExperimental<infer Schema, any> ? Schema : never;
+export type InstantSchema<DB extends IDatabaseExperimental<any>> =
+  DB extends IDatabaseExperimental<infer Schema> ? Schema : never;
 
 export type InstantEntity<
-  DB extends IDatabaseExperimental<any, any>,
-  EntityName extends DB extends IDatabaseExperimental<infer Schema, any>
+  DB extends IDatabaseExperimental<any>,
+  EntityName extends DB extends IDatabaseExperimental<infer Schema>
     ? Schema extends InstantGraph<infer Entities, any>
       ? keyof Entities
       : never
     : never,
   Query extends
-    | (DB extends IDatabaseExperimental<infer Schema, any>
+    | (DB extends IDatabaseExperimental<infer Schema>
         ? Schema extends InstantGraph<infer Entities, any>
           ? {
               [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
@@ -43,7 +43,7 @@ export type InstantEntity<
     // XXX: is this check needed anymore?
     | {} = {},
 > =
-  DB extends IDatabaseExperimental<infer Schema, any>
+  DB extends IDatabaseExperimental<infer Schema>
     ? Schema extends InstantGraph<infer Entities, any>
       ? EntityName extends keyof Entities
         ? InstaQLQueryEntityResult<Entities, EntityName, Query>
@@ -51,7 +51,5 @@ export type InstantEntity<
       : never
     : never;
 
-export type InstantSchemaDatabase<
-  Schema extends InstantGraph<any, any>,
-  R extends RoomSchemaShape = {},
-> = IDatabaseExperimental<Schema, R>;
+export type InstantSchemaDatabase<Schema extends InstantGraph<any, any>> =
+  IDatabaseExperimental<Schema>;

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -5,35 +5,42 @@ import type {
   Remove$,
 } from "./queryTypes";
 import type { InstantGraph } from "./schemaTypes";
-import type { IDatabase } from "./coreTypes";
+import type { IDatabase, IDatabaseExperimental } from "./coreTypes";
 import { RoomSchemaShape } from "./presence";
 
-export type InstantQuery<DB extends IDatabase<any, any, any>> =
-  DB extends IDatabase<infer Schema, any, any>
+export type InstantQuery<DB extends IDatabaseExperimental<any, any, any>> =
+  DB extends IDatabaseExperimental<infer Schema, any, any>
     ? Schema extends InstantGraph<any, any, any>
       ? InstaQLQueryParams<Schema>
       : never
     : never;
 
-export type InstantQueryResult<DB extends IDatabase<any, any, any>, Q> =
-  DB extends IDatabase<infer Schema, any, infer CardinalityInference>
+export type InstantQueryResult<
+  DB extends IDatabaseExperimental<any, any, any>,
+  Q,
+> =
+  DB extends IDatabaseExperimental<
+    infer Schema,
+    any,
+    infer CardinalityInference
+  >
     ? Schema extends InstantGraph<infer E, any>
       ? InstaQLQueryResult<E, Remove$<Q>, CardinalityInference>
       : never
     : never;
 
-export type InstantSchema<DB extends IDatabase<any, any, any>> =
-  DB extends IDatabase<infer Schema, any, any> ? Schema : never;
+export type InstantSchema<DB extends IDatabaseExperimental<any, any, any>> =
+  DB extends IDatabaseExperimental<infer Schema, any, any> ? Schema : never;
 
 export type InstantEntity<
-  DB extends IDatabase<any, any, any>,
-  EntityName extends DB extends IDatabase<infer Schema, any, any>
+  DB extends IDatabaseExperimental<any, any, any>,
+  EntityName extends DB extends IDatabaseExperimental<infer Schema, any, any>
     ? Schema extends InstantGraph<infer Entities, any>
       ? keyof Entities
       : never
     : never,
   Query extends
-    | (DB extends IDatabase<infer Schema, any, any>
+    | (DB extends IDatabaseExperimental<infer Schema, any, any>
         ? Schema extends InstantGraph<infer Entities, any>
           ? {
               [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
@@ -42,7 +49,7 @@ export type InstantEntity<
         : never)
     | {} = {},
 > =
-  DB extends IDatabase<infer Schema, any, any>
+  DB extends IDatabaseExperimental<infer Schema, any, any>
     ? Schema extends InstantGraph<infer Entities, any>
       ? EntityName extends keyof Entities
         ? InstaQLQueryEntityResult<Entities, EntityName, Query, true>
@@ -54,4 +61,4 @@ export type InstantSchemaDatabase<
   Schema extends InstantGraph<any, any>,
   R extends RoomSchemaShape = {},
   CI extends boolean = true,
-> = IDatabase<Schema, R, CI>;
+> = IDatabaseExperimental<Schema, R, CI>;

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -5,54 +5,48 @@ import type {
   Remove$,
 } from "./queryTypes";
 import type { InstantGraph } from "./schemaTypes";
-import type { IDatabase, IDatabaseExperimental } from "./coreTypes";
+import type { IDatabaseExperimental } from "./coreTypes";
 import { RoomSchemaShape } from "./presence";
 
-export type InstantQuery<DB extends IDatabaseExperimental<any, any, any>> =
-  DB extends IDatabaseExperimental<infer Schema, any, any>
+export type InstantQuery<DB extends IDatabaseExperimental<any, any>> =
+  DB extends IDatabaseExperimental<infer Schema, any>
     ? Schema extends InstantGraph<any, any, any>
       ? InstaQLQueryParams<Schema>
       : never
     : never;
 
-export type InstantQueryResult<
-  DB extends IDatabaseExperimental<any, any, any>,
-  Q,
-> =
-  DB extends IDatabaseExperimental<
-    infer Schema,
-    any,
-    infer CardinalityInference
-  >
+export type InstantQueryResult<DB extends IDatabaseExperimental<any, any>, Q> =
+  DB extends IDatabaseExperimental<infer Schema, any>
     ? Schema extends InstantGraph<infer E, any>
-      ? InstaQLQueryResult<E, Remove$<Q>, CardinalityInference>
+      ? InstaQLQueryResult<E, Remove$<Q>>
       : never
     : never;
 
-export type InstantSchema<DB extends IDatabaseExperimental<any, any, any>> =
-  DB extends IDatabaseExperimental<infer Schema, any, any> ? Schema : never;
+export type InstantSchema<DB extends IDatabaseExperimental<any, any>> =
+  DB extends IDatabaseExperimental<infer Schema, any> ? Schema : never;
 
 export type InstantEntity<
-  DB extends IDatabaseExperimental<any, any, any>,
-  EntityName extends DB extends IDatabaseExperimental<infer Schema, any, any>
+  DB extends IDatabaseExperimental<any, any>,
+  EntityName extends DB extends IDatabaseExperimental<infer Schema, any>
     ? Schema extends InstantGraph<infer Entities, any>
       ? keyof Entities
       : never
     : never,
   Query extends
-    | (DB extends IDatabaseExperimental<infer Schema, any, any>
+    | (DB extends IDatabaseExperimental<infer Schema, any>
         ? Schema extends InstantGraph<infer Entities, any>
           ? {
               [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
             }
           : never
         : never)
+    // XXX: is this check needed anymore?
     | {} = {},
 > =
-  DB extends IDatabaseExperimental<infer Schema, any, any>
+  DB extends IDatabaseExperimental<infer Schema, any>
     ? Schema extends InstantGraph<infer Entities, any>
       ? EntityName extends keyof Entities
-        ? InstaQLQueryEntityResult<Entities, EntityName, Query, true>
+        ? InstaQLQueryEntityResult<Entities, EntityName, Query>
         : never
       : never
     : never;
@@ -60,5 +54,4 @@ export type InstantEntity<
 export type InstantSchemaDatabase<
   Schema extends InstantGraph<any, any>,
   R extends RoomSchemaShape = {},
-  CI extends boolean = true,
-> = IDatabaseExperimental<Schema, R, CI>;
+> = IDatabaseExperimental<Schema, R>;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -20,7 +20,7 @@ import type {
   PresenceSlice,
   RoomSchemaShape,
 } from "./presence";
-import type { IDatabase } from "./coreTypes";
+import type { IDatabase, IDatabaseExperimental } from "./coreTypes";
 import type {
   Query,
   QueryResponse,
@@ -102,11 +102,31 @@ type SubscriptionState<Q, Schema, WithCardinalityInference extends boolean> =
       pageInfo: PageInfoResponse<Q>;
     };
 
+type SubscriptionStateExperimental<
+  Q,
+  Schema,
+  WithCardinalityInference extends boolean,
+> =
+  | { error: { message: string }; data: undefined; pageInfo: undefined }
+  | {
+      error: undefined;
+      data: QueryResponse<Q, Schema, WithCardinalityInference>;
+      pageInfo: PageInfoResponse<Q>;
+    };
+
 type LifecycleSubscriptionState<
   Q,
   Schema,
   WithCardinalityInference extends boolean,
 > = SubscriptionState<Q, Schema, WithCardinalityInference> & {
+  isLoading: boolean;
+};
+
+type LifecycleSubscriptionStateExperimental<
+  Q,
+  Schema,
+  WithCardinalityInference extends boolean,
+> = SubscriptionStateExperimental<Q, Schema, WithCardinalityInference> & {
   isLoading: boolean;
 };
 
@@ -120,39 +140,12 @@ const defaultConfig = {
 };
 
 // hmr
-function initGlobalInstantCoreStore(): Record<
-  string,
-  InstantCore<any, any, any>
-> {
+function initGlobalInstantCoreStore(): Record<string, any> {
   globalThis.__instantDbStore = globalThis.__instantDbStore ?? {};
   return globalThis.__instantDbStore;
 }
 
 const globalInstantCoreStore = initGlobalInstantCoreStore();
-
-function init_experimental<
-  Schema extends InstantGraph<any, any, any>,
-  WithCardinalityInference extends boolean = true,
->(
-  config: Config & {
-    schema: Schema;
-    cardinalityInference?: WithCardinalityInference;
-  },
-  Storage?: any,
-  NetworkListener?: any,
-): InstantCore<
-  Schema,
-  Schema extends InstantGraph<any, infer RoomSchema, any> ? RoomSchema : never,
-  WithCardinalityInference
-> {
-  return _init_internal<
-    Schema,
-    Schema extends InstantGraph<any, infer RoomSchema, any>
-      ? RoomSchema
-      : never,
-    WithCardinalityInference
-  >(config, Storage, NetworkListener);
-}
 
 // main
 
@@ -609,13 +602,273 @@ function coerceQuery(o: any) {
   return JSON.parse(JSON.stringify(o));
 }
 
-// dev
+// ----------------
+// XXX-EXPERIMENTAL
+
+class InstantCoreExperimental<
+  Schema extends InstantGraph<any, any> | {} = {},
+  RoomSchema extends RoomSchemaShape = {},
+  WithCardinalityInference extends boolean = false,
+> implements
+    IDatabaseExperimental<Schema, RoomSchema, WithCardinalityInference>
+{
+  public withCardinalityInference?: WithCardinalityInference;
+  public _reactor: Reactor<RoomSchema>;
+  public auth: Auth;
+  public storage: Storage;
+
+  public tx =
+    txInit<
+      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
+    >();
+
+  constructor(reactor: Reactor<RoomSchema>) {
+    this._reactor = reactor;
+    this.auth = new Auth(this._reactor);
+    this.storage = new Storage(this._reactor);
+  }
+
+  /**
+   * Use this to write data! You can create, update, delete, and link objects
+   *
+   * @see https://instantdb.com/docs/instaml
+   *
+   * @example
+   *   // Create a new object in the `goals` namespace
+   *   const goalId = id();
+   *   db.transact(tx.goals[goalId].update({title: "Get fit"}))
+   *
+   *   // Update the title
+   *   db.transact(tx.goals[goalId].update({title: "Get super fit"}))
+   *
+   *   // Delete it
+   *   db.transact(tx.goals[goalId].delete())
+   *
+   *   // Or create an association:
+   *   todoId = id();
+   *   db.transact([
+   *    tx.todos[todoId].update({ title: 'Go on a run' }),
+   *    tx.goals[goalId].link({todos: todoId}),
+   *  ])
+   */
+  transact(
+    chunks: TransactionChunk<any, any> | TransactionChunk<any, any>[],
+  ): Promise<TransactionResult> {
+    return this._reactor.pushTx(chunks);
+  }
+
+  getLocalId(name: string): Promise<string> {
+    return this._reactor.getLocalId(name);
+  }
+
+  /**
+   * Use this to query your data!
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *  // listen to all goals
+   *  db.subscribeQuery({ goals: {} }, (resp) => {
+   *    console.log(resp.data.goals)
+   *  })
+   *
+   *  // goals where the title is "Get Fit"
+   *  db.subscribeQuery(
+   *    { goals: { $: { where: { title: "Get Fit" } } } },
+   *    (resp) => {
+   *      console.log(resp.data.goals)
+   *    }
+   *  )
+   *
+   *  // all goals, _alongside_ their todos
+   *  db.subscribeQuery({ goals: { todos: {} } }, (resp) => {
+   *    console.log(resp.data.goals)
+   *  });
+   */
+  subscribeQuery<
+    Q extends Schema extends InstantGraph<any, any>
+      ? InstaQLQueryParams<Schema>
+      : Exactly<Query, Q>,
+  >(
+    query: Q,
+    cb: (
+      resp: SubscriptionStateExperimental<Q, Schema, WithCardinalityInference>,
+    ) => void,
+  ) {
+    return this._reactor.subscribeQuery(query, cb);
+  }
+
+  /**
+   * Listen for the logged in state. This is useful
+   * for deciding when to show a login screen.
+   *
+   * @see https://instantdb.com/docs/auth
+   * @example
+   *   const unsub = db.subscribeAuth((auth) => {
+   *     if (auth.user) {
+   *     console.log('logged in as', auth.user.email)
+   *    } else {
+   *      console.log('logged out')
+   *    }
+   *  })
+   */
+  subscribeAuth(cb: (auth: AuthResult) => void): UnsubscribeFn {
+    return this._reactor.subscribeAuth(cb);
+  }
+
+  /**
+   * Join a room to publish and subscribe to topics and presence.
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   * @example
+   * // init
+   * const db = init();
+   * const room = db.joinRoom(roomType, roomId);
+   * // usage
+   * const unsubscribeTopic = room.subscribeTopic("foo", console.log);
+   * const unsubscribePresence = room.subscribePresence({}, console.log);
+   * room.publishTopic("hello", { message: "hello world!" });
+   * room.publishPresence({ name: "joe" });
+   * // later
+   * unsubscribePresence();
+   * unsubscribeTopic();
+   * room.leaveRoom();
+   */
+  joinRoom<RoomType extends keyof RoomSchema>(
+    roomType: RoomType = "_defaultRoomType" as RoomType,
+    roomId: string = "_defaultRoomId",
+  ): RoomHandle<
+    RoomSchema[RoomType]["presence"],
+    RoomSchema[RoomType]["topics"]
+  > {
+    const leaveRoom = this._reactor.joinRoom(roomId);
+
+    return {
+      leaveRoom,
+      subscribeTopic: (topic, onEvent) =>
+        this._reactor.subscribeTopic(roomId, topic, onEvent),
+      subscribePresence: (opts, onChange) =>
+        this._reactor.subscribePresence(roomType, roomId, opts, onChange),
+      publishTopic: (topic, data) =>
+        this._reactor.publishTopic({ roomType, roomId, topic, data }),
+      publishPresence: (data) =>
+        this._reactor.publishPresence(roomType, roomId, data),
+      getPresence: (opts) => this._reactor.getPresence(roomType, roomId, opts),
+    };
+  }
+
+  shutdown() {
+    delete globalInstantCoreStore[this._reactor.config.appId];
+    this._reactor.shutdown();
+  }
+
+  /**
+   * Use this for one-off queries.
+   * Returns local data if available, otherwise fetches from the server.
+   * Because we want to avoid stale data, this method will throw an error
+   * if the user is offline or there is no active connection to the server.
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *
+   *  const resp = await db.queryOnce({ goals: {} });
+   *  console.log(resp.data.goals)
+   */
+  queryOnce<
+    Q extends Schema extends InstantGraph<any, any>
+      ? InstaQLQueryParams<Schema>
+      : Exactly<Query, Q>,
+  >(
+    query: Q,
+  ): Promise<{
+    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    pageInfo: PageInfoResponse<Q>;
+  }> {
+    return this._reactor.queryOnce(query);
+  }
+}
+
+function init_experimental<
+  Schema extends InstantGraph<any, any, any>,
+  WithCardinalityInference extends boolean = true,
+>(
+  config: Config & {
+    schema: Schema;
+    cardinalityInference?: WithCardinalityInference;
+  },
+  Storage?: any,
+  NetworkListener?: any,
+): InstantCoreExperimental<
+  Schema,
+  Schema extends InstantGraph<any, infer RoomSchema, any> ? RoomSchema : never,
+  WithCardinalityInference
+> {
+  return _init_internal_experimental<
+    Schema,
+    Schema extends InstantGraph<any, infer RoomSchema, any>
+      ? RoomSchema
+      : never,
+    WithCardinalityInference
+  >(config, Storage, NetworkListener);
+}
+
+function _init_internal_experimental<
+  Schema extends {} | InstantGraph<any, any, any>,
+  RoomSchema extends RoomSchemaShape,
+  WithCardinalityInference extends boolean = false,
+>(
+  config: Config,
+  Storage?: any,
+  NetworkListener?: any,
+): InstantCoreExperimental<Schema, RoomSchema, WithCardinalityInference> {
+  const existingClient = globalInstantCoreStore[
+    config.appId
+  ] as InstantCoreExperimental<any, RoomSchema, WithCardinalityInference>;
+
+  if (existingClient) {
+    return existingClient;
+  }
+
+  const reactor = new Reactor<RoomSchema>(
+    {
+      ...defaultConfig,
+      ...config,
+    },
+    Storage || IndexedDBStorage,
+    NetworkListener || WindowNetworkListener,
+  );
+
+  const client = new InstantCoreExperimental<
+    any,
+    RoomSchema,
+    WithCardinalityInference
+  >(reactor);
+  globalInstantCoreStore[config.appId] = client;
+
+  if (typeof window !== "undefined" && typeof window.location !== "undefined") {
+    const showDevtool =
+      // show widget by default?
+      ("devtool" in config ? Boolean(config.devtool) : defaultOpenDevtool) &&
+      // only run on localhost (dev env)
+      window.location.hostname === "localhost" &&
+      // used by dash and other internal consumers
+      !Boolean((globalThis as any)._nodevtool);
+
+    if (showDevtool) {
+      createDevtool(config.appId);
+    }
+  }
+
+  return client;
+}
 
 export {
   // bada bing bada boom
   init,
   init_experimental,
   _init_internal,
+  _init_internal_experimental,
   id,
   tx,
   txInit,
@@ -631,6 +884,7 @@ export {
   IndexedDBStorage,
   WindowNetworkListener,
   InstantCore as InstantClient,
+  InstantCoreExperimental as InstantClientExperimental,
   Auth,
   Storage,
 
@@ -648,7 +902,9 @@ export {
   type AuthToken,
   type TxChunk,
   type SubscriptionState,
+  type SubscriptionStateExperimental,
   type LifecycleSubscriptionState,
+  type LifecycleSubscriptionStateExperimental,
 
   // presence types
   type PresenceOpts,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -589,7 +589,7 @@ function coerceQuery(o: any) {
 // XXX-EXPERIMENTAL
 
 class InstantCoreExperimental<
-  Schema extends InstantGraph<any, any> | undefined = undefined,
+  Schema extends InstantGraph<any, any, any>,
 > implements IDatabaseExperimental<Schema>
 {
   public _reactor: Reactor<RoomSchemaOf<Schema>>;
@@ -597,9 +597,7 @@ class InstantCoreExperimental<
   public storage: Storage;
 
   public tx =
-    txInit<
-      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
-    >();
+    txInit<Schema>();
 
   constructor(reactor: Reactor<RoomSchemaOf<Schema>>) {
     this._reactor = reactor;
@@ -746,9 +744,7 @@ class InstantCoreExperimental<
    *  console.log(resp.data.goals)
    */
   queryOnce<
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
+    Q extends InstaQLQueryParams<Schema>,
   >(
     query: Q,
   ): Promise<{

--- a/client/packages/core/src/presence.ts
+++ b/client/packages/core/src/presence.ts
@@ -12,6 +12,13 @@ export type RoomSchemaShape = {
   };
 };
 
+export type DefaultRoomSchemaShape = {
+  _defaultRoomType: {
+    presence: {}, 
+    topics: {}
+  }
+}
+
 export type PresenceOpts<PresenceShape, Keys extends keyof PresenceShape> = {
   user?: boolean;
   peers?: string[];

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -92,7 +92,12 @@ type Remove$<T> = T extends object
   ? { [K in keyof T as Exclude<K, "$">]: Remove$<T[K]> }
   : T;
 
-type QueryResponse<
+type QueryResponse<Q, Schema> = ResponseOf<
+  { [K in keyof Q]: Remove$<Q[K]> },
+  Schema
+>;
+
+type QueryResponseExperimental<
   Q,
   Schema,
   WithCardinalityInference extends boolean = false,
@@ -227,9 +232,10 @@ type InstaQLQueryParams<S extends InstantGraph<any, any>> = {
     | ($Option & InstaQLQuerySubqueryParams<S, K>);
 };
 
-export {
+export type{
   Query,
   QueryResponse,
+  QueryResponseExperimental,
   PageInfoResponse,
   InstantObject,
   Exactly,

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -100,10 +100,10 @@ type QueryResponse<Q, Schema> = ResponseOf<
 type QueryResponseExperimental<
   Q,
   Schema,
-  WithCardinalityInference extends boolean = false,
 > =
+  // XXX: do I need this top-level check?
   Schema extends InstantGraph<infer E, any>
-    ? InstaQLQueryResult<E, Q, WithCardinalityInference>
+    ? InstaQLQueryResult<E, Q>
     : ResponseOf<{ [K in keyof Q]: Remove$<Q[K]> }, Schema>;
 
 type PageInfoResponse<T> = {
@@ -150,35 +150,25 @@ type InstaQLQueryEntityLinksResult<
   Query extends {
     [LinkAttrName in keyof Entities[EntityName]["links"]]?: any;
   },
-  WithCardinalityInference extends boolean,
 > = {
   [QueryPropName in keyof Query]: Entities[EntityName]["links"][QueryPropName] extends LinkAttrDef<
     infer Cardinality,
     infer LinkedEntityName
   >
     ? LinkedEntityName extends keyof Entities
-      ? WithCardinalityInference extends true
         ? Cardinality extends "one"
           ?
               | InstaQLQueryEntityResult<
                   Entities,
                   LinkedEntityName,
-                  Query[QueryPropName],
-                  WithCardinalityInference
+                  Query[QueryPropName]
                 >
               | undefined
           : InstaQLQueryEntityResult<
               Entities,
               LinkedEntityName,
-              Query[QueryPropName],
-              WithCardinalityInference
+              Query[QueryPropName]
             >[]
-        : InstaQLQueryEntityResult<
-            Entities,
-            LinkedEntityName,
-            Query[QueryPropName],
-            WithCardinalityInference
-          >[]
       : never
     : never;
 };
@@ -189,26 +179,22 @@ type InstaQLQueryEntityResult<
   Query extends {
     [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
   },
-  WithCardinalityInference extends boolean,
 > = { id: string } & ResolveAttrs<Entities, EntityName> &
   InstaQLQueryEntityLinksResult<
     Entities,
     EntityName,
-    Query,
-    WithCardinalityInference
+    Query
   >;
 
 type InstaQLQueryResult<
   Entities extends EntitiesDef,
   Query,
-  WithCardinalityInference extends boolean,
 > = {
   [QueryPropName in keyof Query]: QueryPropName extends keyof Entities
     ? InstaQLQueryEntityResult<
         Entities,
         QueryPropName,
-        Query[QueryPropName],
-        WithCardinalityInference
+        Query[QueryPropName]
       >[]
     : never;
 };

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -6,6 +6,8 @@ import {
   type AttrsDefs,
   type EntitiesWithLinks,
   type LinksDef,
+  RoomsDef,
+  InstantSchema,
 } from "./schemaTypes";
 
 // ==========
@@ -54,6 +56,32 @@ function graph<
     // correctly aligned and does not allow for substituting a type that might
     // be broader or have additional properties.
     links as LinksDef<any>,
+  );
+}
+
+// XXXTODO: add docstring
+function schema<
+  EntitiesWithoutLinks extends EntitiesDef,
+  const Links extends LinksDef<EntitiesWithoutLinks>,
+  Rooms extends RoomsDef,
+>({
+  entities,
+  links,
+  rooms,
+}: {
+  entities: EntitiesWithoutLinks;
+  links: Links;
+  rooms: Rooms;
+}) {
+  return new InstantSchema(
+    enrichEntitiesWithLinks<EntitiesWithoutLinks, Links>(entities, links),
+    // (XXX): LinksDef<any> stems from TypeScript’s inability to reconcile the
+    // type EntitiesWithLinks<EntitiesWithoutLinks, Links> with
+    // EntitiesWithoutLinks. TypeScript is strict about ensuring that types are
+    // correctly aligned and does not allow for substituting a type that might
+    // be broader or have additional properties.
+    links as LinksDef<any>,
+    rooms,
   );
 }
 

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -73,6 +73,30 @@ export class InstantGraph<
   }
 }
 
+interface RoomDef {
+  presence: EntityDef<any, any, any>;
+  topics?: {
+    [TopicName: string]: EntityDef<any, any, any>;
+  }
+}
+
+export interface RoomsDef {
+  [RoomType: string]: RoomDef;
+}
+
+
+export class InstantSchema<
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  Rooms extends RoomSchemaShape,
+> {
+  constructor(
+    public entities: Entities,
+    public links: Links,
+    public rooms: Rooms,
+  ) {}
+}
+
 export type RoomSchemaOf<S> =
   S extends InstantGraph<any, any, infer R>
     ? R extends RoomSchemaShape
@@ -131,11 +155,12 @@ export class EntityDef<
   }
 }
 
-export type EntitiesDef = Record<string, EntityDef<any, any, any>>;
+export interface EntitiesDef { 
+  [EntityName: string]: EntityDef<any, any, any>
+};
 
-export type LinksDef<Entities extends EntitiesDef> = Record<
-  string,
-  LinkDef<
+export interface LinksDef<Entities extends EntitiesDef> {
+  [linkName: string]: LinkDef<
     Entities,
     keyof Entities,
     string,
@@ -144,7 +169,7 @@ export type LinksDef<Entities extends EntitiesDef> = Record<
     string,
     CardinalityKind
   >
->;
+}
 
 export type LinkDef<
   Entities extends EntitiesDef,

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -1,4 +1,4 @@
-import type { RoomSchemaShape } from "./presence";
+import type { DefaultRoomSchemaShape, RoomSchemaShape } from "./presence";
 
 export class LinkAttrDef<
   Cardinality extends CardinalityKind,
@@ -72,6 +72,29 @@ export class InstantGraph<
     );
   }
 }
+
+export type RoomSchemaOf<S> =
+  S extends InstantGraph<any, any, infer R>
+    ? R extends RoomSchemaShape
+      ? R
+      : never
+    : never;
+
+export type PresenceOf<
+  S,
+  RoomType extends keyof RoomSchemaOf<S>,
+> = RoomSchemaOf<S>[RoomType] extends { presence: infer P } ? P : {};
+
+export type TopicsOf<
+  S,
+  RoomType extends keyof RoomSchemaOf<S>,
+> = RoomSchemaOf<S>[RoomType] extends { topics: infer T } ? T : {};
+
+export type TopicOf<
+  S, 
+  RoomType extends keyof RoomSchemaOf<S>, 
+  TopicType extends keyof TopicsOf<S, RoomType>
+> = TopicsOf<S, RoomType>[TopicType];
 
 // ==========
 // base types

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -87,10 +87,9 @@ function init_experimental<
 }
 
 class InstantReactNative<
-  Schema extends InstantGraph<any, any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> extends InstantReact<Schema, RoomSchema, WithCardinalityInference> {
+  Schema extends {} = {},
+  RoomSchema extends RoomSchemaShape = {}
+> extends InstantReact<Schema, RoomSchema> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
 }

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -77,17 +77,12 @@ function init_experimental<
     cardinalityInference?: WithCardinalityInference;
   },
 ) {
-  return new InstantReactNativeExperimental<
-    Schema,
-    Schema extends InstantGraph<any, infer RoomSchema, any>
-      ? RoomSchema
-      : never
-  >(config);
+  return new InstantReactNativeExperimental<Schema>(config);
 }
 
 class InstantReactNative<
   Schema extends {} = {},
-  RoomSchema extends RoomSchemaShape = {}
+  RoomSchema extends RoomSchemaShape = {},
 > extends InstantReact<Schema, RoomSchema> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
@@ -95,9 +90,8 @@ class InstantReactNative<
 
 // XXX-EXPERIMENTAL
 class InstantReactNativeExperimental<
-  Schema extends InstantGraph<any, any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {},
-> extends InstantReactExperimental<Schema, RoomSchema> {
+  Schema extends InstantGraph<any, any, any>,
+> extends InstantReactExperimental<Schema> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
 }

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -40,6 +40,7 @@ import {
   type ValueTypes,
   type InstantEntity,
 } from "@instantdb/core";
+import { InstantReactExperimental } from "@instantdb/react/dist/module/InstantReactExperimental";
 
 /**
  *
@@ -50,7 +51,7 @@ import {
  * @example
  *  const db = init({ appId: "my-app-id" })
  *
- * // You can also provide a schema for type safety and editor autocomplete!
+ *  // You can also provide a schema for type safety and editor autocomplete!
  *
  *  type Schema = {
  *    goals: {
@@ -76,7 +77,7 @@ function init_experimental<
     cardinalityInference?: WithCardinalityInference;
   },
 ) {
-  return new InstantReactNative<
+  return new InstantReactNativeExperimental<
     Schema,
     Schema extends InstantGraph<any, infer RoomSchema, any>
       ? RoomSchema
@@ -90,6 +91,16 @@ class InstantReactNative<
   RoomSchema extends RoomSchemaShape = {},
   WithCardinalityInference extends boolean = false,
 > extends InstantReact<Schema, RoomSchema, WithCardinalityInference> {
+  static Storage = Storage;
+  static NetworkListener = NetworkListener;
+}
+
+// XXX-EXPERIMENTAL
+class InstantReactNativeExperimental<
+  Schema extends InstantGraph<any, any, any> | {} = {},
+  RoomSchema extends RoomSchemaShape = {},
+  WithCardinalityInference extends boolean = false,
+> extends InstantReactExperimental<Schema, RoomSchema, WithCardinalityInference> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
 }

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -81,8 +81,7 @@ function init_experimental<
     Schema,
     Schema extends InstantGraph<any, infer RoomSchema, any>
       ? RoomSchema
-      : never,
-    WithCardinalityInference
+      : never
   >(config);
 }
 
@@ -98,8 +97,7 @@ class InstantReactNative<
 class InstantReactNativeExperimental<
   Schema extends InstantGraph<any, any, any> | {} = {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> extends InstantReactExperimental<Schema, RoomSchema, WithCardinalityInference> {
+> extends InstantReactExperimental<Schema, RoomSchema> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
 }

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -60,7 +60,7 @@ export type TypingIndicatorHandle<PresenceShape> = {
 export const defaultActivityStopTimeout = 1_000;
 
 export class InstantReactRoom<
-  Schema extends InstantGraph<any, any> | {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape,
   RoomType extends keyof RoomSchema,
 > {
@@ -69,7 +69,7 @@ export class InstantReactRoom<
   id: string;
 
   constructor(
-    _core: InstantClient<Schema, RoomSchema, any>,
+    _core: InstantClient<Schema, RoomSchema>,
     type: RoomType,
     id: string,
   ) {
@@ -296,26 +296,21 @@ const defaultAuthState = {
 };
 
 export abstract class InstantReact<
-  Schema extends InstantGraph<any, any> | {} = {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> implements IDatabase<Schema, RoomSchema, WithCardinalityInference>
+> implements IDatabase<Schema, RoomSchema>
 {
-  public withCardinalityInference?: WithCardinalityInference;
-  public tx =
-    txInit<
-      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
-    >();
+  public tx = txInit<InstantGraph<any, any>>();
 
   public auth: Auth;
   public storage: Storage;
-  public _core: InstantClient<Schema, RoomSchema, WithCardinalityInference>;
+  public _core: InstantClient<Schema, RoomSchema>;
 
   static Storage?: any;
   static NetworkListener?: any;
 
   constructor(config: Config | ConfigWithSchema<any>) {
-    this._core = _init_internal<Schema, RoomSchema, WithCardinalityInference>(
+    this._core = _init_internal<Schema, RoomSchema>(
       config,
       // @ts-expect-error because TS can't resolve subclass statics
       this.constructor.Storage,
@@ -405,12 +400,10 @@ export abstract class InstantReact<
    *  db.useQuery(auth.user ? { goals: {} } : null)
    */
   useQuery = <
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
+    Q extends Exactly<Query, Q>,
   >(
     query: null | Q,
-  ): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+  ): LifecycleSubscriptionState<Q, Schema> => {
     return useQuery(this._core, query).state;
   };
 
@@ -480,13 +473,11 @@ export abstract class InstantReact<
    *  console.log(resp.data.goals)
    */
   queryOnce = <
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
+    Q extends Exactly<Query, Q>,
   >(
     query: Q,
   ): Promise<{
-    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    data: QueryResponse<Q, Schema>;
     pageInfo: PageInfoResponse<Q>;
   }> => {
     return this._core.queryOnce(query);

--- a/client/packages/react/src/InstantReactExperimental.ts
+++ b/client/packages/react/src/InstantReactExperimental.ts
@@ -23,6 +23,7 @@ import {
   type PageInfoResponse,
   InstantClientExperimental,
   _init_internal_experimental,
+  LifecycleSubscriptionStateExperimental,
 } from "@instantdb/core";
 import {
   KeyboardEvent,
@@ -36,6 +37,7 @@ import {
 import { useQuery, useQueryExperimental } from "./useQuery";
 import { useTimeout } from "./useTimeout";
 import { IDatabaseExperimental } from "@instantdb/core/dist/module/coreTypes";
+import { QueryResponseExperimental } from "@instantdb/core/dist/module/queryTypes";
 
 export type PresenceHandle<
   PresenceShape,
@@ -67,12 +69,12 @@ export class InstantReactRoom<
   RoomSchema extends RoomSchemaShape,
   RoomType extends keyof RoomSchema,
 > {
-  _core: InstantClient<Schema, RoomSchema>;
+  _core: InstantClientExperimental<Schema, RoomSchema>;
   type: RoomType;
   id: string;
 
   constructor(
-    _core: InstantClient<Schema, RoomSchema, any>,
+    _core: InstantClientExperimental<Schema, RoomSchema, any>,
     type: RoomType,
     id: string,
   ) {
@@ -413,7 +415,7 @@ export abstract class InstantReactExperimental<
       : Exactly<Query, Q>,
   >(
     query: null | Q,
-  ): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+  ): LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference> => {
     return useQueryExperimental(this._core, query).state;
   };
 
@@ -489,7 +491,7 @@ export abstract class InstantReactExperimental<
   >(
     query: Q,
   ): Promise<{
-    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    data: QueryResponseExperimental<Q, Schema, WithCardinalityInference>;
     pageInfo: PageInfoResponse<Q>;
   }> => {
     return this._core.queryOnce(query);

--- a/client/packages/react/src/InstantReactExperimental.ts
+++ b/client/packages/react/src/InstantReactExperimental.ts
@@ -1,0 +1,497 @@
+import {
+  // types
+  InstantClient,
+  Auth,
+  Storage,
+  txInit,
+  _init_internal,
+  i,
+  type AuthState,
+  type Config,
+  type Query,
+  type Exactly,
+  type TransactionChunk,
+  type LifecycleSubscriptionState,
+  type PresenceOpts,
+  type PresenceResponse,
+  type RoomSchemaShape,
+  type InstaQLQueryParams,
+  type ConfigWithSchema,
+  type IDatabase,
+  type InstantGraph,
+  type QueryResponse,
+  type PageInfoResponse,
+  InstantClientExperimental,
+  _init_internal_experimental,
+} from "@instantdb/core";
+import {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { useQuery, useQueryExperimental } from "./useQuery";
+import { useTimeout } from "./useTimeout";
+import { IDatabaseExperimental } from "@instantdb/core/dist/module/coreTypes";
+
+export type PresenceHandle<
+  PresenceShape,
+  Keys extends keyof PresenceShape,
+> = PresenceResponse<PresenceShape, Keys> & {
+  publishPresence: (data: Partial<PresenceShape>) => void;
+};
+
+export type TypingIndicatorOpts = {
+  timeout?: number | null;
+  stopOnEnter?: boolean;
+  // Perf opt - `active` will always be an empty array
+  writeOnly?: boolean;
+};
+
+export type TypingIndicatorHandle<PresenceShape> = {
+  active: PresenceShape[];
+  setActive(active: boolean): void;
+  inputProps: {
+    onKeyDown: (e: KeyboardEvent) => void;
+    onBlur: () => void;
+  };
+};
+
+export const defaultActivityStopTimeout = 1_000;
+
+export class InstantReactRoom<
+  Schema extends InstantGraph<any, any> | {},
+  RoomSchema extends RoomSchemaShape,
+  RoomType extends keyof RoomSchema,
+> {
+  _core: InstantClient<Schema, RoomSchema>;
+  type: RoomType;
+  id: string;
+
+  constructor(
+    _core: InstantClient<Schema, RoomSchema, any>,
+    type: RoomType,
+    id: string,
+  ) {
+    this._core = _core;
+    this.type = type;
+    this.id = id;
+  }
+
+  /**
+   * Listen for broadcasted events given a room and topic.
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   * @example
+   *  function App({ roomId }) {
+   *    db.room(roomType, roomId).useTopicEffect("chat", (message, peer) => {
+   *      console.log("New message", message, 'from', peer.name);
+   *    });
+   *
+   *    // ...
+   *  }
+   */
+  useTopicEffect = <TopicType extends keyof RoomSchema[RoomType]["topics"]>(
+    topic: TopicType,
+    onEvent: (
+      event: RoomSchema[RoomType]["topics"][TopicType],
+      peer: RoomSchema[RoomType]["presence"],
+    ) => any,
+  ): void => {
+    useEffect(() => {
+      const unsub = this._core._reactor.subscribeTopic(
+        this.id,
+        topic,
+        (event, peer) => {
+          onEvent(event, peer);
+        },
+      );
+
+      return unsub;
+    }, [this.id, topic]);
+  };
+
+  /**
+   * Broadcast an event to a room.
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   * @example
+   * function App({ roomId }) {
+   *   const publishTopic = db.room(roomType, roomId).usePublishTopic("clicks");
+   *
+   *   return (
+   *     <button onClick={() => publishTopic({ ts: Date.now() })}>Click me</button>
+   *   );
+   * }
+   *
+   */
+  usePublishTopic = <Topic extends keyof RoomSchema[RoomType]["topics"]>(
+    topic: Topic,
+  ): ((data: RoomSchema[RoomType]["topics"][Topic]) => void) => {
+    useEffect(() => this._core._reactor.joinRoom(this.id), [this.id]);
+
+    const publishTopic = useCallback(
+      (data) => {
+        this._core._reactor.publishTopic({
+          roomType: this.type,
+          roomId: this.id,
+          topic,
+          data,
+        });
+      },
+      [this.id, topic],
+    );
+
+    return publishTopic;
+  };
+
+  /**
+   * Listen for peer's presence data in a room, and publish the current user's presence.
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   * @example
+   *  function App({ roomId }) {
+   *    const {
+   *      peers,
+   *      publishPresence
+   *    } = db.room(roomType, roomId).usePresence({ keys: ["name", "avatar"] });
+   *
+   *    // ...
+   *  }
+   */
+  usePresence = <Keys extends keyof RoomSchema[RoomType]["presence"]>(
+    opts: PresenceOpts<RoomSchema[RoomType]["presence"], Keys> = {},
+  ): PresenceHandle<RoomSchema[RoomType]["presence"], Keys> => {
+    const [state, setState] = useState<
+      PresenceResponse<RoomSchema[RoomType]["presence"], Keys>
+    >(() => {
+      return (
+        this._core._reactor.getPresence(this.type, this.id, opts) ?? {
+          peers: {},
+          isLoading: true,
+        }
+      );
+    });
+
+    useEffect(() => {
+      const unsub = this._core._reactor.subscribePresence(
+        this.type,
+        this.id,
+        opts,
+        (data) => {
+          setState(data);
+        },
+      );
+
+      return unsub;
+    }, [this.id, opts.user, opts.peers?.join(), opts.keys?.join()]);
+
+    return {
+      ...state,
+      publishPresence: (data) => {
+        this._core._reactor.publishPresence(this.type, this.id, data);
+      },
+    };
+  };
+
+  /**
+   * Publishes presence data to a room
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   * @example
+   *  function App({ roomId }) {
+   *    db.room(roomType, roomId).useSyncPresence({ name, avatar, color });
+   *
+   *    // ...
+   *  }
+   */
+  useSyncPresence = (
+    data: Partial<RoomSchema[RoomType]["presence"]>,
+    deps?: any[],
+  ): void => {
+    useEffect(() => this._core._reactor.joinRoom(this.id), [this.id]);
+    useEffect(() => {
+      return this._core._reactor.publishPresence(this.type, this.id, data);
+    }, [this.type, this.id, deps ?? JSON.stringify(data)]);
+  };
+
+  /**
+   * Manage typing indicator state
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   * @example
+   *  function App({ roomId }) {
+   *    const {
+   *      active,
+   *      setActive,
+   *      inputProps,
+   *    } = db.room(roomType, roomId).useTypingIndicator("chat-input", opts);
+   *
+   *    return <input {...inputProps} />;
+   *  }
+   */
+  useTypingIndicator = (
+    inputName: string,
+    opts: TypingIndicatorOpts = {},
+  ): TypingIndicatorHandle<RoomSchema[RoomType]["presence"]> => {
+    const timeout = useTimeout();
+
+    const onservedPresence = this.usePresence({
+      keys: [inputName],
+    });
+
+    const active = useMemo(() => {
+      const presenceSnapshot = this._core._reactor.getPresence(
+        this.type,
+        this.id,
+      );
+
+      return opts?.writeOnly
+        ? []
+        : Object.values(presenceSnapshot?.peers ?? {}).filter(
+            (p) => p[inputName] === true,
+          );
+    }, [opts?.writeOnly, onservedPresence]);
+
+    const setActive = (isActive: boolean) => {
+      this._core._reactor.publishPresence(this.type, this.id, {
+        [inputName]: isActive,
+      } as unknown as Partial<RoomSchema[RoomType]>);
+
+      if (!isActive) return;
+
+      if (opts?.timeout === null || opts?.timeout === 0) return;
+
+      timeout.set(opts?.timeout ?? defaultActivityStopTimeout, () => {
+        this._core._reactor.publishPresence(this.type, this.id, {
+          [inputName]: null,
+        } as Partial<RoomSchema[RoomType]>);
+      });
+    };
+
+    return {
+      active,
+      setActive: (a: boolean) => {
+        setActive(a);
+      },
+      inputProps: {
+        onKeyDown: (e: KeyboardEvent) => {
+          const isEnter = opts?.stopOnEnter && e.key === "Enter";
+          const isActive = !isEnter;
+
+          setActive(isActive);
+        },
+        onBlur: () => {
+          setActive(false);
+        },
+      },
+    };
+  };
+}
+
+const defaultAuthState = {
+  isLoading: true,
+  user: undefined,
+  error: undefined,
+};
+
+export abstract class InstantReactExperimental<
+  Schema extends InstantGraph<any, any> | {} = {},
+  RoomSchema extends RoomSchemaShape = {},
+  WithCardinalityInference extends boolean = false,
+> implements IDatabaseExperimental<Schema, RoomSchema, WithCardinalityInference>
+{
+  public withCardinalityInference?: WithCardinalityInference;
+  public tx =
+    txInit<
+      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
+    >();
+
+  public auth: Auth;
+  public storage: Storage;
+  public _core: InstantClientExperimental<Schema, RoomSchema, WithCardinalityInference>;
+
+  static Storage?: any;
+  static NetworkListener?: any;
+
+  constructor(config: Config | ConfigWithSchema<any>) {
+    this._core = _init_internal_experimental<Schema, RoomSchema, WithCardinalityInference>(
+      config,
+      // @ts-expect-error because TS can't resolve subclass statics
+      this.constructor.Storage,
+      // @ts-expect-error because TS can't resolve subclass statics
+      this.constructor.NetworkListener,
+    );
+    this.auth = this._core.auth;
+    this.storage = this._core.storage;
+  }
+
+  getLocalId = (name: string) => {
+    return this._core.getLocalId(name);
+  };
+
+  /**
+   * Obtain a handle to a room, which allows you to listen to topics and presence data
+   *
+   * If you don't provide a `type` or `id`, Instant will default to `_defaultRoomType` and `_defaultRoomId`
+   * as the room type and id, respectively.
+   *
+   * @see https://instantdb.com/docs/presence-and-topics
+   *
+   * @example
+   *  const {
+   *   useTopicEffect,
+   *   usePublishTopic,
+   *   useSyncPresence,
+   *   useTypingIndicator,
+   * } = db.room(roomType, roomId);
+   */
+  room<RoomType extends keyof RoomSchema>(
+    type: RoomType = "_defaultRoomType" as RoomType,
+    id: string = "_defaultRoomId",
+  ) {
+    return new InstantReactRoom<Schema, RoomSchema, RoomType>(
+      this._core,
+      type,
+      id,
+    );
+  }
+
+  /**
+   * Use this to write data! You can create, update, delete, and link objects
+   *
+   * @see https://instantdb.com/docs/instaml
+   *
+   * @example
+   *   // Create a new object in the `goals` namespace
+   *   const goalId = id();
+   *   db.transact(tx.goals[goalId].update({title: "Get fit"}))
+   *
+   *   // Update the title
+   *   db.transact(tx.goals[goalId].update({title: "Get super fit"}))
+   *
+   *   // Delete it
+   *   db.transact(tx.goals[goalId].delete())
+   *
+   *   // Or create an association:
+   *   todoId = id();
+   *   db.transact([
+   *    tx.todos[todoId].update({ title: 'Go on a run' }),
+   *    tx.goals[goalId].link({todos: todoId}),
+   *  ])
+   */
+  transact = (
+    chunks: TransactionChunk<any, any> | TransactionChunk<any, any>[],
+  ) => {
+    return this._core.transact(chunks);
+  };
+
+  /**
+   * Use this to query your data!
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *  // listen to all goals
+   *  db.useQuery({ goals: {} })
+   *
+   *  // goals where the title is "Get Fit"
+   *  db.useQuery({ goals: { $: { where: { title: "Get Fit" } } } })
+   *
+   *  // all goals, _alongside_ their todos
+   *  db.useQuery({ goals: { todos: {} } })
+   *
+   *  // skip if `user` is not logged in
+   *  db.useQuery(auth.user ? { goals: {} } : null)
+   */
+  useQuery = <
+    Q extends Schema extends InstantGraph<any, any>
+      ? InstaQLQueryParams<Schema>
+      : Exactly<Query, Q>,
+  >(
+    query: null | Q,
+  ): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+    return useQueryExperimental(this._core, query).state;
+  };
+
+  /**
+   * Listen for the logged in state. This is useful
+   * for deciding when to show a login screen.
+   *
+   * Check out the docs for an example `Login` component too!
+   *
+   * @see https://instantdb.com/docs/auth
+   * @example
+   *  function App() {
+   *    const { isLoading, user, error } = db.useAuth()
+   *    if (isLoading) {
+   *      return <div>Loading...</div>
+   *    }
+   *    if (error) {
+   *      return <div>Uh oh! {error.message}</div>
+   *    }
+   *    if (user) {
+   *      return <Main user={user} />
+   *    }
+   *    return <Login />
+   *  }
+   *
+   */
+  useAuth = (): AuthState => {
+    // We use a ref to store the result of the query.
+    // This is becuase `useSyncExternalStore` uses `Object.is`
+    // to compare the previous and next state.
+    // If we don't use a ref, the state will always be considered different, so
+    // the component will always re-render.
+    const resultCacheRef = useRef<AuthState>(
+      this._core._reactor._currentUserCached,
+    );
+
+    // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
+    // if `subscribe` changes, so we use `useCallback` to memoize the function.
+    const subscribe = useCallback((cb: Function) => {
+      const unsubscribe = this._core.subscribeAuth((auth) => {
+        resultCacheRef.current = { isLoading: false, ...auth };
+        cb();
+      });
+
+      return unsubscribe;
+    }, []);
+
+    const state = useSyncExternalStore<AuthState>(
+      subscribe,
+      () => resultCacheRef.current,
+      () => defaultAuthState,
+    );
+    return state;
+  };
+
+  /**
+   * Use this for one-off queries.
+   * Returns local data if available, otherwise fetches from the server.
+   * Because we want to avoid stale data, this method will throw an error
+   * if the user is offline or there is no active connection to the server.
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *
+   *  const resp = await db.queryOnce({ goals: {} });
+   *  console.log(resp.data.goals)
+   */
+  queryOnce = <
+    Q extends Schema extends InstantGraph<any, any>
+      ? InstaQLQueryParams<Schema>
+      : Exactly<Query, Q>,
+  >(
+    query: Q,
+  ): Promise<{
+    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    pageInfo: PageInfoResponse<Q>;
+  }> => {
+    return this._core.queryOnce(query);
+  };
+}

--- a/client/packages/react/src/InstantReactExperimental.ts
+++ b/client/packages/react/src/InstantReactExperimental.ts
@@ -74,7 +74,7 @@ export class InstantReactRoom<
   id: string;
 
   constructor(
-    _core: InstantClientExperimental<Schema, RoomSchema, any>,
+    _core: InstantClientExperimental<Schema, RoomSchema>,
     type: RoomType,
     id: string,
   ) {
@@ -303,10 +303,8 @@ const defaultAuthState = {
 export abstract class InstantReactExperimental<
   Schema extends InstantGraph<any, any> | {} = {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> implements IDatabaseExperimental<Schema, RoomSchema, WithCardinalityInference>
+> implements IDatabaseExperimental<Schema, RoomSchema>
 {
-  public withCardinalityInference?: WithCardinalityInference;
   public tx =
     txInit<
       Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
@@ -314,13 +312,13 @@ export abstract class InstantReactExperimental<
 
   public auth: Auth;
   public storage: Storage;
-  public _core: InstantClientExperimental<Schema, RoomSchema, WithCardinalityInference>;
+  public _core: InstantClientExperimental<Schema, RoomSchema>;
 
   static Storage?: any;
   static NetworkListener?: any;
 
   constructor(config: Config | ConfigWithSchema<any>) {
-    this._core = _init_internal_experimental<Schema, RoomSchema, WithCardinalityInference>(
+    this._core = _init_internal_experimental<Schema, RoomSchema>(
       config,
       // @ts-expect-error because TS can't resolve subclass statics
       this.constructor.Storage,
@@ -415,7 +413,7 @@ export abstract class InstantReactExperimental<
       : Exactly<Query, Q>,
   >(
     query: null | Q,
-  ): LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference> => {
+  ): LifecycleSubscriptionStateExperimental<Q, Schema> => {
     return useQueryExperimental(this._core, query).state;
   };
 
@@ -491,7 +489,7 @@ export abstract class InstantReactExperimental<
   >(
     query: Q,
   ): Promise<{
-    data: QueryResponseExperimental<Q, Schema, WithCardinalityInference>;
+    data: QueryResponseExperimental<Q, Schema>;
     pageInfo: PageInfoResponse<Q>;
   }> => {
     return this._core.queryOnce(query);

--- a/client/packages/react/src/InstantReactWeb.ts
+++ b/client/packages/react/src/InstantReactWeb.ts
@@ -2,6 +2,6 @@ import type { InstantGraph, RoomSchemaShape } from "@instantdb/core";
 import { InstantReact } from "./InstantReact";
 
 export class InstantReactWeb<
-  Schema extends {},
+  Schema extends {} = {},
   RoomSchema extends RoomSchemaShape = {},
 > extends InstantReact<Schema, RoomSchema> {}

--- a/client/packages/react/src/InstantReactWeb.ts
+++ b/client/packages/react/src/InstantReactWeb.ts
@@ -2,7 +2,6 @@ import type { InstantGraph, RoomSchemaShape } from "@instantdb/core";
 import { InstantReact } from "./InstantReact";
 
 export class InstantReactWeb<
-  Schema extends InstantGraph<any, any> | {} = {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> extends InstantReact<Schema, RoomSchema, WithCardinalityInference> {}
+> extends InstantReact<Schema, RoomSchema> {}

--- a/client/packages/react/src/InstantReactWebExperimental.ts
+++ b/client/packages/react/src/InstantReactWebExperimental.ts
@@ -1,0 +1,9 @@
+// XXX-EXPERIMENTAL
+import type { InstantGraph, RoomSchemaShape } from "@instantdb/core";
+import { InstantReactExperimental } from "./InstantReactExperimental";
+
+export class InstantReactWebExperimental<
+  Schema extends InstantGraph<any, any> | {} = {},
+  RoomSchema extends RoomSchemaShape = {},
+  WithCardinalityInference extends boolean = false,
+> extends InstantReactExperimental<Schema, RoomSchema, WithCardinalityInference> {}

--- a/client/packages/react/src/InstantReactWebExperimental.ts
+++ b/client/packages/react/src/InstantReactWebExperimental.ts
@@ -5,5 +5,4 @@ import { InstantReactExperimental } from "./InstantReactExperimental";
 export class InstantReactWebExperimental<
   Schema extends InstantGraph<any, any> | {} = {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> extends InstantReactExperimental<Schema, RoomSchema, WithCardinalityInference> {}
+> extends InstantReactExperimental<Schema, RoomSchema> {}

--- a/client/packages/react/src/InstantReactWebExperimental.ts
+++ b/client/packages/react/src/InstantReactWebExperimental.ts
@@ -1,8 +1,7 @@
 // XXX-EXPERIMENTAL
-import type { InstantGraph, RoomSchemaShape } from "@instantdb/core";
+import type { InstantGraph } from "@instantdb/core";
 import { InstantReactExperimental } from "./InstantReactExperimental";
 
 export class InstantReactWebExperimental<
-  Schema extends InstantGraph<any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {},
-> extends InstantReactExperimental<Schema, RoomSchema> {}
+  Schema extends InstantGraph<any, any>,
+> extends InstantReactExperimental<Schema> {}

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -34,7 +34,9 @@ import {
 } from "@instantdb/core";
 
 import { InstantReact } from "./InstantReact";
+import { InstantReactExperimental } from "./InstantReactExperimental";
 import { InstantReactWeb } from "./InstantReactWeb";
+import { InstantReactWebExperimental } from "./InstantReactWebExperimental";
 import { init, init_experimental } from "./init";
 import { Cursors } from "./Cursors";
 
@@ -45,11 +47,13 @@ export {
   init,
   init_experimental,
   InstantReactWeb,
+  InstantReactWebExperimental,
   Cursors,
   i,
 
   // internal
   InstantReact,
+  InstantReactExperimental,
 
   // types
   type Config,

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -35,20 +35,13 @@ export function init<
 }
 
 // XXX-EXPERIMENTAL
-export function init_experimental<
-  Schema extends InstantGraph<any, any, any>,
-  WithCardinalityInference extends boolean = true,
->(
+export function init_experimental<Schema extends InstantGraph<any, any, any>>(
   config: Config & {
     schema: Schema;
-    cardinalityInference?: WithCardinalityInference;
   },
 ) {
   return new InstantReactWebExperimental<
     Schema,
-    Schema extends InstantGraph<any, any, infer RoomSchema>
-      ? RoomSchema
-      : never,
-    WithCardinalityInference
+    Schema extends InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never
   >(config);
 }

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -40,8 +40,5 @@ export function init_experimental<Schema extends InstantGraph<any, any, any>>(
     schema: Schema;
   },
 ) {
-  return new InstantReactWebExperimental<
-    Schema,
-    Schema extends InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never
-  >(config);
+  return new InstantReactWebExperimental<Schema>(config);
 }

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -5,6 +5,7 @@ import type {
   RoomSchemaShape,
 } from "@instantdb/core";
 import { InstantReactWeb } from "./InstantReactWeb";
+import { InstantReactWebExperimental } from "./InstantReactWebExperimental";
 
 /**
  *
@@ -33,6 +34,7 @@ export function init<
   return new InstantReactWeb<Schema, RoomSchema>(config);
 }
 
+// XXX-EXPERIMENTAL
 export function init_experimental<
   Schema extends InstantGraph<any, any, any>,
   WithCardinalityInference extends boolean = true,
@@ -42,7 +44,7 @@ export function init_experimental<
     cardinalityInference?: WithCardinalityInference;
   },
 ) {
-  return new InstantReactWeb<
+  return new InstantReactWebExperimental<
     Schema,
     Schema extends InstantGraph<any, any, infer RoomSchema>
       ? RoomSchema

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -91,12 +91,10 @@ export function useQuery<
 
 // XXX-EXPERIMENTAL
 export function useQueryExperimental<
-  Q extends Schema extends InstantGraph<any, any>
-    ? InstaQLQueryParams<Schema>
-    : Exactly<Query, Q>,
-  Schema extends InstantGraph<any, any, any> | {},
+  Q extends InstaQLQueryParams<Schema>,
+  Schema extends InstantGraph<any, any, any>,
 >(
-  _core: InstantClientExperimental<Schema, any>,
+  _core: InstantClientExperimental<Schema>,
   _query: null | Q,
 ): {
   state: LifecycleSubscriptionStateExperimental<Q, Schema>;

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -7,6 +7,8 @@ import {
   type LifecycleSubscriptionState,
   type InstaQLQueryParams,
   type InstantGraph,
+  InstantClientExperimental,
+  LifecycleSubscriptionStateExperimental,
 } from "@instantdb/core";
 import { useCallback, useRef, useSyncExternalStore } from "react";
 
@@ -82,6 +84,70 @@ export function useQuery<
 
   const state = useSyncExternalStore<
     LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+  >(
+    subscribe,
+    () => resultCacheRef.current,
+    () => defaultState,
+  );
+  return { state, query };
+}
+
+// XXX-EXPERIMENTAL
+export function useQueryExperimental<
+  Q extends Schema extends InstantGraph<any, any>
+    ? InstaQLQueryParams<Schema>
+    : Exactly<Query, Q>,
+  Schema extends InstantGraph<any, any, any> | {},
+  WithCardinalityInference extends boolean,
+>(
+  _core: InstantClientExperimental<Schema, any, WithCardinalityInference>,
+  _query: null | Q,
+): {
+  state: LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference>;
+  query: any;
+} {
+  const query = _query ? coerceQuery(_query) : null;
+  const queryHash = weakHash(query);
+
+  // We use a ref to store the result of the query.
+  // This is becuase `useSyncExternalStore` uses `Object.is`
+  // to compare the previous and next state.
+  // If we don't use a ref, the state will always be considered different, so
+  // the component will always re-render.
+  const resultCacheRef = useRef<
+    LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference>
+  >(stateForResult(_core._reactor.getPreviousResult(query)));
+
+  // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
+  // if `subscribe` changes, so we use `useCallback` to memoize the function.
+  const subscribe = useCallback(
+    (cb) => {
+      // Don't subscribe if query is null
+      if (!query) {
+        const unsubscribe = () => {};
+        return unsubscribe;
+      }
+
+      const unsubscribe = _core.subscribeQuery<Q>(query, (result) => {
+        resultCacheRef.current = {
+          isLoading: !Boolean(result),
+          data: undefined,
+          pageInfo: undefined,
+          error: undefined,
+          ...result,
+        };
+
+        cb();
+      });
+
+      return unsubscribe;
+    },
+    // Build a new subscribe function if the query changes
+    [queryHash],
+  );
+
+  const state = useSyncExternalStore<
+    LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference>
   >(
     subscribe,
     () => resultCacheRef.current,

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -95,12 +95,11 @@ export function useQueryExperimental<
     ? InstaQLQueryParams<Schema>
     : Exactly<Query, Q>,
   Schema extends InstantGraph<any, any, any> | {},
-  WithCardinalityInference extends boolean,
 >(
-  _core: InstantClientExperimental<Schema, any, WithCardinalityInference>,
+  _core: InstantClientExperimental<Schema, any>,
   _query: null | Q,
 ): {
-  state: LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference>;
+  state: LifecycleSubscriptionStateExperimental<Q, Schema>;
   query: any;
 } {
   const query = _query ? coerceQuery(_query) : null;
@@ -112,7 +111,7 @@ export function useQueryExperimental<
   // If we don't use a ref, the state will always be considered different, so
   // the component will always re-render.
   const resultCacheRef = useRef<
-    LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionStateExperimental<Q, Schema>
   >(stateForResult(_core._reactor.getPreviousResult(query)));
 
   // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
@@ -144,7 +143,7 @@ export function useQueryExperimental<
   );
 
   const state = useSyncExternalStore<
-    LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionStateExperimental<Q, Schema>
   >(
     subscribe,
     () => resultCacheRef.current,

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -30,16 +30,13 @@ function stateForResult(result: any) {
 }
 
 export function useQuery<
-  Q extends Schema extends InstantGraph<any, any>
-    ? InstaQLQueryParams<Schema>
-    : Exactly<Query, Q>,
-  Schema extends InstantGraph<any, any, any> | {},
-  WithCardinalityInference extends boolean,
+  Q extends Exactly<Query, Q>,
+  Schema extends {},
 >(
-  _core: InstantClient<Schema, any, WithCardinalityInference>,
+  _core: InstantClient<Schema, any>,
   _query: null | Q,
 ): {
-  state: LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>;
+  state: LifecycleSubscriptionState<Q, Schema>;
   query: any;
 } {
   const query = _query ? coerceQuery(_query) : null;
@@ -51,7 +48,7 @@ export function useQuery<
   // If we don't use a ref, the state will always be considered different, so
   // the component will always re-render.
   const resultCacheRef = useRef<
-    LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionState<Q, Schema>
   >(stateForResult(_core._reactor.getPreviousResult(query)));
 
   // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
@@ -83,7 +80,7 @@ export function useQuery<
   );
 
   const state = useSyncExternalStore<
-    LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionState<Q, Schema>
   >(
     subscribe,
     () => resultCacheRef.current,

--- a/client/sandbox/react-nextjs/pages/play/ephemeral.tsx
+++ b/client/sandbox/react-nextjs/pages/play/ephemeral.tsx
@@ -91,9 +91,9 @@ function Demo() {
   inputIndicator.active[0]?.__notInSchema;
 
   useEffect(() => {
-    const user = db._core._reactor.getPresence("demo-room", roomId, {
-      keys: ["test"],
-    }).user;
+    const room = db.room('demo-room');
+    const presence = room.usePresence({keys: ['test']});
+    const user = presence.user;
 
     user?.test;
     // @ts-expect-error

--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -5,6 +5,9 @@ const _graph = i.graph(
     messages: i.entity({
       content: i.string(),
     }),
+    profiles: i.entity({
+      name: i.string(),
+    }),
     $users: i.entity({
       email: i.string().unique().indexed(),
     }),
@@ -22,11 +25,23 @@ const _graph = i.graph(
         label: "createdMessages",
       },
     },
+    messageProfile: {
+      forward: {
+        on: "messages",
+        has: "one",
+        label: "profile",
+      },
+      reverse: {
+        on: "profiles",
+        has: "many",
+        label: "messages",
+      },
+    },
   },
 );
 
 type _Graph = typeof _graph;
 
-export interface Graph extends _Graph {};
+export interface Graph extends _Graph {}
 const graph: Graph = _graph;
 export default graph;

--- a/client/sandbox/strong-init-vite/src/App.tsx
+++ b/client/sandbox/strong-init-vite/src/App.tsx
@@ -9,7 +9,7 @@ const db = init_experimental({
 });
 
 function App() {
-  const { isLoading, data, error } = db.useQuery({ messages: {} });
+  const { isLoading, data, error } = db.useQuery({ messages: { profile: {} } });
   if (isLoading || error) return null;
   const { messages } = data;
 
@@ -17,14 +17,20 @@ function App() {
     <div>
       <div>
         {messages.map((m) => (
-          <div key={m.id}>{m.content}</div>
+          <div key={m.id}>
+            {m.profile?.name} | {m.content}
+          </div>
         ))}
       </div>
       <button
         onClick={() => {
-          db.transact(
-            db.tx.messages[id()].update({ content: "Hello, world!" }),
-          );
+          const profileId = id();
+          db.transact([
+            db.tx.profiles[profileId].update({ name: "Alice" }),
+            db.tx.messages[id()]
+              .update({ content: "Hello, world!" })
+              .link({ profile: profileId }),
+          ]);
         }}
       >
         Add message


### PR DESCRIPTION
In-progress PR: am going to use this as a master to change a bunch of things.

--- 

### Change 1: Split Paths
Previously, _both_ `init` and `init_experimental` reused a bunch of the same subclasses:  classes like `InstantReact`, `InstantReactWeb`, `InstantCore`, and so on. 

This approach is good for code sharing, but it also complects the two features:

1. We have to be extra careful about changes we make to experimental types, because it _could_ affect the current `init` types.
2. Type changes on strong init will affect normal init: For example, `CardinalityInference` has seeped through all our classes, even though the normal `init` does not have to deal with this at all. 
3. Strong init is affected by normal init: For example, we need to handle the case where `RoomSchema` comes in a different position for arguments. 

I went ahead and split the codepaths: `init` creates `InstantReact`, `InstantCore`, etc, while `init_experimental` creates `InstantReactExperimental`, etc 

This will let us be a lot more bold with changes to strong_init, knowing we won't affect the current flow. 

Once we land this, I am going to fast follow to: 

a. Remove strong-init bits in the normal `init` flow 
b. Remove the normal-init bits in the `strong-init` flow 

### Change 2: Remove strong-init parts from normal-init 

- Removes `WithCardinalityInference` from normal init flows
- Removes InstantGraph checks in normal init flows

### Change 3: cardinalityInference by default for strong-init

- Updated strong-init so we do cardinalityInference by default

### Change 4: Schema <- RoomSchema for strong init classes

- We used to extract RoomSchema, but this was only due to backwards compatibility with normal init classes. Updated our strong init classes to just care about Schema