### PR TITLE
Make broadcast work with multiple instances

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/hazelcast-broadcast.tsx
+++ b/client/sandbox/react-nextjs/pages/play/hazelcast-broadcast.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import Head from "next/head";
+import config from "../../config";
+
+let __id = 0;
+function nextId() {
+  return ++__id;
+}
+
+function Page() {
+  const [pages, setPages] = useState([
+    { port: 8888, id: nextId() },
+    { port: 8888, id: nextId() },
+    { port: 8888, id: nextId() },
+    { port: 8889, id: nextId() },
+    { port: 8889, id: nextId() },
+    { port: 8889, id: nextId() },
+  ]);
+
+  return (
+    <div>
+      <Head>
+        <title>Instant Example App: Hazelcast</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <div className="text-sm text-gray-800">
+        <button
+          className="border p-2 m-1"
+          onClick={() => {
+            setPages([...pages, { port: 8888, id: nextId() }]);
+          }}
+        >
+          Add pane with port 8888
+        </button>
+
+        <button
+          className="border p-2 m-1"
+          onClick={() => {
+            setPages([...pages, { port: 8889, id: nextId() }]);
+          }}
+        >
+          Add pane with port 8889
+        </button>
+        <div className="flex flex-wrap gap-x-2 gap-y-2">
+          {pages.map(({ port, id }) => (
+            <div
+              key={id}
+              className="flex w-1/4 flex-grow h-[30vh] bg-white rounded border shadow-sm relative min-h-[250px] min-w-[250px]"
+            >
+              <iframe
+                className="flex-1"
+                src={`http://localhost:3000/examples/5-reactions?__appId=${config.appId}&port=${port}`}
+              />
+              <div className="absolute p-2">Port {port}</div>
+              <button
+                className="absolute p-2 right-0"
+                onClick={() => {
+                  setPages(pages.filter((x) => x.id !== id));
+                }}
+              >
+                X
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Page;

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -292,6 +292,12 @@
                                         :room-id room-id
                                         :client-event-id client-event-id})))
 
+(defn- handle-refresh-presence!
+  [store-conn sess-id {:keys [room-id data]}]
+  (rs/send-event! store-conn sess-id {:op :refresh-presence
+                                      :room-id room-id
+                                      :data data}))
+
 (defn- handle-client-broadcast!
   "Broadcasts a client message to other sessions in the room"
   [store-conn eph-store-atom sess-id {:keys [client-event-id room-id topic data] :as _event}]
@@ -299,24 +305,35 @@
         app-id (-> auth :app :id)
         _ (assert-in-room! @eph-store-atom app-id room-id sess-id)
         current-user (-> auth :user)
-        ids-to-notify (-> (eph/get-room-session-ids @eph-store-atom app-id room-id)
-                          (disj sess-id))
+        {:keys [local-ids remote-ids]} (eph/get-room-session-ids @eph-store-atom app-id room-id)
         base-msg {:room-id room-id
                   :topic topic
                   :data {:peer-id sess-id
                          :user (when current-user
                                  {:id (:id current-user)})
                          :data data}}]
-    (rs/try-broadcast-event! store-conn ids-to-notify (assoc base-msg :op :server-broadcast))
+
+    (doseq [notify-sess-id local-ids
+            :let [q (:receive-q (rs/get-socket @store-conn notify-sess-id))]
+            :when (and q (not= sess-id notify-sess-id))]
+      (receive-queue/enqueue->receive-q q
+                                        (assoc base-msg
+                                               :op :server-broadcast
+                                               :session-id notify-sess-id
+                                               :app-id app-id)))
+    (when (seq remote-ids)
+      (eph/broadcast app-id remote-ids base-msg))
+
     (rs/send-event! store-conn sess-id (assoc base-msg
                                               :op :client-broadcast-ok
                                               :client-event-id client-event-id))))
 
-(defn- handle-refresh-presence!
-  [store-conn sess-id {:keys [room-id data]}]
-  (rs/send-event! store-conn sess-id {:op :refresh-presence
-                                      :room-id room-id
-                                      :data data}))
+(defn- handle-server-broadcast! [store-conn sess-id {:keys [app-id room-id topic data]}]
+  (when (eph/in-room? @store-conn app-id room-id sess-id)
+    (rs/send-event! store-conn sess-id {:op :server-broadcast
+                                        :room-id room-id
+                                        :topic topic
+                                        :data data})))
 
 (defn handle-event [store-conn eph-store-atom session event]
   (tracer/with-span! {:name "receive-worker/handle-event"}
@@ -335,8 +352,9 @@
         :join-room (handle-join-room! store-conn eph-store-atom id event)
         :leave-room (handle-leave-room! store-conn eph-store-atom id event)
         :set-presence (handle-set-presence! store-conn eph-store-atom id event)
+        :refresh-presence (handle-refresh-presence! store-conn id event)
         :client-broadcast (handle-client-broadcast! store-conn eph-store-atom id event)
-        :refresh-presence (handle-refresh-presence! store-conn id event)))))
+        :server-broadcast (handle-server-broadcast! store-conn id event)))))
 
 ;; --------------
 ;; Receive Workers
@@ -624,12 +642,12 @@
 ;; System
 
 (defn group-fn [{:keys [item] :as _input}]
-  (let [{:keys [session-id op room-id]} item]
+  (let [{:keys [session-id op room-id topic]} item]
     (case op
       :transact
       [:transact session-id]
 
-      (:join-room :leave-room :set-presence :client-broadcast)
+      (:join-room :leave-room :set-presence :client-broadcast :server-broadcast)
       [:room session-id room-id]
 
       (:add-query :remove-query)

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -642,7 +642,7 @@
 ;; System
 
 (defn group-fn [{:keys [item] :as _input}]
-  (let [{:keys [session-id op room-id topic]} item]
+  (let [{:keys [session-id op room-id]} item]
     (case op
       :transact
       [:transact session-id]

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -328,8 +328,8 @@
                                               :op :client-broadcast-ok
                                               :client-event-id client-event-id))))
 
-(defn- handle-server-broadcast! [store-conn sess-id {:keys [app-id room-id topic data]}]
-  (when (eph/in-room? @store-conn app-id room-id sess-id)
+(defn- handle-server-broadcast! [store-conn eph-store-atom sess-id {:keys [app-id room-id topic data]}]
+  (when (eph/in-room? @eph-store-atom app-id room-id sess-id)
     (rs/send-event! store-conn sess-id {:op :server-broadcast
                                         :room-id room-id
                                         :topic topic
@@ -354,7 +354,7 @@
         :set-presence (handle-set-presence! store-conn eph-store-atom id event)
         :refresh-presence (handle-refresh-presence! store-conn id event)
         :client-broadcast (handle-client-broadcast! store-conn eph-store-atom id event)
-        :server-broadcast (handle-server-broadcast! store-conn id event)))))
+        :server-broadcast (handle-server-broadcast! store-conn eph-store-atom id event)))))
 
 ;; --------------
 ;; Receive Workers

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -189,6 +189,28 @@
   (make-serializer-config SetPresenceMergeV1
                           set-presence-serializer))
 
+;; --------------
+;; Broadcast data
+
+(defrecord RoomBroadcastV1 [^UUID app-id session-ids base-msg])
+
+(defn room-broadcast-message [^UUID app-id session-ids base-msg]
+  (->RoomBroadcastV1 app-id session-ids base-msg))
+
+(def ^ByteArraySerializer room-broadcast-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 6)
+    (write ^bytes [_ obj]
+      (nippy/fast-freeze obj))
+    (read [_ ^bytes in]
+      (nippy/fast-thaw in))
+    (destroy [_])))
+
+(def room-broadcast-config
+  (make-serializer-config RoomBroadcastV1
+                          room-broadcast-serializer))
+
 ;; -----------------
 ;; Global serializer
 
@@ -208,6 +230,7 @@
 
 (def serializer-configs
   [remove-session-config
+   room-broadcast-config
    join-room-config
    set-presence-config
    room-key-config])

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -123,7 +123,9 @@
       (let [attrs (.getAttributes span)]
         (when-let [op (.get attrs op-attr-key)]
           (or (= op ":set-presence")
-              (= op ":refresh-presence")))))
+              (= op ":refresh-presence")
+              (= op ":server-broadcast")
+              (= op ":client-broadcast")))))
     (fn [_span]
       false)))
 


### PR DESCRIPTION
This updates broadcast to work across multiple instances.

Some of the room's sessions may be on other physical machines when we broadcast a message to everybody in the room. We use a hazelcast topic to notify those other sessions that they need to broadcast the message.

Two changes to make this work:
1. Similar to https://github.com/instantdb/instant/pull/457, we send `:server-broadcast` events through the receive-q instead of doing a single `rs/try-broadcast-event!`
2. In `:client-broadcast` we first notify any sessions that are on the same machine, then we send a message through a hazelcast topic with the list of remote session ids and the data to broadcast. The listener on the topic will put a `:server-broadcast` event on the `receive-q` for the sessions that it has locally.

There is a new [http://localhost:4000/play/hazelcast-broadcast](http://localhost:4000/play/hazelcast-broadcast) playground to make it easy to test.