### PR TITLE
Set a default query timeout of 30 seconds

### DIFF
--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -137,35 +137,7 @@
     (merge {:detailed-query (pr-str query)}
            pool-stats)))
 
-(defn select
-  [conn query]
-  (tracer/with-span! {:name "sql/select"
-                      :attributes (span-attrs conn query)}
-    (io/tag-io
-      (sql/query conn query {:builder-fn rs/as-unqualified-maps}))))
-
-(defn select-qualified
-  [conn query]
-  (tracer/with-span! {:name "sql/select-qualified"
-                      :attributes (span-attrs conn query)}
-    (io/tag-io
-      (sql/query conn query {:builder-fn rs/as-maps}))))
-
-(defn select-arrays
-  [conn query]
-  (tracer/with-span! {:name "sql/select-arrays"
-                      :attributes (span-attrs conn query)}
-    (io/tag-io
-      (sql/query conn query {:builder-fn rs/as-unqualified-arrays}))))
-
-(defn select-string-keys
-  [conn query]
-  (tracer/with-span! {:name "sql/select-string-keys"
-                      :attributes (span-attrs conn query)}
-    (io/tag-io
-      (sql/query conn query {:builder-fn as-string-maps}))))
-
-(def select-one (comp first select))
+(def ^:dynamic *query-timeout-seconds* 30)
 
 (defmacro with-translating-psql-exceptions
   [& body]
@@ -174,6 +146,44 @@
      (catch PSQLException e#
        (throw (ex/translate-and-throw-psql-exception! e#)))))
 
+(defn select
+  [conn query]
+  (tracer/with-span! {:name "sql/select"
+                      :attributes (span-attrs conn query)}
+    (with-translating-psql-exceptions
+      (io/tag-io
+        (sql/query conn query {:builder-fn rs/as-unqualified-maps
+                               :timeout *query-timeout-seconds*})))))
+
+(defn select-qualified
+  [conn query]
+  (tracer/with-span! {:name "sql/select-qualified"
+                      :attributes (span-attrs conn query)}
+    (with-translating-psql-exceptions
+      (io/tag-io
+        (sql/query conn query {:builder-fn rs/as-maps
+                               :timeout *query-timeout-seconds*})))))
+
+(defn select-arrays
+  [conn query]
+  (tracer/with-span! {:name "sql/select-arrays"
+                      :attributes (span-attrs conn query)}
+    (with-translating-psql-exceptions
+      (io/tag-io
+        (sql/query conn query {:builder-fn rs/as-unqualified-arrays
+                               :timeout *query-timeout-seconds*})))))
+
+(defn select-string-keys
+  [conn query]
+  (tracer/with-span! {:name "sql/select-string-keys"
+                      :attributes (span-attrs conn query)}
+    (with-translating-psql-exceptions
+      (io/tag-io
+        (sql/query conn query {:builder-fn as-string-maps
+                               :timeout *query-timeout-seconds*})))))
+
+(def select-one (comp first select))
+
 (defn execute!
   [conn query]
   (tracer/with-span! {:name  "sql/execute!"
@@ -181,7 +191,8 @@
     (with-translating-psql-exceptions
       (io/tag-io
         (next-jdbc/execute! conn query {:builder-fn rs/as-unqualified-maps
-                                        :return-keys true})))))
+                                        :return-keys true
+                                        :timeout *query-timeout-seconds*})))))
 (defn execute-one!
   [conn query]
   (tracer/with-span! {:name  "sql/execute-one!"
@@ -189,14 +200,16 @@
     (with-translating-psql-exceptions
       (io/tag-io
         (next-jdbc/execute-one! conn query {:builder-fn rs/as-unqualified-maps
-                                            :return-keys true})))))
+                                            :return-keys true
+                                            :timeout *query-timeout-seconds*})))))
 
 (defn do-execute! [conn query]
   (tracer/with-span! {:name  "sql/do-execute!"
                       :attributes (span-attrs conn query)}
     (with-translating-psql-exceptions
       (io/tag-io
-        (next-jdbc/execute! conn query {:return-keys false})))))
+        (next-jdbc/execute! conn query {:return-keys false
+                                        :timeout *query-timeout-seconds*})))))
 
 (defn patch-hikari []
   ;; Hikari will send an extra query to ensure the connection is valid

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -304,7 +304,7 @@
                 e))
 
       ;; This could be other things besides a timeout,
-      ;; but we don'thave any way to check :/
+      ;; but we don't have any way to check :/
       :query-canceled
       (throw+ {::type ::timeout
                ::message "The query took too long to complete."}

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -303,6 +303,13 @@
                  ::pg-error-data data}
                 e))
 
+      ;; This could be other things besides a timeout,
+      ;; but we don'thave any way to check :/
+      :query-canceled
+      (throw+ {::type ::timeout
+               ::message "The query took too long to complete."}
+              e)
+
       :raise-exception
       (throw+ {::type ::sql-raise
                ::message (format "Raised Exception: %s" server-message)


### PR DESCRIPTION
Sets a default query timeout of 30 seconds. This should only affect admin queries because client queries coming through the websocket already have a 5 second timeout.

If the requests takes longer than 30 seconds, we'll return a 429 that looks like:

```js
> await adminDb.query({posts: {}}).catch(e => console.log(e))
{
  status: 429,
  body: {
    type: 'timeout',
    message: 'The query took too long to complete.',
    hint: null
  }
}

```