### PR TITLE
Put errors back into the receive queue

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -377,7 +377,7 @@
 ;; --------------
 ;; Receive Workers
 
-(defn- handle-instant-exception [store-conn session original-event instant-ex]
+(defn- handle-instant-exception [session original-event instant-ex]
   (let [sess-id (:session/id session)
         q (:receive-q (:session/socket session))
         {:keys [client-event-id]} original-event
@@ -426,7 +426,7 @@
                                            :hint hint
                                            :session-id sess-id})))))
 
-(defn- handle-uncaught-err [store-conn session original-event root-err]
+(defn- handle-uncaught-err [session original-event root-err]
   (let [sess-id (:session/id session)
         q (:receive-q (:session/socket session))
         {:keys [client-event-id]} original-event]
@@ -488,10 +488,10 @@
                   instant-ex (ex/find-instant-exception e)
                   root-err (root-cause e)]
               (cond
-                instant-ex (handle-instant-exception
-                            store-conn session original-event instant-ex)
-                :else (handle-uncaught-err
-                       store-conn session original-event root-err))))
+                instant-ex (handle-instant-exception session
+                                                     original-event
+                                                     instant-ex)
+                :else (handle-uncaught-err session original-event root-err))))
           (finally
             (swap! pending-handlers disj pending-handler)))))))
 

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -15,6 +15,7 @@
    [instant.db.transaction :as tx]
    [instant.db.instaql :as iq]
    [instant.lib.ring.websocket :as ws]
+   [instant.grouped-queue :as grouped-queue]
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.query :as rq]
    [instant.reactive.receive-queue :as receive-queue])
@@ -34,7 +35,7 @@
 (defn- with-session [f]
   (let [sess-id (UUID/randomUUID)
         fake-ws-conn (a/chan 1)
-        receive-q (LinkedBlockingQueue.)
+        receive-q (grouped-queue/create {:group-fn session/group-fn})
         room-refresh-ch (a/chan (a/sliding-buffer 1))
         store-conn (rs/init-store)
         eph-store-atom (atom {})
@@ -48,7 +49,8 @@
                        :receive-q receive-q
                        :ping-job (future)
                        :pending-handlers (atom #{})}
-        query-reactive rq/instaql-query-reactive!]
+        query-reactive rq/instaql-query-reactive!
+        stop-signal (atom false)]
     (session/on-open store-conn socket)
     (session/on-open store-conn second-socket)
 
@@ -65,10 +67,13 @@
                       (let [res (query-reactive store-conn base-ctx instaql-query return-type)]
                         (swap! *instaql-query-results* assoc-in [session-id instaql-query] res)
                         res))]
+        (session/start-receive-worker store-conn eph-store-atom receive-q stop-signal 0)
         (f store-conn eph-store-atom {:socket socket
                                       :second-socket second-socket})
+
         (session/on-close store-conn eph-store-atom socket)
-        (session/on-close store-conn eph-store-atom second-socket)))))
+        (session/on-close store-conn eph-store-atom second-socket)
+        (reset! stop-signal true)))))
 
 (defn- blocking-send-msg [{:keys [ws-conn id]} msg]
   (session/handle-receive *store-conn* *eph-store-atom* (rs/get-session @*store-conn* id) msg {})


### PR DESCRIPTION
This should prevent a session that is causing a lot of errors from backing up the receive queue.

When we get an error in handle-receive, instead of sending the error over the websocket immediately, we'll put the error in the receive queue. We use the grouped-queue to handle those one at a time so that any session having trouble receiving messages won't block the entire queue.

Other things that would be nice here:
  1. Batching messages to the client
  2. Some way to disconnect sessions that are showing lots of errors.