### PR TITLE
Nested future-cancel

### DIFF
--- a/server/test/instant/util/async_test.clj
+++ b/server/test/instant/util/async_test.clj
@@ -1,0 +1,52 @@
+(ns instant.util.async-test
+  (:require [instant.util.async :refer [vfuture vfut-bg]]
+            [clojure.test :refer [is deftest testing]]))
+
+(deftest child-vfutures-are-canceled
+  (testing "demonstrate the problem"
+    (let [signal (atom nil)
+          go-ahead (promise)
+          v (future @(future @go-ahead (reset! signal :whoops!)))]
+      (Thread/sleep 50)
+      (future-cancel v)
+      (Thread/sleep 50)
+      (deliver go-ahead true)
+      (Thread/sleep 50)
+      (is (thrown? java.util.concurrent.CancellationException @v))
+      (is (= :whoops! @signal))))
+  (testing "demonstrate the fix"
+    (let [signal (atom nil)
+          go-ahead (promise)
+          v (vfuture @(vfuture @go-ahead (reset! signal :whoops!)))]
+      (Thread/sleep 50)
+      (future-cancel v)
+      (Thread/sleep 50)
+      (deliver go-ahead true)
+     (Thread/sleep 50)
+      (is (thrown? java.util.concurrent.CancellationException @v))
+      (is (= @signal nil)))))
+
+(deftest vfut-bg-doesn't-keep-track-of-children
+  (let [signal (atom nil)
+        go-ahead (promise)
+        v (vfut-bg @(vfuture @go-ahead (reset! signal :whoops!)))]
+    (Thread/sleep 50)
+    (future-cancel v)
+    (Thread/sleep 50)
+    (deliver go-ahead true)
+    (Thread/sleep 50)
+    (is (thrown? java.util.concurrent.CancellationException @v))
+    (is (= :whoops! @signal))))
+
+(deftest vfuture-in-vfut-bg-keep-track-of-children
+  @(vfut-bg
+     (let [signal (atom nil)
+           go-ahead (promise)
+           v (vfuture @(vfuture @go-ahead (reset! signal :whoops!)))]
+       (Thread/sleep 50)
+       (future-cancel v)
+       (Thread/sleep 50)
+       (deliver go-ahead true)
+       (Thread/sleep 50)
+       (is (thrown? java.util.concurrent.CancellationException @v))
+       (is (= @signal nil)))))


### PR DESCRIPTION
Followup to https://github.com/instantdb/instant/pull/490

When we call `future-cancel` on events that timeout in `handle-receive`, we can see child spans that continue long after the parent has been canceled and completes.

My hypothesis is that the child futures we create aren't being canceled when we cancel the parent future and that's what is causing the child spans to continue working. This leads to the system getting overwhelmed because we just keep piling up canceled work in the background.

A small test that demonstrates the problem:

```clojure
(let [signal (atom nil)
      go-ahead (promise)
      v (future @(future @go-ahead (reset! signal :whoops!)))]
  (Thread/sleep 50)
  (future-cancel v)
  (Thread/sleep 50)
  (deliver go-ahead true)
  (Thread/sleep 50)
  (is (thrown? java.util.concurrent.CancellationException @v))
  (is (= :whoops! @signal))))
```

This PR adds tracking of the `vfuture`s created as direct descendents in a `vfuture` and will cancel any child `vfuture` before canceling itself when `future-cancel` is called on it.

One limitation is that we lose track of the child futures if we don't deref them in the parent (e.g. `(vfuture (vfuture @go-ahead (reset! signal :whoops!)))` won't cancel the inner future), but that seems fine to me. If you wanted it to be canceled, you should have kept track of it.

We don't keep track of children in `vfut-bg` since it will spawn a lot of child futures and we don't normally cancel them.

I was seeing thread pinning locally when we called `.close` on the connection in `sql/cancel-in-progress`, so I also updated that to only close the connection if we didn't open the connection in the body of `defsql`. The connection will get closed in the `finally` clause--that happens in the same thread, which seems to prevent the pinning issue.