### PR TITLE
Index process

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -494,7 +494,7 @@ function jobGroupDescription(jobs) {
   for (const job of jobs) {
     actions.add(jobActions[job.job_type]);
   }
-  return joinInSentence([...actions]) || "updating schema";
+  return joinInSentence([...actions].sort()) || "updating schema";
 }
 
 async function waitForIndexingJobsToFinish(appId, data) {

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -400,7 +400,7 @@ function indexingJobCompletedActionMessage(job) {
     return `adding uniqueness constraint to ${job.attr_name}`;
   }
   if (job.job_type === "remove-unique") {
-    return `removing uniqueness constraint to ${job.attr_name}`;
+    return `removing uniqueness constraint from ${job.attr_name}`;
   }
 }
 

--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -491,7 +491,7 @@ function InvalidTriplesSample({
               <td className="pr-2">
                 <pre>{t.entity_id}</pre>
               </td>
-              <td className="pr-2 truncate" style={{ maxWidth: "12rem" }}>
+              <td className="pr-2 truncate" style={{ maxWidth: '12rem' }}>
                 {JSON.stringify(t.value)}
               </td>
               <td className="pr-2">{t.json_type}</td>
@@ -625,7 +625,15 @@ function EditIndexed({
 
       <ActionButton
         type="submit"
-        label="Update index status"
+        label={
+          valueNotChanged
+            ? indexChecked
+              ? 'Indexed'
+              : 'Not indexed'
+            : indexChecked
+              ? 'Index attribute'
+              : 'Remove index'
+        }
         submitLabel={jobWorkingStatus(indexingJob) || 'Updating attribute...'}
         errorMessage="Failed to update attribute"
         disabled={buttonDisabled}
@@ -806,7 +814,15 @@ function EditUnique({
 
       <ActionButton
         type="submit"
-        label="Update uniqueness"
+        label={
+          valueNotChanged
+            ? uniqueChecked
+              ? 'Unique'
+              : 'Not unique'
+            : uniqueChecked
+              ? 'Add uniqueness constraint'
+              : 'Remove uniqueness constraint'
+        }
         submitLabel={jobWorkingStatus(indexingJob) || 'Updating attribute...'}
         errorMessage="Failed to update attribute"
         disabled={buttonDisabled}

--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -284,6 +284,7 @@ export function EditRowDialog({
                     tabIndex={tabIndex}
                     value={value}
                     options={[
+                      { value: '', label: '-' },
                       { value: 'false', label: 'false' },
                       { value: 'true', label: 'true' },
                     ]}

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -390,7 +390,7 @@ export function Explorer({
                       {' '}
                       where <strong>{currentNav.where[0]}</strong> ={' '}
                       <em className="rounded-sm border bg-white px-1">
-                        {currentNav.where[1]}
+                        {JSON.stringify(currentNav.where[1])}
                       </em>
                     </>
                   ) : null}

--- a/client/www/lib/indexingJobs.ts
+++ b/client/www/lib/indexingJobs.ts
@@ -11,7 +11,7 @@ export async function createJob(
   }: {
     appId: string;
     attrId: string;
-    jobType: 'check-data-type' | 'remove-data-type';
+    jobType: InstantIndexingJob['job_type'];
     checkedDataType?: CheckedDataType | null | undefined;
   },
   token: string,

--- a/client/www/lib/types.ts
+++ b/client/www/lib/types.ts
@@ -40,11 +40,23 @@ export type InstantAppInvite = {
   expired: boolean;
 }[];
 
+export type InstantIndexingJobInvalidTriple = {
+  entity_id: string;
+  value: any;
+  json_type: 'string' | 'number' | 'boolean' | 'null' | 'object' | 'array';
+};
 export type InstantIndexingJob = {
   id: string;
   app_id: string;
   attr_id: string;
-  job_type: 'remove-data-type' | 'check-data-type' | string;
+  job_type:
+    | 'remove-data-type'
+    | 'check-data-type'
+    | 'index'
+    | 'remove-index'
+    | 'unique'
+    | 'remove-unique'
+    | string;
   job_status:
     | 'completed'
     | 'waiting'
@@ -58,6 +70,8 @@ export type InstantIndexingJob = {
   error:
     | 'invalid-triple-error'
     | 'invalid-attr-state-error'
+    | 'triple-not-unique-error'
+    | 'triple-too-large-error'
     | 'unexpected-error'
     | string
     | null
@@ -66,14 +80,8 @@ export type InstantIndexingJob = {
   created_at: string;
   updated_at: string;
   done_at: string;
-  invalid_triples_sample:
-    | {
-        entity_id: string;
-        value: any;
-        json_type: 'string' | 'number' | 'boolean' | 'null' | 'object' | 'array';
-      }[]
-    | null
-    | undefined;
+  invalid_unique_value: any;
+  invalid_triples_sample: InstantIndexingJobInvalidTriple[] | null | undefined;
 };
 
 export type DashResponse = {

--- a/server/resources/migrations/38_uniqueing.down.sql
+++ b/server/resources/migrations/38_uniqueing.down.sql
@@ -1,0 +1,5 @@
+alter table attrs drop column setting_unique;
+
+alter table indexing_jobs drop column invalid_unique_value;
+alter table indexing_jobs drop column invalid_entity_id;
+alter table indexing_jobs drop column error_detail;

--- a/server/resources/migrations/38_uniqueing.up.sql
+++ b/server/resources/migrations/38_uniqueing.up.sql
@@ -1,0 +1,5 @@
+alter table attrs add column setting_unique boolean;
+
+alter table indexing_jobs add column invalid_unique_value jsonb;
+alter table indexing_jobs add column invalid_entity_id uuid;
+alter table indexing_jobs add column error_detail text;

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -427,7 +427,6 @@
   ([^clojure.lang.ExceptionInfo e job]
    (mark-error-from-ex-info! aurora/conn-pool e job))
   ([conn ^clojure.lang.ExceptionInfo e job]
-   (def -e e)
    (let [error-data (ex-data e)
          validation-error (some-> error-data
                                   ::ex/hint

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -11,6 +11,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.system-catalog :as system-catalog]
    [instant.util.async :as ua]
+   [instant.util.exception :as ex]
    [instant.util.tracer :as tracer]
    [instant.jdbc.sql :as sql]
    [next.jdbc :as next-jdbc])
@@ -25,11 +26,17 @@
 (def job-types #{"check-data-type"
                  "remove-data-type"
                  "index"
-                 "unique"})
+                 "remove-index"
+                 "unique"
+                 "remove-unique"})
 
-;; This is the key we use to ensure that we don't
-;; check and index simultaneously
-(def check-and-index-serial-key "index")
+;; This is the key we use for checking to ensure we don't set the type
+;; to two values simultaneously
+(def check-serial-key "check")
+;; This is the key we use for checking to ensure we don't start multiple indexing
+;; jobs for the same attr
+(def index-serial-key "index")
+(def unique-serial-key "unique")
 
 (def check-data-type-stages ["validate" ;; make sure this will work
                              "update-attr-start" ;; update attr to prevent adding invalid data
@@ -45,7 +52,30 @@
                               "update-attr-done" ;; update attr to mark checking finished
                               ])
 
+(def index-stages ["update-attr-start"
+                   "estimate-work"
+                   "update-triples"
+                   "update-attr-done"])
+
+(def remove-index-stages ["update-attr-start"
+                          "estimate-work"
+                          "update-triples"
+                          "update-attr-done"])
+
+(def unique-stages ["update-attr-start"
+                    "estimate-work"
+                    "update-triples"
+                    "update-attr-done"])
+
+(def remove-unique-stages ["update-attr-start"
+                           "estimate-work"
+                           "update-triples"
+                           "update-attr-done"])
+
+
 (def invalid-triple-error "invalid-triple-error")
+(def triple-too-large-error "triple-too-large-error")
+(def triple-not-unique-error "triple-not-unique-error")
 (def invalid-attr-state-error "invalid-attr-state-error")
 (def unexpected-error "unexpected-error")
 
@@ -92,6 +122,7 @@
                     :created_at
                     :updated_at
                     :done_at
+                    :invalid_unique_value
                     :invalid_triples_sample]))
 
 (defn get-for-client-q [app-id & wheres]
@@ -100,17 +131,43 @@
               :from :idents
               :where [:= :attr-id :j.attr-id]}
              :attr-name]
-            [[:case [:= :error invalid-triple-error]
+            [[:case-expr :error
+              [:inline invalid-triple-error]
+              [:case-expr :job-type
+               "check-data-type"
+               {:select [[[:json_agg :t]]]
+                :from [[{:select [:t.entity-id :t.value [[:jsonb_typeof :t.value] :json-type]]
+                         :from [[:triples :t]]
+                         :limit 10
+                         :where [:and
+                                 [:= :app-id app-id]
+                                 [:not= nil :j.checked-data-type]
+                                 [:= :t.app_id :j.app_id]
+                                 [:= :t.attr_id :j.attr_id]
+                                 [:not [:triples_valid_value :j.checked-data-type :t.value]]]}
+                        :t]]}]
+              [:inline triple-not-unique-error]
               {:select [[[:json_agg :t]]]
                :from [[{:select [:t.entity-id :t.value [[:jsonb_typeof :t.value] :json-type]]
                         :from [[:triples :t]]
                         :limit 10
                         :where [:and
                                 [:= :app-id app-id]
-                                [:not= nil :j.checked-data-type]
                                 [:= :t.app_id :j.app_id]
                                 [:= :t.attr_id :j.attr_id]
-                                [:not [:triples_valid_value :j.checked-data-type :t.value]]]}
+                                [:= :t.value :j.invalid-unique-value]]}
+                       :t]]}
+
+              [:inline triple-too-large-error]
+              {:select [[[:json_agg :t]]]
+               :from [[{:select [:t.entity-id :t.value [[:jsonb_typeof :t.value] :json-type]]
+                        :from [[:triples :t]]
+                        :limit 10
+                        :where [:and
+                                [:= :app-id app-id]
+                                [:= :t.app_id :j.app_id]
+                                [:= :t.attr_id :j.attr_id]
+                                [:= :t.entity_id :j.invalid-entity-id]]}
                        :t]]}
               ] :invalid-triples-sample]]
    :from [[:indexing-jobs :j]]
@@ -187,7 +244,7 @@
    (create-job! conn {:app-id app-id
                       :group-id group-id
                       :attr-id attr-id
-                      :job-serial-key "index"
+                      :job-serial-key check-serial-key
                       :job-type "check-data-type"
                       :checked-data-type checked-data-type
                       :job-stage "validate"})))
@@ -201,8 +258,60 @@
    (create-job! conn {:app-id app-id
                       :group-id group-id
                       :attr-id attr-id
-                      :job-serial-key "index"
+                      :job-serial-key check-serial-key
                       :job-type "remove-data-type"
+                      :job-stage "update-attr-start"})))
+
+(defn create-index-job!
+  ([params]
+   (create-index-job! aurora/conn-pool params))
+  ([conn {:keys [app-id
+                 group-id
+                 attr-id]}]
+   (create-job! conn {:app-id app-id
+                      :group-id group-id
+                      :attr-id attr-id
+                      :job-serial-key index-serial-key
+                      :job-type "index"
+                      :job-stage "update-attr-start"})))
+
+(defn create-remove-index-job!
+  ([params]
+   (create-remove-index-job! aurora/conn-pool params))
+  ([conn {:keys [app-id
+                 group-id
+                 attr-id]}]
+   (create-job! conn {:app-id app-id
+                      :group-id group-id
+                      :attr-id attr-id
+                      :job-serial-key index-serial-key
+                      :job-type "remove-index"
+                      :job-stage "update-attr-start"})))
+
+(defn create-unique-job!
+  ([params]
+   (create-unique-job! aurora/conn-pool params))
+  ([conn {:keys [app-id
+                 group-id
+                 attr-id]}]
+   (create-job! conn {:app-id app-id
+                      :group-id group-id
+                      :attr-id attr-id
+                      :job-serial-key unique-serial-key
+                      :job-type "unique"
+                      :job-stage "update-attr-start"})))
+
+(defn create-remove-unique-job!
+  ([params]
+   (create-remove-unique-job! aurora/conn-pool params))
+  ([conn {:keys [app-id
+                 group-id
+                 attr-id]}]
+   (create-job! conn {:app-id app-id
+                      :group-id group-id
+                      :attr-id attr-id
+                      :job-serial-key unique-serial-key
+                      :job-type "remove-unique"
                       :job-stage "update-attr-start"})))
 
 (defn job-available-wheres
@@ -245,16 +354,14 @@
   ([job next-stage]
    (update-work-estimate! aurora/conn-pool next-stage job))
   ([conn next-stage job]
-   (let [estimate (case (:job_type job)
-                    ("check-data-type" "remove-data-type" "index" "unique")
-                    (-> (sql/select-one
-                         conn
-                         (hsql/format {:select :%count.*
-                                       :from :triples
-                                       :where [:and
-                                               [:= :app-id (:app_id job)]
-                                               [:= :attr-id (:attr_id job)]]}))
-                        :count))]
+   (let [estimate (-> (sql/select-one
+                       conn
+                       (hsql/format {:select :%count.*
+                                     :from :triples
+                                     :where [:and
+                                             [:= :app-id (:app_id job)]
+                                             [:= :attr-id (:attr_id job)]]}))
+                      :count)]
      (sql/execute-one! conn (hsql/format {:update :indexing-jobs
                                           :where (job-update-wheres
                                                   [:= :id (:id job)])
@@ -305,16 +412,53 @@
                                           :set {:job-stage stage}})))))
 
 (defn mark-error!
-  ([error job]
-   (mark-error! aurora/conn-pool error job))
-  ([conn error job]
-   (tracer/with-span! (assoc (job-span-attrs "mark-error" job)
-                             :error error)
+  ([props job]
+   (mark-error! aurora/conn-pool props job))
+  ([conn props job]
+   (tracer/with-span! (merge (job-span-attrs "mark-error" job)
+                             props)
      (sql/execute-one! conn (hsql/format {:update :indexing-jobs
                                           :where (job-update-wheres
                                                   [:= :id (:id job)])
-                                          :set {:job-status "errored"
-                                                :error error}})))))
+                                          :set (merge {:job-status "errored"}
+                                                      props)})))))
+
+(defn mark-error-from-ex-info!
+  ([^clojure.lang.ExceptionInfo e job]
+   (mark-error-from-ex-info! aurora/conn-pool e job))
+  ([conn ^clojure.lang.ExceptionInfo e job]
+   (def -e e)
+   (let [error-data (ex-data e)
+         validation-error (some-> error-data
+                                  ::ex/hint
+                                  :errors
+                                  first)
+         job-error-fields (case (::ex/type error-data)
+                            ::ex/record-not-unique
+                            {:error triple-not-unique-error
+                             :invalid-unique-value [:cast
+                                                    (-> error-data
+                                                        ::ex/hint
+                                                        :value)
+                                                    :jsonb]}
+
+                            ::ex/validation-failed
+                            (if (and (some-> validation-error
+                                             :hint
+                                             :entity-id)
+                                     (some-> validation-error
+                                             :hint
+                                             :value-too-large?))
+                              {:error triple-too-large-error
+                               :invalid-entity-id [:cast
+                                                   (-> validation-error
+                                                       :hint
+                                                       :entity-id)
+                                                   :uuid]}
+                              {:error unexpected-error})
+
+                            {:error unexpected-error})]
+     (mark-error! conn job-error-fields job))))
 
 (def batch-size 1000)
 
@@ -328,6 +472,7 @@
             :set {:checked-data-type [:cast checked_data_type :checked_data_type]}
             :where [:in :ctid
                     {:select :ctid
+                     :for :update
                      :from :triples
                      :limit batch-size
                      :where [:and
@@ -398,7 +543,7 @@
                            :set {:checked-data-type [:cast (:checked_data_type job) :checked_data_type]
                                  :checking-data-type true}})
      (set-next-stage! conn "revalidate" job)
-     (mark-error! conn invalid-attr-state-error job))))
+     (mark-error! conn {:error invalid-attr-state-error} job))))
 
 (defn update-attr-for-check-done!
   ([job]
@@ -410,7 +555,7 @@
                                    [:= :checking-data-type true]]
                            :set {:checking-data-type false}})
      (mark-job-completed! conn job)
-     (mark-error! conn invalid-attr-state-error job))))
+     (mark-error! conn {:error invalid-attr-state-error} job))))
 
 (defn rollback-attr-for-check!
   ([job]
@@ -430,7 +575,7 @@
    (if (has-invalid-row? conn job)
      (do
        (rollback-attr-for-check! conn job)
-       (mark-error! conn invalid-triple-error job))
+       (mark-error! conn {:error invalid-triple-error} job))
      (set-next-stage! conn next-stage job))))
 
 (defn run-next-check-step
@@ -459,7 +604,7 @@
                            :set {:checked-data-type nil
                                  :checking-data-type true}})
      (set-next-stage! conn "estimate-work" job)
-     (mark-error! conn invalid-attr-state-error job))))
+     (mark-error! conn {:error invalid-attr-state-error} job))))
 
 (defn update-attr-for-remove-data-type-done!
   ([job]
@@ -471,7 +616,7 @@
                                    [:= :checking-data-type true]]
                            :set {:checking-data-type false}})
      (mark-job-completed! conn job)
-     (mark-error! conn invalid-attr-state-error job))))
+     (mark-error! conn {:error invalid-attr-state-error} job))))
 
 (defn remove-data-type-next-batch!
   ([job]
@@ -483,6 +628,7 @@
             :set {:checked-data-type nil}
             :where [:in :ctid
                     {:select :ctid
+                     :for :update
                      :from :triples
                      :limit batch-size
                      :where [:and
@@ -514,6 +660,300 @@
      "update-triples" (remove-data-type-batch-and-update-job! conn job)
      "update-attr-done" (update-attr-for-remove-data-type-done! conn job))))
 
+(defn update-attr-for-index-start!
+  ([job]
+   (update-attr-for-index-start! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :set {:is-indexed true
+                                 :indexing true}})
+     (set-next-stage! conn "estimate-work" job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn update-attr-for-index-done!
+  ([job]
+   (update-attr-for-index-done! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :where [[:= :is-indexed true]
+                                   [:= :indexing true]]
+                           :set {:indexing false}})
+     (mark-job-completed! conn job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn index-next-batch!
+  ([job]
+   (index-next-batch! aurora/conn-pool job))
+  ([conn {:keys [app_id attr_id job_type]}]
+   (assert (= "index" job_type))
+   (let [q {:update :triples
+            :set {:ave true}
+            :where [:in :ctid
+                    {:select :ctid
+                     :for :update
+                     :from :triples
+                     :limit batch-size
+                     :where [:and
+                             [:= :app-id app_id]
+                             [:= :attr-id attr_id]
+                             [:not :ave]]}]}
+         res (sql/do-execute! conn (hsql/format q))]
+     (:next.jdbc/update-count (first res)))))
+
+(defn abort-index! [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :is-indexed true]
+                              [:= :indexing true]]
+                      :set {:indexing false
+                            :is-indexed false}})
+  ;; It would be better to do this in a batch or even to
+  ;; create a new job to undo the update
+  (sql/do-execute! conn (hsql/format {:update :triples
+                                      :set {:ave false}
+                                      :where [:and
+                                              [:= :app-id (:app_id job)]
+                                              [:= :attr-id (:attr_id job)]
+                                              :ave]})))
+
+(defn index-batch-and-update-job!
+  ([job]
+   (index-batch-and-update-job! aurora/conn-pool job))
+  ([conn job]
+   (tracer/with-span! (job-span-attrs "index" job)
+     (try
+       (let [update-count (index-next-batch! conn job)]
+         (tracer/add-data! {:attributes {:update-count update-count}})
+         (cond->> job
+           (not (zero? update-count)) (add-work-completed! conn update-count)
+           (< update-count batch-size) (set-next-stage! conn "update-attr-done")))
+       (catch clojure.lang.ExceptionInfo e
+         (abort-index! conn job)
+         (mark-error-from-ex-info! conn e job))))))
+
+(defn run-next-index-step
+  ([job]
+   (run-next-index-step aurora/conn-pool job))
+  ([conn job]
+   (case (:job_stage job)
+     "update-attr-start" (update-attr-for-index-start! conn job)
+     "estimate-work" (update-work-estimate! conn "update-triples" job)
+     "update-triples" (index-batch-and-update-job! conn job)
+     "update-attr-done" (update-attr-for-index-done! conn job))))
+
+(defn update-attr-for-remove-index-start!
+  ([job]
+   (update-attr-for-remove-index-start! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :set {:is-indexed false
+                                 :indexing true}})
+     (set-next-stage! conn "estimate-work" job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn update-attr-for-remove-index-done!
+  ([job]
+   (update-attr-for-remove-index-done! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :where [[:= :is-indexed false]
+                                   [:= :indexing true]]
+                           :set {:indexing false}})
+     (mark-job-completed! conn job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn remove-index-next-batch!
+  ([job]
+   (remove-index-next-batch! aurora/conn-pool job))
+  ([conn {:keys [app_id attr_id job_type]}]
+   (assert (= "remove-index" job_type))
+   (let [q {:update :triples
+            :set {:ave false}
+            :where [:in :ctid
+                    {:select :ctid
+                     :for :update
+                     :from :triples
+                     :limit batch-size
+                     :where [:and
+                             [:= :app-id app_id]
+                             [:= :attr-id attr_id]
+                             :ave]}]}
+         res (sql/do-execute! conn (hsql/format q))]
+     (:next.jdbc/update-count (first res)))))
+
+(defn remove-index-batch-and-update-job!
+  ([job]
+   (remove-index-batch-and-update-job! aurora/conn-pool job))
+  ([conn job]
+   (tracer/with-span! (job-span-attrs "remove-index" job)
+     (let [update-count (remove-index-next-batch! conn job)]
+       (tracer/add-data! {:attributes {:update-count update-count}})
+       (cond->> job
+         (not (zero? update-count)) (add-work-completed! conn update-count)
+         (< update-count batch-size) (set-next-stage! conn "update-attr-done"))))))
+
+(defn run-next-remove-index-step
+  ([job]
+   (run-next-index-step aurora/conn-pool job))
+  ([conn job]
+   (assert (= "remove-index" (:job_type job)))
+   (case (:job_stage job)
+     "update-attr-start" (update-attr-for-remove-index-start! conn job)
+     "estimate-work" (update-work-estimate! conn "update-triples" job)
+     "update-triples" (remove-index-batch-and-update-job! conn job)
+     "update-attr-done" (update-attr-for-remove-index-done! conn job))))
+
+(defn update-attr-for-unique-start!
+  ([job]
+   (update-attr-for-unique-start! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :set {:is-unique true
+                                 :setting-unique true}})
+     (set-next-stage! conn "estimate-work" job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn update-attr-for-unique-done!
+  ([job]
+   (update-attr-for-unique-done! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :where [[:= :is-unique true]
+                                   [:= :setting-unique true]]
+                           :set {:setting-unique false}})
+     (mark-job-completed! conn job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn unique-next-batch!
+  ([job]
+   (unique-next-batch! aurora/conn-pool job))
+  ([conn {:keys [app_id attr_id job_type]}]
+   (assert (= "unique" job_type))
+   (let [q {:update :triples
+            :set {:av true}
+            :where [:in :ctid
+                    {:select :ctid
+                     :for :update
+                     :from :triples
+                     :limit batch-size
+                     :where [:and
+                             [:= :app-id app_id]
+                             [:= :attr-id attr_id]
+                             [:not :av]]}]}
+         res (sql/do-execute! conn (hsql/format q))]
+     (:next.jdbc/update-count (first res)))))
+
+(defn abort-unique! [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :is-unique true]
+                              [:= :setting-unique true]]
+                      :set {:setting-unique false
+                            :is-unique false}})
+  ;; It would be better to do this in a batch or even to
+  ;; create a new job to undo the update
+  (sql/do-execute! conn (hsql/format {:update :triples
+                                      :set {:av false}
+                                      :where [:and
+                                              [:= :app-id (:app_id job)]
+                                              [:= :attr-id (:attr_id job)]
+                                              :av]})))
+
+(defn unique-batch-and-update-job!
+  ([job]
+   (unique-batch-and-update-job! aurora/conn-pool job))
+  ([conn job]
+   (tracer/with-span! (job-span-attrs "unique" job)
+     (try
+       (let [update-count (unique-next-batch! conn job)]
+         (tracer/add-data! {:attributes {:update-count update-count}})
+         (cond->> job
+           (not (zero? update-count)) (add-work-completed! conn update-count)
+           (< update-count batch-size) (set-next-stage! conn "update-attr-done")))
+       (catch clojure.lang.ExceptionInfo e
+         (abort-unique! conn job)
+         (mark-error-from-ex-info! conn e job))))))
+
+(defn run-next-unique-step
+  ([job]
+   (run-next-unique-step aurora/conn-pool job))
+  ([conn job]
+   (case (:job_stage job)
+     "update-attr-start" (update-attr-for-unique-start! conn job)
+     "estimate-work" (update-work-estimate! conn "update-triples" job)
+     "update-triples" (unique-batch-and-update-job! conn job)
+     "update-attr-done" (update-attr-for-unique-done! conn job))))
+
+(defn update-attr-for-remove-unique-start!
+  ([job]
+   (update-attr-for-remove-unique-start! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :set {:is-unique false
+                                 :setting-unique true}})
+     (set-next-stage! conn "estimate-work" job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn update-attr-for-remove-unique-done!
+  ([job]
+   (update-attr-for-remove-unique-done! aurora/conn-pool job))
+  ([conn job]
+   (if (update-attr! conn {:app-id (:app_id job)
+                           :attr-id (:attr_id job)
+                           :where [[:= :is-unique false]
+                                   [:= :setting-unique true]]
+                           :set {:setting-unique false}})
+     (mark-job-completed! conn job)
+     (mark-error! conn {:error invalid-attr-state-error} job))))
+
+(defn remove-unique-next-batch!
+  ([job]
+   (remove-unique-next-batch! aurora/conn-pool job))
+  ([conn {:keys [app_id attr_id job_type]}]
+   (assert (= "remove-unique" job_type))
+   (let [q {:update :triples
+            :set {:av false}
+            :where [:in :ctid
+                    {:select :ctid
+                     :for :update
+                     :from :triples
+                     :limit batch-size
+                     :where [:and
+                             [:= :app-id app_id]
+                             [:= :attr-id attr_id]
+                             :av]}]}
+         res (sql/do-execute! conn (hsql/format q))]
+     (:next.jdbc/update-count (first res)))))
+
+(defn remove-unique-batch-and-update-job!
+  ([job]
+   (remove-unique-batch-and-update-job! aurora/conn-pool job))
+  ([conn job]
+   (tracer/with-span! (job-span-attrs "remove-unique" job)
+     (let [update-count (remove-unique-next-batch! conn job)]
+       (tracer/add-data! {:attributes {:update-count update-count}})
+       (cond->> job
+         (not (zero? update-count)) (add-work-completed! conn update-count)
+         (< update-count batch-size) (set-next-stage! conn "update-attr-done"))))))
+
+(defn run-next-remove-unique-step
+  ([job]
+   (run-next-unique-step aurora/conn-pool job))
+  ([conn job]
+   (assert (= "remove-unique" (:job_type job)))
+   (case (:job_stage job)
+     "update-attr-start" (update-attr-for-remove-unique-start! conn job)
+     "estimate-work" (update-work-estimate! conn "update-triples" job)
+     "update-triples" (remove-unique-batch-and-update-job! conn job)
+     "update-attr-done" (update-attr-for-remove-unique-done! conn job))))
+
 (defn run-next-step
   ([job]
    (run-next-step aurora/conn-pool job))
@@ -522,7 +962,11 @@
      (assert (= "processing" (:job_status job)) (:job_status job))
      (case (:job_type job)
        "check-data-type" (run-next-check-step conn job)
-       "remove-data-type" (run-next-remove-data-type-step conn job)))))
+       "remove-data-type" (run-next-remove-data-type-step conn job)
+       "index" (run-next-index-step conn job)
+       "remove-index" (run-next-remove-index-step conn job)
+       "unique" (run-next-unique-step conn job)
+       "remove-unique" (run-next-remove-unique-step conn job)))))
 
 (defn enqueue-job
   ([job]
@@ -543,23 +987,33 @@
          (enqueue-job chan job)
          (tracer/record-info! (job-span-attrs "unable-to-release-job" updated-job)))))))
 
+(defn handle-process [chan job-id]
+  (try
+    (tracer/with-span! {:name "indexing-jobs/grab-job"
+                        :attributes {:job-id job-id}}
+      (if-let [job (grab-job! job-id)]
+        (process-job chan job)
+        (tracer/add-data! {:attributes {:job-not-grabbed true}})))
+    (catch Throwable t
+      (discord/send-error-async! (format "%s unexpected job error job-id=%s msg=%s"
+                                         (:dww discord/mention-constants)
+                                         job-id
+                                         (.getMessage t)))
+      (tracer/record-exception-span! t {:name "indexing-jobs/process-error"
+                                        :escaping? false
+                                        :attributes {:job-id job-id}})
+      (sql/execute-one! aurora/conn-pool
+                        (hsql/format {:update :indexing-jobs
+                                      :where (job-update-wheres
+                                              [:= :id job-id])
+                                      :set {:job-status "errored"
+                                            :error unexpected-error
+                                            :error-detail (.getMessage t)}})))))
+
 (defn start-process [chan]
   (loop []
     (when-let [job-id (a/<!! chan)]
-      (try
-        (tracer/with-span! {:name "indexing-jobs/grab-job"
-                            :attributes {:job-id job-id}}
-          (if-let [job (grab-job! job-id)]
-            (process-job chan job)
-            (tracer/add-data! {:attributes {:job-not-grabbed true}})))
-        (catch Throwable t
-          (discord/send-error-async! (format "%s unexpected job error job-id=%s msg=%s"
-                                             (:dww discord/mention-constants)
-                                             job-id
-                                             (.getMessage t)))
-          (tracer/record-exception-span! t {:name "indexing-jobs/process-error"
-                                            :escaping? false
-                                            :attributes {:job-id job-id}})))
+      (handle-process chan job-id)
       (recur))))
 
 (defn grab-forgotten-jobs!
@@ -636,7 +1090,10 @@
     (doseq [{:keys [i process]} workers]
       (tracer/with-span! {:name "indexing-jobs/wait-for-worker-to-stop"
                           :attributes {:i i}}
-        @process))))
+        (try
+          @process
+          (catch Exception _e
+            nil))))))
 
 (defn restart []
   (stop)
@@ -665,6 +1122,7 @@
                      [:cast checked-data-type :checked_data_type]}
                :where [:in :ctid
                        {:select :ctid
+                        :for :update
                         :from :triples
                         :limit batch-size
                         :where [:and

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -71,6 +71,10 @@
 
 (s/def ::checked-data-type checked-data-types)
 
+(s/def ::indexing? boolean?)
+(s/def ::checking-data-type? boolean?)
+(s/def ::setting-unique? boolean?)
+
 (s/def ::attr-common (s/keys :req-un
                              [::id
                               ::forward-identity
@@ -79,7 +83,10 @@
                               ::unique?
                               ::index?]
                              :opt-un
-                             [::checked-data-type]))
+                             [::checked-data-type
+                              ::indexing?
+                              ::checking-data-type?
+                              ::setting-unique?]))
 
 (s/def ::blob-attr ::attr-common)
 
@@ -460,7 +467,8 @@
            on_delete
            checked_data_type
            checking_data_type
-           indexing]}]
+           indexing
+           setting_unique]}]
   (cond-> {:id id
            :value-type (keyword value_type)
            :cardinality (keyword cardinality)
@@ -476,7 +484,8 @@
     reverse_ident (assoc :reverse-identity [reverse_ident rev_etype rev_label])
     checked_data_type (assoc :checked-data-type (keyword checked_data_type))
     checking_data_type (assoc :checking-data-type? true)
-    indexing (assoc :indexing? true)))
+    indexing (assoc :indexing? true)
+    setting_unique (assoc :setting-unique? true)))
 
 (defn index-attrs
   "Groups attrs by common lookup patterns so that we can efficiently look them up."

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -24,12 +24,12 @@
 
    [post-owner-attr true] => :vae if ?owner is actualized
    [posts-owner-attr false] => :eav if ?owner isn't actualized"
-  [{:keys [value-type index? unique?]} v-actualized?]
+  [{:keys [value-type index? indexing? unique? setting-unique?]} v-actualized?]
   (let [ref? (= value-type :ref)
         e-idx (if ref? :eav :ea)
         v-idx (cond
-                unique? :av
-                index? :ave
+                (and unique? (not setting-unique?)) :av
+                (and index? (not indexing?)) :ave
                 ref? :vae
                 :else :ea ;; this means we are searching over an unindexed blob attr
                 )]

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -24,8 +24,6 @@
             IPersistentVector
             IPersistentMap)))
 
-(require 'tool)
-
 (defn ->pg-text-array
   "Formats as text[] in pg, i.e. {item-1, item-2, item3}"
   [col]
@@ -139,15 +137,8 @@
     (merge {:detailed-query (pr-str query)}
            pool-stats)))
 
-(def portal-agent (agent nil))
-
-(defn record-query-async [query]
-  (send-off portal-agent (fn [_]
-                           (tap> (tool/unsafe-sql-format-query query)))))
-
 (defn select
   [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name "sql/select"
                       :attributes (span-attrs conn query)}
     (io/tag-io
@@ -155,7 +146,6 @@
 
 (defn select-qualified
   [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name "sql/select-qualified"
                       :attributes (span-attrs conn query)}
     (io/tag-io
@@ -163,7 +153,6 @@
 
 (defn select-arrays
   [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name "sql/select-arrays"
                       :attributes (span-attrs conn query)}
     (io/tag-io
@@ -171,7 +160,6 @@
 
 (defn select-string-keys
   [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name "sql/select-string-keys"
                       :attributes (span-attrs conn query)}
     (io/tag-io
@@ -188,7 +176,6 @@
 
 (defn execute!
   [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name  "sql/execute!"
                       :attributes (span-attrs conn query)}
     (with-translating-psql-exceptions
@@ -197,7 +184,6 @@
                                         :return-keys true})))))
 (defn execute-one!
   [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name  "sql/execute-one!"
                       :attributes (span-attrs conn query)}
     (with-translating-psql-exceptions
@@ -206,7 +192,6 @@
                                             :return-keys true})))))
 
 (defn do-execute! [conn query]
-  (record-query-async query)
   (tracer/with-span! {:name  "sql/do-execute!"
                       :attributes (span-attrs conn query)}
     (with-translating-psql-exceptions

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -133,8 +133,8 @@
         client-defs (-> req :body :schema)
         check-types? (-> req :body :check_types)
         background-updates? (-> req :body :supports_background_updates)]
-    (response/ok (schema-model/plan! app-id
-                                     {:check-types? check-types?
+    (response/ok (schema-model/plan! {:app-id app-id
+                                      :check-types? check-types?
                                       :background-updates? background-updates?}
                                      client-defs))))
 
@@ -143,8 +143,8 @@
         client-defs (-> req :body :schema)
         check-types? (-> req :body :check_types)
         background-updates? (-> req :body :supports_background_updates)
-        plan (schema-model/plan! app-id
-                                 {:check-types? check-types?
+        plan (schema-model/plan! {:app-id app-id
+                                  :check-types? check-types?
                                   :background-updates? background-updates?}
                                  client-defs)
         plan-result (schema-model/apply-plan! app-id plan)]

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -31,8 +31,8 @@
                                                :app-id id})]
     {:user user :app app}))
 
-;; -------- 
-;; App crud 
+;; --------
+;; App crud
 
 (defn apps-list-get [req]
   (let [{user-id :id} (req->superadmin-user! req)
@@ -63,8 +63,8 @@
         app (app-model/delete-by-id! {:id app-id})]
     (response/ok {:app app})))
 
-;; ---------- 
-;; Transfers 
+;; ---------
+;; Transfers
 
 (defn transfer-app-invite-email [inviter-user app invitee-email]
   (let [title "Instant"]
@@ -110,8 +110,8 @@
 
     (response/ok {:count rejected-count})))
 
-;; --------- 
-;; Rules 
+;; -----
+;; Rules
 
 (defn app-rules-get [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
@@ -125,20 +125,28 @@
     (response/ok {:rules (rule-model/put! {:app-id app-id
                                            :code code})})))
 
-;; --------- 
-;; Schema 
+;; ------
+;; Schema
 
 (defn app-schema-plan-post [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
         client-defs (-> req :body :schema)
-        check-types? (-> req :body :check_types)]
-    (response/ok (schema-model/plan! app-id check-types? client-defs))))
+        check-types? (-> req :body :check_types)
+        background-updates? (-> req :body :supports_background_updates)]
+    (response/ok (schema-model/plan! app-id
+                                     {:check-types? check-types?
+                                      :background-updates? background-updates?}
+                                     client-defs))))
 
 (defn app-schema-apply-post [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
         client-defs (-> req :body :schema)
         check-types? (-> req :body :check_types)
-        plan (schema-model/plan! app-id check-types? client-defs)
+        background-updates? (-> req :body :supports_background_updates)
+        plan (schema-model/plan! app-id
+                                 {:check-types? check-types?
+                                  :background-updates? background-updates?}
+                                 client-defs)
         plan-result (schema-model/apply-plan! app-id plan)]
     (response/ok (merge plan plan-result))))
 

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -311,20 +311,26 @@
                       (catch Exception _e
                         ;; We may get a truncated value, so just give that back to the user
                         (:value triple)))]
-          (throw-validation-err! :triple
-                                 value
-                                 [{:message (case (:constraint data)
-                                              "valid_value_data_type" "Invalid value type for triple."
-                                              "indexed_values_are_constrained" (if (= "true" (:av triple))
-                                                                                 "Value is too large for a unique attribute."
-                                                                                 "Value is too large for an indexed attribute.")
-                                              (format "Check Violation: %s" (name condition)))
-                                   :hint {:value value
-                                          :checked-data-type (:checked-data-type triple)
-                                          :attr-id (:attr-id triple)
-                                          :entity-id (:entity-id triple)
-                                          :value-too-large? (= (:constraint data)
-                                                               "indexed_values_are_constrained")}}]))
+          (throw-validation-err!
+           :triple
+           value
+           [{:message (case (:constraint data)
+                        "valid_value_data_type" "Invalid value type for triple."
+
+                        "indexed_values_are_constrained"
+                        (if (= "t" (:av triple))
+                          "Value is too large for a unique attribute."
+                          "Value is too large for an indexed attribute.")
+
+                        (format "Check Violation: %s" (name (:constraint data))))
+             :hint (merge
+                    {:value value
+                     :checked-data-type (:checked-data-type triple)
+                     :attr-id (:attr-id triple)
+                     :entity-id (:entity-id triple)}
+                    (when (= (:constraint data)
+                             "indexed_values_are_constrained")
+                      {:value-too-large? true}))}]))
         (throw+ {::type ::record-check-violation
                  ::message (format "Check Violation: %s" (name condition))
                  ::hint hint

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -82,7 +82,6 @@
                             (count prefix)
                             (+ (count prefix) 36))
                       uuid-util/coerce)
-          ;; probably run this through json?
           value (-> (subs (:detail pg-data)
                           (+ (count prefix) 36 2)
                           (string/last-index-of (:detail pg-data) ") already exists.")))]

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -6,13 +6,14 @@
    [inflections.core :as inflections]
    [instant.jdbc.pgerrors :as pgerrors]
    [instant.util.json :refer [<-json]]
-   [instant.util.string :refer [indexes-of safe-name]])
+   [instant.util.string :refer [indexes-of safe-name]]
+   [instant.util.uuid :as uuid-util])
   (:import
    (java.io IOException)
    (org.postgresql.util PSQLException)))
 
-;; -------- 
-;; Spec 
+;; ----
+;; Spec
 
 (s/def ::type #{::record-not-found
                 ::record-expired
@@ -45,8 +46,8 @@
   (s/explain-data ::instant-exception {::type ::record-not-found
                                        ::message "Record not found"
                                        :extra "extra"}))
-;; -------- 
-;; Try / Catch Mechanism 
+;; ---------------------
+;; Try / Catch Mechanism
 
 (defn throw+
   ([instant-ex] (throw+ instant-ex nil))
@@ -57,8 +58,8 @@
   (throw+ {::type ::record-not-found
            ::message "hey!"}))
 
-;; -------- 
-;; Records 
+;; -------
+;; Records
 
 (defn throw-expiration-err! [record-type hint]
   {::type ::record-expired
@@ -72,16 +73,33 @@
              ::hint (assoc hint :record-type record-type)}))
   record)
 
-(defn throw-record-not-unique!
-  ([record-type] (throw-record-not-unique! record-type nil))
-  ([record-type e]
-   (throw+ {::type ::record-not-unique
-            ::message (format "Record not unique: %s" (name record-type))
-            ::hint {:record-type record-type}}
-           e)))
+(defn extract-unique-triple-data [pg-data]
+  (when (and (= "triples" (:table pg-data))
+             (= "av_index" (:constraint pg-data))
+             (string/starts-with? (:detail pg-data) "Key (app_id, attr_id, value)="))
+    (let [prefix "Key (app_id, attr_id, value)=(00000000-0000-0000-0000-000000000000, "
+          attr-id (-> (subs (:detail pg-data)
+                            (count prefix)
+                            (+ (count prefix) 36))
+                      uuid-util/coerce)
+          ;; probably run this through json?
+          value (-> (subs (:detail pg-data)
+                          (+ (count prefix) 36 2)
+                          (string/last-index-of (:detail pg-data) ") already exists.")))]
+      {:attr-id attr-id
+       :value value})))
 
-;; -------- 
-;; Permissions 
+(defn throw-record-not-unique!
+  ([record-type] (throw-record-not-unique! record-type nil nil))
+  ([record-type pg-data e]
+   (let [extra-hint-data (extract-unique-triple-data pg-data)]
+     (throw+ {::type ::record-not-unique
+              ::message (format "Record not unique: %s" (name record-type))
+              ::hint (merge {:record-type record-type} extra-hint-data)}
+             e))))
+
+;; -----------
+;; Permissions
 
 (defn assert-permitted! [perm input pass?]
   (when-not pass?
@@ -108,7 +126,7 @@
                                       :hint (::hint cause-data)}}))}
             e)))
 
-;; ----------
+;; -----------
 ;; Validations
 
 (defn throw-validation-err! [input-type input errors]
@@ -122,7 +140,7 @@
   (when (seq errors)
     (throw-validation-err! input-type input errors)))
 
-;; ----------
+;; ------
 ;; Params
 
 (defn get-param! [obj ks coercer]
@@ -194,11 +212,11 @@
            ::hint {:sess-id sess-id
                    :exception-message (.getMessage io-ex)}}
           io-ex))
-;; --------- 
-;; Spec 
+;; ----
+;; Spec
 
 (defn- best-problem
-  "Picks the most specific problem. 
+  "Picks the most specific problem.
    We use a heuristic: we sort by `path`, `in` length, and the last element in `in`."
   [explain]
   (->> explain
@@ -212,7 +230,7 @@
   (#{"clojure.core"} (namespace x)))
 
 (defn- walk-pred
-  "explain-data returns a `pred`. To make it a bit cleaner, 
+  "explain-data returns a `pred`. To make it a bit cleaner,
    we walk it and remove the `namespace` part for common symbols and keywords"
   [pred]
   (w/postwalk
@@ -229,8 +247,8 @@
     [{:expected (walk-pred pred)
       :in in}]))
 
-;; ----------------------- 
-;; PSQL Exception Wrappers 
+;; -----------------------
+;; PSQL Exception Wrappers
 
 (defn kw-table-name [str-table]
   (-> (or str-table "unknown")
@@ -242,9 +260,8 @@
 (comment
   (kw-table-name "app_oauth_codes"))
 
-(defn extract-invalid-value-constraint-triple [{:keys [table constraint detail]}]
+(defn extract-triple-from-constraint [{:keys [table constraint detail]}]
   (when (and (= table "triples")
-             (= constraint "valid_value_data_type")
              detail
              (string/starts-with? detail "Failing row contains"))
     ;; The error detail looks like "Failing row contains (app_id, entity_id, ...),
@@ -277,7 +294,7 @@
         hint (select-keys data [:table :condition :constraint])]
     (case condition
       :unique-violation
-      (throw-record-not-unique! (kw-table-name table) e)
+      (throw-record-not-unique! (kw-table-name table) data e)
 
       :foreign-key-violation
       (throw+ {::type ::record-foreign-key-invalid
@@ -287,16 +304,27 @@
               e)
 
       :check-violation
-      (if-let [triple (extract-invalid-value-constraint-triple data)]
-        (throw-validation-err! :triple
-                               (some-> (:value triple)
-                                       <-json)
-                               [{:message "Invalid value type for triple."
-                                 :hint {:value (some-> (:value triple)
-                                                       <-json)
-                                        :checked-data-type (:checked-data-type triple)
-                                        :attr-id (:attr-id triple)
-                                        :entity-id (:entity-id triple)}}])
+      (if-let [triple (extract-triple-from-constraint data)]
+        (let [value (try
+                      (some-> (:value triple)
+                              <-json)
+                      (catch Exception _e
+                        ;; We may get a truncated value, so just give that back to the user
+                        (:value triple)))]
+          (throw-validation-err! :triple
+                                 value
+                                 [{:message (case (:constraint data)
+                                              "valid_value_data_type" "Invalid value type for triple."
+                                              "indexed_values_are_constrained" (if (= "true" (:av triple))
+                                                                                 "Value is too large for a unique attribute."
+                                                                                 "Value is too large for an indexed attribute.")
+                                              (format "Check Violation: %s" (name condition)))
+                                   :hint {:value value
+                                          :checked-data-type (:checked-data-type triple)
+                                          :attr-id (:attr-id triple)
+                                          :entity-id (:entity-id triple)
+                                          :value-too-large? (= (:constraint data)
+                                                               "indexed_values_are_constrained")}}]))
         (throw+ {::type ::record-check-violation
                  ::message (format "Check Violation: %s" (name condition))
                  ::hint hint
@@ -316,7 +344,7 @@
                ::pg-error-data data}
               e))))
 
-;; --------
+;; -----
 ;; Oauth
 
 (defn throw-oauth-err!
@@ -327,7 +355,7 @@
             ::message message}
            cause)))
 
-;; -------------
+;; --------
 ;; Wrappers
 
 (defn find-instant-exception [^Exception e]

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -260,7 +260,7 @@
 (comment
   (kw-table-name "app_oauth_codes"))
 
-(defn extract-triple-from-constraint [{:keys [table constraint detail]}]
+(defn extract-triple-from-constraint [{:keys [table detail]}]
   (when (and (= table "triples")
              detail
              (string/starts-with? detail "Failing row contains"))

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -254,11 +254,11 @@
                     :attr-id attr-id})
 
               _ (jobs/enqueue-job job-queue job)
-              _ (time (wait-for (fn []
-                                  (every? (fn [{:keys [id]}]
-                                            (= "completed" (:job_status (jobs/get-by-id id))))
-                                          [job]))
-                                1000))
+              _ (wait-for (fn []
+                            (every? (fn [{:keys [id]}]
+                                      (= "completed" (:job_status (jobs/get-by-id id))))
+                                    [job]))
+                          1000)
               triples (triple-model/fetch aurora/conn-pool
                                           (:id app)
                                           [[:= :attr-id attr-id]])]
@@ -311,7 +311,7 @@
                                            :index? false
                                            :value-type :blob
                                            :cardinality :one}]])
-              _ (dotimes [x 10]
+              _ (dotimes [x 5]
                   (tx/transact! aurora/conn-pool
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)
@@ -327,15 +327,15 @@
                     :attr-id attr-id})
 
               _ (jobs/enqueue-job job-queue job)
-              _ (time (wait-for (fn []
-                                  (every? (fn [{:keys [id]}]
-                                            (= "errored" (:job_status (jobs/get-by-id id))))
-                                          [job]))
-                                1000))
+              _ (wait-for (fn []
+                            (every? (fn [{:keys [id]}]
+                                      (= "errored" (:job_status (jobs/get-by-id id))))
+                                    [job]))
+                          1000)
               triples (triple-model/fetch aurora/conn-pool
                                           (:id app)
                                           [[:= :attr-id attr-id]])
-              job (jobs/get-by-id-for-client (:app_id job) (:id job))]
+              job-for-client (jobs/get-by-id-for-client (:app_id job) (:id job))]
           (is (pos? (count triples)))
 
           (is (every? (fn [{:keys [index]}]
@@ -348,4 +348,77 @@
                          :setting-unique?))))
 
           ;; XXX: next up, check that we get an invalid triple
-          )))))
+          (is (= "triple-not-unique-error" (:error job-for-client)))
+
+          (is (= ["a" "a"]
+                 (map #(get % "value") (-> job-for-client
+                                           :invalid_triples_sample)))))))))
+
+(deftest rejects-too-large-values
+  (with-queue job-queue
+    (with-empty-app
+      (fn [app]
+        (let [attr-id (random-uuid)
+
+              _ (tx/transact! aurora/conn-pool
+                              (attr-model/get-by-app-id (:id app))
+                              (:id app)
+                              [[:add-attr {:id attr-id
+                                           :forward-identity [(random-uuid) "etype" "label"]
+                                           :unique? false
+                                           :index? false
+                                           :value-type :blob
+                                           :cardinality :one}]])
+              _ (dotimes [x 5]
+                  (tx/transact! aurora/conn-pool
+                                (attr-model/get-by-app-id (:id app))
+                                (:id app)
+                                (for [i (range 1002)]
+                                  [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
+              bad-id (random-uuid)
+              _ (tx/transact! aurora/conn-pool
+                              (attr-model/get-by-app-id (:id app))
+                              (:id app)
+                              [[:add-triple bad-id attr-id (apply str (repeatedly 1024 random-uuid))]])
+              unique-job (jobs/create-unique-job!
+                          {:app-id (:id app)
+                           :attr-id attr-id})
+              index-job (jobs/create-index-job!
+                         {:app-id (:id app)
+                          :attr-id attr-id})
+
+              _ (jobs/enqueue-job job-queue unique-job)
+              _ (jobs/enqueue-job job-queue index-job)
+              _ (wait-for (fn []
+                            (every? (fn [{:keys [id]}]
+                                      (not (contains? #{"processing" "waiting"} (:job_status (jobs/get-by-id id)))))
+                                    [unique-job
+                                     index-job]))
+                          1000)
+              triples (triple-model/fetch aurora/conn-pool
+                                          (:id app)
+                                          [[:= :attr-id attr-id]])
+              unique-job-for-client (jobs/get-by-id-for-client (:id app) (:id unique-job))
+              index-job-for-client (jobs/get-by-id-for-client (:id app) (:id index-job))]
+          (is (pos? (count triples)))
+
+          (is (every? (fn [{:keys [index]}]
+                        (and (not (contains? index :ave))
+                             (not (contains? index :av))))
+                      triples))
+          (let [attrs (attr-model/get-by-app-id (:id app))]
+            (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                         :unique?)))
+            (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                         :setting-unique?)))
+            (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                         :index?)))
+            (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                         :indexing?))))
+
+          (is (= "triple-too-large-error" (:error unique-job-for-client)))
+          (is (= "triple-too-large-error" (:error index-job-for-client)))
+
+          (is (= [(str bad-id)]
+                 (map #(get % "entity_id") (-> unique-job-for-client
+                                               :invalid_triples_sample)))))))))

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -172,7 +172,6 @@
                             (attr-model/seek-by-id attrs)
                             :checked-data-type))))))))))
 
-;; XXX: NEXTUP AFTER TESTS: MAKE SURE TO IGNORE INDEXES WHILE INDEXING AND UNIQUE WHILE UNIQUEING
 (deftest index-works
   (with-queue job-queue
     (with-zeneca-app

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -3,162 +3,349 @@
             [instant.db.indexing-jobs :as jobs]
             [instant.db.model.attr :as attr-model]
             [instant.db.model.triple :as triple-model]
-            [instant.fixtures :refer [with-zeneca-app]]
+            [instant.db.transaction :as tx]
+            [instant.fixtures :refer [with-empty-app with-zeneca-app]]
             [instant.jdbc.aurora :as aurora]
             [instant.util.test :refer [wait-for]]
             [clojure.core.async :as a]
             [clojure.test :refer [deftest testing is]]))
 
+(defmacro with-queue [job-queue & body]
+  `(let [chan# (a/chan 1024)
+         process# (future (jobs/start-process chan#))
+         ~job-queue chan#]
+     (try
+       ~@body
+       (finally
+         (a/close! chan#)
+         (when (= :timeout (deref process# 1000 :timeout))
+           (throw (Exception. "Timeout in with-queue")))))))
+
 (deftest checks-types-works
-  (with-zeneca-app
-    (fn [app r]
-      (let [job-queue (a/chan 1024)
-            process (future (jobs/start-process job-queue))
-            title-job (jobs/create-check-data-type-job!
-                       {:app-id (:id app)
-                        :attr-id (resolvers/->uuid r :books/title)
-                        :checked-data-type "string"})
+  (with-queue job-queue
+    (with-zeneca-app
+      (fn [app r]
+        (let [title-job (jobs/create-check-data-type-job!
+                         {:app-id (:id app)
+                          :attr-id (resolvers/->uuid r :books/title)
+                          :checked-data-type "string"})
 
-            order-job (jobs/create-check-data-type-job!
-                       {:app-id (:id app)
-                        :attr-id (resolvers/->uuid r :bookshelves/order)
-                        :checked-data-type "number"})
+              order-job (jobs/create-check-data-type-job!
+                         {:app-id (:id app)
+                          :attr-id (resolvers/->uuid r :bookshelves/order)
+                          :checked-data-type "number"})
 
-            created-at-job (jobs/create-check-data-type-job!
-                            {:app-id (:id app)
-                             :attr-id (resolvers/->uuid r :users/createdAt)
-                             :checked-data-type "date"})
+              created-at-job (jobs/create-check-data-type-job!
+                              {:app-id (:id app)
+                               :attr-id (resolvers/->uuid r :users/createdAt)
+                               :checked-data-type "date"})
 
-            _ (jobs/enqueue-job job-queue title-job)
-            _ (jobs/enqueue-job job-queue order-job)
-            _ (jobs/enqueue-job job-queue created-at-job)
-            _ (wait-for (fn []
-                          (every? (fn [{:keys [id]}]
-                                    (= "completed" (:job_status (jobs/get-by-id id))))
-                                  [title-job
-                                   order-job
-                                   created-at-job]))
-                        1000)
-            title-triples (triple-model/fetch aurora/conn-pool
-                                              (:id app)
-                                              [[:= :attr-id (resolvers/->uuid r :books/title)]])
-            order-triples (triple-model/fetch aurora/conn-pool
-                                              (:id app)
-                                              [[:= :attr-id (resolvers/->uuid r :bookshelves/order)]])
+              _ (jobs/enqueue-job job-queue title-job)
+              _ (jobs/enqueue-job job-queue order-job)
+              _ (jobs/enqueue-job job-queue created-at-job)
+              _ (wait-for (fn []
+                            (every? (fn [{:keys [id]}]
+                                      (= "completed" (:job_status (jobs/get-by-id id))))
+                                    [title-job
+                                     order-job
+                                     created-at-job]))
+                          1000)
+              title-triples (triple-model/fetch aurora/conn-pool
+                                                (:id app)
+                                                [[:= :attr-id (resolvers/->uuid r :books/title)]])
+              order-triples (triple-model/fetch aurora/conn-pool
+                                                (:id app)
+                                                [[:= :attr-id (resolvers/->uuid r :bookshelves/order)]])
 
-            created-at-triples (triple-model/fetch aurora/conn-pool
-                                                   (:id app)
-                                                   [[:= :attr-id (resolvers/->uuid r :users/createdAt)]])]
-        (is (pos? (count title-triples)))
-        (is (pos? (count order-triples)))
-        (is (pos? (count created-at-triples)))
-        (is (every? (fn [{:keys [triple checked-data-type]}]
-                      (and (string? (nth triple 2))
-                           (= checked-data-type "string")))
-                    title-triples))
-        (is (every? (fn [{:keys [triple checked-data-type]}]
-                      (and (number? (nth triple 2))
-                           (= checked-data-type "number")))
-                    order-triples))
-
-        (is (every? (fn [{:keys [triple checked-data-type]}]
-                      (= checked-data-type "date"))
-                    created-at-triples))
-
-        (let [attrs (attr-model/get-by-app-id (:id app))]
-          (is (= :string (-> (resolvers/->uuid r :books/title)
-                             (attr-model/seek-by-id attrs)
-                             :checked-data-type)))
-          (is (= :number (-> (resolvers/->uuid r :bookshelves/order)
-                             (attr-model/seek-by-id attrs)
-                             :checked-data-type)))
-          (is (= :date (-> (resolvers/->uuid r :users/createdAt)
-                           (attr-model/seek-by-id attrs)
-                           :checked-data-type)))
-          (is (every? (fn [a]
-                        (not (:checking-data-type? a)))
-                      attrs)))))))
-
-(deftest indexing-jobs-errors-with-invalid-triples
-  (with-zeneca-app
-    (fn [app r]
-      (let [job-queue (a/chan 1024)
-            process (future (jobs/start-process job-queue))
-            handle-job (jobs/create-check-data-type-job!
-                        {:app-id (:id app)
-                         :attr-id (resolvers/->uuid r :users/handle)
-                         :checked-data-type "number"})
-
-            _ (jobs/enqueue-job job-queue handle-job)
-            _ (wait-for (fn []
-                          (every? (fn [{:keys [id]}]
-                                    (= "errored" (:job_status (jobs/get-by-id id))))
-                                  [handle-job]))
-                        1000)
-            handle-triples (triple-model/fetch aurora/conn-pool
-                                               (:id app)
-                                               [[:= :attr-id (resolvers/->uuid r :users/handle)]])]
-        (is (pos? (count handle-triples)))
-        (testing "didn't set invalid checked-data-type"
-          (is (every? (fn [{:keys [checked-data-type]}]
-                        (nil? checked-data-type))
-                      handle-triples)))
-        (= 5 (count (jobs/invalid-triples 100 (:id handle-job))))
-
-        (let [attrs (attr-model/get-by-app-id (:id app))]
-          (is (nil? (-> (resolvers/->uuid r :users/handle)
-                        (attr-model/seek-by-id attrs)
-                        :checked-data-type)))
-          (is (every? (fn [a]
-                        (not (:checking-data-type? a)))
-                      attrs)))))))
-
-(deftest remove-types-works
-  (with-zeneca-app
-    (fn [app r]
-      (let [job-queue (a/chan 1024)
-            process (future (jobs/start-process job-queue))
-            title-job (jobs/create-check-data-type-job!
-                       {:app-id (:id app)
-                        :attr-id (resolvers/->uuid r :books/title)
-                        :checked-data-type "string"})
-
-            _ (jobs/enqueue-job job-queue title-job)
-            _ (wait-for (fn []
-                          (every? (fn [{:keys [id]}]
-                                    (= "completed" (:job_status (jobs/get-by-id id))))
-                                  [title-job]))
-                        1000)
-            title-triples (triple-model/fetch aurora/conn-pool
-                                              (:id app)
-                                              [[:= :attr-id (resolvers/->uuid r :books/title)]])]
-        (testing "setup worked"
+              created-at-triples (triple-model/fetch aurora/conn-pool
+                                                     (:id app)
+                                                     [[:= :attr-id (resolvers/->uuid r :users/createdAt)]])]
           (is (pos? (count title-triples)))
+          (is (pos? (count order-triples)))
+          (is (pos? (count created-at-triples)))
           (is (every? (fn [{:keys [triple checked-data-type]}]
                         (and (string? (nth triple 2))
                              (= checked-data-type "string")))
                       title-triples))
+          (is (every? (fn [{:keys [triple checked-data-type]}]
+                        (and (number? (nth triple 2))
+                             (= checked-data-type "number")))
+                      order-triples))
+
+          (is (every? (fn [{:keys [triple checked-data-type]}]
+                        (= checked-data-type "date"))
+                      created-at-triples))
+
           (let [attrs (attr-model/get-by-app-id (:id app))]
             (is (= :string (-> (resolvers/->uuid r :books/title)
                                (attr-model/seek-by-id attrs)
-                               :checked-data-type)))))
-        (let [remove-type-job (jobs/create-remove-data-type-job!
-                               {:app-id (:id app)
-                                :attr-id (resolvers/->uuid r :books/title)})
-              _ (jobs/enqueue-job job-queue remove-type-job)
+                               :checked-data-type)))
+            (is (= :number (-> (resolvers/->uuid r :bookshelves/order)
+                               (attr-model/seek-by-id attrs)
+                               :checked-data-type)))
+            (is (= :date (-> (resolvers/->uuid r :users/createdAt)
+                             (attr-model/seek-by-id attrs)
+                             :checked-data-type)))
+            (is (every? (fn [a]
+                          (not (:checking-data-type? a)))
+                        attrs))))))))
+
+(deftest check-type-errors-with-invalid-triples
+  (with-queue job-queue
+    (with-zeneca-app
+      (fn [app r]
+        (let [handle-job (jobs/create-check-data-type-job!
+                          {:app-id (:id app)
+                           :attr-id (resolvers/->uuid r :users/handle)
+                           :checked-data-type "number"})
+
+              _ (jobs/enqueue-job job-queue handle-job)
+              _ (wait-for (fn []
+                            (every? (fn [{:keys [id]}]
+                                      (= "errored" (:job_status (jobs/get-by-id id))))
+                                    [handle-job]))
+                          1000)
+              handle-triples (triple-model/fetch aurora/conn-pool
+                                                 (:id app)
+                                                 [[:= :attr-id (resolvers/->uuid r :users/handle)]])]
+          (is (pos? (count handle-triples)))
+          (testing "didn't set invalid checked-data-type"
+            (is (every? (fn [{:keys [checked-data-type]}]
+                          (nil? checked-data-type))
+                        handle-triples)))
+          (= 5 (count (jobs/invalid-triples 100 (:id handle-job))))
+
+          (let [attrs (attr-model/get-by-app-id (:id app))]
+            (is (nil? (-> (resolvers/->uuid r :users/handle)
+                          (attr-model/seek-by-id attrs)
+                          :checked-data-type)))
+            (is (every? (fn [a]
+                          (not (:checking-data-type? a)))
+                        attrs))))))))
+
+(deftest remove-types-works
+  (with-queue job-queue
+    (with-zeneca-app
+      (fn [app r]
+        (let [title-job (jobs/create-check-data-type-job!
+                         {:app-id (:id app)
+                          :attr-id (resolvers/->uuid r :books/title)
+                          :checked-data-type "string"})
+
+              _ (jobs/enqueue-job job-queue title-job)
               _ (wait-for (fn []
                             (every? (fn [{:keys [id]}]
                                       (= "completed" (:job_status (jobs/get-by-id id))))
-                                    [remove-type-job]))
+                                    [title-job]))
                           1000)
               title-triples (triple-model/fetch aurora/conn-pool
                                                 (:id app)
                                                 [[:= :attr-id (resolvers/->uuid r :books/title)]])]
-          (is (pos? (count title-triples)))
-          (is (every? (fn [{:keys [checked-data-type]}]
-                        (nil? checked-data-type))
-                      title-triples))
+          (testing "setup worked"
+            (is (pos? (count title-triples)))
+            (is (every? (fn [{:keys [triple checked-data-type]}]
+                          (and (string? (nth triple 2))
+                               (= checked-data-type "string")))
+                        title-triples))
+            (let [attrs (attr-model/get-by-app-id (:id app))]
+              (is (= :string (-> (resolvers/->uuid r :books/title)
+                                 (attr-model/seek-by-id attrs)
+                                 :checked-data-type)))))
+          (let [remove-type-job (jobs/create-remove-data-type-job!
+                                 {:app-id (:id app)
+                                  :attr-id (resolvers/->uuid r :books/title)})
+                _ (jobs/enqueue-job job-queue remove-type-job)
+                _ (wait-for (fn []
+                              (every? (fn [{:keys [id]}]
+                                        (= "completed" (:job_status (jobs/get-by-id id))))
+                                      [remove-type-job]))
+                            1000)
+                title-triples (triple-model/fetch aurora/conn-pool
+                                                  (:id app)
+                                                  [[:= :attr-id (resolvers/->uuid r :books/title)]])]
+            (is (pos? (count title-triples)))
+            (is (every? (fn [{:keys [checked-data-type]}]
+                          (nil? checked-data-type))
+                        title-triples))
+            (let [attrs (attr-model/get-by-app-id (:id app))]
+              (is (nil? (-> (resolvers/->uuid r :books/title)
+                            (attr-model/seek-by-id attrs)
+                            :checked-data-type))))))))))
+
+;; XXX: NEXTUP AFTER TESTS: MAKE SURE TO IGNORE INDEXES WHILE INDEXING AND UNIQUE WHILE UNIQUEING
+(deftest index-works
+  (with-queue job-queue
+    (with-zeneca-app
+      (fn [app r]
+        (let [title-job (jobs/create-index-job!
+                         {:app-id (:id app)
+                          :attr-id (resolvers/->uuid r :books/title)})
+
+              _ (jobs/enqueue-job job-queue title-job)
+              _ (wait-for (fn []
+                            (every? (fn [{:keys [id]}]
+                                      (= "completed" (:job_status (jobs/get-by-id id))))
+                                    [title-job]))
+                          1000)
+              title-triples (triple-model/fetch aurora/conn-pool
+                                                (:id app)
+                                                [[:= :attr-id (resolvers/->uuid r :books/title)]])]
+          (testing "index"
+            (is (pos? (count title-triples)))
+
+            (is (every? (fn [{:keys [index]}]
+                          (contains? index :ave))
+                        title-triples))
+            (let [attrs (attr-model/get-by-app-id (:id app))]
+              (is (-> (resolvers/->uuid r :books/title)
+                      (attr-model/seek-by-id attrs)
+                      :index?))
+              (is (not (-> (resolvers/->uuid r :books/title)
+                           (attr-model/seek-by-id attrs)
+                           :indexing)))))
+          (testing "remove-index"
+            (let [remove-index-job (jobs/create-remove-index-job!
+                                    {:app-id (:id app)
+                                     :attr-id (resolvers/->uuid r :books/title)})
+                  _ (jobs/enqueue-job job-queue remove-index-job)
+                  _ (wait-for (fn []
+                                (every? (fn [{:keys [id]}]
+                                          (= "completed" (:job_status (jobs/get-by-id id))))
+                                        [remove-index-job]))
+                              1000)
+                  title-triples (triple-model/fetch aurora/conn-pool
+                                                    (:id app)
+                                                    [[:= :attr-id (resolvers/->uuid r :books/title)]])]
+              (is (pos? (count title-triples)))
+              (is (every? (fn [{:keys [index]}]
+                            (not (contains? index :ave)))
+                          title-triples))
+              (let [attrs (attr-model/get-by-app-id (:id app))]
+                (is (not (-> (resolvers/->uuid r :books/title)
+                             (attr-model/seek-by-id attrs)
+                             :index?)))
+                (is (not (-> (resolvers/->uuid r :books/title)
+                             (attr-model/seek-by-id attrs)
+                             :indexing)))))))))))
+
+(deftest unique-works
+  (with-queue job-queue
+    (with-empty-app
+      (fn [app]
+        (let [attr-id (random-uuid)
+
+              _ (tx/transact! aurora/conn-pool
+                              (attr-model/get-by-app-id (:id app))
+                              (:id app)
+                              [[:add-attr {:id attr-id
+                                           :forward-identity [(random-uuid) "etype" "label"]
+                                           :unique? false
+                                           :index? false
+                                           :value-type :blob
+                                           :cardinality :one}]])
+              _ (dotimes [x 20]
+                  (tx/transact! aurora/conn-pool
+                                (attr-model/get-by-app-id (:id app))
+                                (:id app)
+                                (for [i (range 1002)]
+                                  [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
+              job (jobs/create-unique-job!
+                   {:app-id (:id app)
+                    :attr-id attr-id})
+
+              _ (jobs/enqueue-job job-queue job)
+              _ (time (wait-for (fn []
+                                  (every? (fn [{:keys [id]}]
+                                            (= "completed" (:job_status (jobs/get-by-id id))))
+                                          [job]))
+                                1000))
+              triples (triple-model/fetch aurora/conn-pool
+                                          (:id app)
+                                          [[:= :attr-id attr-id]])]
+          (testing "unique"
+            (is (pos? (count triples)))
+
+            (is (every? (fn [{:keys [index]}]
+                          (contains? index :av))
+                        triples))
+            (let [attrs (attr-model/get-by-app-id (:id app))]
+              (is (-> (attr-model/seek-by-id attr-id attrs)
+                      :unique?))
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :setting-unique?)))))
+          (testing "remove-unique"
+            (let [remove-unique-job (jobs/create-remove-unique-job!
+                                     {:app-id (:id app)
+                                      :attr-id attr-id})
+                  _ (jobs/enqueue-job job-queue remove-unique-job)
+                  _ (wait-for (fn []
+                                (every? (fn [{:keys [id]}]
+                                          (= "completed" (:job_status (jobs/get-by-id id))))
+                                        [remove-unique-job]))
+                              1000)
+                  triples (triple-model/fetch aurora/conn-pool
+                                              (:id app)
+                                              [[:= :attr-id attr-id]])]
+              (is (pos? (count triples)))
+              (is (every? (fn [{:keys [index]}]
+                            (not (contains? index :av)))
+                          triples))
+              (let [attrs (attr-model/get-by-app-id (:id app))]
+                (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                             :unique?)))
+                (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                             :setting-unique?)))))))))))
+
+(deftest rejects-not-unique-values
+  (with-queue job-queue
+    (with-empty-app
+      (fn [app]
+        (let [attr-id (random-uuid)
+
+              _ (tx/transact! aurora/conn-pool
+                              (attr-model/get-by-app-id (:id app))
+                              (:id app)
+                              [[:add-attr {:id attr-id
+                                           :forward-identity [(random-uuid) "etype" "label"]
+                                           :unique? false
+                                           :index? false
+                                           :value-type :blob
+                                           :cardinality :one}]])
+              _ (dotimes [x 10]
+                  (tx/transact! aurora/conn-pool
+                                (attr-model/get-by-app-id (:id app))
+                                (:id app)
+                                (for [i (range 1002)]
+                                  [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
+              _ (tx/transact! aurora/conn-pool
+                              (attr-model/get-by-app-id (:id app))
+                              (:id app)
+                              [[:add-triple (random-uuid) attr-id "a"]
+                               [:add-triple (random-uuid) attr-id "a"]])
+              job (jobs/create-unique-job!
+                   {:app-id (:id app)
+                    :attr-id attr-id})
+
+              _ (jobs/enqueue-job job-queue job)
+              _ (time (wait-for (fn []
+                                  (every? (fn [{:keys [id]}]
+                                            (= "errored" (:job_status (jobs/get-by-id id))))
+                                          [job]))
+                                1000))
+              triples (triple-model/fetch aurora/conn-pool
+                                          (:id app)
+                                          [[:= :attr-id attr-id]])
+              job (jobs/get-by-id-for-client (:app_id job) (:id job))]
+          (is (pos? (count triples)))
+
+          (is (every? (fn [{:keys [index]}]
+                        (not (contains? index :av)))
+                      triples))
           (let [attrs (attr-model/get-by-app-id (:id app))]
-            (is (nil? (-> (resolvers/->uuid r :books/title)
-                          (attr-model/seek-by-id attrs)
-                          :checked-data-type)))))))))
+            (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                         :unique?)))
+            (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                         :setting-unique?))))
+
+          ;; XXX: next up, check that we get an invalid triple
+          )))))


### PR DESCRIPTION
Uses the background indexing jobs for adding/removing index and uniqueness.

Here's what setting and removing `indexed` from the explorer looks like

https://github.com/user-attachments/assets/1926295e-20d3-4842-9455-2ac6c36b5808



Uniqueness is similar, with helpful errors if the attribute has duplicate values. Clicking on the "multiple entities with value X" link will go to the explorer with all entities with that value present.

https://github.com/user-attachments/assets/fbe82ed9-42ec-44a2-b8ca-ef370d287782


If you have data that's too big to index, you'll also get an error:

https://github.com/user-attachments/assets/49b78e56-c51b-451b-954e-b8ad1c9eedf3

Updating from the cli is similar


https://github.com/user-attachments/assets/a261a193-2d33-479c-a8ee-f8bc0a6c413b


TODO before deploying:
- [ ] Run migration