### PR TITLE
[client][strong-init] use schema to help our attr generation

### DIFF
--- a/client/packages/core/__tests__/src/Reactor.test.js
+++ b/client/packages/core/__tests__/src/Reactor.test.js
@@ -112,7 +112,7 @@ test("rewrite mutations", () => {
   ];
 
   // create transactions without any attributes
-  const optimisticSteps = instaml.transform({}, ops);
+  const optimisticSteps = instaml.transform2({ attrs: {} }, ops);
 
   const mutations = new Map([["k", { "tx-steps": optimisticSteps }]]);
 
@@ -128,7 +128,7 @@ test("rewrite mutations", () => {
     ._rewriteMutations(zenecaIdToAttr, mutations)
     .get("k")["tx-steps"];
 
-  const serverSteps = instaml.transform(zenecaIdToAttr, ops);
+  const serverSteps = instaml.transform2({ attrs: zenecaIdToAttr }, ops);
   expect(rewrittenSteps).toEqual(serverSteps);
 });
 
@@ -159,7 +159,7 @@ test("rewrite mutations works with multiple transactions", () => {
 
   for (const k of keys) {
     const attrs = reactor.optimisticAttrs();
-    const steps = instaml.transform(attrs, ops);
+    const steps = instaml.transform2({ attrs }, ops);
     const mut = {
       op: "transact",
       "tx-steps": steps,
@@ -176,7 +176,7 @@ test("rewrite mutations works with multiple transactions", () => {
     reactor.pendingMutations.currentValue,
   );
 
-  const serverSteps = instaml.transform(zenecaIdToAttr, ops);
+  const serverSteps = instaml.transform2({ attrs: zenecaIdToAttr }, ops);
   for (const k of keys) {
     expect(rewrittenMutations.get(k)["tx-steps"]).toEqual(serverSteps);
   }

--- a/client/packages/core/__tests__/src/Reactor.test.js
+++ b/client/packages/core/__tests__/src/Reactor.test.js
@@ -112,7 +112,7 @@ test("rewrite mutations", () => {
   ];
 
   // create transactions without any attributes
-  const optimisticSteps = instaml.transform2({ attrs: {} }, ops);
+  const optimisticSteps = instaml.transform({ attrs: {} }, ops);
 
   const mutations = new Map([["k", { "tx-steps": optimisticSteps }]]);
 
@@ -128,7 +128,7 @@ test("rewrite mutations", () => {
     ._rewriteMutations(zenecaIdToAttr, mutations)
     .get("k")["tx-steps"];
 
-  const serverSteps = instaml.transform2({ attrs: zenecaIdToAttr }, ops);
+  const serverSteps = instaml.transform({ attrs: zenecaIdToAttr }, ops);
   expect(rewrittenSteps).toEqual(serverSteps);
 });
 
@@ -159,7 +159,7 @@ test("rewrite mutations works with multiple transactions", () => {
 
   for (const k of keys) {
     const attrs = reactor.optimisticAttrs();
-    const steps = instaml.transform2({ attrs }, ops);
+    const steps = instaml.transform({ attrs }, ops);
     const mut = {
       op: "transact",
       "tx-steps": steps,
@@ -176,7 +176,7 @@ test("rewrite mutations works with multiple transactions", () => {
     reactor.pendingMutations.currentValue,
   );
 
-  const serverSteps = instaml.transform2({ attrs: zenecaIdToAttr }, ops);
+  const serverSteps = instaml.transform({ attrs: zenecaIdToAttr }, ops);
   for (const k of keys) {
     expect(rewrittenMutations.get(k)["tx-steps"]).toEqual(serverSteps);
   }

--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -14,7 +14,7 @@ test("simple update transform", () => {
   const testId = uuid();
 
   const ops = instatx.tx.books[testId].update({ title: "New Title" });
-  const result = instaml.transform(zenecaAttrs, ops);
+  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     ["add-triple", testId, zenecaAttrToId["books/title"], "New Title"],
@@ -30,8 +30,11 @@ test("simple update transform", () => {
 test("ignores id attrs", () => {
   const testId = uuid();
 
-  const ops = instatx.tx.books[testId].update({ title: "New Title", id: 'ploop' });
-  const result = instaml.transform(zenecaAttrs, ops);
+  const ops = instatx.tx.books[testId].update({
+    title: "New Title",
+    id: "ploop",
+  });
+  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     ["add-triple", testId, zenecaAttrToId["books/title"], "New Title"],
@@ -48,7 +51,7 @@ test("optimistically adds attrs if they don't exist", () => {
 
   const ops = instatx.tx.books[testId].update({ newAttr: "New Title" });
 
-  const result = instaml.transform(zenecaAttrs, ops);
+  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     [
@@ -82,7 +85,7 @@ test("lookup resolves attr ids", () => {
 
   const stopaLookup = [zenecaAttrToId["users/email"], "stopa@instantdb.com"];
 
-  const result = instaml.transform(zenecaAttrs, ops);
+  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     ["add-triple", stopaLookup, zenecaAttrToId["users/handle"], "stopa"],
@@ -108,7 +111,7 @@ test("lookup creates unique attrs for custom lookups", () => {
     "newAttrValue",
   ];
 
-  const result = instaml.transform(zenecaAttrs, ops);
+  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
   const expected = [
     [
       "add-attr",
@@ -138,7 +141,7 @@ test("lookup creates unique attrs for lookups in link values", () => {
     .update({})
     .link({ posts: instatx.lookup("slug", "life-is-good") });
 
-  const result = instaml.transform({}, ops);
+  const result = instaml.transform2({ attrs: {} }, ops);
 
   expect(result).toEqual([
     [
@@ -197,7 +200,7 @@ test("lookup creates unique attrs for lookups in link values with arrays", () =>
     ],
   });
 
-  const result = instaml.transform({}, ops);
+  const result = instaml.transform2({ attrs: {} }, ops);
 
   const expected = [
     [
@@ -275,7 +278,10 @@ test("lookup creates unique attrs for lookups in link values when fwd-ident exis
     "index?": true,
   };
 
-  const result = instaml.transform({ attrId: existingRefAttr }, ops);
+  const result = instaml.transform2(
+    { attrs: { [attrId]: existingRefAttr } },
+    ops,
+  );
 
   expect(result).toEqual([
     [
@@ -329,7 +335,10 @@ test("lookup creates unique attrs for lookups in link values when rev-ident exis
     "index?": true,
   };
 
-  const result = instaml.transform({ attrId: existingRefAttr }, ops);
+  const result = instaml.transform2(
+    { attrs: { [attrId]: existingRefAttr } },
+    ops,
+  );
 
   expect(result).toEqual([
     [
@@ -404,7 +413,7 @@ test("lookup doesn't override attrs for lookups in link values", () => {
     },
   };
 
-  const result = instaml.transform(attrs, ops);
+  const result = instaml.transform2({ attrs }, ops);
 
   expect(result).toEqual([
     ["add-triple", uid, userIdAttrId, uid],
@@ -449,7 +458,7 @@ test("lookup doesn't override attrs for lookups in self links", () => {
     .update({})
     .link({ parent: instatx.lookup("slug", "life-is-good") });
 
-  const result1 = instaml.transform(attrs, ops1);
+  const result1 = instaml.transform2({ attrs }, ops1);
 
   expect(result1.filter((x) => x[0] !== "add-triple")).toEqual([]);
 
@@ -457,7 +466,7 @@ test("lookup doesn't override attrs for lookups in self links", () => {
     .update({})
     .link({ child: instatx.lookup("slug", "life-is-good") });
 
-  const result2 = instaml.transform(attrs, ops2);
+  const result2 = instaml.transform2({ attrs }, ops2);
 
   expect(result2.filter((x) => x[0] !== "add-triple")).toEqual([]);
 });
@@ -475,7 +484,7 @@ test("lookup creates unique ref attrs for ref lookup", () => {
     uid,
   ];
 
-  const result = instaml.transform({}, ops);
+  const result = instaml.transform2({ attrs: {} }, ops);
   const expected = [
     [
       "add-attr",
@@ -538,7 +547,7 @@ test("lookup creates unique ref attrs for ref lookup in link value", () => {
     uid,
   ];
 
-  const result = instaml.transform({}, ops);
+  const result = instaml.transform2({ attrs: {} }, ops);
 
   const expected = [
     [
@@ -578,8 +587,8 @@ test("lookup creates unique ref attrs for ref lookup in link value", () => {
 
 test("it throws if you use an invalid link attr", () => {
   expect(() =>
-    instaml.transform(
-      {},
+    instaml.transform2(
+      { attrs: {} },
       instatx.tx.users[
         instatx.lookup("user_pref.email", "test@example.com")
       ].update({
@@ -621,8 +630,8 @@ test("it doesn't throw if you have a period in your attr", () => {
   };
 
   expect(
-    instaml.transform(
-      attrs,
+    instaml.transform2(
+      { attrs },
       instatx.tx.users[instatx.lookup("attr.with.dot", "value")].update({
         a: 1,
       }),
@@ -641,7 +650,7 @@ test("it doesn't create duplicate ref attrs", () => {
     instatx.tx.nsB[bid].update({}).link({ nsA: aid }),
   ];
 
-  const result = instaml.transform({}, ops);
+  const result = instaml.transform2({ attrs: {} }, ops);
 
   const expected = [
     [
@@ -693,7 +702,7 @@ test("it doesn't create duplicate ref attrs", () => {
   }
 });
 
-test("Uses schema to build optimistic attrs", () => {
+test("Schema: uses info in `attrs` and `links`", () => {
   const schema = i.graph(
     {
       comments: i.entity({
@@ -777,7 +786,449 @@ test("Uses schema to build optimistic attrs", () => {
     ["add-triple", commentId, expect.any(String), "test-slug"],
     ["add-triple", commentId, expect.any(String), bookId],
   ];
-  expect(result).toHaveLength(expected.length);  
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("Schema: doesn't create duplicate ref attrs", () => {
+  const schema = i.graph(
+    {
+      comments: i.entity({}),
+      books: i.entity({}),
+    },
+    {
+      commentBooks: {
+        forward: {
+          on: "comments",
+          has: "one",
+          label: "book",
+        },
+        reverse: {
+          on: "books",
+          has: "many",
+          label: "comments",
+        },
+      },
+    },
+  );
+
+  const commentId = uuid();
+  const bookId = uuid();
+  const ops = [
+    instatx.tx.comments[commentId].update({}).link({ book: bookId }),
+    instatx.tx.books[bookId].update({}).link({ comments: commentId }),
+  ];
+
+  const result = instaml.transform2({ attrs: zenecaAttrs, schema }, ops);
+
+  const expected = [
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "comments", "id"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "unique?": true,
+        "value-type": "blob",
+      },
+    ],
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "comments", "book"],
+        id: expect.any(String),
+        "index?": false,
+        isUnsynced: true,
+        "reverse-identity": [expect.any(String), "books", "comments"],
+        "unique?": false,
+        "value-type": "ref",
+      },
+    ],
+    ["add-triple", commentId, expect.any(String), commentId],
+    ["add-triple", commentId, expect.any(String), bookId],
+    ["add-triple", bookId, expect.any(String), bookId],
+    ["add-triple", commentId, expect.any(String), bookId],
+  ];
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("Schema: lookup creates unique attrs for custom lookups", () => {
+  const schema = i.graph(
+    {
+      users: i.entity({
+        nickname: i.string().unique().indexed(),
+      }),
+    },
+    {},
+  );
+
+  const ops = instatx.tx.users[instatx.lookup("nickname", "stopanator")].update(
+    {
+      handle: "stopa",
+    },
+  );
+
+  const lookup = [
+    // The attr is going to be created, so we don't know its value yet
+    expect.any(String),
+    "stopanator",
+  ];
+
+  const result = instaml.transform2({ attrs: zenecaAttrs, schema }, ops);
+  const expected = [
+    [
+      "add-attr",
+      {
+        cardinality: "one",
+        "forward-identity": [expect.any(String), "users", "nickname"],
+        id: expect.any(String),
+        "index?": true,
+        isUnsynced: true,
+        "unique?": true,
+        "value-type": "blob",
+      },
+    ],
+    ["add-triple", lookup, zenecaAttrToId["users/handle"], "stopa"],
+    ["add-triple", lookup, zenecaAttrToId["users/id"], lookup],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("Schema: lookup creates unique attrs for lookups in link values", () => {
+  const schema = i.graph(
+    {
+      posts: i.entity({
+        slug: i.string().unique().indexed(),
+      }),
+      users: i.entity({}),
+    },
+    {
+      postUsers: {
+        forward: {
+          on: "users",
+          has: "many",
+          label: "authoredPosts",
+        },
+        reverse: {
+          on: "posts",
+          has: "one",
+          label: "author",
+        },
+      },
+    },
+  );
+
+  const uid = uuid();
+  const ops = instatx.tx.users[uid]
+    .update({})
+    .link({ authoredPosts: instatx.lookup("slug", "life-is-good") });
+
+  const result = instaml.transform2({ attrs: {}, schema }, ops);
+
+  expect(result).toEqual([
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "authoredPosts"],
+        "reverse-identity": [expect.any(String), "posts", "author"],
+        "value-type": "ref",
+        // TODO: should this be one?
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "posts", "slug"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "life-is-good"],
+    ],
+  ]);
+});
+
+test("Schema: lookup creates unique attrs for lookups in link values with arrays", () => {
+  const schema = i.graph(
+    {
+      posts: i.entity({
+        slug: i.string().unique().indexed(),
+      }),
+      users: i.entity({}),
+    },
+    {
+      postUsers: {
+        forward: {
+          on: "users",
+          has: "many",
+          label: "authoredPosts",
+        },
+        reverse: {
+          on: "posts",
+          has: "one",
+          label: "author",
+        },
+      },
+    },
+  );
+
+  const uid = uuid();
+  const ops = instatx.tx.users[uid].update({}).link({
+    authoredPosts: [
+      instatx.lookup("slug", "life-is-good"),
+      instatx.lookup("slug", "check-this-out"),
+    ],
+  });
+
+  const result = instaml.transform2({ attrs: {}, schema }, ops);
+
+  const expected = [
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "authoredPosts"],
+        "reverse-identity": [expect.any(String), "posts", "author"],
+        "value-type": "ref",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "posts", "slug"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "life-is-good"],
+    ],
+    [
+      "add-triple",
+      uid,
+      expect.any(String),
+      [expect.any(String), "check-this-out"],
+    ],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("Schema: lookup creates unique ref attrs for ref lookup", () => {
+  const schema = i.graph(
+    {
+      users: i.entity({}),
+      user_prefs: i.entity({}),
+    },
+    {
+      user_user_prefs: {
+        forward: {
+          on: "user_prefs",
+          has: "one",
+          label: "user",
+        },
+        reverse: {
+          on: "users",
+          has: "one",
+          label: "user_pref",
+        },
+      },
+    },
+  );
+
+  const uid = uuid();
+  const ops = [
+    instatx.tx.users[uid].update({}),
+    instatx.tx.user_prefs[instatx.lookup("user.id", uid)].update({}),
+  ];
+
+  const lookup = [
+    // The attr is going to be created, so we don't know its value yet
+    expect.any(String),
+    uid,
+  ];
+
+  const result = instaml.transform2({ attrs: {}, schema }, ops);
+  const expected = [
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "user_prefs", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "user_prefs", "user"],
+        "reverse-identity": [expect.any(String), "users", "user_pref"],
+        "value-type": "ref",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    ["add-triple", lookup, expect.any(String), lookup],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test("Schema: lookup creates unique ref attrs for ref lookup in link value", () => {
+  const schema = i.graph(
+    {
+      users: i.entity({}),
+      user_prefs: i.entity({}),
+    },
+    {
+      user_user_prefs: {
+        forward: {
+          on: "users",
+          has: "one",
+          label: "user_pref",
+        },
+        reverse: {
+          on: "user_prefs",
+          has: "one",
+          label: "user",
+        },
+      },
+    },
+  );
+  const uid = uuid();
+  const ops = [
+    instatx.tx.users[uid]
+      .update({})
+      .link({ user_pref: instatx.lookup("user.id", uid) }),
+  ];
+
+  const lookup = [
+    // The attr is going to be created, so we don't know its value yet
+    expect.any(String),
+    uid,
+  ];
+
+  const result = instaml.transform2({ attrs: {}, schema }, ops);
+
+  const expected = [
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "user_pref"],
+        "reverse-identity": [expect.any(String), "user_prefs", "user"],
+        "value-type": "ref",
+        cardinality: "one",
+        "unique?": true,
+        "index?": true,
+        isUnsynced: true,
+      },
+    ],
+    [
+      "add-attr",
+      {
+        id: expect.any(String),
+        "forward-identity": [expect.any(String), "users", "id"],
+        "value-type": "blob",
+        cardinality: "one",
+        "unique?": true,
+        "index?": false,
+        isUnsynced: true,
+      },
+    ],
+    ["add-triple", uid, expect.any(String), uid],
+    ["add-triple", uid, expect.any(String), lookup],
+  ];
+
+  expect(result).toHaveLength(expected.length);
   for (const item of expected) {
     expect(result).toContainEqual(item);
   }

--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -14,7 +14,7 @@ test("simple update transform", () => {
   const testId = uuid();
 
   const ops = instatx.tx.books[testId].update({ title: "New Title" });
-  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     ["add-triple", testId, zenecaAttrToId["books/title"], "New Title"],
@@ -34,7 +34,7 @@ test("ignores id attrs", () => {
     title: "New Title",
     id: "ploop",
   });
-  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     ["add-triple", testId, zenecaAttrToId["books/title"], "New Title"],
@@ -51,7 +51,7 @@ test("optimistically adds attrs if they don't exist", () => {
 
   const ops = instatx.tx.books[testId].update({ newAttr: "New Title" });
 
-  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     [
@@ -85,7 +85,7 @@ test("lookup resolves attr ids", () => {
 
   const stopaLookup = [zenecaAttrToId["users/email"], "stopa@instantdb.com"];
 
-  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
 
   const expected = [
     ["add-triple", stopaLookup, zenecaAttrToId["users/handle"], "stopa"],
@@ -111,7 +111,7 @@ test("lookup creates unique attrs for custom lookups", () => {
     "newAttrValue",
   ];
 
-  const result = instaml.transform2({ attrs: zenecaAttrs }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
   const expected = [
     [
       "add-attr",
@@ -141,7 +141,7 @@ test("lookup creates unique attrs for lookups in link values", () => {
     .update({})
     .link({ posts: instatx.lookup("slug", "life-is-good") });
 
-  const result = instaml.transform2({ attrs: {} }, ops);
+  const result = instaml.transform({ attrs: {} }, ops);
 
   expect(result).toEqual([
     [
@@ -200,7 +200,7 @@ test("lookup creates unique attrs for lookups in link values with arrays", () =>
     ],
   });
 
-  const result = instaml.transform2({ attrs: {} }, ops);
+  const result = instaml.transform({ attrs: {} }, ops);
 
   const expected = [
     [
@@ -278,7 +278,7 @@ test("lookup creates unique attrs for lookups in link values when fwd-ident exis
     "index?": true,
   };
 
-  const result = instaml.transform2(
+  const result = instaml.transform(
     { attrs: { [attrId]: existingRefAttr } },
     ops,
   );
@@ -335,7 +335,7 @@ test("lookup creates unique attrs for lookups in link values when rev-ident exis
     "index?": true,
   };
 
-  const result = instaml.transform2(
+  const result = instaml.transform(
     { attrs: { [attrId]: existingRefAttr } },
     ops,
   );
@@ -413,7 +413,7 @@ test("lookup doesn't override attrs for lookups in link values", () => {
     },
   };
 
-  const result = instaml.transform2({ attrs }, ops);
+  const result = instaml.transform({ attrs }, ops);
 
   expect(result).toEqual([
     ["add-triple", uid, userIdAttrId, uid],
@@ -458,7 +458,7 @@ test("lookup doesn't override attrs for lookups in self links", () => {
     .update({})
     .link({ parent: instatx.lookup("slug", "life-is-good") });
 
-  const result1 = instaml.transform2({ attrs }, ops1);
+  const result1 = instaml.transform({ attrs }, ops1);
 
   expect(result1.filter((x) => x[0] !== "add-triple")).toEqual([]);
 
@@ -466,7 +466,7 @@ test("lookup doesn't override attrs for lookups in self links", () => {
     .update({})
     .link({ child: instatx.lookup("slug", "life-is-good") });
 
-  const result2 = instaml.transform2({ attrs }, ops2);
+  const result2 = instaml.transform({ attrs }, ops2);
 
   expect(result2.filter((x) => x[0] !== "add-triple")).toEqual([]);
 });
@@ -484,7 +484,7 @@ test("lookup creates unique ref attrs for ref lookup", () => {
     uid,
   ];
 
-  const result = instaml.transform2({ attrs: {} }, ops);
+  const result = instaml.transform({ attrs: {} }, ops);
   const expected = [
     [
       "add-attr",
@@ -547,7 +547,7 @@ test("lookup creates unique ref attrs for ref lookup in link value", () => {
     uid,
   ];
 
-  const result = instaml.transform2({ attrs: {} }, ops);
+  const result = instaml.transform({ attrs: {} }, ops);
 
   const expected = [
     [
@@ -587,7 +587,7 @@ test("lookup creates unique ref attrs for ref lookup in link value", () => {
 
 test("it throws if you use an invalid link attr", () => {
   expect(() =>
-    instaml.transform2(
+    instaml.transform(
       { attrs: {} },
       instatx.tx.users[
         instatx.lookup("user_pref.email", "test@example.com")
@@ -630,7 +630,7 @@ test("it doesn't throw if you have a period in your attr", () => {
   };
 
   expect(
-    instaml.transform2(
+    instaml.transform(
       { attrs },
       instatx.tx.users[instatx.lookup("attr.with.dot", "value")].update({
         a: 1,
@@ -650,7 +650,7 @@ test("it doesn't create duplicate ref attrs", () => {
     instatx.tx.nsB[bid].update({}).link({ nsA: aid }),
   ];
 
-  const result = instaml.transform2({ attrs: {} }, ops);
+  const result = instaml.transform({ attrs: {} }, ops);
 
   const expected = [
     [
@@ -736,7 +736,7 @@ test("Schema: uses info in `attrs` and `links`", () => {
       book: bookId,
     });
 
-  const result = instaml.transform2(
+  const result = instaml.transform(
     {
       attrs: zenecaAttrs,
       schema: schema,
@@ -821,7 +821,7 @@ test("Schema: doesn't create duplicate ref attrs", () => {
     instatx.tx.books[bookId].update({}).link({ comments: commentId }),
   ];
 
-  const result = instaml.transform2({ attrs: zenecaAttrs, schema }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs, schema }, ops);
 
   const expected = [
     [
@@ -882,7 +882,7 @@ test("Schema: lookup creates unique attrs for custom lookups", () => {
     "stopanator",
   ];
 
-  const result = instaml.transform2({ attrs: zenecaAttrs, schema }, ops);
+  const result = instaml.transform({ attrs: zenecaAttrs, schema }, ops);
   const expected = [
     [
       "add-attr",
@@ -935,7 +935,7 @@ test("Schema: lookup creates unique attrs for lookups in link values", () => {
     .update({})
     .link({ authoredPosts: instatx.lookup("slug", "life-is-good") });
 
-  const result = instaml.transform2({ attrs: {}, schema }, ops);
+  const result = instaml.transform({ attrs: {}, schema }, ops);
 
   expect(result).toEqual([
     [
@@ -1018,7 +1018,7 @@ test("Schema: lookup creates unique attrs for lookups in link values with arrays
     ],
   });
 
-  const result = instaml.transform2({ attrs: {}, schema }, ops);
+  const result = instaml.transform({ attrs: {}, schema }, ops);
 
   const expected = [
     [
@@ -1113,7 +1113,7 @@ test("Schema: lookup creates unique ref attrs for ref lookup", () => {
     uid,
   ];
 
-  const result = instaml.transform2({ attrs: {}, schema }, ops);
+  const result = instaml.transform({ attrs: {}, schema }, ops);
   const expected = [
     [
       "add-attr",
@@ -1196,7 +1196,7 @@ test("Schema: lookup creates unique ref attrs for ref lookup in link value", () 
     uid,
   ];
 
-  const result = instaml.transform2({ attrs: {}, schema }, ops);
+  const result = instaml.transform({ attrs: {}, schema }, ops);
 
   const expected = [
     [

--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -477,7 +477,7 @@ test("objects are created by etype", () => {
   const chunk = tx.user[stopa.id].update({
     email: "this-should-not-change-users-stopa@gmail.com",
   });
-  const txSteps = instaml.transform(store.attrs, chunk);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   const newStopa = query(
     { store: newStore },
@@ -504,7 +504,7 @@ test("object values", () => {
     jsonField: { hello: "world" },
     otherJsonField: { world: "hello" },
   });
-  const txSteps = instaml.transform(store.attrs, chunk);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   const newStopa = query(
     { store: newStore },
@@ -668,7 +668,7 @@ test("$isNull", () => {
     tx.books[randomUUID()].update({ title: null }),
     tx.books[randomUUID()].update({ pageCount: 20 }),
   ];
-  const txSteps = instaml.transform(store.attrs, chunks);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunks);
   const newStore = transact(store, txSteps);
   expect(query({ store: newStore }, q).data.books.map((x) => x.title)).toEqual([
     null,
@@ -680,7 +680,7 @@ test("$isNull with relations", () => {
   const q = { users: { $: { where: { bookshelves: { $isNull: true } } } } };
   expect(query({ store }, q).data.users.length).toEqual(0);
   const chunks = [tx.users[randomUUID()].update({ handle: "dww" })];
-  const txSteps = instaml.transform(store.attrs, chunks);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunks);
   const newStore = transact(store, txSteps);
   expect(query({ store: newStore }, q).data.users.map((x) => x.handle)).toEqual(
     ["dww"],
@@ -704,7 +704,7 @@ test("$isNull with relations", () => {
 
   const storeWithNullTitle = transact(
     newStore,
-    instaml.transform(newStore.attrs, [
+    instaml.transform2({ attrs: newStore.attrs }, [
       tx.books[bookId].update({ title: null }),
     ]),
   );
@@ -733,7 +733,7 @@ test("$not", () => {
     tx.tests[randomUUID()].update({ val: null }),
     tx.tests[randomUUID()].update({ undefinedVal: "d" }),
   ];
-  const txSteps = instaml.transform(store.attrs, chunks);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunks);
   const newStore = transact(store, txSteps);
   expect(query({ store: newStore }, q).data.tests.map((x) => x.val)).toEqual([
     "b",

--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -477,7 +477,7 @@ test("objects are created by etype", () => {
   const chunk = tx.user[stopa.id].update({
     email: "this-should-not-change-users-stopa@gmail.com",
   });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   const newStopa = query(
     { store: newStore },
@@ -504,7 +504,7 @@ test("object values", () => {
     jsonField: { hello: "world" },
     otherJsonField: { world: "hello" },
   });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   const newStopa = query(
     { store: newStore },
@@ -668,7 +668,7 @@ test("$isNull", () => {
     tx.books[randomUUID()].update({ title: null }),
     tx.books[randomUUID()].update({ pageCount: 20 }),
   ];
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunks);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunks);
   const newStore = transact(store, txSteps);
   expect(query({ store: newStore }, q).data.books.map((x) => x.title)).toEqual([
     null,
@@ -680,7 +680,7 @@ test("$isNull with relations", () => {
   const q = { users: { $: { where: { bookshelves: { $isNull: true } } } } };
   expect(query({ store }, q).data.users.length).toEqual(0);
   const chunks = [tx.users[randomUUID()].update({ handle: "dww" })];
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunks);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunks);
   const newStore = transact(store, txSteps);
   expect(query({ store: newStore }, q).data.users.map((x) => x.handle)).toEqual(
     ["dww"],
@@ -704,7 +704,7 @@ test("$isNull with relations", () => {
 
   const storeWithNullTitle = transact(
     newStore,
-    instaml.transform2({ attrs: newStore.attrs }, [
+    instaml.transform({ attrs: newStore.attrs }, [
       tx.books[bookId].update({ title: null }),
     ]),
   );
@@ -733,7 +733,7 @@ test("$not", () => {
     tx.tests[randomUUID()].update({ val: null }),
     tx.tests[randomUUID()].update({ undefinedVal: "d" }),
   ];
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunks);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunks);
   const newStore = transact(store, txSteps);
   expect(query({ store: newStore }, q).data.tests.map((x) => x.val)).toEqual([
     "b",

--- a/client/packages/core/__tests__/src/store.test.js
+++ b/client/packages/core/__tests__/src/store.test.js
@@ -1,7 +1,13 @@
 import { test, expect } from "vitest";
 import zenecaAttrs from "./data/zeneca/attrs.json";
 import zenecaTriples from "./data/zeneca/triples.json";
-import { createStore, transact, allMapValues, toJSON, fromJSON } from "../../src/store";
+import {
+  createStore,
+  transact,
+  allMapValues,
+  toJSON,
+  fromJSON,
+} from "../../src/store";
 import query from "../../src/instaql";
 import uuid from "../../src/utils/uuid";
 import { tx } from "../../src/instatx";
@@ -60,7 +66,7 @@ function checkIndexIntegrity(store) {
 test("simple add", () => {
   const id = uuid();
   const chunk = tx.users[id].update({ handle: "bobby" });
-  const txSteps = instaml.transform(store.attrs, chunk);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   expect(
     query({ store: newStore }, { users: {} }).data.users.map((x) => x.handle),
@@ -74,7 +80,7 @@ test("cardinality-one add", () => {
   const chunk = tx.users[id]
     .update({ handle: "bobby" })
     .update({ handle: "bob" });
-  const txSteps = instaml.transform(store.attrs, chunk);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   const ret = datalog
     .query(newStore, {
@@ -96,7 +102,10 @@ test("link/unlink", () => {
   const bookshelfChunk = tx.bookshelves[bookshelfId].update({
     name: "my books",
   });
-  const txSteps = instaml.transform(store.attrs, [userChunk, bookshelfChunk]);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+    userChunk,
+    bookshelfChunk,
+  ]);
   const newStore = transact(store, txSteps);
   expect(
     query(
@@ -120,7 +129,7 @@ test("link/unlink", () => {
       bookshelves: bookshelfId,
     })
     .link({ bookshelves: secondBookshelfId });
-  const secondTxSteps = instaml.transform(newStore.attrs, [
+  const secondTxSteps = instaml.transform2({ attrs: newStore.attrs }, [
     unlinkFirstChunk,
     secondBookshelfChunk,
   ]);
@@ -153,7 +162,7 @@ test("link/unlink multi", () => {
   const bookshelf2Chunk = tx.bookshelves[bookshelfId2].update({
     name: "my books 2",
   });
-  const txSteps = instaml.transform(store.attrs, [
+  const txSteps = instaml.transform2({ attrs: store.attrs }, [
     userChunk,
     bookshelf1Chunk,
     bookshelf2Chunk,
@@ -182,7 +191,7 @@ test("link/unlink multi", () => {
       bookshelves: [bookshelfId1, bookshelfId2],
     })
     .link({ bookshelves: bookshelfId3 });
-  const secondTxSteps = instaml.transform(newStore.attrs, [
+  const secondTxSteps = instaml.transform2({ attrs: newStore.attrs }, [
     unlinkChunk,
     bookshelf3Chunk,
   ]);
@@ -210,7 +219,10 @@ test("delete entity", () => {
   const bookshelfChunk = tx.bookshelves[bookshelfId].update({
     name: "my books",
   });
-  const txSteps = instaml.transform(store.attrs, [userChunk, bookshelfChunk]);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+    userChunk,
+    bookshelfChunk,
+  ]);
   const newStore = transact(store, txSteps);
   checkIndexIntegrity(newStore);
 
@@ -229,8 +241,8 @@ test("delete entity", () => {
   expect(retOne).contains("my books");
   expect(retTwo).contains(userId);
 
-  const txStepsTwo = instaml.transform(
-    newStore.attrs,
+  const txStepsTwo = instaml.transform2(
+    { attrs: newStore.attrs },
     tx.bookshelves[bookshelfId].delete(),
   );
   const newStoreTwo = transact(newStore, txStepsTwo);
@@ -259,7 +271,10 @@ test("new attrs", () => {
     .update({ handle: "bobby" })
     .link({ colors: colorId });
   const colorChunk = tx.colors[colorId].update({ name: "red" });
-  const txSteps = instaml.transform(store.attrs, [userChunk, colorChunk]);
+  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+    userChunk,
+    colorChunk,
+  ]);
   const newStore = transact(store, txSteps);
   expect(
     query(

--- a/client/packages/core/__tests__/src/store.test.js
+++ b/client/packages/core/__tests__/src/store.test.js
@@ -66,7 +66,7 @@ function checkIndexIntegrity(store) {
 test("simple add", () => {
   const id = uuid();
   const chunk = tx.users[id].update({ handle: "bobby" });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   expect(
     query({ store: newStore }, { users: {} }).data.users.map((x) => x.handle),
@@ -80,7 +80,7 @@ test("cardinality-one add", () => {
   const chunk = tx.users[id]
     .update({ handle: "bobby" })
     .update({ handle: "bob" });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, chunk);
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunk);
   const newStore = transact(store, txSteps);
   const ret = datalog
     .query(newStore, {
@@ -102,7 +102,7 @@ test("link/unlink", () => {
   const bookshelfChunk = tx.bookshelves[bookshelfId].update({
     name: "my books",
   });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+  const txSteps = instaml.transform({ attrs: store.attrs }, [
     userChunk,
     bookshelfChunk,
   ]);
@@ -129,7 +129,7 @@ test("link/unlink", () => {
       bookshelves: bookshelfId,
     })
     .link({ bookshelves: secondBookshelfId });
-  const secondTxSteps = instaml.transform2({ attrs: newStore.attrs }, [
+  const secondTxSteps = instaml.transform({ attrs: newStore.attrs }, [
     unlinkFirstChunk,
     secondBookshelfChunk,
   ]);
@@ -162,7 +162,7 @@ test("link/unlink multi", () => {
   const bookshelf2Chunk = tx.bookshelves[bookshelfId2].update({
     name: "my books 2",
   });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+  const txSteps = instaml.transform({ attrs: store.attrs }, [
     userChunk,
     bookshelf1Chunk,
     bookshelf2Chunk,
@@ -191,7 +191,7 @@ test("link/unlink multi", () => {
       bookshelves: [bookshelfId1, bookshelfId2],
     })
     .link({ bookshelves: bookshelfId3 });
-  const secondTxSteps = instaml.transform2({ attrs: newStore.attrs }, [
+  const secondTxSteps = instaml.transform({ attrs: newStore.attrs }, [
     unlinkChunk,
     bookshelf3Chunk,
   ]);
@@ -219,7 +219,7 @@ test("delete entity", () => {
   const bookshelfChunk = tx.bookshelves[bookshelfId].update({
     name: "my books",
   });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+  const txSteps = instaml.transform({ attrs: store.attrs }, [
     userChunk,
     bookshelfChunk,
   ]);
@@ -241,7 +241,7 @@ test("delete entity", () => {
   expect(retOne).contains("my books");
   expect(retTwo).contains(userId);
 
-  const txStepsTwo = instaml.transform2(
+  const txStepsTwo = instaml.transform(
     { attrs: newStore.attrs },
     tx.bookshelves[bookshelfId].delete(),
   );
@@ -271,7 +271,7 @@ test("new attrs", () => {
     .update({ handle: "bobby" })
     .link({ colors: colorId });
   const colorChunk = tx.colors[colorId].update({ name: "red" });
-  const txSteps = instaml.transform2({ attrs: store.attrs }, [
+  const txSteps = instaml.transform({ attrs: store.attrs }, [
     userChunk,
     colorChunk,
   ]);

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -899,7 +899,7 @@ export default class Reactor {
   /** Applies transactions locally and sends transact message to server */
   pushTx = (chunks) => {
     try {
-      const txSteps = instaml.transform(
+      const txSteps = instaml.transform2(
         { attrs: this.optimisticAttrs() },
         chunks,
       );

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -899,7 +899,7 @@ export default class Reactor {
   /** Applies transactions locally and sends transact message to server */
   pushTx = (chunks) => {
     try {
-      const txSteps = instaml.transform2(
+      const txSteps = instaml.transform(
         { attrs: this.optimisticAttrs() },
         chunks,
       );

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -900,7 +900,7 @@ export default class Reactor {
   pushTx = (chunks) => {
     try {
       const txSteps = instaml.transform(
-        { attrs: this.optimisticAttrs() },
+        { attrs: this.optimisticAttrs(), schema: this.config.schema },
         chunks,
       );
       return this.pushOps(txSteps);

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -899,7 +899,10 @@ export default class Reactor {
   /** Applies transactions locally and sends transact message to server */
   pushTx = (chunks) => {
     try {
-      const txSteps = instaml.transform(this.optimisticAttrs(), chunks);
+      const txSteps = instaml.transform(
+        { attrs: this.optimisticAttrs() },
+        chunks,
+      );
       return this.pushOps(txSteps);
     } catch (e) {
       return this.pushOps([], e);

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -240,7 +240,7 @@ function toTxSteps(attrs, step) {
 
 function objectPropsFromSchema(schema, etype, label) {
   const attr = schema.entities[etype]?.attrs?.[label];
-  if (label === "id") return {};
+  if (label === "id") return null;
   if (!attr) {
     throw new Error(`${etype}.${label} does not exist in your schema`);
   }
@@ -254,7 +254,7 @@ function objectPropsFromSchema(schema, etype, label) {
 function createObjectAttr(schema, etype, label, props) {
   const schemaObjectProps = schema
     ? objectPropsFromSchema(schema, etype, label)
-    : {};
+    : null;
   const attrId = uuid();
   const fwdIdentId = uuid();
   const fwdIdent = [fwdIdentId, etype, label];
@@ -266,7 +266,7 @@ function createObjectAttr(schema, etype, label, props) {
     "unique?": false,
     "index?": false,
     isUnsynced: true,
-    ...schemaObjectProps,
+    ...(schemaObjectProps || {}),
     ...(props || {}),
   };
 }
@@ -296,7 +296,9 @@ function refPropsFromSchema(schema, etype, label) {
 }
 
 function createRefAttr(schema, etype, label, props) {
-  const schemaRefProps = schema ? refPropsFromSchema(schema, etype, label) : {};
+  const schemaRefProps = schema
+    ? refPropsFromSchema(schema, etype, label)
+    : null;
   const attrId = uuid();
   const fwdIdent = [uuid(), etype, label];
   const revIdent = [uuid(), label, etype];
@@ -309,7 +311,7 @@ function createRefAttr(schema, etype, label, props) {
     "unique?": false,
     "index?": false,
     isUnsynced: true,
-    ...schemaRefProps,
+    ...(schemaRefProps || {}),
     ...(props || {}),
   };
 }
@@ -388,7 +390,7 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
   // before we get to it
   for (const op of ops) {
     for (const { etype, lookupPair, linkLabel } of lookupPairsOfOp(op)) {
-      debugger
+      debugger;
       const identName = lookupPair[0];
       // We got a link eid that's a lookup, linkLabel is the label of the ident,
       // e.g. `posts` in `link({posts: postIds})`
@@ -411,7 +413,9 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
         } else {
           const attr = getAttrByFwdIdentName(attrs, linkEtype, identName);
           if (!attr) {
-            addAttr(createObjectAttr(schema, linkEtype, identName, lookupProps));
+            addAttr(
+              createObjectAttr(schema, linkEtype, identName, lookupProps),
+            );
           }
           addUnsynced(attr);
         }

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -388,6 +388,7 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
   // before we get to it
   for (const op of ops) {
     for (const { etype, lookupPair, linkLabel } of lookupPairsOfOp(op)) {
+      debugger
       const identName = lookupPair[0];
       // We got a link eid that's a lookup, linkLabel is the label of the ident,
       // e.g. `posts` in `link({posts: postIds})`

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -461,7 +461,7 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
   return [attrs, addOps];
 }
 
-export function transform2(ctx, inputChunks) {
+export function transform(ctx, inputChunks) {
   const chunks = Array.isArray(inputChunks) ? inputChunks : [inputChunks];
   const ops = chunks.flatMap((tx) => getOps(tx));
   const [newAttrs, addAttrTxSteps] = createMissingAttrs(ctx, ops);

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -461,14 +461,6 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
   return [attrs, addOps];
 }
 
-export function transform(attrs, inputChunks) {
-  const chunks = Array.isArray(inputChunks) ? inputChunks : [inputChunks];
-  const ops = chunks.flatMap((tx) => getOps(tx));
-  const [newAttrs, addAttrTxSteps] = createMissingAttrs({ attrs }, ops);
-  const txSteps = ops.flatMap((op) => toTxSteps(newAttrs, op));
-  return [...addAttrTxSteps, ...txSteps];
-}
-
 export function transform2(ctx, inputChunks) {
   const chunks = Array.isArray(inputChunks) ? inputChunks : [inputChunks];
   const ops = chunks.flatMap((tx) => getOps(tx));

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -390,7 +390,6 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
   // before we get to it
   for (const op of ops) {
     for (const { etype, lookupPair, linkLabel } of lookupPairsOfOp(op)) {
-      debugger;
       const identName = lookupPair[0];
       // We got a link eid that's a lookup, linkLabel is the label of the ident,
       // e.g. `posts` in `link({posts: postIds})`

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -251,7 +251,7 @@ function objectPropsFromSchema(schema, etype, label) {
   };
 }
 
-function createObjectAttr2(schema, etype, label, props) {
+function createObjectAttr(schema, etype, label, props) {
   const schemaObjectProps = schema
     ? objectPropsFromSchema(schema, etype, label)
     : {};
@@ -410,7 +410,7 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
         } else {
           const attr = getAttrByFwdIdentName(attrs, linkEtype, identName);
           if (!attr) {
-            addAttr(createObjectAttr2(schema, linkEtype, identName, lookupProps));
+            addAttr(createObjectAttr(schema, linkEtype, identName, lookupProps));
           }
           addUnsynced(attr);
         }
@@ -419,7 +419,7 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
       } else {
         const attr = getAttrByFwdIdentName(attrs, etype, identName);
         if (!attr) {
-          addAttr(createObjectAttr2(schema, etype, identName, lookupProps));
+          addAttr(createObjectAttr(schema, etype, identName, lookupProps));
         }
         addUnsynced(attr);
       }
@@ -438,7 +438,7 @@ function createMissingAttrs({ attrs: existingAttrs, schema }, ops) {
         if (UPDATE_ACTIONS.has(action)) {
           if (!fwdAttr) {
             addAttr(
-              createObjectAttr2(
+              createObjectAttr(
                 schema,
                 etype,
                 label,

--- a/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
+++ b/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from "react";
+import config from "../../config";
+import { init, init_experimental, tx, id, i } from "@instantdb/react";
+import { useRouter } from "next/router";
+
+const schema = i.graph(
+  {
+    comments: i.entity({
+      slug: i.string().unique().indexed(),
+    }),
+    $users: i.entity({
+      email: i.string().unique().indexed(),
+    }),
+  },
+  {
+    commentAuthors: {
+      forward: {
+        on: "comments",
+        has: "one",
+        label: "author",
+      },
+      reverse: {
+        on: "$users",
+        has: "many",
+        label: "authoredComments",
+      },
+    },
+  },
+);
+
+function Example({ appId, useSchema }: { appId: string; useSchema: boolean }) {
+  const myConfig = { ...config, appId };
+  const db = useSchema
+    ? init_experimental({ ...myConfig, schema })
+    : (init(myConfig) as any);
+  const q = db.useQuery({ comments: {} });
+  const [attrs, setAttrs] = useState<any>();
+  useEffect(() => {
+    const unsub = db._core._reactor.subscribeAttrs((res: any) => {
+      setAttrs(res);
+    });
+    return unsub;
+  });
+
+  return (
+    <div>
+      <div>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() =>
+            db.transact(
+              tx.comments[id()].update({ slug: "oi" }).link({ author: id() }),
+            )
+          }
+        >
+          Create comment
+        </button>
+      </div>
+      <div className="p-2"></div>
+      <div>
+        <div className="bold">Using Schema? = {JSON.stringify(useSchema)}</div>
+        <div>Attrs:</div>
+        <pre>
+          {JSON.stringify(
+            Object.values(attrs || {}).filter(
+              (x: any) => x.catalog !== "system",
+            ),
+            null,
+            2,
+          )}
+          {JSON.stringify(q, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+async function provisionEphemeralApp() {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: "Pagination example",
+      // Uncomment and start a new app to test rules
+      /* rules: {
+        code: {
+          goals: {
+            allow: {
+              // data.number % 2 == 0 gives me a typecasting error
+              // so does int(data.number) % 2 == 0
+              view: "data.number == 2 || data.number == 4 || data.number == 6 || data.number == 8 || data.number == 10",
+            },
+          },
+        },
+      }, */
+    }),
+  });
+
+  return r.json();
+}
+
+async function verifyEphemeralApp({ appId }: { appId: string }) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  return r.json();
+}
+
+function App({
+  urlAppId,
+  useSchema,
+}: {
+  urlAppId: string | undefined;
+  useSchema: boolean;
+}) {
+  const router = useRouter();
+  const [appId, setAppId] = useState();
+
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (appId) {
+      return;
+    }
+    if (urlAppId) {
+      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
+        if (res.app) {
+          setAppId(res.app.id);
+        } else {
+          provisionEphemeralApp().then((res) => {
+            if (res.app) {
+              router.replace({
+                pathname: router.pathname,
+                query: { ...router.query, app: res.app.id },
+              });
+
+              setAppId(res.app.id);
+            } else {
+              console.log(res);
+              setError("Could not create app.");
+            }
+          });
+        }
+      });
+    } else {
+      provisionEphemeralApp().then((res) => {
+        if (res.app) {
+          router.replace({
+            pathname: router.pathname,
+            query: { ...router.query, app: res.app.id },
+          });
+
+          setAppId(res.app.id);
+        } else {
+          console.log(res);
+          setError("Could not create app.");
+        }
+      });
+    }
+  }, []);
+
+  if (error) {
+    return (
+      <div>
+        <p>There was an error</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!appId) {
+    return <div>Loading...</div>;
+  }
+
+  return <Example appId={appId} useSchema={useSchema} />;
+}
+
+function Page() {
+  const router = useRouter();
+  if (router.isReady) {
+    return (
+      <App
+        urlAppId={router.query.app as string}
+        useSchema={router.query.schema === "true"}
+      />
+    );
+  } else {
+    return <div>Loading...</div>;
+  }
+}
+
+export default Page;

--- a/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
+++ b/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
@@ -55,6 +55,14 @@ function Example({ appId, useSchema }: { appId: string; useSchema: boolean }) {
         >
           Create comment
         </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() =>
+            db.transact(tx.profiles[id()].update({ name: "stonado" }))
+          }
+        >
+          Create something that isnt' in schema
+        </button>
       </div>
       <div className="p-2"></div>
       <div>


### PR DESCRIPTION
Previously, if a user creates an object that didn't exist before, we would make our best guess and create the object for them. 

This was useful, but would sometimes create surprising results if you used non-standard links. For example, for `posts.owner`, our guess would assume that `owner` was the namespace. 

Now that we pass in a schema in strong init, we can use the schema to help user create missing attrs. 

For missing object attrs:
1. We use the `schema` to decide if they need to be indexed or unique 

For missing ref attrs: 
1. We use the schema to set the forward identity, reverse identity, cardinality, indexed, unique 

If a missing attr is _not_ in the schema:

This is likely a mistake, and we throw a validation error

@dwwoelfel @nezaj 