### PR TITLE
Depend on the InstantClient instance in useQuery hook

### DIFF
--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -77,7 +77,7 @@ export function useQuery<
       return unsubscribe;
     },
     // Build a new subscribe function if the query changes
-    [queryHash],
+    [queryHash, _core],
   );
 
   const state = useSyncExternalStore<


### PR DESCRIPTION
Fixes a bug in the dashboard where we don't resubscribe to queries after an update to `apps`. Could also impact users, but they're unlikely to hit this bug because it requires calling private methods (`db._core.shutdown()`).

If the user were to call `db._core.shutdown()` (like we do in the dashboard's `useEffect`), then any calls to useQuery when you reconnect with `init` won't trigger the `useEffect` in `useQuery` and we won't send the subscription to the server.