### PR TITLE
[strong-init] schema helpers: fix up docs and update our strong-init sandbox

### DIFF
--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
@@ -1,6 +1,9 @@
 import {
   id,
   init_experimental as core_init_experimental,
+  InstantQuery,
+  InstantEntity,
+  InstantQueryResult,
 } from "@instantdb/core";
 import { init_experimental as react_init_experimental } from "@instantdb/react";
 import { init_experimental as react_native_init_experimental } from "@instantdb/react-native";
@@ -57,6 +60,43 @@ coreDB.tx.messages[id()]
   .update({ content: "Hello world" })
   .link({ creator: "foo" });
 
+// type helpers
+type CoreDB = typeof coreDB;
+const coreMessagesQuery = {
+  messages: {
+    creator: {},
+  },
+} satisfies InstantQuery<CoreDB>;
+
+type CoreMessage = InstantEntity<CoreDB, "messages">;
+let coreMessage: CoreMessage = 1 as any;
+coreMessage.content;
+
+type CoreMessageWithCreator = InstantEntity<
+  CoreDB,
+  "messages",
+  { creator: {} }
+>;
+let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
+coreMessageWithCreator.creator?.id;
+
+type MessageCreatorResult = InstantQueryResult<
+  CoreDB,
+  typeof coreMessagesQuery
+>;
+function subMessagesWithCreator(
+  resultCB: (data: MessageCreatorResult) => void,
+) {
+  coreDB.subscribeQuery(coreMessagesQuery, (result) => {
+    if (result.data) {
+      resultCB(result.data);
+    }
+  });
+}
+
+// to silence ts warnings
+((..._args) => {})(coreMessagesQuery, subMessagesWithCreator);
+
 // ----
 // React
 
@@ -96,6 +136,38 @@ function ReactNormalApp() {
   );
 }
 
+// type helpers
+type ReactDB = typeof reactDB;
+const reactMessagesQuery = {
+  messages: {
+    creator: {},
+  },
+} satisfies InstantQuery<ReactDB>;
+
+type ReactMessage = InstantEntity<ReactDB, "messages">;
+let reactMessage: ReactMessage = 1 as any;
+reactMessage.content;
+
+type ReactMessageWithCreator = InstantEntity<
+  ReactDB,
+  "messages",
+  { creator: {} }
+>;
+let reactMessageWithCreator: ReactMessageWithCreator = 1 as any;
+reactMessageWithCreator.creator?.id;
+
+type ReactMessageCreatorResult = InstantQueryResult<
+  ReactDB,
+  typeof reactMessagesQuery
+>;
+function useMessagesWithCreator(): ReactMessageCreatorResult | undefined {
+  const result = reactDB.useQuery(reactMessagesQuery);
+  return result.data;
+}
+
+// to silence ts warnings
+((..._args) => {})(reactMessagesQuery, useMessagesWithCreator);
+
 // ----
 // React-Native
 
@@ -129,6 +201,40 @@ function ReactNativeNormalApp() {
   );
 }
 
+// type helpers
+type ReactNativeDB = typeof reactNativeDB;
+const reactNativeMessagesQuery = {
+  messages: {
+    creator: {},
+  },
+} satisfies InstantQuery<ReactNativeDB>;
+
+type ReactNativeMessage = InstantEntity<ReactNativeDB, "messages">;
+let reactNativeMessage: ReactNativeMessage = 1 as any;
+reactNativeMessage.content;
+
+type ReactNativeMessageWithCreator = InstantEntity<
+  ReactNativeDB,
+  "messages",
+  { creator: {} }
+>;
+let reactNativeMessageWithCreator: ReactNativeMessageWithCreator = 1 as any;
+reactNativeMessageWithCreator.creator?.id;
+
+type ReactNativeMessageCreatorResult = InstantQueryResult<
+  ReactNativeDB,
+  typeof reactNativeMessagesQuery
+>;
+function useMessagesWithCreatorRN():
+  | ReactNativeMessageCreatorResult
+  | undefined {
+  const result = reactNativeDB.useQuery(reactNativeMessagesQuery);
+  return result.data;
+}
+
+// to silence ts warnings
+((..._args) => {})(reactNativeMessagesQuery, useMessagesWithCreatorRN);
+
 // ----
 // Admin
 
@@ -148,6 +254,39 @@ await adminDB.transact(
     .update({ content: "Hello world" })
     .link({ creator: "foo" }),
 );
+
+// type helpers
+type AdminDB = typeof adminDB;
+const adminMessagesQuery = {
+  messages: {
+    creator: {},
+  },
+} satisfies InstantQuery<AdminDB>;
+
+type AdminMessage = InstantEntity<AdminDB, "messages">;
+let adminMessage: AdminMessage = 1 as any;
+adminMessage.content;
+
+type AdminMessageWithCreator = InstantEntity<
+  AdminDB,
+  "messages",
+  { creator: {} }
+>;
+let adminMessageWithCreator: AdminMessageWithCreator = 1 as any;
+adminMessageWithCreator.creator?.id;
+
+type AdminMessageCreatorResult = InstantQueryResult<
+  AdminDB,
+  typeof adminMessagesQuery
+>;
+
+async function getMessagesWithCreator(): Promise<AdminMessageCreatorResult> {
+  const result = await adminDB.query(adminMessagesQuery);
+  return result;
+}
+
+// to silence ts warnings
+((..._args) => {})(adminMessagesQuery, getMessagesWithCreator);
 
 // to silence ts warnings
 export { ReactNormalApp, ReactNativeNormalApp };

--- a/client/www/pages/docs/strong-init.md
+++ b/client/www/pages/docs/strong-init.md
@@ -90,10 +90,28 @@ const db = init_experimental({
 
 Sometimes, you'll want to abstract out your query and result types. For example, a query's result might be consumed across multiple React components, each with their own prop types. For such cases, we provide `InstantQuery` and `InstantQueryResult`.
 
-To declare a query and validate its type against your schema, you can import `InstantQuery` and leverage [TypeScript's `satisfies` operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) like so: `const myQuery = { myTable: {} } satisfies InstantQuery<DB>;`.
+To declare a query and validate its type against your schema, you can import `InstantQuery` and leverage [TypeScript's `satisfies` operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) like so:
 
-To obtain the resolved result type of your query, import `InstantQueryResult` and provide it your DB and query types `type MyQueryResult = InstantQueryResult<DB, typeof myQuery>`.
+```typescript
+const myQuery = { myTable: {} } satisfies InstantQuery<DB>;
+```
 
-If you only want the type of a single entity, you can leverage `InstantEntity`. `InstantEntity` resolves an entity type from your DB: `type Todo = InstantEntity<DB, 'todos'>`. You can specify links relative to the entity, too: `type Todo = InstantEntity<DB, 'todos', { category: {}, assignee: {} }>`
+To obtain the resolved result type of your query, import `InstantQueryResult` and provide it your DB and query types
+
+```typescript
+type MyQueryResult = InstantQueryResult<DB, typeof myQuery>;
+```
+
+If you only want the type of a single entity, you can leverage `InstantEntity`. `InstantEntity` resolves an entity type from your DB:
+
+```typescript
+type Todo = InstantEntity<DB, 'todos'>;
+```
+
+You can specify links relative to the entity, too:
+
+```typescript
+type Todo = InstantEntity<DB, 'todos', { category: {}; assignee: {} }>;
+```
 
 [Here's a full example](https://github.com/instantdb/instant/blob/main/client/sandbox/react-nextjs/pages/play/strong-todos.tsx) demonstranting reusable query types in a React app.


### PR DESCRIPTION
- Our schema helper example was really tough to read. I made a small improvement, so it at least looks a bit nicer. There's a lot more to do with the docs (i.e instead of `myTable`, using actual examples, and fixing this up in general, but for now just starting off simple with the visual improvement)
- I also started to use these examples in our strong-init sandboxes 

**Docs: before**
<img width="821" alt="CleanShot 2024-11-12 at 16 27 26@2x" src="https://github.com/user-attachments/assets/af402836-c436-48b4-bb21-92f044470f7a">

**Docs: after** 

<img width="769" alt="CleanShot 2024-11-12 at 16 27 44@2x" src="https://github.com/user-attachments/assets/6aa2ccba-14d0-4ff7-bc79-52949b3f73f8">


@dwwoelfel @nezaj 