### PR TITLE
defsql

### DIFF
--- a/server/.clj-kondo/.gitignore
+++ b/server/.clj-kondo/.gitignore
@@ -2,3 +2,5 @@
 !.gitignore
 !config.edn
 !ci-config.edn
+!hooks/defsql.clj
+!hooks

--- a/server/.clj-kondo/config.edn
+++ b/server/.clj-kondo/config.edn
@@ -3,6 +3,8 @@
            :unresolved-var {:exclude [ring.util.http-response/set-cookie
                                       amazonica.aws.s3]}}
  :ignore [:inline-def]
+ :hooks {:analyze-call {instant.jdbc.sql/defsql hooks.defsql/defsql}}
  :lint-as {instant.jdbc.sql/with-connection clojure.core/let
+
            instant.util.tracer/with-exceptions-silencer clojure.core/fn
            clojure.core.cache/defcache clojure.core/defrecord}}

--- a/server/.clj-kondo/config.edn
+++ b/server/.clj-kondo/config.edn
@@ -5,6 +5,5 @@
  :ignore [:inline-def]
  :hooks {:analyze-call {instant.jdbc.sql/defsql hooks.defsql/defsql}}
  :lint-as {instant.jdbc.sql/with-connection clojure.core/let
-
            instant.util.tracer/with-exceptions-silencer clojure.core/fn
            clojure.core.cache/defcache clojure.core/defrecord}}

--- a/server/.clj-kondo/hooks/defsql.clj
+++ b/server/.clj-kondo/hooks/defsql.clj
@@ -1,0 +1,22 @@
+(ns hooks.defsql
+  (:require [clj-kondo.hooks-api :as api]))
+
+
+(defn defsql [{:keys [node]}]
+  (let [[name query-fn] (rest (:children node))
+        conn-token (api/token-node 'conn)
+        query-token (api/token-node 'query)
+        tag-token (api/token-node '_tag)
+        new-node (api/list-node
+                  (list
+                   (api/token-node 'defn)
+                   name
+                   (api/list-node
+                    (list
+                     (api/vector-node [conn-token query-token])
+                     (api/list-node (list query-fn conn-token query-token))))
+                   (api/list-node
+                    (list
+                     (api/vector-node [tag-token conn-token query-token])
+                     (api/list-node (list query-fn conn-token query-token))))))]
+    {:node new-node}))

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1627,7 +1627,7 @@
   (tracer/with-span! {:name "datalog/send-query-single"}
     (let [{:keys [query pattern-metas]} (match-query :match-0- app-id named-patterns)
           sql-query (hsql/format query)
-          sql-res (sql/select-string-keys conn sql-query)]
+          sql-res (sql/select-string-keys ::send-query-single conn sql-query)]
       (sql-result->result sql-res
                           pattern-metas
                           ;; No need to parse uuids because the db driver will
@@ -1654,7 +1654,7 @@
                                                        nested-named-patterns)
           sql-query (hsql/format query)
           sql-res (when query ;; we may not have a query if everything is missing attrs
-                    (->> (sql/select-arrays conn sql-query)
+                    (->> (sql/select-arrays ::send-query-nested conn sql-query)
                          ;; remove header row
                          second
                          ;; all results are in one json blob in first result
@@ -1681,7 +1681,7 @@
                       args-col)
           hsql-query (batch-queries (map :query batch-data))
           sql-query (hsql/format hsql-query)
-          sql-res (-> (sql/select-arrays conn sql-query)
+          sql-res (-> (sql/select-arrays ::send-query-batch conn sql-query)
                       second ;; remove header row
                       first ;; all results are in one json blob in first result
                       )]

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -161,6 +161,7 @@
   [conn app-id]
   (with-cache-invalidation app-id
     (sql/do-execute!
+     ::delete-by-app-id!
      conn
      ["DELETE FROM attrs WHERE attrs.app_id = ?::uuid" app-id])))
 
@@ -265,6 +266,7 @@
      (validate-on-deletes! attrs))
    (with-cache-invalidation app-id
      (sql/do-execute!
+      ::insert-multi!
       conn
       (hsql/format
        {:with [[[:attr-values
@@ -377,6 +379,7 @@
   (validate-reserved-names! updates)
   (with-cache-invalidation app-id
     (sql/do-execute!
+     ::update-multi!
      conn
      (hsql/format
       {:with (concat
@@ -440,6 +443,7 @@
   [conn app-id ids]
   (with-cache-invalidation app-id
     (sql/do-execute!
+     ::delte-multi!
      conn
      (hsql/format
       {:delete-from :attrs
@@ -572,6 +576,7 @@
   (wrap-attrs
    (map row->attr
         (sql/select
+         ::get-by-app-id*
          conn
          (hsql/format
           {:select [:attrs.*

--- a/server/src/instant/db/model/transaction.clj
+++ b/server/src/instant/db/model/transaction.clj
@@ -6,6 +6,7 @@
 (defn create!
   ([params] (create! aurora/conn-pool params))
   ([conn {:keys [app-id]}]
-   (sql/execute-one! conn
+   (sql/execute-one! ::create!
+                     conn
                      ["INSERT INTO transactions (app_id) VALUES (?::uuid)"
                       app-id])))

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -141,12 +141,6 @@
 
 (def ^:dynamic *query-timeout-seconds* 30)
 
-(defmacro with-translating-psql-exceptions
-  [& body]
-  `(try
-     ~@body
-     (catch PSQLException e#
-       (throw (ex/translate-and-throw-psql-exception! e#)))))
 
 (defmacro defsql [name query-fn opts]
   (let [span-name (format "sql/%s" name)]

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -29,6 +29,7 @@
   ([conn {:keys [app-id code]}]
    (with-cache-invalidation app-id
      (sql/execute-one!
+      ::put!
       conn
       ["INSERT INTO rules (app_id, code) VALUES (?::uuid, ?::jsonb)
           ON CONFLICT (app_id) DO UPDATE SET code = excluded.code"
@@ -39,6 +40,7 @@
   ([conn {:keys [app-id code]}]
    (with-cache-invalidation app-id
      (sql/execute-one!
+      ::merge!
       conn
       (hsql/format {:insert-into :rules
                     :values [{:app-id app-id
@@ -47,7 +49,8 @@
                     :do-update-set {:code [:|| :rules.code :excluded.code]}})))))
 
 (defn get-by-app-id* [conn app-id]
-  (sql/select-one conn ["SELECT * FROM rules WHERE app_id = ?::uuid" app-id]))
+  (sql/select-one ::get-by-app-id*
+                  conn ["SELECT * FROM rules WHERE app_id = ?::uuid" app-id]))
 
 (defn get-by-app-id
   ([{:keys [app-id]}]
@@ -61,6 +64,7 @@
   ([conn {:keys [app-id]}]
    (with-cache-invalidation app-id
      (sql/do-execute!
+      ::delete-by-app-id!
       conn
       ["DELETE FROM rules WHERE app_id = ?::uuid" app-id]))))
 

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -220,10 +220,10 @@
      ;; with-redefs rebinds globally, this binding trick will make sure
      ;; anything happening in parallel doesn't affect our count
      (binding [*count-atom* ~count-atom]
-       (with-redefs [sql/select-arrays (fn [conn# query#]
+       (with-redefs [sql/select-arrays (fn [tag# conn# query#]
                                          (when *count-atom*
                                            (swap! *count-atom* inc))
-                                         (select-arrays# conn# query#))]
+                                         (select-arrays# tag# conn# query#))]
          ~@body))))
 
 (deftest queries


### PR DESCRIPTION
Creates a new `defsql` macro to centralize all of the boilerplate we add for each sql fetching function.

Before:
```clj
(defn select
  [conn query]
  (tracer/with-span! {:name "sql/select"
                      :attributes (span-attrs conn query)}
    (with-translating-psql-exceptions
      (io/tag-io
        (sql/query conn query {:builder-fn rs/as-unqualified-maps
                               :timeout *query-timeout-seconds*})))))
```

After:
```clj
(defsql select sql/query {:builder-fn rs/as-unqualified-maps})
```

[Direct link to the changes to sql.clj](https://github.com/instantdb/instant/compare/defsql?expand=1#diff-4c3638c4ecdec4d03b7ae656618dabf60e715e115daa42b50a9b27c2cf2fe928)

Also adds an optional prefix argument to all of the `sql/*` functions that takes a tag to put in the span. Example:

```clojure
(sql/select ::get-apps conn ["select * from apps"])
```

```log
[98c3] 1ms [sql/select] query_tag=:apps/get-apps
```

This will help us determine which queries are slow and which queries are running.

I tagged a bunch of the existing queries, but not all of them.