### PR TITLE
[strong-init] support shapes for backwards compatibility

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -24,6 +24,7 @@ import {
   type InstantSchemaDatabase,
   type InstantObject,
   type InstantEntity,
+  type BackwardsCompatibleSchema,
   type IInstantDatabase,
 
   // schema types
@@ -905,6 +906,7 @@ export {
   type IInstantDatabase,
   type InstantObject,
   type InstantEntity,
+  type BackwardsCompatibleSchema,
 
   // schema types
   type AttrsDefs,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -61,6 +61,7 @@ import type {
   TopicsOf,
   ValueTypes,
   InstantUnknownSchema,
+  BackwardsCompatibleSchema,
 } from "./schemaTypes";
 
 const defaultOpenDevtool = true;
@@ -913,4 +914,5 @@ export {
   type InstantSchemaDef,
   type InstantUnknownSchema,
   type IInstantDatabase,
+  type BackwardsCompatibleSchema,
 };

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -10,6 +10,7 @@ import {
   InstantReactAbstractDatabase,
 
   // types
+  type BackwardsCompatibleSchema,
   type IInstantDatabase,
   type Config,
   type Query,
@@ -144,4 +145,5 @@ export {
   type InstaQLResult,
   type InstantSchemaDef,
   type InstantUnknownSchema,
+  type BackwardsCompatibleSchema,
 };

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -36,6 +36,7 @@ import {
   type InstaQLResult,
   type InstantUnknownSchema,
   type InstantSchemaDef,
+  type BackwardsCompatibleSchema,
 } from "@instantdb/core";
 
 import { InstantReact } from "./InstantReact";
@@ -92,4 +93,5 @@ export {
   type InstaQLResult,
   type InstantUnknownSchema,
   type InstantSchemaDef,
+  type BackwardsCompatibleSchema,
 };

--- a/client/sandbox/strong-init-vite/src/typescript_tests_normal_as_experimental.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_normal_as_experimental.tsx
@@ -1,0 +1,158 @@
+import {
+  id,
+  init_experimental as core_init,
+ BackwardsCompatibleSchema,
+} from "@instantdb/core";
+import { init_experimental as react_init } from "@instantdb/react";
+import { init_experimental as react_native_init } from "@instantdb/react-native";
+import { init_experimental as admin_init } from "@instantdb/admin";
+
+type Message = {
+  content: string;
+};
+
+type User = {
+  email: string;
+};
+
+type Schema = {
+  messages: Message;
+  creator: User;
+};
+
+type EmojiName = "fire" | "wave" | "confetti" | "heart";
+
+type Rooms = {
+  chat: {
+    presence: {
+      name: string;
+      avatarURI: string;
+    };
+    topics: {
+      emoji: {
+        name: EmojiName;
+        rotationAngle: number;
+        directionAngle: number;
+      };
+    };
+  };
+};
+
+type SchemaDef =BackwardsCompatibleSchema<Schema, Rooms>;
+// ----
+// Core
+
+const coreDB = core_init<SchemaDef>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+// rooms
+const coreRoom = coreDB.joinRoom("chat");
+coreRoom.getPresence({});
+coreRoom.publishTopic("emoji", {
+  name: "confetti",
+  rotationAngle: 0,
+  directionAngle: 0,
+});
+
+// queries
+coreDB.subscribeQuery({ messages: { creator: {} } }, (result) => {
+  if (result.error) {
+    return;
+  }
+  const { messages } = result.data;
+  messages[0].content;
+});
+
+// transactions
+coreDB.tx.messages[id()]
+  .update({ content: "Hello world" })
+  .link({ creator: "foo" });
+
+// ----
+// React
+
+const reactDB = react_init<SchemaDef>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+function ReactNormalApp() {
+  // rooms
+  const reactRoom = reactDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactDB.useQuery({ messages: {} });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+
+  // transactions
+  reactDB.transact(
+    reactDB.tx.messages[id()]
+      .update({ content: "Hello world" })
+      .link({ creator: "foo" }),
+  );
+
+  // to silence ts warnings
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messages;
+}
+
+// ----
+// React-Native
+
+const reactNativeDB = react_native_init<SchemaDef>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+function ReactNativeNormalApp() {
+  // rooms
+  const reactRoom = reactNativeDB.room("chat");
+  const reactPresence = reactRoom.usePresence({ keys: ["name"] });
+  const _reactPublishEmoji = reactRoom.usePublishTopic("emoji");
+  const _reactPresenceUser = reactPresence.user!;
+  const _reactPresencePeers = reactPresence.peers!;
+  // queries
+  const { isLoading, error, data } = reactNativeDB.useQuery({
+    messages: {},
+  });
+  if (isLoading || error) {
+    return null;
+  }
+  const { messages } = data;
+  messages[0].content;
+  // to silence ts warnings
+  _reactPublishEmoji;
+  _reactPresenceUser;
+  _reactPresencePeers;
+  messages;
+}
+
+// ----
+// Admin
+
+const adminDB = admin_init<SchemaDef>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID!,
+  adminToken: import.meta.env.VITE_INSTANT_ADMIN_TOKEN!,
+});
+
+// queries
+const adminQueryResult = await adminDB.query({ messages: { creator: {} } });
+adminQueryResult.messages[0].content;
+
+// transacts
+await adminDB.transact(
+  adminDB.tx.messages[id()]
+    .update({ content: "Hello world" })
+    .link({ creator: "foo" }),
+);
+
+// to silence ts warnings
+export { ReactNormalApp, ReactNativeNormalApp };


### PR DESCRIPTION
## Context

In normal init, folks could previously provide types as shapes, like so: 

```typescript
const db = init<Schema, Rooms>(...)
```

With `init_experimental`, this will no longer work. The current solutions are either to go untyped: 

```typescript
const db = init_experimental({ appId } );
```

Or, to upgrade to the schema object: 

```typescript
ocnst db = init({ appId, schema })
```

### Problem 

However, it can be cumbersome to create this schema object. When we upgrade users to strong init, it would suck to force them into a breaking change. 

### Solution 

I added a helper type, called `BackwardsCompatibleSchema`. This takes in the old `Schema` and `Rooms` shape, and creates an `InstantSchemaDef` type, which behaves _just_ as the Rooms and schema types did before. 

@dwwoelfel @nezaj 