### PR TITLE
[DOCS] Cursors prop name correction

### DIFF
--- a/client/www/pages/docs/presence-and-topics.md
+++ b/client/www/pages/docs/presence-and-topics.md
@@ -208,7 +208,7 @@ import { Cursors } from '@instantdb/react';
 // ...
 
 return (
-  <Cursors room={room} currentUserColor="tomato">
+  <Cursors room={room} className="h-full w-full" userCursorColor="tomato">
     {/* Your app here */}
   </Cursors>
 );
@@ -220,7 +220,7 @@ You can provide a `renderCursor` function to return your own custom cursor compo
 <Cursors
   room={room}
   className="cursors"
-  currentUserColor="papayawhip"
+  userCursorColor="papayawhip"
   renderCursor={renderCoolCustomCursor}
 />
 ```


### PR DESCRIPTION
We are using an incorrect prop name `currentUserColor` in docs whereas the [correct prop name is `userCursorColor`](https://github.com/instantdb/instant/blob/ff52fb3024a7c1c3e3e37498ecd23280b7fa8834/client/packages/react/src/Cursors.tsx/#L20).

Also, adding `className="h-full w-full"` helps us understand styles/classes need to be applied to the `Cursors` element to make it visible.