### PR TITLE
Allow admins to edit the users table

### DIFF
--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -40,6 +40,7 @@ export function EditNamespaceDialog({
   namespaces,
   onClose,
   readOnly,
+  isSystemCatalogNs,
   pushNavStack,
 }: {
   db: InstantReactWeb;
@@ -48,6 +49,7 @@ export function EditNamespaceDialog({
   namespaces: SchemaNamespace[];
   onClose: (p?: { ok: boolean }) => void;
   readOnly: boolean;
+  isSystemCatalogNs: boolean;
   pushNavStack: PushNavStack;
 }) {
   const [screen, setScreen] = useState<
@@ -78,10 +80,10 @@ export function EditNamespaceDialog({
               {namespace.name}
             </h5>
             <Button
-              disabled={readOnly}
+              disabled={isSystemCatalogNs}
               title={
-                readOnly
-                  ? `The ${namespace.name} namespace is read-only.`
+                isSystemCatalogNs
+                  ? `The ${namespace.name} namespace can't be deleted.`
                   : undefined
               }
               size="mini"
@@ -116,10 +118,10 @@ export function EditNamespaceDialog({
 
           <div>
             <Button
-              disabled={readOnly}
+              disabled={isSystemCatalogNs}
               title={
-                readOnly
-                  ? `The ${namespace.name} namespace is read-only.`
+                isSystemCatalogNs
+                  ? `Attributes can't be added to the ${namespace.name} namespace directly. You can still create links to them by adding the links from one of your namespaces.`
                   : undefined
               }
               size="mini"
@@ -147,7 +149,7 @@ export function EditNamespaceDialog({
       ) : screen.type === 'edit' && screenAttr ? (
         <EditAttrForm
           appId={appId}
-          readOnly={readOnly}
+          isSystemCatalogNs={isSystemCatalogNs}
           db={db}
           attr={screenAttr}
           onClose={() => setScreen({ type: 'main' })}
@@ -506,12 +508,12 @@ function InvalidTriplesSample({
 function EditIndexed({
   appId,
   attr,
-  readOnly,
+  isSystemCatalogNs,
   pushNavStack,
 }: {
   appId: string;
   attr: SchemaAttr;
-  readOnly: boolean;
+  isSystemCatalogNs: boolean;
   pushNavStack: PushNavStack;
 }) {
   const token = useAuthToken();
@@ -580,7 +582,7 @@ function EditIndexed({
 
   const valueNotChanged = indexChecked === attr.isIndex;
 
-  const buttonDisabled = readOnly || valueNotChanged;
+  const buttonDisabled = isSystemCatalogNs || valueNotChanged;
 
   const closeDialog = useClose();
 
@@ -588,10 +590,10 @@ function EditIndexed({
     <ActionForm className="flex flex-col gap-1">
       <div className="flex gap-2">
         <Checkbox
-          disabled={readOnly}
+          disabled={isSystemCatalogNs}
           title={
-            readOnly
-              ? `The ${attr.namespace} namespace is read-only.`
+            isSystemCatalogNs
+              ? `Attributes in the ${attr.namespace} namespace can't be edited.`
               : undefined
           }
           checked={indexChecked}
@@ -638,7 +640,9 @@ function EditIndexed({
         errorMessage="Failed to update attribute"
         disabled={buttonDisabled}
         title={
-          readOnly ? `The ${attr.namespace} namespace is read-only.` : undefined
+          isSystemCatalogNs
+            ? `Attributes in the ${attr.namespace} namespace can't be edited.`
+            : undefined
         }
         onClick={updateIndexed}
       />
@@ -649,12 +653,12 @@ function EditIndexed({
 function EditUnique({
   appId,
   attr,
-  readOnly,
+  isSystemCatalogNs,
   pushNavStack,
 }: {
   appId: string;
   attr: SchemaAttr;
-  readOnly: boolean;
+  isSystemCatalogNs: boolean;
   pushNavStack: PushNavStack;
 }) {
   const token = useAuthToken();
@@ -723,7 +727,7 @@ function EditUnique({
 
   const valueNotChanged = uniqueChecked === attr.isUniq;
 
-  const buttonDisabled = readOnly || valueNotChanged;
+  const buttonDisabled = isSystemCatalogNs || valueNotChanged;
 
   const closeDialog = useClose();
 
@@ -731,10 +735,10 @@ function EditUnique({
     <ActionForm className="flex flex-col gap-1">
       <div className="flex gap-2">
         <Checkbox
-          disabled={readOnly}
+          disabled={isSystemCatalogNs}
           title={
-            readOnly
-              ? `The ${attr.namespace} namespace is read-only.`
+            isSystemCatalogNs
+              ? `Attributes in the ${attr.namespace} namespace can't be edited.`
               : undefined
           }
           checked={uniqueChecked}
@@ -827,7 +831,9 @@ function EditUnique({
         errorMessage="Failed to update attribute"
         disabled={buttonDisabled}
         title={
-          readOnly ? `The ${attr.namespace} namespace is read-only.` : undefined
+          isSystemCatalogNs
+            ? `Attributes in the ${attr.namespace} namespace can't be edited.`
+            : undefined
         }
         onClick={updateUniqueness}
       />
@@ -838,12 +844,12 @@ function EditUnique({
 function EditCheckedDataType({
   appId,
   attr,
-  readOnly,
+  isSystemCatalogNs,
   pushNavStack,
 }: {
   appId: string;
   attr: SchemaAttr;
-  readOnly: boolean;
+  isSystemCatalogNs: boolean;
   pushNavStack: PushNavStack;
 }) {
   const token = useAuthToken();
@@ -921,7 +927,7 @@ function EditCheckedDataType({
     (checkedDataType === indexingJob?.checked_data_type &&
       indexingJob?.job_status === 'completed');
 
-  const buttonDisabled = readOnly || typeNotChanged;
+  const buttonDisabled = isSystemCatalogNs || typeNotChanged;
 
   const buttonLabel = typeNotChanged
     ? `Type is ${checkedDataType}`
@@ -945,6 +951,12 @@ function EditCheckedDataType({
         </h6>
         <div className="flex gap-2">
           <Select
+            disabled={isSystemCatalogNs}
+            title={
+              isSystemCatalogNs
+                ? `Attributes in the ${attr.namespace} namespace can't be edited.`
+                : undefined
+            }
             value={checkedDataType || 'any'}
             onChange={(v) => {
               if (!v) {
@@ -1005,7 +1017,9 @@ function EditCheckedDataType({
         errorMessage="Failed to update attribute"
         disabled={buttonDisabled}
         title={
-          readOnly ? `The ${attr.namespace} namespace is read-only.` : undefined
+          isSystemCatalogNs
+            ? `Attributes in the ${attr.namespace} namespace can't be changed.`
+            : undefined
         }
         onClick={updateCheckedType}
       />
@@ -1018,14 +1032,14 @@ function EditAttrForm({
   appId,
   attr,
   onClose,
-  readOnly,
+  isSystemCatalogNs,
   pushNavStack,
 }: {
   db: InstantReactWeb;
   appId: string;
   attr: SchemaAttr;
   onClose: () => void;
-  readOnly: boolean;
+  isSystemCatalogNs: boolean;
   pushNavStack: PushNavStack;
 }) {
   const [screen, setScreen] = useState<{ type: 'main' } | { type: 'delete' }>({
@@ -1121,10 +1135,10 @@ function EditAttrForm({
         </div>
 
         <Button
-          disabled={readOnly && attr.type !== 'ref'}
+          disabled={isSystemCatalogNs && attr.type !== 'ref'}
           title={
-            readOnly && attr.type !== 'ref'
-              ? `The ${attr.namespace} namespace is read-only.`
+            isSystemCatalogNs && attr.type !== 'ref'
+              ? `Attributes in the ${attr.namespace} can't be edited`
               : undefined
           }
           variant="secondary"
@@ -1143,13 +1157,13 @@ function EditAttrForm({
             <EditIndexed
               appId={appId}
               attr={attr}
-              readOnly={readOnly}
+              isSystemCatalogNs={isSystemCatalogNs}
               pushNavStack={pushNavStack}
             />
             <EditUnique
               appId={appId}
               attr={attr}
-              readOnly={readOnly}
+              isSystemCatalogNs={isSystemCatalogNs}
               pushNavStack={pushNavStack}
             />
           </div>
@@ -1157,7 +1171,7 @@ function EditAttrForm({
           <EditCheckedDataType
             appId={appId}
             attr={attr}
-            readOnly={readOnly}
+            isSystemCatalogNs={isSystemCatalogNs}
             pushNavStack={pushNavStack}
           />
           <ActionForm className="flex flex-col gap-1">
@@ -1167,10 +1181,10 @@ function EditAttrForm({
               <strong>update your code</strong> to the new name.
             </Content>
             <TextInput
-              disabled={readOnly}
+              disabled={isSystemCatalogNs}
               title={
-                readOnly
-                  ? `The ${attr.namespace} namespace is read-only.`
+                isSystemCatalogNs
+                  ? `Attributes in the ${attr.namespace} namespace can't be edited.`
                   : undefined
               }
               value={attrName}
@@ -1182,10 +1196,12 @@ function EditAttrForm({
                 label={`Rename ${attr.name} → ${attrName}`}
                 submitLabel="Renaming attribute..."
                 errorMessage="Failed to rename attribute"
-                disabled={readOnly || !attrName || attrName === attr.name}
+                disabled={
+                  isSystemCatalogNs || !attrName || attrName === attr.name
+                }
                 title={
-                  readOnly
-                    ? `The ${attr.namespace} namespace is read-only.`
+                  isSystemCatalogNs
+                    ? `Attributes in the ${attr.namespace} namespace can't be edited.`
                     : undefined
                 }
                 onClick={renameBlobAttr}

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -116,7 +116,12 @@ export function Explorer({
     [namespaces, currentNav?.namespace],
   );
 
-  const readOnlyNs = selectedNamespace && selectedNamespace.name === '$users';
+  const isSystemCatalogNs =
+    selectedNamespace != null &&
+    selectedNamespace.name != null &&
+    selectedNamespace.name.startsWith('$');
+
+  const readOnlyNs = isSystemCatalogNs && selectedNamespace.name !== '$users';
 
   const [limit, setLimit] = useState(50);
   const [offsets, setOffsets] = useState<{ [namespace: string]: number }>({});
@@ -244,7 +249,8 @@ export function Explorer({
       <Dialog open={Boolean(editNs)} onClose={() => setEditNs(null)}>
         {selectedNamespace ? (
           <EditNamespaceDialog
-            readOnly={!!readOnlyNs}
+            readOnly={readOnlyNs}
+            isSystemCatalogNs={isSystemCatalogNs}
             appId={appId}
             db={db}
             namespace={selectedNamespace}

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -291,7 +291,7 @@ export function Select({
   disabled?: boolean;
   emptyLabel?: string;
   tabIndex?: number;
-  title?: string | null | undefined;
+  title?: string | undefined;
 }) {
   return (
     <select

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -282,6 +282,7 @@ export function Select({
   disabled,
   emptyLabel,
   tabIndex,
+  title,
 }: {
   value?: string;
   options: { label: string; value: string }[];
@@ -290,9 +291,11 @@ export function Select({
   disabled?: boolean;
   emptyLabel?: string;
   tabIndex?: number;
+  title?: string | null | undefined;
 }) {
   return (
     <select
+      title={title}
       tabIndex={tabIndex}
       value={value ?? undefined}
       disabled={disabled}

--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -123,7 +123,7 @@
 (comment
   (batch (gen/generate (s/gen ::tx-steps))))
 
-(defn prevent-$users-updates [op attrs]
+(defn prevent-system-catalog-attrs-updates! [op attrs]
   (doseq [attr attrs
           :let [etype (attr-model/fwd-etype attr)]]
     (when (and etype (string/starts-with? etype "$"))
@@ -184,7 +184,7 @@
            (reduce
             (fn [acc [op & args]]
               (when (#{:add-attr :update-attr} op)
-                (prevent-$users-updates op args))
+                (prevent-system-catalog-attrs-updates! op args))
               (let [res (case op
                           :add-attr
                           (attr-model/insert-multi! conn app-id args)


### PR DESCRIPTION
Allows admins to edit the $users table in the explorer.

Here's what it looks like:


https://github.com/user-attachments/assets/83cd3c4f-9d67-48df-8539-0bdaf834dc4c


But you still can't edit the attributes in the namespace, unless they're refs to other namespaces:

https://github.com/user-attachments/assets/5767b4a7-f596-4f4f-8841-82c8f6156a49


