### PR TITLE
[cli] Hoist up `noAppIdErrorMessage`

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -23,6 +23,13 @@ const verbose = Boolean(process.env.INSTANT_CLI_VERBOSE);
 
 // consts
 
+const noAppIdErrorMessage = `
+No app ID found.
+Add \`INSTANT_APP_ID=<ID>\` to your .env file.
+(Or \`NEXT_PUBLIC_INSTANT_APP_ID\`, \`VITE_INSTANT_APP_ID\`)
+Or provide an app ID via the CLI \`instant-cli pull-schema <ID>\`.
+`.trim();
+
 const instantDashOrigin = dev
   ? "http://localhost:3000"
   : "https://instantdb.com";
@@ -1084,7 +1091,6 @@ async function getAppIdWithErrorLogging(defaultAppIdOrName) {
       uuidAppId
     );
   }
-
   const appId =
     // finally, check .env
     process.env.INSTANT_APP_ID ||
@@ -1264,10 +1270,3 @@ ${indentLines(JSON.stringify(linksEntriesCode, null, "  "), 1)}
 export default graph;
 `;
 }
-
-const noAppIdErrorMessage = `
-No app ID found.
-Add \`INSTANT_APP_ID=<ID>\` to your .env file.
-(Or \`NEXT_PUBLIC_INSTANT_APP_ID\`, \`VITE_INSTANT_APP_ID\`)
-Or provide an app ID via the CLI \`instant-cli pull-schema <ID>\`.
-`.trim();


### PR DESCRIPTION
See: https://github.com/instantdb/instant/issues/496

when instant couldn't find the app id, we would not actually show the error message. Instead, we'd throw a js error: 

```bash
file:///Users/stopa/projects/instant/client/packages/cli/index.js:1106
      noAppIdErrorMessage
      ^

ReferenceError: Cannot access 'noAppIdErrorMessage' before initialization
    at getAppIdWithErrorLogging (file:///Users/stopa/projects/instant/client/packages/cli/index.js:1106:7)
    at pushSchema (file:///Users/stopa/projects/instant/client/packages/cli/index.js:584:23)
    at Command.<anonymous> (file:///Users/stopa/projects/instant/client/packages/cli/index.js:72:5)
```

Hoisting it up so we actually show the error 

@dwwoelfel @nezaj 