### PR TITLE
[strong-init-v2] make schema optional

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -39,7 +39,7 @@ import {
   type ResolveAttrs,
   type ValueTypes,
   type DoNotUseInstantSchema,
-  DoNotUseUnknownSchema,
+  type DoNotUseUnknownSchema,
 } from "@instantdb/core";
 
 import version from "./version";

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -65,7 +65,7 @@ type DoNotUseConfig<Schema extends DoNotUseInstantSchema<any, any, any>> = {
   appId: string;
   adminToken: string;
   apiURI?: string;
-  schema: Schema;
+  schema?: Schema;
 };
 
 type DoNotUseFilledConfig<Schema extends DoNotUseInstantSchema<any, any, any>> =

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -39,6 +39,7 @@ import {
   type ResolveAttrs,
   type ValueTypes,
   type DoNotUseInstantSchema,
+  DoNotUseUnknownSchema,
 } from "@instantdb/core";
 
 import version from "./version";
@@ -199,7 +200,7 @@ function init_experimental<
 }
 
 function do_not_use_init_experimental<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
+  Schema extends DoNotUseInstantSchema<any, any, any> = DoNotUseUnknownSchema,
 >(config: DoNotUseConfig<Schema>) {
   return new DoNotUseInstantAdmin<Schema>(config);
 }
@@ -931,4 +932,6 @@ export {
   type LinksDef,
   type ResolveAttrs,
   type ValueTypes,
+  type DoNotUseInstantSchema,
+  type DoNotUseUnknownSchema,
 };

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -938,7 +938,6 @@ export {
   type EntityDef,
   type RoomsDef,
   type InstantGraph,
-  type DoNotUseInstantSchema,
   type LinkAttrDef,
   type LinkDef,
   type LinksDef,
@@ -949,5 +948,6 @@ export {
   type TopicsOf,
   type DoNotUseInstantEntity,
   type DoNotUseInstaQLQueryResult,
+  type DoNotUseInstantSchema,
   type DoNotUseUnknownSchema,
 };

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -827,7 +827,7 @@ function do_not_use_init_experimental<
 function _do_not_use_init_internal<
   Schema extends DoNotUseInstantSchema<any, any, any>,
 >(
-  config: Config,
+  config: DoNotUseConfig<Schema>,
   Storage?: any,
   NetworkListener?: any,
 ): DoNotUseInstantCore<Schema> {
@@ -843,7 +843,7 @@ function _do_not_use_init_internal<
     {
       ...defaultConfig,
       ...config,
-      cardinalityInference: true,
+      cardinalityInference: config.schema ? true : false,
     },
     Storage || IndexedDBStorage,
     NetworkListener || WindowNetworkListener,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -59,6 +59,7 @@ import type {
   RoomsOf,
   TopicsOf,
   ValueTypes,
+  DoNotUseUnknownSchema,
 } from "./schemaTypes";
 
 const defaultOpenDevtool = true;
@@ -77,7 +78,7 @@ export type DoNotUseConfig<S extends DoNotUseInstantSchema<any, any, any>> = {
   websocketURI?: string;
   apiURI?: string;
   devtool?: boolean;
-  schema: S;
+  schema?: S;
 };
 
 export type ConfigWithSchema<S extends InstantGraph<any, any>> = Config & {
@@ -813,16 +814,14 @@ class DoNotUseInstantCore<Schema extends DoNotUseInstantSchema<any, any, any>>
   }
 }
 
-function do_not_use_init_experimental<Schema extends DoNotUseInstantSchema<any, any, any>>(
+function do_not_use_init_experimental<
+  Schema extends DoNotUseInstantSchema<any, any, any> = DoNotUseUnknownSchema,
+>(
   config: DoNotUseConfig<Schema>,
   Storage?: any,
   NetworkListener?: any,
 ): DoNotUseInstantCore<Schema> {
-  return _do_not_use_init_internal<Schema>(
-    config,
-    Storage,
-    NetworkListener,
-  );
+  return _do_not_use_init_internal<Schema>(config, Storage, NetworkListener);
 }
 
 function _do_not_use_init_internal<
@@ -950,4 +949,5 @@ export {
   type TopicsOf,
   type DoNotUseInstantEntity,
   type DoNotUseInstaQLQueryResult,
+  type DoNotUseUnknownSchema,
 };

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -10,6 +10,7 @@ import type {
   LinkAttrDef,
   ResolveAttrs,
   ResolveEntityAttrs,
+  DoNotUseUnknownSchema,
 } from "./schemaTypes";
 
 // NonEmpty disallows {}, so that you must provide at least one field

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -6,11 +6,9 @@ import type {
   EntitiesDef,
   IInstantDataSchema,
   InstantGraph,
-  DoNotUseInstantSchema,
   LinkAttrDef,
   ResolveAttrs,
   ResolveEntityAttrs,
-  DoNotUseUnknownSchema,
 } from "./schemaTypes";
 
 // NonEmpty disallows {}, so that you must provide at least one field
@@ -148,7 +146,7 @@ type Exactly<Parent, Child> = Parent & {
 // ==========
 // InstaQL helpers
 
-type DoNotUseInstaQLQueryEntityLinksResult<
+type DoNotUseInstaQLSubqueryResult<
   Schema extends IInstantDataSchema<EntitiesDef, any>,
   EntityName extends keyof Schema["entities"],
   Query extends {
@@ -222,8 +220,8 @@ type DoNotUseInstantEntity<
   Subquery extends {
     [QueryPropName in keyof Schema["entities"][EntityName]["links"]]?: any;
   } = {},
-> = { id: string } & ResolveEntityAttrs<Schema["entities"][EntityName]> &
-  DoNotUseInstaQLQueryEntityLinksResult<Schema, EntityName, Subquery>;
+> = ResolveEntityAttrs<Schema["entities"][EntityName]> &
+  DoNotUseInstaQLSubqueryResult<Schema, EntityName, Subquery>;
 
 type InstaQLQueryEntityResult<
   Entities extends EntitiesDef,

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -328,3 +328,43 @@ export class DoNotUseInstantSchema<
     public rooms: Rooms,
   ) {}
 }
+
+export type UnknownEntity = EntityDef<
+  {
+    id: DataAttrDef<string, true>;
+    [AttrName: string]: DataAttrDef<unknown, any>;
+  },
+  { [LinkName: string]: LinkAttrDef<"many", string> },
+  void
+>;
+
+export type DoNotUseUnknownEntities = {
+  [EntityName: string]: UnknownEntity;
+};
+
+export type DoNotUseUnknownLinks<Entities extends EntitiesDef> = {
+  [LinkName: string]: LinkDef<
+    Entities,
+    string,
+    string,
+    "many",
+    string,
+    string,
+    "many"
+  >;
+};
+
+export type DoNotUseUnknownRooms = {
+  [RoomName: string]: {
+    presence: EntityDef<any, any, any>;
+    topics: {
+      [TopicName: string]: EntityDef<any, any, any>;
+    };
+  };
+};
+
+export type DoNotUseUnknownSchema = DoNotUseInstantSchema<
+  DoNotUseUnknownEntities,
+  DoNotUseUnknownLinks<DoNotUseUnknownEntities>,
+  DoNotUseUnknownRooms
+>;

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -47,6 +47,7 @@ import {
   type DoNotUseInstaQLQueryResult,
   type DoNotUseConfig,
   DoNotUseInstantSchema,
+  DoNotUseUnknownSchema,
 } from "@instantdb/core";
 
 /**
@@ -93,9 +94,9 @@ function init_experimental<
   >(config);
 }
 
-function do_not_use_init_experimental<Schema extends DoNotUseInstantSchema<any, any, any>>(
-  config: DoNotUseConfig<Schema>,
-) {
+function do_not_use_init_experimental<
+  Schema extends DoNotUseInstantSchema<any, any, any> = DoNotUseUnknownSchema,
+>(config: DoNotUseConfig<Schema>) {
   return new DoNotUseInstantReactNative<Schema>(config);
 }
 
@@ -158,4 +159,6 @@ export {
   type ValueTypes,
   type DoNotUseInstantEntity,
   type DoNotUseInstaQLQueryResult,
+  type DoNotUseInstantSchema,
+  type DoNotUseUnknownSchema,
 };

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -46,8 +46,8 @@ import {
   type DoNotUseInstantEntity,
   type DoNotUseInstaQLQueryResult,
   type DoNotUseConfig,
-  DoNotUseInstantSchema,
-  DoNotUseUnknownSchema,
+  type DoNotUseInstantSchema,
+  type DoNotUseUnknownSchema,
 } from "@instantdb/core";
 
 /**

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -33,6 +33,8 @@ import {
   type ValueTypes,
   type DoNotUseInstantEntity,
   type DoNotUseInstaQLQueryResult,
+  type DoNotUseUnknownSchema,
+  type DoNotUseInstantSchema,
 } from "@instantdb/core";
 
 import { InstantReact } from "./InstantReact";
@@ -87,4 +89,6 @@ export {
   type ValueTypes,
   type DoNotUseInstantEntity,
   type DoNotUseInstaQLQueryResult,
+  type DoNotUseUnknownSchema,
+  type DoNotUseInstantSchema,
 };

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -5,6 +5,7 @@ import type {
   InstantGraph,
   DoNotUseInstantSchema,
   RoomSchemaShape,
+  DoNotUseUnknownSchema,
 } from "@instantdb/core";
 import { InstantReactWeb } from "./InstantReactWeb";
 import { DoNotUseInstantReactWeb } from "./DoNotUseInstantReactWeb";
@@ -55,7 +56,7 @@ export function init_experimental<
 }
 
 export function do_not_use_init_experimental<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
+  Schema extends DoNotUseInstantSchema<any, any, any> = DoNotUseUnknownSchema,
 >(config: DoNotUseConfig<Schema>) {
   return new DoNotUseInstantReactWeb<Schema>(config);
 }

--- a/client/sandbox/strong-init-vite/src/helpers.ts
+++ b/client/sandbox/strong-init-vite/src/helpers.ts
@@ -1,7 +1,0 @@
-export type IsAny<T> = 0 extends 1 & T ? true : false;
-
-/**
- * Returns true if T is _not_ `any`, and extends Expected.
- */
-export type SpecificallyExtends<T, Expected> =
-  IsAny<T> extends true ? never : T extends Expected ? true : never;

--- a/client/sandbox/strong-init-vite/src/helpers.ts
+++ b/client/sandbox/strong-init-vite/src/helpers.ts
@@ -4,4 +4,4 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
  * Returns true if T is _not_ `any`, and extends Expected.
  */
 export type SpecificallyExtends<T, Expected> =
-  IsAny<T> extends true ? false : T extends Expected ? true : false;
+  IsAny<T> extends true ? never : T extends Expected ? true : never;

--- a/client/sandbox/strong-init-vite/src/helpers.ts
+++ b/client/sandbox/strong-init-vite/src/helpers.ts
@@ -1,0 +1,7 @@
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+ * Returns true if T is _not_ `any`, and extends Expected.
+ */
+export type SpecificallyExtends<T, Expected> =
+  IsAny<T> extends true ? false : T extends Expected ? true : false;

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
@@ -95,7 +95,8 @@ function subMessagesWithCreator(
 }
 
 // to silence ts warnings
-((..._args) => {})(coreMessagesQuery, subMessagesWithCreator);
+coreMessagesQuery;
+subMessagesWithCreator;
 
 // ----
 // React
@@ -128,12 +129,10 @@ function ReactNormalApp() {
   );
 
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messages;
 }
 
 // type helpers
@@ -166,7 +165,8 @@ function useMessagesWithCreator(): ReactMessageCreatorResult | undefined {
 }
 
 // to silence ts warnings
-((..._args) => {})(reactMessagesQuery, useMessagesWithCreator);
+reactMessagesQuery;
+useMessagesWithCreator;
 
 // ----
 // React-Native
@@ -233,7 +233,8 @@ function useMessagesWithCreatorRN():
 }
 
 // to silence ts warnings
-((..._args) => {})(reactNativeMessagesQuery, useMessagesWithCreatorRN);
+reactNativeMessagesQuery;
+useMessagesWithCreatorRN;
 
 // ----
 // Admin
@@ -286,7 +287,8 @@ async function getMessagesWithCreator(): Promise<AdminMessageCreatorResult> {
 }
 
 // to silence ts warnings
-((..._args) => {})(adminMessagesQuery, getMessagesWithCreator);
+adminMessagesQuery;
+getMessagesWithCreator;
 
 // to silence ts warnings
 export { ReactNormalApp, ReactNativeNormalApp };

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
@@ -9,6 +9,7 @@ import { do_not_use_init_experimental as react_init_experimental } from "@instan
 import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
 import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
 import schema, { AppSchema } from "../instant.schema.v2";
+import { SpecificallyExtends } from "./helpers";
 
 // ----
 // Core
@@ -63,7 +64,11 @@ function ReactNormalApp() {
     return null;
   }
   const { messages } = data;
-  messages[0].content;
+  const message = messages[0];
+  const messageIsTyped: SpecificallyExtends<
+    typeof message,
+    { id: string; content: string }
+  > = true;
 
   // transactions
   reactDB.transact(
@@ -73,12 +78,10 @@ function ReactNormalApp() {
   );
 
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messageIsTyped;
 }
 
 // ----
@@ -104,14 +107,16 @@ function ReactNativeNormalApp() {
     return null;
   }
   const { messages } = data;
-  messages[0].content;
+  const message = messages[0];
+  const messageIsTyped: SpecificallyExtends<
+    typeof message,
+    { id: string; content: string }
+  > = true;
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messageIsTyped;
 }
 
 // ----
@@ -120,12 +125,16 @@ function ReactNativeNormalApp() {
 const adminDB = admin_init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID!,
   adminToken: import.meta.env.VITE_INSTANT_ADMIN_TOKEN!,
-  schema: schema,
+  schema,
 });
 
 // queries
 const adminQueryResult = await adminDB.query({ messages: { creator: {} } });
-adminQueryResult.messages[0].content;
+const message = adminQueryResult.messages[0];
+const messageIsTyped: SpecificallyExtends<
+  typeof message,
+  { id: string; content: string }
+> = true;
 
 // transacts
 await adminDB.transact(
@@ -135,16 +144,18 @@ await adminDB.transact(
 );
 
 // to silence ts warnings
-export { ReactNormalApp, ReactNativeNormalApp };
+ReactNormalApp;
+ReactNativeNormalApp;
+messageIsTyped;
 
 // ------------
 // type helpers
 
-const messagesQuery: InstaQLQueryParams<AppSchema> = {
+const messagesQuery = {
   messages: {
     creator: {},
   },
-};
+} satisfies InstaQLQueryParams<AppSchema>;
 
 type CoreMessage = DoNotUseInstantEntity<AppSchema, "messages">;
 let coreMessage: CoreMessage = 1 as any;
@@ -156,7 +167,8 @@ type CoreMessageWithCreator = DoNotUseInstantEntity<
   { creator: {} }
 >;
 let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
-coreMessageWithCreator.creator?.id;
+const creatorId = coreMessageWithCreator.creator?.id;
+const creatorIdIsString: SpecificallyExtends<typeof creatorId, string> = true;
 
 type MessageCreatorResult = DoNotUseInstaQLQueryResult<
   AppSchema,
@@ -173,4 +185,6 @@ function subMessagesWithCreator(
 }
 
 // to silence ts warnings
-((..._args) => {})(messagesQuery, subMessagesWithCreator);
+messagesQuery;
+subMessagesWithCreator;
+creatorIdIsString;

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
@@ -9,7 +9,6 @@ import { do_not_use_init_experimental as react_init_experimental } from "@instan
 import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
 import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
 import schema, { AppSchema } from "../instant.schema.v2";
-import { SpecificallyExtends } from "./helpers";
 
 // ----
 // Core
@@ -35,7 +34,9 @@ coreDB.subscribeQuery({ messages: { creator: {} } }, (result) => {
     return;
   }
   const { messages } = result.data;
-  messages[0].content;
+  const message = messages[0];
+  message.content;
+  message.creator?.email;
 });
 
 // transactions
@@ -59,16 +60,16 @@ function ReactNormalApp() {
   const _reactPresenceUser = reactPresence.user!;
   const _reactPresencePeers = reactPresence.peers!;
   // queries
-  const { isLoading, error, data } = reactDB.useQuery({ messages: {} });
+  const { isLoading, error, data } = reactDB.useQuery({
+    messages: { creator: {} },
+  });
   if (isLoading || error) {
     return null;
   }
   const { messages } = data;
   const message = messages[0];
-  const messageIsTyped: SpecificallyExtends<
-    typeof message,
-    { id: string; content: string }
-  > = true;
+  message.content;
+  message.creator?.email;
 
   // transactions
   reactDB.transact(
@@ -81,7 +82,6 @@ function ReactNormalApp() {
   _reactPublishEmoji;
   _reactPresenceUser;
   _reactPresencePeers;
-  messageIsTyped;
 }
 
 // ----
@@ -101,22 +101,19 @@ function ReactNativeNormalApp() {
   const _reactPresencePeers = reactPresence.peers!;
   // queries
   const { isLoading, error, data } = reactNativeDB.useQuery({
-    messages: {},
+    messages: { creator: {} },
   });
   if (isLoading || error) {
     return null;
   }
   const { messages } = data;
   const message = messages[0];
-  const messageIsTyped: SpecificallyExtends<
-    typeof message,
-    { id: string; content: string }
-  > = true;
+  message.content;
+  message.creator?.email;
   // to silence ts warnings
   _reactPublishEmoji;
   _reactPresenceUser;
   _reactPresencePeers;
-  messageIsTyped;
 }
 
 // ----
@@ -131,11 +128,8 @@ const adminDB = admin_init_experimental({
 // queries
 const adminQueryResult = await adminDB.query({ messages: { creator: {} } });
 const message = adminQueryResult.messages[0];
-const messageIsTyped: SpecificallyExtends<
-  typeof message,
-  { id: string; content: string }
-> = true;
-
+message.content;
+message.creator?.email;
 // transacts
 await adminDB.transact(
   adminDB.tx.messages[id()]
@@ -146,7 +140,6 @@ await adminDB.transact(
 // to silence ts warnings
 ReactNormalApp;
 ReactNativeNormalApp;
-messageIsTyped;
 
 // ------------
 // type helpers
@@ -167,8 +160,8 @@ type CoreMessageWithCreator = DoNotUseInstantEntity<
   { creator: {} }
 >;
 let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
-const creatorId = coreMessageWithCreator.creator?.id;
-const creatorIdIsString: SpecificallyExtends<typeof creatorId, string> = true;
+coreMessageWithCreator.content;
+coreMessageWithCreator.creator?.email;
 
 type MessageCreatorResult = DoNotUseInstaQLQueryResult<
   AppSchema,
@@ -187,4 +180,3 @@ function subMessagesWithCreator(
 // to silence ts warnings
 messagesQuery;
 subMessagesWithCreator;
-creatorIdIsString;

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
@@ -4,6 +4,7 @@ import {
   InstaQLQueryParams,
   DoNotUseInstantEntity,
   DoNotUseInstaQLQueryResult,
+  DoNotUseUnknownSchema,
 } from "@instantdb/core";
 import { do_not_use_init_experimental as react_init_experimental } from "@instantdb/react";
 import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
@@ -152,32 +153,33 @@ export { ReactNormalApp, ReactNativeNormalApp };
 // ------------
 // type helpers
 
-const messagesQuery: InstaQLQueryParams<DoNotUseUnknownSchema> = {
-  messages: {
-    creator: {},
+const postsQuery = {
+  posts: {
+    comments: {},
   },
-};
+} satisfies InstaQLQueryParams<DoNotUseUnknownSchema>;
 
-type CoreMessage = DoNotUseInstantEntity<DoNotUseUnknownSchema, "messages">;
-let coreMessage: CoreMessage = 1 as any;
-coreMessage.content;
+type CorePost = DoNotUseInstantEntity<DoNotUseUnknownSchema, "messages">;
+let coreMessage: CorePost = 1 as any;
+coreMessage.id;
 
-type CoreMessageWithCreator = DoNotUseInstantEntity<
+type CorePostWithCreator = DoNotUseInstantEntity<
   DoNotUseUnknownSchema,
   "messages",
   { creator: {} }
 >;
-let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
-coreMessageWithCreator.creator?.id;
+let coreMessageWithCreator: CorePostWithCreator = 1 as any;
+coreMessageWithCreator.creator[0].id;
 
 type MessageCreatorResult = DoNotUseInstaQLQueryResult<
   DoNotUseUnknownSchema,
-  InstaQLQueryParams<DoNotUseUnknownSchema>
+  typeof postsQuery
 >;
+
 function subMessagesWithCreator(
   resultCB: (data: MessageCreatorResult) => void,
 ) {
-  coreDB.subscribeQuery(messagesQuery, (result) => {
+  coreDB.subscribeQuery(postsQuery, (result) => {
     if (result.data) {
       resultCB(result.data);
     }
@@ -185,4 +187,5 @@ function subMessagesWithCreator(
 }
 
 // to silence ts warnings
-((..._args) => {})(messagesQuery, subMessagesWithCreator);
+postsQuery;
+subMessagesWithCreator;

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
@@ -9,7 +9,6 @@ import {
 import { do_not_use_init_experimental as react_init_experimental } from "@instantdb/react";
 import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
 import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
-import { SpecificallyExtends } from "./helpers";
 
 // ----
 // Core
@@ -35,13 +34,8 @@ coreDB.subscribeQuery({ posts: { comments: {} } }, (result) => {
   }
   const { posts } = result.data;
   const post = posts[0];
-  const postHasId: SpecificallyExtends<typeof post, { id: string }> = true;
-  const comments = post.comments[0];
-  const commentsHasId: SpecificallyExtends<typeof comments, { id: string }> =
-    true;
-  // to silence ts warnings
-  postHasId;
-  commentsHasId;
+  post.id;
+  post.comments[0].id;
 });
 
 // transactions
@@ -72,10 +66,8 @@ function ReactNormalApp() {
   }
   const { posts } = data;
   const post = posts[0];
-  const postHasId: SpecificallyExtends<typeof post, { id: string }> = true;
-  const comments = post.comments[0];
-  const commentsHasId: SpecificallyExtends<typeof comments, { id: string }> =
-    true;
+  post.id;
+  post.comments[0].id;
 
   // transactions
   reactDB.transact(
@@ -85,8 +77,6 @@ function ReactNormalApp() {
   );
 
   // to silence ts warnings
-  postHasId;
-  commentsHasId;
   _reactPublishEmoji;
   _reactPresenceUser;
   _reactPresencePeers;
@@ -115,17 +105,13 @@ function ReactNativeNormalApp() {
   }
   const { posts } = data;
   const post = posts[0];
-  const postHasId: SpecificallyExtends<typeof post, { id: string }> = true;
-  const comments = post.comments[0];
-  const commentsHasId: SpecificallyExtends<typeof comments, { id: string }> =
-    true;
+  post.id;
+  post.comments[0].id;
 
   // to silence ts warnings
   _reactPublishEmoji;
   _reactPresenceUser;
   _reactPresencePeers;
-  postHasId;
-  commentsHasId;
 }
 
 // ----

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
@@ -1,0 +1,176 @@
+import {
+  id,
+  do_not_use_init_experimental as core_init_experimental,
+  InstaQLQueryParams,
+  DoNotUseInstantEntity,
+  DoNotUseInstaQLQueryResult,
+} from "@instantdb/core";
+import { do_not_use_init_experimental as react_init_experimental } from "@instantdb/react";
+import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
+import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
+import schema, { AppSchema } from "../instant.schema.v2";
+
+// ----
+// Core
+
+const coreDB = core_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+// rooms
+const coreRoom = coreDB.joinRoom("chat");
+coreRoom.getPresence({});
+
+coreRoom.publishTopic("emoji", {
+  name: "confetti",
+  rotationAngle: 0,
+  directionAngle: 0,
+});
+
+// queries
+coreDB.subscribeQuery({ messages: { creator: {} } }, (result) => {
+  if (result.error) {
+    return;
+  }
+  const { messages } = result.data;
+  messages[0].content;
+  messages[0].creator[0].foo
+});
+
+// transactions
+coreDB.tx.messages[id()]
+  .update({ content: "Hello world" })
+  .link({ creator: "foo" });
+
+// ----
+// React
+
+const reactDB = react_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+  schema,
+});
+
+function ReactNormalApp() {
+  // rooms
+  const reactRoom = reactDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactDB.useQuery({ messages: {} });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+
+  // transactions
+  reactDB.transact(
+    reactDB.tx.messages[id()]
+      .update({ content: "Hello there!" })
+      .link({ creator: "foo" }),
+  );
+
+  // to silence ts warnings
+  ((..._args) => {})(
+    _reactPublishEmoji,
+    _reactPresenceUser,
+    _reactPresencePeers,
+    messages,
+  );
+}
+
+// ----
+// React-Native
+
+const reactNativeDB = react_native_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+  schema: schema,
+});
+
+function ReactNativeNormalApp() {
+  // rooms
+  const reactRoom = reactNativeDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactNativeDB.useQuery({
+    messages: {},
+  });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+  // to silence ts warnings
+  ((..._args) => {})(
+    _reactPublishEmoji,
+    _reactPresenceUser,
+    _reactPresencePeers,
+    messages,
+  );
+}
+
+// ----
+// Admin
+
+const adminDB = admin_init_experimental({
+  appId: import.meta.env.VITE_INSTANT_APP_ID!,
+  adminToken: import.meta.env.VITE_INSTANT_ADMIN_TOKEN!,
+  schema: schema,
+});
+
+// queries
+const adminQueryResult = await adminDB.query({ messages: { creator: {} } });
+adminQueryResult.messages[0].content;
+
+// transacts
+await adminDB.transact(
+  adminDB.tx.messages[id()]
+    .update({ content: "Hello world" })
+    .link({ creator: "foo" }),
+);
+
+// to silence ts warnings
+export { ReactNormalApp, ReactNativeNormalApp };
+
+// ------------
+// type helpers
+
+const messagesQuery: InstaQLQueryParams<AppSchema> = {
+  messages: {
+    creator: {},
+  },
+};
+
+type CoreMessage = DoNotUseInstantEntity<AppSchema, "messages">;
+let coreMessage: CoreMessage = 1 as any;
+coreMessage.content;
+
+type CoreMessageWithCreator = DoNotUseInstantEntity<
+  AppSchema,
+  "messages",
+  { creator: {} }
+>;
+let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
+coreMessageWithCreator.creator?.id;
+
+type MessageCreatorResult = DoNotUseInstaQLQueryResult<
+  AppSchema,
+  InstaQLQueryParams<AppSchema>
+>;
+function subMessagesWithCreator(
+  resultCB: (data: MessageCreatorResult) => void,
+) {
+  coreDB.subscribeQuery(messagesQuery, (result) => {
+    if (result.data) {
+      resultCB(result.data);
+    }
+  });
+}
+
+// to silence ts warnings
+((..._args) => {})(messagesQuery, subMessagesWithCreator);

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
@@ -8,7 +8,7 @@ import {
 import { do_not_use_init_experimental as react_init_experimental } from "@instantdb/react";
 import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
 import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
-import schema, { AppSchema } from "../instant.schema.v2";
+import { SpecificallyExtends } from "./helpers";
 
 // ----
 // Core
@@ -28,18 +28,24 @@ coreRoom.publishTopic("emoji", {
 });
 
 // queries
-coreDB.subscribeQuery({ messages: { creator: {} } }, (result) => {
+coreDB.subscribeQuery({ posts: { comments: {} } }, (result) => {
   if (result.error) {
     return;
   }
-  const { messages } = result.data;
-  messages[0].content;
-  messages[0].creator[0].foo
+  const { posts } = result.data;
+  const post = posts[0];
+  const postHasId: SpecificallyExtends<typeof post, { id: string }> = true;
+  const comments = post.comments[0];
+  const commentsHasId: SpecificallyExtends<typeof comments, { id: string }> =
+    true;
+  // to silence ts warnings
+  postHasId;
+  commentsHasId;
 });
 
 // transactions
-coreDB.tx.messages[id()]
-  .update({ content: "Hello world" })
+coreDB.tx.posts[id()]
+  .update({ title: "Hello world", num: 1 })
   .link({ creator: "foo" });
 
 // ----
@@ -47,7 +53,6 @@ coreDB.tx.messages[id()]
 
 const reactDB = react_init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID,
-  schema,
 });
 
 function ReactNormalApp() {
@@ -58,12 +63,18 @@ function ReactNormalApp() {
   const _reactPresenceUser = reactPresence.user!;
   const _reactPresencePeers = reactPresence.peers!;
   // queries
-  const { isLoading, error, data } = reactDB.useQuery({ messages: {} });
+  const { isLoading, error, data } = reactDB.useQuery({
+    posts: { comments: {} },
+  });
   if (isLoading || error) {
     return null;
   }
-  const { messages } = data;
-  messages[0].content;
+  const { posts } = data;
+  const post = posts[0];
+  const postHasId: SpecificallyExtends<typeof post, { id: string }> = true;
+  const comments = post.comments[0];
+  const commentsHasId: SpecificallyExtends<typeof comments, { id: string }> =
+    true;
 
   // transactions
   reactDB.transact(
@@ -73,12 +84,11 @@ function ReactNormalApp() {
   );
 
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  postHasId;
+  commentsHasId;
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
 }
 
 // ----
@@ -86,7 +96,6 @@ function ReactNormalApp() {
 
 const reactNativeDB = react_native_init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID,
-  schema: schema,
 });
 
 function ReactNativeNormalApp() {
@@ -98,20 +107,24 @@ function ReactNativeNormalApp() {
   const _reactPresencePeers = reactPresence.peers!;
   // queries
   const { isLoading, error, data } = reactNativeDB.useQuery({
-    messages: {},
+    posts: { comments: {} },
   });
   if (isLoading || error) {
     return null;
   }
-  const { messages } = data;
-  messages[0].content;
+  const { posts } = data;
+  const post = posts[0];
+  const postHasId: SpecificallyExtends<typeof post, { id: string }> = true;
+  const comments = post.comments[0];
+  const commentsHasId: SpecificallyExtends<typeof comments, { id: string }> =
+    true;
+
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  postHasId;
+  commentsHasId;
 }
 
 // ----
@@ -120,7 +133,6 @@ function ReactNativeNormalApp() {
 const adminDB = admin_init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID!,
   adminToken: import.meta.env.VITE_INSTANT_ADMIN_TOKEN!,
-  schema: schema,
 });
 
 // queries
@@ -140,18 +152,18 @@ export { ReactNormalApp, ReactNativeNormalApp };
 // ------------
 // type helpers
 
-const messagesQuery: InstaQLQueryParams<AppSchema> = {
+const messagesQuery: InstaQLQueryParams<DoNotUseUnknownSchema> = {
   messages: {
     creator: {},
   },
 };
 
-type CoreMessage = DoNotUseInstantEntity<AppSchema, "messages">;
+type CoreMessage = DoNotUseInstantEntity<DoNotUseUnknownSchema, "messages">;
 let coreMessage: CoreMessage = 1 as any;
 coreMessage.content;
 
 type CoreMessageWithCreator = DoNotUseInstantEntity<
-  AppSchema,
+  DoNotUseUnknownSchema,
   "messages",
   { creator: {} }
 >;
@@ -159,8 +171,8 @@ let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
 coreMessageWithCreator.creator?.id;
 
 type MessageCreatorResult = DoNotUseInstaQLQueryResult<
-  AppSchema,
-  InstaQLQueryParams<AppSchema>
+  DoNotUseUnknownSchema,
+  InstaQLQueryParams<DoNotUseUnknownSchema>
 >;
 function subMessagesWithCreator(
   resultCB: (data: MessageCreatorResult) => void,

--- a/client/sandbox/strong-init-vite/src/typescript_tests_normal.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_normal.tsx
@@ -94,12 +94,10 @@ function ReactNormalApp() {
   );
 
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messages;
 }
 
 // ----
@@ -126,12 +124,10 @@ function ReactNativeNormalApp() {
   const { messages } = data;
   messages[0].content;
   // to silence ts warnings
-  ((..._args) => {})(
-    _reactPublishEmoji,
-    _reactPresenceUser,
-    _reactPresencePeers,
-    messages,
-  );
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messages;
 }
 
 // ----


### PR DESCRIPTION
Previously, strong-init _required_ that a `schema` was passed in. This now makes `schema` optional. 

There's two benefits to this. First, users will still be able to hack as soon as they install instant, without having to define a schema first. Second, it makes upgrading from normal init easier: if they don't define a schema, the behavior is the same as old init.

There's some cool typescript trickery going on, but the big insight was to default our `Schema` type parameter, to an 'UnknownSchema`, which had the correct settings for links. More on this in the [stackoverflow discussion](https://stackoverflow.com/questions/79187112/what-is-the-idiomatic-way-to-make-a-generic-type-optional)

@dwwoelfel @nezaj 