### PR TITLE
Graceful shutdown of queries on timeout

### DIFF
--- a/server/.clj-kondo/hooks/defsql.clj
+++ b/server/.clj-kondo/hooks/defsql.clj
@@ -3,7 +3,7 @@
 
 
 (defn defsql [{:keys [node]}]
-  (let [[name query-fn] (rest (:children node))
+  (let [[name query-fn opts] (rest (:children node))
         conn-token (api/token-node 'conn)
         query-token (api/token-node 'query)
         tag-token (api/token-node '_tag)
@@ -14,9 +14,9 @@
                    (api/list-node
                     (list
                      (api/vector-node [conn-token query-token])
-                     (api/list-node (list query-fn conn-token query-token))))
+                     (api/list-node (list query-fn conn-token query-token opts))))
                    (api/list-node
                     (list
                      (api/vector-node [tag-token conn-token query-token])
-                     (api/list-node (list query-fn conn-token query-token))))))]
+                     (api/list-node (list query-fn conn-token query-token opts))))))]
     {:node new-node}))

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -1,7 +1,13 @@
 {:paths ["src" "resources" "data"]
  :deps {cheshire/cheshire {:mvn/version "5.10.0"}
         clj-http/clj-http {:mvn/version "3.12.3"}
-        com.github.seancorfield/next.jdbc {:mvn/version "1.2.796"}
+
+        com.github.seancorfield/next.jdbc
+        {:git/url "https://github.com/seancorfield/next-jdbc.git"
+         ;; Includes fix for https://github.com/seancorfield/next-jdbc/issues/287
+         ;; version is 1.3.next (last release is 1.3.955)
+         :sha "a75468105f484758ddebeb69871b04ac08acbd94"}
+
         compojure/compojure {:mvn/version "1.6.2"}
         luminus/ring-undertow-adapter {:mvn/version "1.2.8"}
         metosin/ring-http-response {:mvn/version "0.9.2"}

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -174,14 +174,15 @@
           (try
             (io/tag-io
               (let [create-connection?# (not (instance? Connection ~'conn))
+                    opts# (merge ~opts
+                                 {:timeout *query-timeout-seconds*})
                     c# (if create-connection?#
                          (next-jdbc/get-connection ~'conn)
                          ~'conn)]
                 (try
-                  (with-open [ps# (next-jdbc/prepare c# ~'query)
+                  (with-open [ps# (next-jdbc/prepare c# ~'query opts#)
                               _cleanup# (register-in-progress c# ps#)]
-                    (~query-fn ps# nil (merge ~opts
-                                              {:timeout *query-timeout-seconds*})))
+                    (~query-fn ps# nil opts#))
                   (finally
                     ;; Don't close the connection if a java.sql.Connection was
                     ;; passed in, or we'll end transactions before they're done.

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -191,18 +191,6 @@
             (catch PSQLException e#
               (throw (ex/translate-and-throw-psql-exception! e#)))))))))
 
-(defn next-do-execute!
-  "For some reason, next-jdbc overrides {:return-keys false}
-   when you call next-jdbc/execute! on a prepared statement.
-   This wrapper is here to undo that."
-  [connectable sql-params opts]
-  (if (instance? PreparedStatement connectable)
-    (if-let [result-set (when (.execute connectable)
-                          (.getResultSet connectable))]
-      (rs/datafiable-result-set result-set connectable opts)
-      [{:next.jdbc/update-count (.getUpdateCount connectable)}])
-    (next-jdbc/execute! connectable sql-params opts)))
-
 (defsql select sql/query {:builder-fn rs/as-unqualified-maps})
 (defsql select-qualified sql/query {:builder-fn rs/as-maps})
 (defsql select-arrays sql/query {:builder-fn rs/as-unqualified-arrays})
@@ -212,7 +200,7 @@
                                      :return-keys true})
 (defsql execute-one! next-jdbc/execute-one! {:builder-fn rs/as-unqualified-maps
                                              :return-keys true})
-(defsql do-execute! next-do-execute! {:return-keys false})
+(defsql do-execute! next-jdbc/execute! {:return-keys false})
 
 (defn patch-hikari []
   ;; Hikari will send an extra query to ensure the connection is valid

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -1,6 +1,8 @@
 (ns instant.jdbc.sql-test
-  (:require [instant.jdbc.sql :as sql]
-            [clojure.test :refer [deftest testing are]]))
+  (:require [instant.jdbc.aurora :as aurora]
+            [instant.jdbc.sql :as sql]
+            [instant.util.test :refer [wait-for]]
+            [clojure.test :refer [deftest testing is are]]))
 
 (deftest ->pgobject
   (testing "formats text[]"
@@ -8,3 +10,26 @@
                            result)
       ["a" "b" "c"] "{\"a\",\"b\",\"c\"}"
       ["a\"b"] "{\"a\"b\"}")))
+
+(deftest in-progress-stmts
+  (let [in-progress (atom #{})]
+    (binding [sql/*in-progress-stmts* in-progress]
+      (let [query (future (sql/select aurora/conn-pool ["select pg_sleep(3)"]))]
+        (wait-for (fn []
+                    (= 1 (count @in-progress)))
+                  1000)
+        (is (= 1 (count @in-progress)))
+        (is (not (future-done? query)))
+        (sql/cancel-in-progress @in-progress)
+        (wait-for (fn []
+                    (future-done? query))
+                  1000)
+        (is (future-done? query))
+        (is (thrown? Exception @query))
+        (is (= 0 (count @in-progress)))))))
+
+(deftest in-progress-removes-itself-on-query-completion
+  (let [in-progress (atom #{})]
+    (binding [sql/*in-progress-stmts* in-progress]
+      (let [query (sql/select aurora/conn-pool ["select 1"])]
+        (is (= 0 (count @in-progress)))))))


### PR DESCRIPTION
This fixes a problem where the postgres connection gets killed when we call `future-cancel` on handle-receive timeouts. 

If the database is overloaded and it causes a bunch of handle-receives to time out, we can get into a feedback loop where canceling the query causes the connection to get killed, putting additional wear on the database when we recreate the connection.

With this PR, we keep track of the in-progress queries and cancel them before we call `future-cancel` on the handler.

There's a dynamic var `*in-progress-stmts*` that you can bind to an atom with a set in it. If bound, the `defsql` handler will put a `Cancelable` in the set while the query is active. You can call `sql/cancel-in-progress` to cancel all of the in-flight queries. We do just that in `session/handle-receive` when the handler times out. Then we can call `future-cancel` without killing our connection.

