### PR TITLE
Faster init through better caching

### DIFF
--- a/server/.clj-kondo/config.edn
+++ b/server/.clj-kondo/config.edn
@@ -4,4 +4,5 @@
                                       amazonica.aws.s3]}}
  :ignore [:inline-def]
  :lint-as {instant.jdbc.sql/with-connection clojure.core/let
-           instant.util.tracer/with-exceptions-silencer clojure.core/fn}}
+           instant.util.tracer/with-exceptions-silencer clojure.core/fn
+           clojure.core.cache/defcache clojure.core/defrecord}}

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -590,8 +590,10 @@
   ([app-id]
    (cache/lookup-or-miss attr-cache app-id (partial get-by-app-id* aurora/conn-pool)))
   ([conn app-id]
-   ;; Don't cache if we're using a custom connection
-   (get-by-app-id* conn app-id)))
+   (if (= conn aurora/conn-pool)
+     (get-by-app-id app-id)
+     ;; Don't cache if we're using a custom connection
+     (get-by-app-id* conn app-id))))
 
 ;; ------
 ;; seek

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -51,7 +51,7 @@
 
 (defn get-by-app-id
   ([{:keys [app-id]}]
-   (cache/lookup-or-miss rule-cache app-id get-by-app-id* aurora/conn-pool))
+   (cache/lookup-or-miss rule-cache app-id (partial get-by-app-id* aurora/conn-pool)))
   ([conn {:keys [app-id]}]
    ;; Don't cache if we're using a custom connection
    (get-by-app-id* conn app-id)))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -11,6 +11,7 @@
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]
    [instant.util.aws :as aws-util]
+   [instant.util.coll :refer [disj-in]]
    [instant.util.hazelcast :as hz-util]
    [instant.util.tracer :as tracer]
    [medley.core :refer [dissoc-in]])
@@ -145,15 +146,6 @@
                                                        :data {}})
       ;; Tracking room-ids for a session is useful for cleanup when a session disconnects
       (update-in [:sessions sess-id :room-ids] (fnil conj #{}) room-id)))
-
-(defn disj-in
-  "Calls dissoc-in to clean up the map when the item at path is empty after
-   calling disj. Useful for cleaning up the room and session maps."
-  [m path item]
-  (let [new-m (update-in m path disj item)]
-    (if (empty? (get-in new-m path))
-      (dissoc-in new-m path)
-      new-m)))
 
 (defn- leave-room
   "Removes a session and its data from a room."

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -7,6 +7,8 @@
    [instant.db.pg-introspect :as pg-introspect]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
+   [instant.model.app :as app-model]
+   [instant.model.instant-user :as instant-user-model]
    [instant.model.rule :as rule-model]
    [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.store :as rs]
@@ -219,11 +221,20 @@
   [{:keys [columns] :as _change}]
   (app-id-from-columns columns))
 
+(defn id-from-columns [columns]
+  (some-> columns
+          (get-column "id")
+          (parse-uuid)))
+
+(defn extract-id
+  [{:keys [columns] :as _change}]
+  (id-from-columns columns))
+
 (defn extract-tx-id [{:keys [columns] :as _change}]
   (get-column columns "id"))
 
 (defn transform-wal-record [{:keys [changes] :as _record}]
-  (let [{:strs [idents triples attrs transactions rules]}
+  (let [{:strs [idents triples attrs transactions rules apps instant_users]}
         (group-by :table changes)
 
         some-changes (or (seq idents)
@@ -237,6 +248,16 @@
     (doseq [rule rules]
       (let [app-id (or app-id (extract-app-id rule))]
         (rule-model/evict-app-id-from-cache app-id)))
+
+    (doseq [app apps]
+      (let [app-id (or app-id (extract-id app))]
+        (app-model/evict-app-id-from-cache app-id)
+        (instant-user-model/evict-app-id-from-cache app-id)))
+
+    (doseq [user instant_users]
+      (let [id (extract-id user)]
+        (instant-user-model/evict-user-id-from-cache app-id)))
+
     (when (and some-changes app-id)
       {:attr-changes attrs
        :ident-changes idents

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -256,7 +256,7 @@
 
     (doseq [user instant_users]
       (let [id (extract-id user)]
-        (instant-user-model/evict-user-id-from-cache app-id)))
+        (instant-user-model/evict-user-id-from-cache id)))
 
     (when (and some-changes app-id)
       {:attr-changes attrs

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -91,8 +91,7 @@
         user (when refresh-token
                (app-user-model/get-by-refresh-token!
                 {:app-id app-id :refresh-token refresh-token}))
-        creator (instant-user-model/get-by-app-id
-                 aurora/conn-pool {:app-id app-id})
+        creator (instant-user-model/get-by-app-id {:app-id app-id})
         admin? (and __admin-token
                     (boolean
                      (app-admin-token-model/fetch! {:app-id app-id

--- a/server/src/instant/util/cache.clj
+++ b/server/src/instant/util/cache.clj
@@ -71,14 +71,13 @@
                          limit))
 
   MultiEvictLRUCacheImpl
-  (evict-impl [this key]
+  (evict-impl [_ key]
     (MultiEvictLRUCache. (dissoc cache key)
                          (dissoc lru key)
                          (disj-in mapping
                                   [(mapping-fn (get cache key))]
                                   key)
                          mapping-fn
-                         ;; XXX: Only tick once??
                          (inc tick)
                          limit))
 

--- a/server/src/instant/util/cache.clj
+++ b/server/src/instant/util/cache.clj
@@ -7,14 +7,13 @@
   [base start-at]
   (into (priority-map/priority-map) (for [[k _] base] [k start-at])))
 
-;; mapping is {item-key -> #{cache-keys}}
-
 (defprotocol MultiEvictLRUCacheImpl
   (evict-impl [this key]))
 
 ;; mapping-fn takes an result in the cache and returns a new cache key
-;; n.b. the mapping-fn should a key that doesn't overlap with a key
-;; that could potentially be in the cache.
+;; n.b. the mapping-fn should return a key that doesn't overlap with a
+;; key that could potentially be in the cache.
+;; mapping is a hash map of {(mapping-fn cache-item) -> #{cache-keys}}
 (defcache MultiEvictLRUCache [cache lru mapping mapping-fn tick limit]
   CacheProtocol
   (lookup [_ item]

--- a/server/src/instant/util/cache.clj
+++ b/server/src/instant/util/cache.clj
@@ -1,0 +1,108 @@
+(ns instant.util.cache
+  (:require [clojure.data.priority-map :as priority-map]
+            [clojure.core.cache :as cache :refer [defcache CacheProtocol]]
+            [instant.util.coll :refer [disj-in]]))
+
+(defn- build-leastness-queue
+  [base start-at]
+  (into (priority-map/priority-map) (for [[k _] base] [k start-at])))
+
+;; mapping is {item-key -> #{cache-keys}}
+
+(defprotocol MultiEvictLRUCacheImpl
+  (evict-impl [this key]))
+
+;; mapping-fn takes an result in the cache and returns a new cache key
+;; n.b. the mapping-fn should a key that doesn't overlap with a key
+;; that could potentially be in the cache.
+(defcache MultiEvictLRUCache [cache lru mapping mapping-fn tick limit]
+  CacheProtocol
+  (lookup [_ item]
+    (get cache item))
+  (lookup [_ item not-found]
+    (get cache item not-found))
+  (has? [_ item]
+    (contains? cache item))
+  (hit [_ item]
+    (let [tick+ (inc tick)]
+      (MultiEvictLRUCache. cache
+                           (if (contains? cache item)
+                             (assoc lru item tick+)
+                             lru)
+                           mapping
+                           mapping-fn
+                           tick+
+                           limit)))
+  (miss [_ item result]
+    (let [tick+ (inc tick)]
+      (if (>= (count lru) limit)
+        (let [k (if (contains? lru item)
+                  item
+                  (first (peek lru))) ;; minimum-key, maybe evict case
+              c (-> cache (dissoc k) (assoc item result))
+              l (-> lru (dissoc k) (assoc item tick+))
+              m (-> mapping
+                    (disj-in [(mapping-fn (get cache k))] k)
+                    (update (mapping-fn result) (fnil conj #{}) item))]
+          (MultiEvictLRUCache. c l m mapping-fn tick+ limit))
+        (MultiEvictLRUCache. (assoc cache item result) ;; no change case
+                             (assoc lru item tick+)
+                             (update mapping (mapping-fn result) (fnil conj #{}) item)
+                             mapping-fn
+                             tick+
+                             limit))))
+  (evict [this key]
+    (if (contains? cache key)
+      (evict-impl this key)
+      (if-let [keys (get mapping key)]
+        (reduce evict-impl
+                this
+                keys)
+        this)))
+  (seed [_ base]
+    (MultiEvictLRUCache. base
+                         (build-leastness-queue base 0)
+                         (reduce-kv (fn [m k v]
+                                      (update m (mapping-fn v) (fnil conj #{}) k))
+                                    {}
+                                    base)
+                         mapping-fn
+                         0
+                         limit))
+
+  MultiEvictLRUCacheImpl
+  (evict-impl [this key]
+    (MultiEvictLRUCache. (dissoc cache key)
+                         (dissoc lru key)
+                         (disj-in mapping
+                                  [(mapping-fn (get cache key))]
+                                  key)
+                         mapping-fn
+                         ;; XXX: Only tick once??
+                         (inc tick)
+                         limit))
+
+  Object
+  (toString [_]
+    (str cache \, \space lru \, \space mapping \, \space tick \, \space limit)))
+
+(defn multi-evict-lru-cache-factory
+  "Returns a MultiEvictLRU cache with the cache and usage-table
+  initialized to `base` -- each entry is initialized with the same
+  usage value.
+
+  Takes a `mapping-fn` that will be applied to the item in the
+  cache. The return value of mapping-fn can be used as an alternative
+  key for evicting the item from the cache.
+
+  Takes a `:threshold` argument that defines the maximum number of
+  elements in the cache before the LRU semantics apply"
+  [base mapping-fn threshold]
+  {:pre [(number? threshold) (< 0 threshold)]}
+  (atom (cache/seed (MultiEvictLRUCache. {}
+                                         (priority-map/priority-map)
+                                         {}
+                                         mapping-fn
+                                         0
+                                         threshold)
+                    base)))

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -87,6 +87,15 @@
     (dissoc m first-key)
     (update m first-key dissoc-in rest-keys)))
 
+(defn disj-in
+  "Calls dissoc-in to clean up the map when the item at path is empty after
+   calling disj. Useful for cleaning up the room and session maps."
+  [m path item]
+  (let [new-m (update-in m path disj item)]
+    (if (empty? (get-in new-m path))
+      (dissoc-in new-m path)
+      new-m)))
+
 (comment
   (def my-map {:a {:b {:c 3 :d 4}} :e 5})
   (dissoc-in my-map [:a :b :c]))

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -1,4 +1,5 @@
-(ns instant.util.coll)
+(ns instant.util.coll
+  (:require [medley.core :as medley]))
 
 (defn split-last [coll]
   (list (butlast coll)
@@ -93,7 +94,7 @@
   [m path item]
   (let [new-m (update-in m path disj item)]
     (if (empty? (get-in new-m path))
-      (dissoc-in new-m path)
+      (medley/dissoc-in new-m path)
       new-m)))
 
 (comment

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2314,9 +2314,10 @@
            (query-pretty (make-ctx) r {:users {:$ {:where {:handle "dww"}}}})
            before-index-result)
 
-          (sql/execute! aurora/conn-pool
-                        ["update attrs set is_indexed = true where id = ?"
-                         handle-attr-id])
+          (attr-model/with-cache-invalidation app-id
+            (sql/execute! aurora/conn-pool
+                          ["update attrs set is_indexed = true where id = ?"
+                           handle-attr-id]))
 
           (testing "incorrect indexes would break the query"
             (is-pretty-eq?
@@ -2325,9 +2326,10 @@
                 :triples (),
                 :aggregate (nil)})))
 
-          (sql/execute! aurora/conn-pool
-                        ["update attrs set indexing = true where id = ?"
-                         handle-attr-id])
+          (attr-model/with-cache-invalidation app-id
+            (sql/execute! aurora/conn-pool
+                          ["update attrs set indexing = true where id = ?"
+                           handle-attr-id]))
 
           (testing "setting in-progress saves the query"
             (is-pretty-eq?
@@ -2382,9 +2384,10 @@
            (query-pretty (make-ctx) r {:users {:$ {:where {:handle "dww"}}}})
            before-index-result)
 
-          (sql/execute! aurora/conn-pool
-                        ["update attrs set is_unique = true where id = ?"
-                         handle-attr-id])
+          (attr-model/with-cache-invalidation app-id
+            (sql/execute! aurora/conn-pool
+                          ["update attrs set is_unique = true where id = ?"
+                           handle-attr-id]))
 
           (testing "incorrect indexes would break the query"
             (is-pretty-eq?
@@ -2393,9 +2396,10 @@
                 :triples (),
                 :aggregate (nil)})))
 
-          (sql/execute! aurora/conn-pool
-                        ["update attrs set setting_unique = true where id = ?"
-                         handle-attr-id])
+          (attr-model/with-cache-invalidation app-id
+            (sql/execute! aurora/conn-pool
+                          ["update attrs set setting_unique = true where id = ?"
+                           handle-attr-id]))
 
           (testing "setting in-progress saves the query"
             (is-pretty-eq?


### PR DESCRIPTION
Improves the caching of attrs and adds caching to `app/get-by-id` and `instant_users/get-by-app-id`.

When all is cached, reduces the number of queries we run for `:init` from 2 to 0 when the user isn't logged in, and 4 to 1 when we need to look up the user by their auth token.

We were fetching attrs a lot more often than we needed to because the `query-op` gets passed a conn-pool that it uses when it calls `attrs/get-by-app-id`. That was causing us to bypass the cache. With this PR we'll stop bypassing the cache if the passed in conn is `aurora/conn-pool`.

We fetch the app creator by the app id, so the cache needs to be evicted when either the app's creator changes or the instant_user changes. This PR introduces a novel lru cache that allows you to evict based on data in the cached item. The main cache key is the app_id, but the cache registers the user_id as an alternative eviction key, allowing you to evict by either the app_id or the user_id.



