### PR TITLE
[strong-init] add a few typescript tests in strong-init sandbox, and fix bugs

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -143,12 +143,12 @@ function init_experimental<
   NetworkListener?: any,
 ): InstantCore<
   Schema,
-  Schema extends InstantGraph<any, infer RoomSchema, any> ? RoomSchema : never,
+  Schema extends InstantGraph<any, any, infer RoomSchema> ? RoomSchema : never,
   WithCardinalityInference
 > {
   return _init_internal<
     Schema,
-    Schema extends InstantGraph<any, infer RoomSchema, any>
+    Schema extends InstantGraph<any, any, infer RoomSchema>
       ? RoomSchema
       : never,
     WithCardinalityInference

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -81,7 +81,7 @@ function init_experimental<
 ) {
   return new InstantReactNative<
     Schema,
-    Schema extends InstantGraph<any, infer RoomSchema, any>
+    Schema extends InstantGraph<any, any, infer RoomSchema>
       ? RoomSchema
       : never,
     WithCardinalityInference

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -385,9 +385,18 @@ importers:
 
   sandbox/strong-init-vite:
     dependencies:
+      '@instantdb/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
+      '@instantdb/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@instantdb/react':
         specifier: workspace:*
         version: link:../../packages/react
+      '@instantdb/react-native':
+        specifier: workspace:*
+        version: link:../../packages/react-native
       instant-cli:
         specifier: workspace:*
         version: link:../../packages/cli

--- a/client/sandbox/strong-init-vite/package.json
+++ b/client/sandbox/strong-init-vite/package.json
@@ -12,6 +12,9 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "@instantdb/react": "workspace:*",
+    "@instantdb/react-native": "workspace:*",
+    "@instantdb/admin": "workspace:*",
+    "@instantdb/core": "workspace:*",
     "instant-cli": "workspace:*"
   },
   "devDependencies": {

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
@@ -1,0 +1,153 @@
+import {
+  id,
+  init_experimental as core_init_experimental,
+} from "@instantdb/core";
+import { init_experimental as react_init_experimental } from "@instantdb/react";
+import { init_experimental as react_native_init_experimental } from "@instantdb/react-native";
+import { init_experimental as admin_init_experimental } from "@instantdb/admin";
+import graph from "../instant.schema";
+
+type EmojiName = "fire" | "wave" | "confetti" | "heart";
+
+type Rooms = {
+  chat: {
+    presence: {
+      name: string;
+      avatarURI: string;
+    };
+    topics: {
+      emoji: {
+        name: EmojiName;
+        rotationAngle: number;
+        directionAngle: number;
+      };
+    };
+  };
+};
+
+// ----
+// Core
+
+const coreDB = core_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+  schema: graph.withRoomSchema<Rooms>(),
+});
+
+// rooms
+const coreRoom = coreDB.joinRoom("chat");
+coreRoom.getPresence({});
+
+coreRoom.publishTopic("emoji", {
+  name: "confetti",
+  rotationAngle: 0,
+  directionAngle: 0,
+});
+
+// queries
+coreDB.subscribeQuery({ messages: { creator: {} } }, (result) => {
+  if (result.error) {
+    return;
+  }
+  const { messages } = result.data;
+  messages[0].content;
+});
+
+// transactions
+coreDB.tx.messages[id()]
+  .update({ content: "Hello world" })
+  .link({ creator: "foo" });
+
+// ----
+// React
+
+const reactDB = react_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+  schema: graph.withRoomSchema<Rooms>(),
+});
+
+function ReactNormalApp() {
+  // rooms
+  const reactRoom = reactDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactDB.useQuery({ messages: {} });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+
+  // transactions
+  reactDB.transact(
+    reactDB.tx.messages[id()]
+      .update({ content: "Hello there!" })
+      .link({ creator: "foo" }),
+  );
+
+  // to silence ts warnings
+  ((..._args) => {})(
+    _reactPublishEmoji,
+    _reactPresenceUser,
+    _reactPresencePeers,
+    messages,
+  );
+}
+
+// ----
+// React-Native
+
+const reactNativeDB = react_native_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+  schema: graph.withRoomSchema<Rooms>(),
+});
+
+function ReactNativeNormalApp() {
+  // rooms
+  const reactRoom = reactNativeDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactNativeDB.useQuery({
+    messages: {},
+  });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+  // to silence ts warnings
+  ((..._args) => {})(
+    _reactPublishEmoji,
+    _reactPresenceUser,
+    _reactPresencePeers,
+    messages,
+  );
+}
+
+// ----
+// Admin
+
+const adminDB = admin_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID!,
+  adminToken: import.meta.env.VITE_INSTANT_ADMIN_TOKEN!,
+  schema: graph,
+});
+
+// queries
+const adminQueryResult = await adminDB.query({ messages: { creator: {} } });
+adminQueryResult.messages[0].content;
+
+// transacts
+await adminDB.transact(
+  adminDB.tx.messages[id()]
+    .update({ content: "Hello world" })
+    .link({ creator: "foo" }),
+);
+
+// to silence ts warnings
+export { ReactNormalApp, ReactNativeNormalApp };

--- a/client/sandbox/strong-init-vite/src/typescript_tests_normal.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_normal.tsx
@@ -1,0 +1,157 @@
+import { id, init as core_init } from "@instantdb/core";
+import { init as react_init } from "@instantdb/react";
+import { init as react_native_init } from "@instantdb/react-native";
+import { init as admin_init } from "@instantdb/admin";
+
+type Message = {
+  content: string;
+};
+
+type User = {
+  email: string;
+};
+
+type Schema = {
+  messages: Message;
+  creator: User;
+};
+
+type EmojiName = "fire" | "wave" | "confetti" | "heart";
+
+type Rooms = {
+  chat: {
+    presence: {
+      name: string;
+      avatarURI: string;
+    };
+    topics: {
+      emoji: {
+        name: EmojiName;
+        rotationAngle: number;
+        directionAngle: number;
+      };
+    };
+  };
+};
+
+// ----
+// Core
+
+const coreDB = core_init<Schema, Rooms>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+// rooms
+const coreRoom = coreDB.joinRoom("chat");
+coreRoom.getPresence({});
+coreRoom.publishTopic("emoji", {
+  name: "confetti",
+  rotationAngle: 0,
+  directionAngle: 0,
+});
+
+// queries
+coreDB.subscribeQuery({ messages: { creator: {} } }, (result) => {
+  if (result.error) {
+    return;
+  }
+  const { messages } = result.data;
+  messages[0].content;
+});
+
+// transactions
+coreDB.tx.messages[id()]
+  .update({ content: "Hello world" })
+  .link({ creator: "foo" });
+
+// ----
+// React
+
+const reactDB = react_init<Schema, Rooms>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+function ReactNormalApp() {
+  // rooms
+  const reactRoom = reactDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactDB.useQuery({ messages: {} });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+
+  // transactions
+  reactDB.transact(
+    reactDB.tx.messages[id()]
+      .update({ content: "Hello world" })
+      .link({ creator: "foo" }),
+  );
+
+  // to silence ts warnings
+  ((..._args) => {})(
+    _reactPublishEmoji,
+    _reactPresenceUser,
+    _reactPresencePeers,
+    messages,
+  );
+}
+
+// ----
+// React-Native
+
+const reactNativeDB = react_native_init<Schema, Rooms>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+function ReactNativeNormalApp() {
+  // rooms
+  const reactRoom = reactNativeDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactNativeDB.useQuery({
+    messages: {},
+  });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+  // to silence ts warnings
+  ((..._args) => {})(
+    _reactPublishEmoji,
+    _reactPresenceUser,
+    _reactPresencePeers,
+    messages,
+  );
+}
+
+// ----
+// Admin
+
+const adminDB = admin_init<Schema>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID!,
+  adminToken: import.meta.env.VITE_INSTANT_ADMIN_TOKEN!,
+});
+
+// queries
+const adminQueryResult = await adminDB.query({ messages: { creator: {} } });
+adminQueryResult.messages[0].content;
+
+// transacts
+await adminDB.transact(
+  adminDB.tx.messages[id()]
+    .update({ content: "Hello world" })
+    .link({ creator: "foo" }),
+);
+
+// to silence ts warnings
+export { ReactNormalApp, ReactNativeNormalApp };


### PR DESCRIPTION
I added two new files: 

- typescript_tests_normal.tsx
- typescript_tests_experimental.tsx

These go through a full flow of rooms, queries, transactions with db's in `core, react, and react-native`. 

While doing this, I realized we had a typescript error in our current implementation, for core and React. We were inferring `RoomSchema` in the wrong argument position. 

Fixed, so that rooms come with typehints again in core and react-native.

@dwwoelfel @nezaj 