### PR TITLE
[cli] support global options

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -166,6 +166,11 @@ function globalOption(flags, description, argParser) {
     opt.argParser(argParser);
   }
   // @ts-ignore
+  // __global does not exist on `Option`, 
+  // but we use it in `getLocalAndGlobalOptions`, to produce 
+  // our own custom list of local and global options.
+  // For more info, see the original PR:
+  // https://github.com/instantdb/instant/pull/505
   opt.__global = true;
   return opt;
 }

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -6,7 +6,7 @@ import { join } from "path";
 import { randomUUID } from "crypto";
 import dotenv from "dotenv";
 import chalk from "chalk";
-import { program } from "commander";
+import { program, Option } from "commander";
 import { input, confirm } from "@inquirer/prompts";
 import envPaths from "env-paths";
 import { loadConfig } from "unconfig";
@@ -48,7 +48,8 @@ const headerChalk = `${logoChalk} ${versionChalk} ` + "\n";
 // Help Footer -- this only shows up in help commands
 const helpFooterChalk =
   "\n" +
-  "Want to learn more?" + "\n" +
+  "Want to learn more?" +
+  "\n" +
   `Check out the docs: ${chalk.blueBright.underline("https://instantdb.com/docs")}
 Join the Discord:   ${chalk.blueBright.underline("https://discord.com/invite/VU53p7uQcE")}
 `.trim();
@@ -57,14 +58,129 @@ program.addHelpText("after", helpFooterChalk);
 
 program.addHelpText("beforeAll", headerChalk);
 
+
+function getLocalAndGlobalOptions(cmd, helper) {
+  const mixOfLocalAndGlobal = helper.visibleOptions(cmd);
+  const localOptionsFromMix = mixOfLocalAndGlobal.filter(
+    (option) => !option.__global,
+  );
+  const globalOptionsFromMix = mixOfLocalAndGlobal.filter(
+    (option) => option.__global,
+  );
+  const globalOptions = helper.visibleGlobalOptions(cmd);
+
+  return [localOptionsFromMix, globalOptionsFromMix.concat(globalOptions)];
+}
+
+// custom `formatHelp`
+// original: https://github.com/tj/commander.js/blob/master/lib/help.js
+function formatHelp(cmd, helper) {
+  const termWidth = helper.padWidth(cmd, helper);
+  const helpWidth = helper.helpWidth || 80;
+  const itemIndentWidth = 2;
+  const itemSeparatorWidth = 2; // between term and description
+  function formatItem(term, description) {
+    if (description) {
+      const fullText = `${term.padEnd(termWidth + itemSeparatorWidth)}${description}`;
+      return helper.wrap(
+        fullText,
+        helpWidth - itemIndentWidth,
+        termWidth + itemSeparatorWidth,
+      );
+    }
+    return term;
+  }
+  function formatList(textArray) {
+    return textArray.join("\n").replace(/^/gm, " ".repeat(itemIndentWidth));
+  }
+
+  // Usage
+  let output = [`Usage: ${helper.commandUsage(cmd)}`, ""];
+
+  // Description
+  const commandDescription = helper.commandDescription(cmd);
+  if (commandDescription.length > 0) {
+    output = output.concat([helper.wrap(commandDescription, helpWidth, 0), ""]);
+  }
+
+  // Arguments
+  const argumentList = helper.visibleArguments(cmd).map((argument) => {
+    return formatItem(
+      helper.argumentTerm(argument),
+      helper.argumentDescription(argument),
+    );
+  });
+  if (argumentList.length > 0) {
+    output = output.concat(["Arguments:", formatList(argumentList), ""]);
+  }
+  const [visibleOptions, visibleGlobalOptions] = getLocalAndGlobalOptions(cmd, helper);
+
+  // Options
+  const optionList = visibleOptions.map((option) => {
+    return formatItem(
+      helper.optionTerm(option),
+      helper.optionDescription(option),
+    );
+  });
+  if (optionList.length > 0) {
+    output = output.concat(["Options:", formatList(optionList), ""]);
+  }
+  // Commands
+  const commandList = helper.visibleCommands(cmd).map((cmd) => {
+    return formatItem(
+      helper.subcommandTerm(cmd),
+      helper.subcommandDescription(cmd),
+    );
+  });
+  if (commandList.length > 0) {
+    output = output.concat(["Commands:", formatList(commandList), ""]);
+  }
+
+  if (this.showGlobalOptions) {
+    const globalOptionList = visibleGlobalOptions.map((option) => {
+      return formatItem(
+        helper.optionTerm(option),
+        helper.optionDescription(option),
+      );
+    });
+    if (globalOptionList.length > 0) {
+      output = output.concat([
+        "Global Options:",
+        formatList(globalOptionList),
+        "",
+      ]);
+    }
+  }
+
+  return output.join("\n");
+}
+
+program.configureHelp({
+  showGlobalOptions: true,
+  formatHelp,
+});
+
+function globalOption(flags, description, argParser) {
+  const opt = new Option(flags, description);
+  if (argParser) {
+    opt.argParser(argParser);
+  }
+  // @ts-ignore
+  opt.__global = true;
+  return opt;
+}
+
 program
   .name("instant-cli")
-  .option("-t --token <TOKEN>", "auth token override")
-  .option("-y", "skip confirmation prompt")
-  .option("-v --version", "output the version number", () => {
-    console.log(version);
-    process.exit(0);
-  })
+  .addOption(globalOption("-t --token <TOKEN>", "Auth token override"))
+  .addOption(globalOption("-y --yes", "Answer 'yes' to all prompts"))
+  .addOption(
+    globalOption("-v --version", "Print the version number", () => {
+      console.log(version);
+      process.exit(0);
+    }),
+  )
+  .addHelpOption(globalOption("-h --help", "Print the help text for a command"))
   .usage(`<command> ${chalk.dim("[options] [args]")}`);
 
 program


### PR DESCRIPTION
### Context

`commander` has some rough support for global options, but they work in a weird way. Once you enable global options, this is how they work: 

**Calling from root: global options show up as local options**

If you write `npx instant-cli -h`, global options will show up as `options`: 

<img width="895" alt="CleanShot 2024-11-20 at 13 18 50@2x" src="https://github.com/user-attachments/assets/4f8d3439-9ca0-4fd2-85d5-0a8c18e132ea">

This is a bit confusing, but happens because in the context of the root command, these options are _not_ global. 

**Calling from a subcommand, all _but_ `-h` show up as global options**: 

If you wrote `npx instant-cli login -h`, you would see: 

<img width="950" alt="CleanShot 2024-11-20 at 13 20 52@2x" src="https://github.com/user-attachments/assets/bd652335-4a0c-41b4-8633-2324af0fed3f">

Here, it _almost_ works as we'd like. Except, the `help` command shows up under `options`, rather than `global options`. 

### Change

It was a bit annoying that in `npx instant-cli -h`, the "options" section was prominently the first thing. These were all global flags, and likely not what the user was most interested in: the user would be most interested in the commands they can run.

So, I enabled Global Options. But to do this, I started to hack the library a bit, so: 

a. The global options showed up at the bottom 
b. The global options showed a consistent list, no matter what command we called.

To do this, 
1. I added a `globalOption`, `getLocalAndGlobalOptions` helper, which returns a consistent list for us 
2. Overrode `formatHelp`, so we could use this function to load the options. 

### After 

<img width="888" alt="CleanShot 2024-11-20 at 13 26 12@2x" src="https://github.com/user-attachments/assets/6e0ca061-57dc-4a8a-8588-5db05ce4437c">

<img width="938" alt="CleanShot 2024-11-20 at 13 26 30@2x" src="https://github.com/user-attachments/assets/c73839d7-8d0b-4bc5-99fa-0fdbd671ae18">

@dwwoelfel @nezaj 
