### PR TITLE
Initialize presence on join room

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1535,6 +1535,8 @@ export default class Reactor {
       };
     }
 
+    this._presence[roomId] = this._presence[roomId] || {};
+
     this._tryJoinRoom(roomId);
 
     return () => {


### PR DESCRIPTION
When we call `useSyncPresence` in the typing indicator example, we're dropping the `publishPresence` command because `this._presence` is empty. Now we set it so that we'll call the initial setPresence after joining the room.

Before the grouped queue improvements, this might have raced on the server and caused a "you haven't joined the room yet" error. But now that we handle events in order, it should be fine.

Before:

<img width="506" alt="Screenshot 2024-11-15 at 10 11 35 AM" src="https://github.com/user-attachments/assets/c33e9816-fb39-4fdb-a615-c4f1adae76df">

After:

<img width="506" alt="Screenshot 2024-11-15 at 10 09 33 AM" src="https://github.com/user-attachments/assets/4763d227-1e5b-4dbb-92fa-78d819b01733">
