### PR TITLE
Send refresh-presence through receive-q

### DIFF
--- a/server/src/instant/flags_impl.clj
+++ b/server/src/instant/flags_impl.clj
@@ -9,6 +9,7 @@
             [instant.jdbc.aurora :as aurora]
             [instant.model.app :as app-model]
             [instant.reactive.ephemeral :as eph]
+            [instant.reactive.receive-queue :refer [receive-q]]
             [instant.reactive.session :as session]
             [instant.reactive.store :as store]
             [instant.util.instaql :refer [instaql-nodes->object-tree]]
@@ -65,7 +66,7 @@
           socket {:id socket-id
                   :http-req nil
                   :ws-conn ws-conn
-                  :receive-q session/receive-q
+                  :receive-q receive-q
                   :pending-handlers (atom #{})}]
 
       ;; Get results in foreground so that flags are initialized before we return
@@ -81,7 +82,7 @@
                         :admin? true})
       (doseq [{:keys [query]} queries]
         (session/on-message {:id socket-id
-                             :receive-q session/receive-q
+                             :receive-q receive-q
                              :data (->json {:op :add-query
                                             :q query
                                             :return-type "tree"})}))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -7,6 +7,7 @@
    [instant.config :as config]
    [instant.flags :as flags]
    [instant.gauges :as gauges]
+   [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]
    [instant.util.aws :as aws-util]
@@ -180,9 +181,14 @@
         session-ids (filter (fn [sess-id]
                               (rs/get-session @store-conn sess-id))
                             (keys room-data))]
-    (rs/try-broadcast-event! store-conn session-ids {:op :refresh-presence
-                                                     :room-id room-id
-                                                     :data room-data})))
+    (doseq [sess-id session-ids
+            :let [q (:receive-q (rs/get-socket @store-conn sess-id))]
+            :when q]
+      (receive-queue/enqueue->receive-q q
+                                        {:op :refresh-presence
+                                         :room-id room-id
+                                         :data room-data
+                                         :session-id sess-id}))))
 
 (defn straight-jacket-refresh-event!
   [store-conn {:keys [room-key room-id on-sent]}]
@@ -383,15 +389,17 @@
         new-apps-rooms (get-in new-v [:rooms])
         changed-rooms (get-changed-rooms old-apps-rooms new-apps-rooms)]
     (when (seq changed-rooms)
-      (tracer/with-span!
-        {:name "refresh-rooms"
-         :attributes {:room-ids (pr-str (map first changed-rooms))}}
-        (ua/vfuture-pmap
-         (fn [[room-id {:keys [data session-ids]}]]
-           (rs/try-broadcast-event! store-conn session-ids {:op :refresh-presence
-                                                            :room-id room-id
-                                                            :data data}))
-         changed-rooms)))))
+      (tracer/with-span! {:name "refresh-rooms"
+                          :attributes {:room-ids (pr-str (map first changed-rooms))}}
+        (doseq [[room-id {:keys [data session-ids]}] changed-rooms
+                sess-id session-ids
+                :let [q (:receive-q (rs/get-socket @store-conn sess-id))]
+                :when q]
+          (receive-queue/enqueue->receive-q q
+                                            {:op :refresh-presence
+                                             :room-id room-id
+                                             :data data
+                                             :session-id sess-id}))))))
 
 (defn straight-jacket-refresh-rooms! [store-conn prev curr]
   (try

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -36,8 +36,6 @@
 ;; we fully migrate to hazelcast
 (defonce hz-ops-q (atom nil))
 
-(def refresh-timeout-ms 500)
-
 ;; room-maps keeps track of the rooms each session is in (for easy removal
 ;; on session close) and some info about the rooms we're subscribed to on
 ;; this machine
@@ -193,13 +191,7 @@
 (defn straight-jacket-refresh-event!
   [store-conn {:keys [room-key room-id on-sent]}]
   (try
-    (let [fut (ua/vfuture (handle-refresh-event store-conn
-                                                room-key
-                                                room-id))
-          ret (deref fut refresh-timeout-ms :timeout)]
-      (when (= :timeout ret)
-        (future-cancel fut)
-        (ex/throw-operation-timeout! :refresh-rooms refresh-timeout-ms)))
+    (handle-refresh-event store-conn room-key room-id)
     (catch Throwable t
       (tracer/record-exception-span! t {:name "rooms-refresh-map/straight-jacket"}))
     (finally (on-sent))))
@@ -403,11 +395,7 @@
 
 (defn straight-jacket-refresh-rooms! [store-conn prev curr]
   (try
-    (let [refresh-fut (ua/vfuture (refresh-rooms! store-conn prev curr))
-          ret (deref refresh-fut refresh-timeout-ms :timeout)]
-      (when (= :timeout ret)
-        (future-cancel refresh-fut)
-        (ex/throw-operation-timeout! :refresh-rooms refresh-timeout-ms)))
+    (refresh-rooms! store-conn prev curr)
     (catch Throwable e
       (tracer/record-exception-span! e {:name "rooms-refresh/straight-jacket"}))))
 

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -11,7 +11,6 @@
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]
    [instant.util.aws :as aws-util]
-   [instant.util.exception :as ex]
    [instant.util.hazelcast :as hz-util]
    [instant.util.tracer :as tracer]
    [medley.core :refer [dissoc-in]])

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -7,7 +7,6 @@
    [instant.db.pg-introspect :as pg-introspect]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
-   [instant.reactive.session :as session]
    [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -8,6 +8,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
    [instant.reactive.session :as session]
+   [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]
    [instant.util.crypt :as crypt-util]
@@ -348,8 +349,8 @@
                 (doseq [{:keys [id]} sockets]
                   (tracer/with-span! {:name "invalidator/send-refresh"
                                       :attributes {:session-id id}}
-                    (session/enqueue->receive-q session/receive-q
-                                                {:op :refresh :session-id id}))))
+                    (receive-queue/enqueue->receive-q {:op :refresh
+                                                       :session-id id}))))
               (catch Throwable t
                 (def -wal-record wal-record)
                 (def -store-value @store-conn)
@@ -364,8 +365,8 @@
         (doseq [{:keys [id]} sockets]
           (tracer/with-span! {:name "invalidator/send-refresh"
                               :session-id id}
-            (session/enqueue->receive-q session/receive-q {:op :refresh
-                                                           :session-id id}))))
+            (receive-queue/enqueue->receive-q {:op :refresh
+                                               :session-id id}))))
       (catch Throwable t
         (def -wal-record wal-record)
         (def -store-value @store-conn)

--- a/server/src/instant/reactive/receive_queue.clj
+++ b/server/src/instant/reactive/receive_queue.clj
@@ -1,0 +1,33 @@
+(ns instant.reactive.receive-queue
+  (:require
+   [instant.gauges :as gauges]
+   [instant.grouped-queue :as grouped-queue])
+  (:import
+   (java.time Duration Instant)))
+
+(declare receive-q)
+
+(defn enqueue->receive-q
+  ([item]
+   (enqueue->receive-q receive-q item))
+  ([q item]
+   (grouped-queue/put! q
+                       {:item item :put-at (Instant/now)})))
+
+
+(defn receive-q-metrics [receive-q]
+  [{:path "instant.reactive.session.receive-q.size"
+    :value (grouped-queue/size receive-q)}
+   {:path "instant.reactive.session.receive-q.longest-waiting-ms"
+    :value (if-let [{:keys [put-at]} (grouped-queue/peek receive-q)]
+             (.toMillis (Duration/between put-at (Instant/now)))
+             0)}])
+
+(defn start [group-fn]
+  (def receive-q (grouped-queue/create {:group-fn group-fn}))
+  (def cleanup-gauge (gauges/add-gauge-metrics-fn
+                      (fn [] (receive-q-metrics receive-q)))))
+
+(defn stop []
+  (when (bound? #'cleanup-gauge)
+    (cleanup-gauge)))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -31,7 +31,6 @@
    [instant.util.exception :as ex]
    [instant.util.uuid :as uuid-util]
    [instant.grouped-queue :as grouped-queue]
-   [instant.gauges :as gauges]
    [instant.reactive.receive-queue :as receive-queue :refer [receive-q]])
   (:import
    (java.util.concurrent CancellationException)

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -20,6 +20,7 @@
             [instant.model.instant-user :as instant-user-model]
             [instant.postmark :as postmark]
             [instant.reactive.ephemeral :as eph]
+            [instant.reactive.receive-queue :as receive-queue]
             [instant.reactive.session :as session]
             [instant.reactive.store :as rs]
             [instant.util.coll :as ucoll]
@@ -42,7 +43,7 @@
 (defn session-get [_req]
   (session/undertow-config rs/store-conn
                            eph/ephemeral-store-atom
-                           session/receive-q
+                           receive-queue/receive-q
                            {:id (squuid)}))
 
 ;; -----------

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -120,7 +120,7 @@
   (if (= :prod (config/get-env))
     (fn [span]
       (let [attrs (.getAttributes span)]
-        (when-let [op (.get op-attr-key)]
+        (when-let [op (.get attrs op-attr-key)]
           (or (= op ":set-presence")
               (= op ":refresh-presence")))))
     (fn [_span]

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -119,9 +119,10 @@
 (def exclude-span?
   (if (= :prod (config/get-env))
     (fn [span]
-      (-> (.getAttributes span)
-          (.get op-attr-key)
-          (= ":set-presence")))
+      (let [attrs (.getAttributes span)]
+        (when-let [op (.get op-attr-key)]
+          (or (= op ":set-presence")
+              (= op ":refresh-presence")))))
     (fn [_span]
       false)))
 

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -16,7 +16,8 @@
    [instant.db.instaql :as iq]
    [instant.lib.ring.websocket :as ws]
    [instant.reactive.ephemeral :as eph]
-   [instant.reactive.query :as rq])
+   [instant.reactive.query :as rq]
+   [instant.reactive.receive-queue :as receive-queue])
   (:import
    (java.util UUID)
    (java.util.concurrent LinkedBlockingQueue)))
@@ -54,7 +55,7 @@
     (binding [*store-conn* store-conn
               *instaql-query-results* (atom {})
               *eph-store-atom* eph-store-atom]
-      (with-redefs [session/receive-q receive-q
+      (with-redefs [receive-queue/receive-q receive-q
                     eph/room-refresh-ch room-refresh-ch
                     ws/send-json! (fn [msg fake-ws-conn]
                                     (a/>!! fake-ws-conn msg))


### PR DESCRIPTION
This should prevent a slow session from tying up the queue.

When we do `set-presence`, we'll put one `refresh-presence` in the receive-q for each session instead of immediately doing a broadcast. This makes `set-presence` finish much faster. If one of the sessions subscribed to the room is slow, then they won't slow down the set-presence broadcast for everyone in the room. 

We also drop `refresh-presence` events if there are multiple in the queue for a session and room, further preventing a slow session from clogging things up. Also acts as a relief valve for sessions that are getting overloaded.

cc @stopachka @nezaj 