### PR TITLE
Use filtered tx-steps for plan

### DIFF
--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -419,7 +419,7 @@
                            (contains? #{:add-attr :update-attr} action))
                          steps)
         tx-res (when (seq tx-steps)
-                 (permissioned-tx/transact! ctx steps))
+                 (permissioned-tx/transact! ctx tx-steps))
         job-steps (filter (fn [[action]]
                             (contains? #{:check-data-type :remove-data-type
                                          :index :remove-index


### PR DESCRIPTION
Fixes `No matching clause: :check-data-type` errors