### PR TITLE
Use cluster size in refinery sampler

### DIFF
--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -16,5 +16,6 @@ Samplers:
               EMAThroughputSampler:
                 # With one server, that's about 65MM/month
                 GoalThroughputPerSec: 25
+                UseClusterSize: true
                 FieldList:
                   - name

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -242,7 +242,7 @@
                                            :index? false
                                            :value-type :blob
                                            :cardinality :one}]])
-              _ (dotimes [x 20]
+              _ (dotimes [x 10]
                   (tx/transact! aurora/conn-pool
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)


### PR DESCRIPTION
It seems like the default is false https://docs.honeycomb.io/manage-data-volume/sample/honeycomb-refinery/sampling-methods/#useclustersize

This might help us keep under the rate limit.