### PR TITLE
Warn on bad versions in make publish and publish-experimental

### DIFF
--- a/client/scripts/publish_packages.clj
+++ b/client/scripts/publish_packages.clj
@@ -77,9 +77,19 @@ export default version;
     (proc/shell "pnpm" "publish-packages" "--" "--tag" tag)
     (proc/shell "pnpm" "publish-packages")))
 
-(defn -main [& _args]
-  (let [tag (first _args)
+(defn -main [& args]
+  (let [tag (first args)
         version (str/trim (slurp "version.md"))]
+    (if tag
+      (when (not (str/includes? version tag))
+        (println (format "When publishing the `%s` tag, the version must contain the tag (e.g. v0.1.2-%s.0)."
+                         tag tag))
+        (println (format "You provided %s" version))
+        (System/exit 1))
+      (when (not (re-find #"^v\d+\.\d+\.\d+$" version))
+        (println (format "Version should match format v0.1.2, but you provided %s"
+                         version))
+        (System/exit 1)))
     (set-package-versions! version)
     (set-dep-versions! version)
     (set-version-js! version)


### PR DESCRIPTION
If you provide a regular version when publishing an experimental tag:

```shell
$ make publish-experimental
(Experimental Build) Building + Publishing Packages...
When publishing the `experimental` tag, the version must contain the tag (e.g. v0.1.2-experimental.0).
You provided v0.15.1
make: *** [publish-experimental] Error 1
```

If you provide a tagged version when publishing to the main branch:

```shell
$ make publish             
Building + Publishing Packages...
Version should match format v0.1.2, but you provided v0.15.1-experimental
make: *** [publish] Error 1
```