### PR TITLE
Don't throw 500s on invalid JWT tokens

### DIFF
--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -3,9 +3,10 @@
    [chime.core :as chime-core]
    [clj-http.client :as clj-http]
    [clojure.core.cache.wrapped :as cache]
-   [clojure.string :as string] 
+   [clojure.string :as string]
    [instant.auth.jwt :refer [verify-jwt]]
    [instant.util.crypt]
+   [instant.util.exception :as ex]
    [instant.util.json :as json]
    [instant.util.tracer :as tracer]
    [instant.util.url :as url])
@@ -134,8 +135,7 @@
     (if (clj-http/success? resp)
       {:date (Instant/now)
        :data (:body resp)}
-      (throw (ex-info "Unable to fetch OAuth configuration."
-                      {:type :oauth-error :message "Unable to fetch OAuth configuration."})))))
+      (ex/throw-oauth-err! "Unable to fetch OAuth configuration."))))
 
 (defn get-discovery [endpoint]
   (:data (cache/lookup-or-miss discovery-endpoint-cache endpoint fetch-discovery)))

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -275,9 +275,13 @@
 ;; --------
 ;; Oauth
 
-(defn throw-oauth-err! [message]
-  (throw+ {::type ::oauth-error
-           ::message message}))
+(defn throw-oauth-err!
+  ([message]
+   (throw-oauth-err! message nil))
+  ([message cause]
+   (throw+ {::type ::oauth-error
+            ::message message}
+           cause)))
 
 ;; -------------
 ;; Wrappers
@@ -288,4 +292,3 @@
       (::type (ex-data cause)) cause
       (nil? (.getCause cause)) nil
       :else (recur (.getCause cause)))))
-


### PR DESCRIPTION
Use `ex/throw-oauth-err!` in `verify-jwt` so that we return a 400 with a good error message instead of a 500.