### PR TITLE
[init] merge into init_experimental

### DIFF
--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -1,21 +1,23 @@
 import { TxChunk } from "./instatx";
 import { RoomSchemaShape } from "./presence";
-import type { InstantGraph, DoNotUseInstantSchema } from "./schemaTypes";
+import type { IContainEntitiesAndLinks, InstantSchemaDef } from "./schemaTypes";
 
 export interface IDatabase<
-  Schema extends InstantGraph<any, any> | {} = {},
-  RoomSchema extends RoomSchemaShape = {},
+  Schema extends IContainEntitiesAndLinks<any, any> | {} = {},
+  _RoomSchema extends RoomSchemaShape = {},
   WithCardinalityInference extends boolean = false,
 > {
   tx: TxChunk<
-    Schema extends InstantGraph<any, any> ? Schema : InstantGraph<any, any>
+    Schema extends IContainEntitiesAndLinks<any, any>
+      ? Schema
+      : InstantSchemaDef<any, any, any>
   >;
 
   withCardinalityInference?: WithCardinalityInference;
 }
 
-export interface IDoNotUseDatabase<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
+export interface IInstantDatabase<
+  Schema extends InstantSchemaDef<any, any, any>,
 > {
   tx: TxChunk<Schema>;
 }

--- a/client/packages/core/src/helperTypes.ts
+++ b/client/packages/core/src/helperTypes.ts
@@ -1,40 +1,87 @@
 import type {
-  InstaQLQueryEntityResult,
-  InstaQLQueryParams,
-  InstaQLQueryResult,
+  InstaQLEntity,
+  InstaQLResult,
+  InstaQLParams,
   Remove$,
 } from "./queryTypes";
-import type { InstantGraph } from "./schemaTypes";
-import type { IDatabase } from "./coreTypes";
-import { RoomSchemaShape } from "./presence";
+import type { IContainEntitiesAndLinks, InstantSchemaDef } from "./schemaTypes";
+import type { IInstantDatabase } from "./coreTypes";
 
-export type InstantQuery<DB extends IDatabase<any, any, any>> =
-  DB extends IDatabase<infer Schema, any, any>
-    ? Schema extends InstantGraph<any, any, any>
-      ? InstaQLQueryParams<Schema>
-      : never
+/**
+ * @deprecated 
+ * `InstantQuery` is deprecated. Use `InstaQLParams` instead. 
+ * 
+ * @example
+ *  // Before
+ *  const db = init_experimental({ ...config, schema });
+ *  type DB = typeof db; 
+ *  const myQuery = { ... } satisfies InstantQuery<DB>;
+ * 
+ *  // After
+ *  type Schema = typeof schema;
+ *  const myQuery = { ... } satisfies InstaQLParams<Schema>;
+ */
+export type InstantQuery<DB extends IInstantDatabase<any>> =
+  DB extends IInstantDatabase<infer Schema>
+    ? InstaQLParams<Schema>
     : never;
 
-export type InstantQueryResult<DB extends IDatabase<any, any, any>, Q> =
-  DB extends IDatabase<infer Schema, any, infer CardinalityInference>
-    ? Schema extends InstantGraph<infer E, any>
-      ? InstaQLQueryResult<E, Remove$<Q>, CardinalityInference>
-      : never
+/**
+ * @deprecated 
+ * `InstantQueryResult` is deprecated. Use `InstaQLResult` instead.
+ * 
+ * @example 
+ * // Before 
+ * const db = init_experimental({ ...config, schema }); 
+ * type DB = typeof db; 
+ * type MyQueryResult = InstantQueryResult<DB, typeof myQuery>; 
+ * 
+ * // After
+ * type Schema = typeof schema; 
+ * type MyQueryResult = InstaQLResult<Schema, typeof myQuery>;
+ */
+export type InstantQueryResult<DB extends IInstantDatabase<any>, Q> =
+  DB extends IInstantDatabase<infer Schema>
+    ? InstaQLResult<Schema, Remove$<Q>>
     : never;
+/**
+ * @deprecated
+ * `InstantSchema` is deprecated. Use typeof schema directly: 
+ * @example 
+ * // Before 
+ * const db = init_experimental({ ...config, schema }); 
+ * type Schema = InstantSchema<typeof db>;
+ * 
+ * // After
+ * type Schema = typeof schema;
+ */
+export type InstantSchema<DB extends IInstantDatabase<any>> =
+  DB extends IInstantDatabase<infer Schema> ? Schema : never;
 
-export type InstantSchema<DB extends IDatabase<any, any, any>> =
-  DB extends IDatabase<infer Schema, any, any> ? Schema : never;
-
+/**
+ * @deprecated
+ * `InstantEntity` is deprecated. Use `InstaQLEntity` instead.
+ * 
+ * @example
+ * // Before
+ * const db = init_experimental({ ...config, schema }); 
+ * type DB = typeof db; 
+ * type MyEntity = InstantEntity<DB, "myEntityName">;
+ * 
+ * // After 
+ * type Schema = typeof schema; 
+ * type MyEntity = InstaQLEntity<Schema, "myEntityName">;
+ */
 export type InstantEntity<
-  DB extends IDatabase<any, any, any>,
-  EntityName extends DB extends IDatabase<infer Schema, any, any>
-    ? Schema extends InstantGraph<infer Entities, any>
+  DB extends IInstantDatabase<any>,
+  EntityName extends DB extends IInstantDatabase<infer Schema>
+    ? Schema extends IContainEntitiesAndLinks<infer Entities, any>
       ? keyof Entities
       : never
     : never,
   Query extends
-    | (DB extends IDatabase<infer Schema, any, any>
-        ? Schema extends InstantGraph<infer Entities, any>
+    | (DB extends IInstantDatabase<infer Schema>
+        ? Schema extends IContainEntitiesAndLinks<infer Entities, any>
           ? {
               [QueryPropName in keyof Entities[EntityName]["links"]]?: any;
             }
@@ -42,16 +89,24 @@ export type InstantEntity<
         : never)
     | {} = {},
 > =
-  DB extends IDatabase<infer Schema, any, any>
-    ? Schema extends InstantGraph<infer Entities, any>
-      ? EntityName extends keyof Entities
-        ? InstaQLQueryEntityResult<Entities, EntityName, Query, true>
-        : never
-      : never
+  DB extends IInstantDatabase<infer Schema>
+    ? InstaQLEntity<Schema, EntityName, Query>
     : never;
 
+/**
+ * @deprecated
+ * `InstantSchemaDatabase` is deprecated. You generally don't need to 
+ * create a return type for a DB. But, if you like you can use `IInstantDatabase`:
+ * 
+ * @example
+ * // Before
+ * type DB = InstantSchemaDatabase<typeof schema>;
+ * 
+ * // After
+ * type DB = IInstantDatabase<typeof schema>;
+ */
 export type InstantSchemaDatabase<
-  Schema extends InstantGraph<any, any>,
-  R extends RoomSchemaShape = {},
-  CI extends boolean = true,
-> = IDatabase<Schema, R, CI>;
+  Schema extends InstantSchemaDef<any, any, any>,
+  _T1 extends any = any,
+  _T2 extends any = any,
+> = IInstantDatabase<Schema>;

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -1,4 +1,4 @@
-import type { DataAttrDef, IInstantDataSchema, InstantGraph, LinkAttrDef } from "./schemaTypes";
+import type { DataAttrDef, IContainEntitiesAndLinks, InstantGraph, LinkAttrDef } from "./schemaTypes";
 
 type Action = "update" | "link" | "unlink" | "delete" | "merge";
 type EType = string;
@@ -9,7 +9,7 @@ type Lookup = string;
 export type Op = [Action, EType, Id | LookupRef, Args];
 
 type UpdateParams<
-  Schema extends IInstantDataSchema<any, any>,
+  Schema extends IContainEntitiesAndLinks<any, any>,
   EntityName extends keyof Schema["entities"],
 > = {
   [AttrName in keyof Schema["entities"][EntityName]["attrs"]]?: Schema["entities"][EntityName]["attrs"][AttrName] extends DataAttrDef<
@@ -20,14 +20,14 @@ type UpdateParams<
       ? ValueType
       : ValueType | null
     : never;
-} & (Schema extends IInstantDataSchema<any, any>
+} & (Schema extends IContainEntitiesAndLinks<any, any>
   ? {}
   : {
       [attribute: string]: any;
     });
 
 type LinkParams<
-  Schema extends IInstantDataSchema<any, any>,
+  Schema extends IContainEntitiesAndLinks<any, any>,
   EntityName extends keyof Schema["entities"],
 > = {
   [LinkName in keyof Schema["entities"][EntityName]["links"]]?: Schema["entities"][EntityName]["links"][LinkName] extends LinkAttrDef<
@@ -41,7 +41,7 @@ type LinkParams<
 } & (Schema extends InstantGraph<any, any> ? {} : { [attribute: string]: any });
 
 export interface TransactionChunk<
-  Schema extends IInstantDataSchema<any, any>,
+  Schema extends IContainEntitiesAndLinks<any, any>,
   EntityName extends keyof Schema["entities"],
 > {
   __ops: Op[];
@@ -127,13 +127,13 @@ export interface TransactionChunk<
 }
 
 export interface ETypeChunk<
-  Schema extends IInstantDataSchema<any, any>,
+  Schema extends IContainEntitiesAndLinks<any, any>,
   EntityName extends keyof Schema["entities"],
 > {
   [id: Id]: TransactionChunk<Schema, EntityName>;
 }
 
-export type TxChunk<Schema extends IInstantDataSchema<any, any>> = {
+export type TxChunk<Schema extends IContainEntitiesAndLinks<any, any>> = {
   [EntityName in keyof Schema["entities"]]: ETypeChunk<Schema, EntityName>;
 };
 
@@ -189,7 +189,7 @@ function etypeChunk(etype: EType): ETypeChunk<any, EType> {
 }
 
 export function txInit<
-  Schema extends IInstantDataSchema<any, any>,
+  Schema extends IContainEntitiesAndLinks<any, any>,
 >(): TxChunk<Schema> {
   return new Proxy(
     {},

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -1,17 +1,18 @@
 import {
   EntityDef,
   DataAttrDef,
-  InstantGraph,
-  DoNotUseInstantSchema,
+  InstantSchemaDef,
   type EntitiesDef,
   type AttrsDefs,
   type EntitiesWithLinks,
   type LinksDef,
   type RoomsDef,
+  type UnknownRooms,
 } from "./schemaTypes";
 
 // ==========
 // API
+
 
 /**
  * Accepts entities and links and merges them into a single graph definition.
@@ -48,7 +49,7 @@ function graph<
   EntitiesWithoutLinks extends EntitiesDef,
   const Links extends LinksDef<EntitiesWithoutLinks>,
 >(entities: EntitiesWithoutLinks, links: Links) {
-  return new InstantGraph(
+  return new InstantSchemaDef(
     enrichEntitiesWithLinks<EntitiesWithoutLinks, Links>(entities, links),
     // (XXX): LinksDef<any> stems from TypeScript’s inability to reconcile the
     // type EntitiesWithLinks<EntitiesWithoutLinks, Links> with
@@ -56,6 +57,7 @@ function graph<
     // correctly aligned and does not allow for substituting a type that might
     // be broader or have additional properties.
     links as LinksDef<any>,
+    undefined as UnknownRooms,
   );
 }
 
@@ -150,8 +152,10 @@ type LinksIndex = Record<
   Record<string, Record<string, { entityName: string; cardinality: string }>>
 >;
 
-// XXX: add docstring
-function do_not_use_schema<
+/**
+ * TODO
+ */
+function schema<
   EntitiesWithoutLinks extends EntitiesDef,
   const Links extends LinksDef<EntitiesWithoutLinks>,
   Rooms extends RoomsDef,
@@ -164,7 +168,7 @@ function do_not_use_schema<
   links: Links;
   rooms: Rooms;
 }) {
-  return new DoNotUseInstantSchema(
+  return new InstantSchemaDef(
     enrichEntitiesWithLinks<EntitiesWithoutLinks, Links>(entities, links),
     // (XXX): LinksDef<any> stems from TypeScript’s inability to reconcile the
     // type EntitiesWithLinks<EntitiesWithoutLinks, Links> with
@@ -179,7 +183,7 @@ function do_not_use_schema<
 export const i = {
   // constructs
   graph,
-  do_not_use_schema,
+  schema,
   entity,
   // value types
   string,

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -7,9 +7,10 @@ import version from "./version";
 import {
   // react
   InstantReact,
-  DoNotUseInstantReact,
+  InstantReactAbstractDatabase,
 
   // types
+  type IInstantDatabase,
   type Config,
   type Query,
   type QueryResponse,
@@ -43,11 +44,11 @@ import {
   type ValueTypes,
   type InstantEntity,
   type ConfigWithSchema,
-  type DoNotUseInstantEntity,
-  type DoNotUseInstaQLQueryResult,
-  type DoNotUseConfig,
-  type DoNotUseInstantSchema,
-  type DoNotUseUnknownSchema,
+  type InstaQLEntity,
+  type InstaQLResult,
+  type InstantConfig,
+  type InstantSchemaDef,
+  type InstantUnknownSchema,
 } from "@instantdb/core";
 
 /**
@@ -77,27 +78,9 @@ function init<Schema extends {} = {}, RoomSchema extends RoomSchemaShape = {}>(
 }
 
 function init_experimental<
-  Schema extends InstantGraph<any, any, any>,
-  WithCardinalityInference extends boolean = true,
->(
-  config: Config & {
-    schema: Schema;
-    cardinalityInference?: WithCardinalityInference;
-  },
-) {
-  return new InstantReactNative<
-    Schema,
-    Schema extends InstantGraph<any, any, infer RoomSchema>
-      ? RoomSchema
-      : never,
-    WithCardinalityInference
-  >(config);
-}
-
-function do_not_use_init_experimental<
-  Schema extends DoNotUseInstantSchema<any, any, any> = DoNotUseUnknownSchema,
->(config: DoNotUseConfig<Schema>) {
-  return new DoNotUseInstantReactNative<Schema>(config);
+  Schema extends InstantSchemaDef<any, any, any> = InstantUnknownSchema,
+>(config: InstantConfig<Schema>) {
+  return new InstantReactNativeDatabase<Schema>(config);
 }
 
 class InstantReactNative<
@@ -113,9 +96,9 @@ class InstantReactNative<
   }
 }
 
-class DoNotUseInstantReactNative<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
-> extends DoNotUseInstantReact<Schema> {
+class InstantReactNativeDatabase<
+  Schema extends InstantSchemaDef<any, any, any>,
+> extends InstantReactAbstractDatabase<Schema> {
   static Storage = Storage;
   static NetworkListener = NetworkListener;
 }
@@ -123,7 +106,6 @@ class DoNotUseInstantReactNative<
 export {
   init,
   init_experimental,
-  do_not_use_init_experimental,
   id,
   tx,
   lookup,
@@ -141,6 +123,7 @@ export {
   type InstantQueryResult,
   type InstantSchema,
   type InstantSchemaDatabase,
+  type IInstantDatabase,
   type InstantEntity,
   type RoomSchemaShape,
 
@@ -157,8 +140,8 @@ export {
   type LinksDef,
   type ResolveAttrs,
   type ValueTypes,
-  type DoNotUseInstantEntity,
-  type DoNotUseInstaQLQueryResult,
-  type DoNotUseInstantSchema,
-  type DoNotUseUnknownSchema,
+  type InstaQLEntity,
+  type InstaQLResult,
+  type InstantSchemaDef,
+  type InstantUnknownSchema,
 };

--- a/client/packages/react/src/DoNotUseInstantReactWeb.ts
+++ b/client/packages/react/src/DoNotUseInstantReactWeb.ts
@@ -1,6 +1,0 @@
-import type { DoNotUseInstantSchema } from "@instantdb/core";
-import { DoNotUseInstantReact } from "./DoNotUseInstantReact";
-
-export class DoNotUseInstantReactWeb<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
-> extends DoNotUseInstantReact<Schema> {}

--- a/client/packages/react/src/InstantReact.ts
+++ b/client/packages/react/src/InstantReact.ts
@@ -11,11 +11,11 @@ import {
   type Query,
   type Exactly,
   type TransactionChunk,
-  type DoNotUseLifecycleSubscriptionState,
+  type LifecycleSubscriptionState,
   type PresenceOpts,
   type PresenceResponse,
   type RoomSchemaShape,
-  type InstaQLQueryParams,
+  type InstaQLParams,
   type ConfigWithSchema,
   type IDatabase,
   type InstantGraph,
@@ -411,11 +411,11 @@ export abstract class InstantReact<
    */
   useQuery = <
     Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
+      ? InstaQLParams<Schema>
       : Exactly<Query, Q>,
   >(
     query: null | Q,
-  ): DoNotUseLifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
+  ): LifecycleSubscriptionState<Q, Schema, WithCardinalityInference> => {
     return useQuery(this._core, query).state;
   };
 
@@ -486,7 +486,7 @@ export abstract class InstantReact<
    */
   queryOnce = <
     Q extends Schema extends InstantGraph<any, any>
-      ? InstaQLQueryParams<Schema>
+      ? InstaQLParams<Schema>
       : Exactly<Query, Q>,
   >(
     query: Q,

--- a/client/packages/react/src/InstantReactAbstractDatabase.ts
+++ b/client/packages/react/src/InstantReactAbstractDatabase.ts
@@ -9,16 +9,16 @@ import {
   type PresenceOpts,
   type PresenceResponse,
   type RoomSchemaShape,
-  type InstaQLQueryParams,
-  type DoNotUseConfig,
+  type InstaQLParams,
+  type InstantConfig,
   type PageInfoResponse,
-  DoNotUseInstantClient,
-  _do_not_use_init_internal,
-  DoNotUseDoNotUseLifecycleSubscriptionState,
-  DoNotUseQueryResponse,
+  InstantCoreDatabase,
+  init_experimental,
+  InstaQLLifecycleState,
+  InstaQLResponse,
   RoomsOf,
-  DoNotUseInstantSchema,
-  IDoNotUseDatabase,
+  InstantSchemaDef,
+  IInstantDatabase,
 } from "@instantdb/core";
 import {
   KeyboardEvent,
@@ -29,7 +29,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { doNotUseUseQuery } from "./useQuery";
+import { useQueryInternal } from "./useQuery";
 import { useTimeout } from "./useTimeout";
 
 export type PresenceHandle<
@@ -57,20 +57,16 @@ export type TypingIndicatorHandle<PresenceShape> = {
 
 export const defaultActivityStopTimeout = 1_000;
 
-export class DoNotUseInstantReactRoom<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
+export class InstantReactRoom<
+  Schema extends InstantSchemaDef<any, any, any>,
   RoomSchema extends RoomSchemaShape,
   RoomType extends keyof RoomSchema,
 > {
-  _core: DoNotUseInstantClient<Schema>;
+  _core: InstantCoreDatabase<Schema>;
   type: RoomType;
   id: string;
 
-  constructor(
-    _core: DoNotUseInstantClient<Schema>,
-    type: RoomType,
-    id: string,
-  ) {
+  constructor(_core: InstantCoreDatabase<Schema>, type: RoomType, id: string) {
     this._core = _core;
     this.type = type;
     this.id = id;
@@ -293,22 +289,22 @@ const defaultAuthState = {
   error: undefined,
 };
 
-export abstract class DoNotUseInstantReact<
-  Schema extends DoNotUseInstantSchema<any, any, any>,
+export default abstract class InstantReactAbstractDatabase<
+  Schema extends InstantSchemaDef<any, any, any>,
   Rooms extends RoomSchemaShape = RoomsOf<Schema>,
-> implements IDoNotUseDatabase<Schema>
+> implements IInstantDatabase<Schema>
 {
   public tx = txInit<Schema>();
 
   public auth: Auth;
   public storage: Storage;
-  public _core: DoNotUseInstantClient<Schema>;
+  public _core: InstantCoreDatabase<Schema>;
 
   static Storage?: any;
   static NetworkListener?: any;
 
-  constructor(config: DoNotUseConfig<Schema>) {
-    this._core = _do_not_use_init_internal<Schema>(
+  constructor(config: InstantConfig<Schema>) {
+    this._core = init_experimental<Schema>(
       config,
       // @ts-expect-error because TS can't resolve subclass statics
       this.constructor.Storage,
@@ -343,11 +339,7 @@ export abstract class DoNotUseInstantReact<
     type: RoomType = "_defaultRoomType" as RoomType,
     id: string = "_defaultRoomId",
   ) {
-    return new DoNotUseInstantReactRoom<Schema, Rooms, RoomType>(
-      this._core,
-      type,
-      id,
-    );
+    return new InstantReactRoom<Schema, Rooms, RoomType>(this._core, type, id);
   }
 
   /**
@@ -397,10 +389,10 @@ export abstract class DoNotUseInstantReact<
    *  // skip if `user` is not logged in
    *  db.useQuery(auth.user ? { goals: {} } : null)
    */
-  useQuery = <Q extends InstaQLQueryParams<Schema>>(
+  useQuery = <Q extends InstaQLParams<Schema>>(
     query: null | Q,
-  ): DoNotUseDoNotUseLifecycleSubscriptionState<Q, Schema> => {
-    return doNotUseUseQuery(this._core, query).state;
+  ): InstaQLLifecycleState<Schema, Q> => {
+    return useQueryInternal(this._core, query).state;
   };
 
   /**
@@ -468,10 +460,10 @@ export abstract class DoNotUseInstantReact<
    *  const resp = await db.queryOnce({ goals: {} });
    *  console.log(resp.data.goals)
    */
-  queryOnce = <Q extends InstaQLQueryParams<Schema>>(
+  queryOnce = <Q extends InstaQLParams<Schema>>(
     query: Q,
   ): Promise<{
-    data: DoNotUseQueryResponse<Q, Schema>;
+    data: InstaQLResponse<Schema, Q>;
     pageInfo: PageInfoResponse<Q>;
   }> => {
     return this._core.queryOnce(query);

--- a/client/packages/react/src/InstantReactWebDatabase.ts
+++ b/client/packages/react/src/InstantReactWebDatabase.ts
@@ -1,0 +1,6 @@
+import type { InstantSchemaDef } from "@instantdb/core";
+import InstantReactAbstractDatabase from "./InstantReactAbstractDatabase";
+
+export default class InstantReactWebDatabase<
+  Schema extends InstantSchemaDef<any, any, any>,
+> extends InstantReactAbstractDatabase<Schema> {}

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -12,11 +12,12 @@ import {
   type InstantObject,
   type InstantEntity,
   type InstantSchemaDatabase,
+  type IInstantDatabase,
   type User,
   type AuthState,
   type Query,
   type Config,
-  type InstaQLQueryParams,
+  type InstaQLParams,
 
   // schema types
   type AttrsDefs,
@@ -31,17 +32,17 @@ import {
   type LinksDef,
   type ResolveAttrs,
   type ValueTypes,
-  type DoNotUseInstantEntity,
-  type DoNotUseInstaQLQueryResult,
-  type DoNotUseUnknownSchema,
-  type DoNotUseInstantSchema,
+  type InstaQLEntity,
+  type InstaQLResult,
+  type InstantUnknownSchema,
+  type InstantSchemaDef,
 } from "@instantdb/core";
 
 import { InstantReact } from "./InstantReact";
-import { DoNotUseInstantReact } from "./DoNotUseInstantReact";
+import InstantReactAbstractDatabase from "./InstantReactAbstractDatabase";
 import { InstantReactWeb } from "./InstantReactWeb";
-import { DoNotUseInstantReactWeb } from "./DoNotUseInstantReactWeb";
-import { init, init_experimental, do_not_use_init_experimental } from "./init";
+import InstantReactWebDatabase from "./InstantReactWebDatabase";
+import { init, init_experimental } from "./init";
 import { Cursors } from "./Cursors";
 
 export {
@@ -50,15 +51,14 @@ export {
   lookup,
   init,
   init_experimental,
-  do_not_use_init_experimental,
   InstantReactWeb,
-  DoNotUseInstantReactWeb,
+  InstantReactWebDatabase,
   Cursors,
   i,
 
   // internal
   InstantReact,
-  DoNotUseInstantReact,
+  InstantReactAbstractDatabase,
 
   // types
   type Config,
@@ -72,7 +72,8 @@ export {
   type InstantSchema,
   type InstantEntity,
   type InstantSchemaDatabase,
-  type InstaQLQueryParams,
+  type IInstantDatabase,
+  type InstaQLParams,
 
   // schema types
   type AttrsDefs,
@@ -87,8 +88,8 @@ export {
   type LinksDef,
   type ResolveAttrs,
   type ValueTypes,
-  type DoNotUseInstantEntity,
-  type DoNotUseInstaQLQueryResult,
-  type DoNotUseUnknownSchema,
-  type DoNotUseInstantSchema,
+  type InstaQLEntity,
+  type InstaQLResult,
+  type InstantUnknownSchema,
+  type InstantSchemaDef,
 };

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -1,14 +1,14 @@
 import type {
   // types
   Config,
-  DoNotUseConfig,
+  InstantConfig,
   InstantGraph,
-  DoNotUseInstantSchema,
+  InstantSchemaDef,
   RoomSchemaShape,
-  DoNotUseUnknownSchema,
+  InstantUnknownSchema,
 } from "@instantdb/core";
 import { InstantReactWeb } from "./InstantReactWeb";
-import { DoNotUseInstantReactWeb } from "./DoNotUseInstantReactWeb";
+import InstantReactWebDatabase from "./InstantReactWebDatabase";
 
 /**
  *
@@ -38,25 +38,7 @@ export function init<
 }
 
 export function init_experimental<
-  Schema extends InstantGraph<any, any, any>,
-  WithCardinalityInference extends boolean = true,
->(
-  config: Config & {
-    schema: Schema;
-    cardinalityInference?: WithCardinalityInference;
-  },
-) {
-  return new InstantReactWeb<
-    Schema,
-    Schema extends InstantGraph<any, any, infer RoomSchema>
-      ? RoomSchema
-      : never,
-    WithCardinalityInference
-  >(config);
-}
-
-export function do_not_use_init_experimental<
-  Schema extends DoNotUseInstantSchema<any, any, any> = DoNotUseUnknownSchema,
->(config: DoNotUseConfig<Schema>) {
-  return new DoNotUseInstantReactWeb<Schema>(config);
+  Schema extends InstantSchemaDef<any, any, any> = InstantUnknownSchema,
+>(config: InstantConfig<Schema>) {
+  return new InstantReactWebDatabase<Schema>(config);
 }

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -4,12 +4,12 @@ import {
   type Query,
   type Exactly,
   type InstantClient,
-  type DoNotUseLifecycleSubscriptionState,
-  type InstaQLQueryParams,
+  type LifecycleSubscriptionState,
+  type InstaQLParams,
   type InstantGraph,
-  DoNotUseInstantClient,
-  DoNotUseDoNotUseLifecycleSubscriptionState,
-  DoNotUseInstantSchema,
+  InstantCoreDatabase,
+  InstaQLLifecycleState,
+  InstantSchemaDef,
 } from "@instantdb/core";
 import { useCallback, useRef, useSyncExternalStore } from "react";
 
@@ -32,7 +32,7 @@ function stateForResult(result: any) {
 
 export function useQuery<
   Q extends Schema extends InstantGraph<any, any>
-    ? InstaQLQueryParams<Schema>
+    ? InstaQLParams<Schema>
     : Exactly<Query, Q>,
   Schema extends InstantGraph<any, any, any> | {},
   WithCardinalityInference extends boolean,
@@ -40,7 +40,7 @@ export function useQuery<
   _core: InstantClient<Schema, any, WithCardinalityInference>,
   _query: null | Q,
 ): {
-  state: DoNotUseLifecycleSubscriptionState<Q, Schema, WithCardinalityInference>;
+  state: LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>;
   query: any;
 } {
   const query = _query ? coerceQuery(_query) : null;
@@ -52,7 +52,7 @@ export function useQuery<
   // If we don't use a ref, the state will always be considered different, so
   // the component will always re-render.
   const resultCacheRef = useRef<
-    DoNotUseLifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
   >(stateForResult(_core._reactor.getPreviousResult(query)));
 
   // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
@@ -84,7 +84,7 @@ export function useQuery<
   );
 
   const state = useSyncExternalStore<
-    DoNotUseLifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
+    LifecycleSubscriptionState<Q, Schema, WithCardinalityInference>
   >(
     subscribe,
     () => resultCacheRef.current,
@@ -93,14 +93,14 @@ export function useQuery<
   return { state, query };
 }
 
-export function doNotUseUseQuery<
-  Q extends InstaQLQueryParams<Schema>,
-  Schema extends DoNotUseInstantSchema<any, any, any>,
+export function useQueryInternal<
+  Q extends InstaQLParams<Schema>,
+  Schema extends InstantSchemaDef<any, any, any>,
 >(
-  _core: DoNotUseInstantClient<Schema>,
+  _core: InstantCoreDatabase<Schema>,
   _query: null | Q,
 ): {
-  state: DoNotUseDoNotUseLifecycleSubscriptionState<Q, Schema>;
+  state: InstaQLLifecycleState<Schema, Q>;
   query: any;
 } {
   const query = _query ? coerceQuery(_query) : null;
@@ -112,7 +112,7 @@ export function doNotUseUseQuery<
   // If we don't use a ref, the state will always be considered different, so
   // the component will always re-render.
   const resultCacheRef = useRef<
-    DoNotUseDoNotUseLifecycleSubscriptionState<Q, Schema>
+    InstaQLLifecycleState<Schema, Q>
   >(stateForResult(_core._reactor.getPreviousResult(query)));
 
   // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
@@ -144,7 +144,7 @@ export function doNotUseUseQuery<
   );
 
   const state = useSyncExternalStore<
-    DoNotUseDoNotUseLifecycleSubscriptionState<Q, Schema>
+    InstaQLLifecycleState<Schema, Q>
   >(
     subscribe,
     () => resultCacheRef.current,

--- a/client/sandbox/react-nextjs/pages/play/strong-todos.tsx
+++ b/client/sandbox/react-nextjs/pages/play/strong-todos.tsx
@@ -1,11 +1,11 @@
 import {
   i,
   init_experimental,
-  type InstantEntity,
-  type InstantQuery,
-  type InstantQueryResult,
-  type InstantSchemaDatabase,
+  InstaQLEntity,
+  type InstaQLParams,
+  type InstaQLResult,
 } from "@instantdb/react";
+
 import config from "../../config";
 
 const schema = i.graph(
@@ -14,27 +14,42 @@ const schema = i.graph(
       text: i.string(),
       completed: i.boolean(),
     }),
+    owner: i.entity({
+      name: i.string(),
+    }),
   },
-  {},
+  {
+    todosOwner: {
+      forward: {
+        on: "todos",
+        has: "one",
+        label: "owner",
+      },
+      reverse: {
+        on: "owner",
+        has: "many",
+        label: "ownedTodos",
+      },
+    },
+  },
 );
+type _Schema = typeof schema;
+// This is a little hack that makes
+// Typescript intellisense look a lot cleaner
+interface Schema extends _Schema {}
 
 const db = init_experimental({
   ...config,
   schema,
 });
 
-type DB = typeof db;
-// for when your want to get the type of DB before calling `init`
-type DB_alternate = InstantSchemaDatabase<typeof schema>;
-
 const todosQuery = {
-  todos: {},
-} satisfies InstantQuery<DB>;
+  todos: {
+    owner: {},
+  },
+} satisfies InstaQLParams<Schema>;
 
-export type Todo = InstantEntity<DB, "todos">;
-
-// alternatively
-export type TodosResult = InstantQueryResult<DB, typeof todosQuery>["todos"];
+export type Todo = InstaQLEntity<Schema, "todos">;
 
 export default function TodoApp() {
   const result = db.useQuery(todosQuery);

--- a/client/sandbox/strong-init-vite/instant.schema.v2.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.v2.ts
@@ -1,6 +1,6 @@
 import { i } from "@instantdb/react";
 
-const _schema = i.do_not_use_schema({
+const _schema = i.schema({
   entities: {
     messages: i.entity({
       content: i.string(),

--- a/client/sandbox/strong-init-vite/src/App.tsx
+++ b/client/sandbox/strong-init-vite/src/App.tsx
@@ -1,7 +1,7 @@
-import { id, do_not_use_init_experimental } from "@instantdb/react";
+import { id, init_experimental } from "@instantdb/react";
 import schema from "../instant.schema.v2";
 
-const db = do_not_use_init_experimental({
+const db = init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID,
   schema,
   apiURI: "http://localhost:8888",

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental.tsx
@@ -4,6 +4,8 @@ import {
   InstantQuery,
   InstantEntity,
   InstantQueryResult,
+  InstantSchema,
+  InstantSchemaDatabase,
 } from "@instantdb/core";
 import { init_experimental as react_init_experimental } from "@instantdb/react";
 import { init_experimental as react_native_init_experimental } from "@instantdb/react-native";
@@ -35,6 +37,8 @@ const coreDB = core_init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID,
   schema: graph.withRoomSchema<Rooms>(),
 });
+type CoreSchema = InstantSchema<typeof coreDB>;
+const coreSchema: CoreSchema = graph.withRoomSchema<Rooms>();
 
 // rooms
 const coreRoom = coreDB.joinRoom("chat");
@@ -62,6 +66,10 @@ coreDB.tx.messages[id()]
 
 // type helpers
 type CoreDB = typeof coreDB;
+const s = graph.withRoomSchema<Rooms>();
+type FromSchemaDatabase = InstantSchemaDatabase<typeof s>;
+const fromSchemaDBWorks: FromSchemaDatabase = coreDB;
+
 const coreMessagesQuery = {
   messages: {
     creator: {},
@@ -89,6 +97,7 @@ function subMessagesWithCreator(
 ) {
   coreDB.subscribeQuery(coreMessagesQuery, (result) => {
     if (result.data) {
+      result.data.messages[0].creator?.email;
       resultCB(result.data);
     }
   });
@@ -97,9 +106,11 @@ function subMessagesWithCreator(
 // to silence ts warnings
 coreMessagesQuery;
 subMessagesWithCreator;
+coreSchema;
+fromSchemaDBWorks;
 
-// ----
-// React
+// // ----
+// // React
 
 const reactDB = react_init_experimental({
   appId: import.meta.env.VITE_INSTANT_APP_ID,
@@ -137,6 +148,9 @@ function ReactNormalApp() {
 
 // type helpers
 type ReactDB = typeof reactDB;
+type ReactSchema = InstantSchema<typeof reactDB>;
+const reactSchema: ReactSchema = graph.withRoomSchema<Rooms>();
+
 const reactMessagesQuery = {
   messages: {
     creator: {},
@@ -167,6 +181,7 @@ function useMessagesWithCreator(): ReactMessageCreatorResult | undefined {
 // to silence ts warnings
 reactMessagesQuery;
 useMessagesWithCreator;
+reactSchema;
 
 // ----
 // React-Native
@@ -203,6 +218,9 @@ function ReactNativeNormalApp() {
 
 // type helpers
 type ReactNativeDB = typeof reactNativeDB;
+type ReactNativeSchema = InstantSchema<typeof reactNativeDB>;
+const rnSchema: ReactNativeSchema = graph.withRoomSchema<Rooms>();
+
 const reactNativeMessagesQuery = {
   messages: {
     creator: {},
@@ -235,6 +253,7 @@ function useMessagesWithCreatorRN():
 // to silence ts warnings
 reactNativeMessagesQuery;
 useMessagesWithCreatorRN;
+rnSchema;
 
 // ----
 // Admin
@@ -287,8 +306,7 @@ async function getMessagesWithCreator(): Promise<AdminMessageCreatorResult> {
 }
 
 // to silence ts warnings
-adminMessagesQuery;
-getMessagesWithCreator;
+((..._args) => {})(adminMessagesQuery, getMessagesWithCreator);
 
 // to silence ts warnings
 export { ReactNormalApp, ReactNativeNormalApp };

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
@@ -1,13 +1,13 @@
 import {
   id,
-  do_not_use_init_experimental as core_init_experimental,
-  InstaQLQueryParams,
-  DoNotUseInstantEntity,
-  DoNotUseInstaQLQueryResult,
+  init_experimental as core_init_experimental,
+  InstaQLParams,
+  InstaQLEntity,
+  InstaQLResult,
 } from "@instantdb/core";
-import { do_not_use_init_experimental as react_init_experimental } from "@instantdb/react";
-import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
-import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
+import { init_experimental as react_init_experimental } from "@instantdb/react";
+import { init_experimental as react_native_init_experimental } from "@instantdb/react-native";
+import { init_experimental as admin_init_experimental } from "@instantdb/admin";
 import schema, { AppSchema } from "../instant.schema.v2";
 
 // ----
@@ -148,13 +148,13 @@ const messagesQuery = {
   messages: {
     creator: {},
   },
-} satisfies InstaQLQueryParams<AppSchema>;
+} satisfies InstaQLParams<AppSchema>;
 
-type CoreMessage = DoNotUseInstantEntity<AppSchema, "messages">;
+type CoreMessage = InstaQLEntity<AppSchema, "messages">;
 let coreMessage: CoreMessage = 1 as any;
 coreMessage.content;
 
-type CoreMessageWithCreator = DoNotUseInstantEntity<
+type CoreMessageWithCreator = InstaQLEntity<
   AppSchema,
   "messages",
   { creator: {} }
@@ -163,9 +163,9 @@ let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
 coreMessageWithCreator.content;
 coreMessageWithCreator.creator?.email;
 
-type MessageCreatorResult = DoNotUseInstaQLQueryResult<
+type MessageCreatorResult = InstaQLResult<
   AppSchema,
-  InstaQLQueryParams<AppSchema>
+  InstaQLParams<AppSchema>
 >;
 function subMessagesWithCreator(
   resultCB: (data: MessageCreatorResult) => void,

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2_no_schema.tsx
@@ -1,14 +1,14 @@
 import {
   id,
-  do_not_use_init_experimental as core_init_experimental,
-  InstaQLQueryParams,
-  DoNotUseInstantEntity,
-  DoNotUseInstaQLQueryResult,
-  DoNotUseUnknownSchema,
+  init_experimental as core_init_experimental,
+  InstaQLParams,
+  InstaQLEntity,
+  InstaQLResult,
+  InstantUnknownSchema,
 } from "@instantdb/core";
-import { do_not_use_init_experimental as react_init_experimental } from "@instantdb/react";
-import { do_not_use_init_experimental as react_native_init_experimental } from "@instantdb/react-native";
-import { do_not_use_init_experimental as admin_init_experimental } from "@instantdb/admin";
+import { init_experimental as react_init_experimental } from "@instantdb/react";
+import { init_experimental as react_native_init_experimental } from "@instantdb/react-native";
+import { init_experimental as admin_init_experimental } from "@instantdb/admin";
 
 // ----
 // Core
@@ -143,22 +143,22 @@ const postsQuery = {
   posts: {
     comments: {},
   },
-} satisfies InstaQLQueryParams<DoNotUseUnknownSchema>;
+} satisfies InstaQLParams<InstantUnknownSchema>;
 
-type CorePost = DoNotUseInstantEntity<DoNotUseUnknownSchema, "messages">;
+type CorePost = InstaQLEntity<InstantUnknownSchema, "messages">;
 let coreMessage: CorePost = 1 as any;
 coreMessage.id;
 
-type CorePostWithCreator = DoNotUseInstantEntity<
-  DoNotUseUnknownSchema,
+type CorePostWithCreator = InstaQLEntity<
+  InstantUnknownSchema,
   "messages",
   { creator: {} }
 >;
 let coreMessageWithCreator: CorePostWithCreator = 1 as any;
 coreMessageWithCreator.creator[0].id;
 
-type MessageCreatorResult = DoNotUseInstaQLQueryResult<
-  DoNotUseUnknownSchema,
+type MessageCreatorResult = InstaQLResult<
+  InstantUnknownSchema,
   typeof postsQuery
 >;
 

--- a/client/www/pages/docs/strong-init.md
+++ b/client/www/pages/docs/strong-init.md
@@ -6,7 +6,7 @@ What if you could use the types you defined in `instant.schema.ts`, inside `init
 
 Here's how it works
 
-If you want to migrate, swap out `init` with `init_experimental` and pass it your app's graph schema object.
+If you want to migrate, swap out `init` with `init_experimental` and pass it your app's schema object.
 
 ```ts
 import { init_experimental } from '@instantdb/react';
@@ -65,8 +65,6 @@ const author = firstUser.author[0];
 const author = firstUser.author; // no more array! 🎉
 ```
 
-If you don't want to migrate your components just yet, you can opt out by adding a `cardinalityInference` flag set to `false` in your `init_experimental` call. This way, you'll get all the typechecking benefits without having to update your logic.
-
 ## Rooms support
 
 Rooms are still expressed in pure TypeScript. You can type rooms with `schema.withRoomSchema<R>`. Here's how it looks:
@@ -88,30 +86,33 @@ const db = init_experimental({
 
 ## Reusable types
 
-Sometimes, you'll want to abstract out your query and result types. For example, a query's result might be consumed across multiple React components, each with their own prop types. For such cases, we provide `InstantQuery` and `InstantQueryResult`.
+Sometimes, you'll want to abstract out your query and result types. For example, a query's result might be consumed across multiple React components, each with their own prop types. For such cases, we provide `InstaQLParams` and `InstaQLResult`.
 
 To declare a query and validate its type against your schema, you can import `InstantQuery` and leverage [TypeScript's `satisfies` operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) like so:
 
 ```typescript
-const myQuery = { myTable: {} } satisfies InstantQuery<DB>;
+const myQuery = { myTable: {} } satisfies InstaQLParams<typeof schema>;
 ```
 
-To obtain the resolved result type of your query, import `InstantQueryResult` and provide it your DB and query types
+To obtain the resolved result type of your query, import `InstaQLResult` and provide it your DB and query types
 
 ```typescript
-type MyQueryResult = InstantQueryResult<DB, typeof myQuery>;
+type MyQueryResult = InstaQLResult<typeof schema, typeof myQuery>;
 ```
 
-If you only want the type of a single entity, you can leverage `InstantEntity`. `InstantEntity` resolves an entity type from your DB:
+If you only want the type of a single entity, you can leverage `InstaQLEntity`. `InstaQLEntity` resolves an entity type from your DB:
 
 ```typescript
-type Todo = InstantEntity<DB, 'todos'>;
+type Todo = InstaQLEntity<typeof schema, 'todos'>;
 ```
 
 You can specify links relative to the entity, too:
 
 ```typescript
-type Todo = InstantEntity<DB, 'todos', { category: {}; assignee: {} }>;
+type TodoWithOwner = InstantEntity<
+  typeof schema, 
+  'todos', 
+  { owner: {} }>;
 ```
 
 [Here's a full example](https://github.com/instantdb/instant/blob/main/client/sandbox/react-nextjs/pages/play/strong-todos.tsx) demonstranting reusable query types in a React app.


### PR DESCRIPTION
This PR: 

Promotes`do_not_use_init_experimental` PR into the latest `init_experimental`. 

The main changes:
- `schema` is now optional in `init_experimental`
  - This makes upgrading from `init` to `init_experimental` much easier
- `cardinalityInference` is no longer an option
  - If `schema` is provided, cardinality inference is on. If it is not, cardinality inference is off
- Better intellisense
  - We are more careful about how we write our types, so the intellisense looks better

**Will strong-init users experience a breaking change?**

`i.graph` returns an InstantSchemaDef now, so they _will not_ experience breaking changes from a different `graph` type. 

However, if some users wrote `init_experimental({ schema, cardinalityInference: false })`, we will not respect the cardinality inference. In this case, typescript will let them know though, and they will need to fix up callsites. This is unlikely to happen, as afaik most users of strong init _use_ cardinality inference. 

**Follow-on PRs**

- I will update instant-cli, so we write an example `i.schema`, instead of `i.graph`. 
- Once I do that, I will make i.graph deprecated
- And with that, I'll launch strong_init updates!

@dwwoelfel @nezaj