### PR TITLE
[2][in-progress][strong-init] de-complect normal-init from strong-init

### DIFF
--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -3,15 +3,12 @@ import { RoomSchemaShape } from "./presence";
 import type { InstantGraph } from "./schemaTypes";
 
 export interface IDatabase<
-  Schema extends InstantGraph<any, any> | {} = {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
 > {
   tx: TxChunk<
-    Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
+    InstantGraph<any, any>
   >;
-
-  withCardinalityInference?: WithCardinalityInference;
 }
 
 // ----------------

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -5,35 +5,42 @@ import type {
   Remove$,
 } from "./queryTypes";
 import type { InstantGraph } from "./schemaTypes";
-import type { IDatabase } from "./coreTypes";
+import type { IDatabase, IDatabaseExperimental } from "./coreTypes";
 import { RoomSchemaShape } from "./presence";
 
-export type InstantQuery<DB extends IDatabase<any, any, any>> =
-  DB extends IDatabase<infer Schema, any, any>
+export type InstantQuery<DB extends IDatabaseExperimental<any, any, any>> =
+  DB extends IDatabaseExperimental<infer Schema, any, any>
     ? Schema extends InstantGraph<any, any, any>
       ? InstaQLQueryParams<Schema>
       : never
     : never;
 
-export type InstantQueryResult<DB extends IDatabase<any, any, any>, Q> =
-  DB extends IDatabase<infer Schema, any, infer CardinalityInference>
+export type InstantQueryResult<
+  DB extends IDatabaseExperimental<any, any, any>,
+  Q,
+> =
+  DB extends IDatabaseExperimental<
+    infer Schema,
+    any,
+    infer CardinalityInference
+  >
     ? Schema extends InstantGraph<infer E, any>
       ? InstaQLQueryResult<E, Remove$<Q>, CardinalityInference>
       : never
     : never;
 
-export type InstantSchema<DB extends IDatabase<any, any, any>> =
-  DB extends IDatabase<infer Schema, any, any> ? Schema : never;
+export type InstantSchema<DB extends IDatabaseExperimental<any, any, any>> =
+  DB extends IDatabaseExperimental<infer Schema, any, any> ? Schema : never;
 
 export type InstantEntity<
-  DB extends IDatabase<any, any, any>,
-  EntityName extends DB extends IDatabase<infer Schema, any, any>
+  DB extends IDatabaseExperimental<any, any, any>,
+  EntityName extends DB extends IDatabaseExperimental<infer Schema, any, any>
     ? Schema extends InstantGraph<infer Entities, any>
       ? keyof Entities
       : never
     : never,
   Query extends
-    | (DB extends IDatabase<infer Schema, any, any>
+    | (DB extends IDatabaseExperimental<infer Schema, any, any>
         ? Schema extends InstantGraph<infer Entities, any>
           ? {
               [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
@@ -42,7 +49,7 @@ export type InstantEntity<
         : never)
     | {} = {},
 > =
-  DB extends IDatabase<infer Schema, any, any>
+  DB extends IDatabaseExperimental<infer Schema, any, any>
     ? Schema extends InstantGraph<infer Entities, any>
       ? EntityName extends keyof Entities
         ? InstaQLQueryEntityResult<Entities, EntityName, Query, true>
@@ -54,4 +61,4 @@ export type InstantSchemaDatabase<
   Schema extends InstantGraph<any, any>,
   R extends RoomSchemaShape = {},
   CI extends boolean = true,
-> = IDatabase<Schema, R, CI>;
+> = IDatabaseExperimental<Schema, R, CI>;

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -92,7 +92,12 @@ type Remove$<T> = T extends object
   ? { [K in keyof T as Exclude<K, "$">]: Remove$<T[K]> }
   : T;
 
-type QueryResponse<
+type QueryResponse<Q, Schema> = ResponseOf<
+  { [K in keyof Q]: Remove$<Q[K]> },
+  Schema
+>;
+
+type QueryResponseExperimental<
   Q,
   Schema,
   WithCardinalityInference extends boolean = false,
@@ -227,9 +232,10 @@ type InstaQLQueryParams<S extends InstantGraph<any, any>> = {
     | ($Option & InstaQLQuerySubqueryParams<S, K>);
 };
 
-export {
+export type{
   Query,
   QueryResponse,
+  QueryResponseExperimental,
   PageInfoResponse,
   InstantObject,
   Exactly,

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -87,10 +87,9 @@ function init_experimental<
 }
 
 class InstantReactNative<
-  Schema extends InstantGraph<any, any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> extends InstantReact<Schema, RoomSchema, WithCardinalityInference> {
+  Schema extends {} = {},
+  RoomSchema extends RoomSchemaShape = {}
+> extends InstantReact<Schema, RoomSchema> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
 }

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -60,7 +60,7 @@ export type TypingIndicatorHandle<PresenceShape> = {
 export const defaultActivityStopTimeout = 1_000;
 
 export class InstantReactRoom<
-  Schema extends InstantGraph<any, any> | {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape,
   RoomType extends keyof RoomSchema,
 > {
@@ -69,7 +69,7 @@ export class InstantReactRoom<
   id: string;
 
   constructor(
-    _core: InstantClient<Schema, RoomSchema, any>,
+    _core: InstantClient<Schema, RoomSchema>,
     type: RoomType,
     id: string,
   ) {
@@ -296,26 +296,21 @@ const defaultAuthState = {
 };
 
 export abstract class InstantReact<
-  Schema extends InstantGraph<any, any> | {} = {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> implements IDatabase<Schema, RoomSchema, WithCardinalityInference>
+> implements IDatabase<Schema, RoomSchema>
 {
-  public withCardinalityInference?: WithCardinalityInference;
-  public tx =
-    txInit<
-      Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
-    >();
+  public tx = txInit<InstantGraph<any, any>>();
 
   public auth: Auth;
   public storage: Storage;
-  public _core: InstantClient<Schema, RoomSchema, WithCardinalityInference>;
+  public _core: InstantClient<Schema, RoomSchema>;
 
   static Storage?: any;
   static NetworkListener?: any;
 
   constructor(config: Config | ConfigWithSchema<any>) {
-    this._core = _init_internal<Schema, RoomSchema, WithCardinalityInference>(
+    this._core = _init_internal<Schema, RoomSchema>(
       config,
       // @ts-expect-error because TS can't resolve subclass statics
       this.constructor.Storage,
@@ -405,12 +400,10 @@ export abstract class InstantReact<
    *  db.useQuery(auth.user ? { goals: {} } : null)
    */
   useQuery = <
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
+    Q extends Exactly<Query, Q>,
   >(
     query: null | Q,
-  ): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+  ): LifecycleSubscriptionState<Q, Schema> => {
     return useQuery(this._core, query).state;
   };
 
@@ -480,13 +473,11 @@ export abstract class InstantReact<
    *  console.log(resp.data.goals)
    */
   queryOnce = <
-    Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
-      : Exactly<Query, Q>,
+    Q extends Exactly<Query, Q>,
   >(
     query: Q,
   ): Promise<{
-    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    data: QueryResponse<Q, Schema>;
     pageInfo: PageInfoResponse<Q>;
   }> => {
     return this._core.queryOnce(query);

--- a/client/packages/react/src/InstantReactExperimental.ts
+++ b/client/packages/react/src/InstantReactExperimental.ts
@@ -23,6 +23,7 @@ import {
   type PageInfoResponse,
   InstantClientExperimental,
   _init_internal_experimental,
+  LifecycleSubscriptionStateExperimental,
 } from "@instantdb/core";
 import {
   KeyboardEvent,
@@ -36,6 +37,7 @@ import {
 import { useQuery, useQueryExperimental } from "./useQuery";
 import { useTimeout } from "./useTimeout";
 import { IDatabaseExperimental } from "@instantdb/core/dist/module/coreTypes";
+import { QueryResponseExperimental } from "@instantdb/core/dist/module/queryTypes";
 
 export type PresenceHandle<
   PresenceShape,
@@ -67,12 +69,12 @@ export class InstantReactRoom<
   RoomSchema extends RoomSchemaShape,
   RoomType extends keyof RoomSchema,
 > {
-  _core: InstantClient<Schema, RoomSchema>;
+  _core: InstantClientExperimental<Schema, RoomSchema>;
   type: RoomType;
   id: string;
 
   constructor(
-    _core: InstantClient<Schema, RoomSchema, any>,
+    _core: InstantClientExperimental<Schema, RoomSchema, any>,
     type: RoomType,
     id: string,
   ) {
@@ -413,7 +415,7 @@ export abstract class InstantReactExperimental<
       : Exactly<Query, Q>,
   >(
     query: null | Q,
-  ): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+  ): LifecycleSubscriptionStateExperimental<Q, Schema, WithCardinalityInference> => {
     return useQueryExperimental(this._core, query).state;
   };
 
@@ -489,7 +491,7 @@ export abstract class InstantReactExperimental<
   >(
     query: Q,
   ): Promise<{
-    data: QueryResponse<Q, Schema, WithCardinalityInference>;
+    data: QueryResponseExperimental<Q, Schema, WithCardinalityInference>;
     pageInfo: PageInfoResponse<Q>;
   }> => {
     return this._core.queryOnce(query);

--- a/client/packages/react/src/InstantReactWeb.ts
+++ b/client/packages/react/src/InstantReactWeb.ts
@@ -2,7 +2,6 @@ import type { InstantGraph, RoomSchemaShape } from "@instantdb/core";
 import { InstantReact } from "./InstantReact";
 
 export class InstantReactWeb<
-  Schema extends InstantGraph<any, any> | {} = {},
+  Schema extends {},
   RoomSchema extends RoomSchemaShape = {},
-  WithCardinalityInference extends boolean = false,
-> extends InstantReact<Schema, RoomSchema, WithCardinalityInference> {}
+> extends InstantReact<Schema, RoomSchema> {}

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -30,16 +30,13 @@ function stateForResult(result: any) {
 }
 
 export function useQuery<
-  Q extends Schema extends InstantGraph<any, any>
-    ? InstaQLQueryParams<Schema>
-    : Exactly<Query, Q>,
-  Schema extends InstantGraph<any, any, any> | {},
-  WithCardinalityInference extends boolean,
+  Q extends Exactly<Query, Q>,
+  Schema extends {},
 >(
-  _core: InstantClient<Schema, any, WithCardinalityInference>,
+  _core: InstantClient<Schema, any>,
   _query: null | Q,
 ): {
-  state: LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>;
+  state: LifecycleSubscriptionState<Q, Schema>;
   query: any;
 } {
   const query = _query ? coerceQuery(_query) : null;
@@ -51,7 +48,7 @@ export function useQuery<
   // If we don't use a ref, the state will always be considered different, so
   // the component will always re-render.
   const resultCacheRef = useRef<
-    LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionState<Q, Schema>
   >(stateForResult(_core._reactor.getPreviousResult(query)));
 
   // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
@@ -83,7 +80,7 @@ export function useQuery<
   );
 
   const state = useSyncExternalStore<
-    LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionState<Q, Schema>
   >(
     subscribe,
     () => resultCacheRef.current,


### PR DESCRIPTION
- Removes `WithCardinalityInference` from normal init flows
- Removes InstantGraph checks in normal init flows