### PR TITLE
[cli] Add styling to subheading in help

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -48,7 +48,7 @@ const headerChalk = `${logoChalk} ${versionChalk} ` + "\n";
 // Help Footer -- this only shows up in help commands
 const helpFooterChalk =
   "\n" +
-  "Want to learn more?" +
+  chalk.dim.bold("Want to learn more?") +
   "\n" +
   `Check out the docs: ${chalk.blueBright.underline("https://instantdb.com/docs")}
 Join the Discord:   ${chalk.blueBright.underline("https://discord.com/invite/VU53p7uQcE")}
@@ -95,7 +95,7 @@ function formatHelp(cmd, helper) {
   }
 
   // Usage
-  let output = [`Usage: ${helper.commandUsage(cmd)}`, ""];
+  let output = [`${helper.commandUsage(cmd)}`, ""];
 
   // Description
   const commandDescription = helper.commandDescription(cmd);
@@ -133,7 +133,7 @@ function formatHelp(cmd, helper) {
     );
   });
   if (commandList.length > 0) {
-    output = output.concat(["Commands:", formatList(commandList), ""]);
+    output = output.concat([chalk.dim.bold("Commands"), formatList(commandList), ""]);
   }
 
   if (this.showGlobalOptions) {
@@ -145,7 +145,7 @@ function formatHelp(cmd, helper) {
     });
     if (globalOptionList.length > 0) {
       output = output.concat([
-        "Global Options:",
+        chalk.dim.bold("Global Options"),
         formatList(globalOptionList),
         "",
       ]);

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -123,7 +123,7 @@ function formatHelp(cmd, helper) {
     );
   });
   if (optionList.length > 0) {
-    output = output.concat(["Options:", formatList(optionList), ""]);
+    output = output.concat([chalk.dim.bold("Options"), formatList(optionList), ""]);
   }
   // Commands
   const commandList = helper.visibleCommands(cmd).map((cmd) => {
@@ -175,6 +175,7 @@ function globalOption(flags, description, argParser) {
   return opt;
 }
 
+
 program
   .name("instant-cli")
   .addOption(globalOption("-t --token <TOKEN>", "Auth token override"))
@@ -198,7 +199,7 @@ program.command("init").description("Create a new app").action(init);
 
 program
   .command("push-schema")
-  .argument("[ID]")
+  .argument("[app-id]")
   .description("Push schema to production.")
   .option(
     "--skip-check-types",
@@ -210,7 +211,7 @@ program
 
 program
   .command("push-perms")
-  .argument("[ID]")
+  .argument("[app-id]")
   .description("Push perms to production.")
   .action(() => {
     pushPerms();
@@ -218,7 +219,7 @@ program
 
 program
   .command("push")
-  .argument("[ID]")
+  .argument("[app-id]")
   .option(
     "--skip-check-types",
     "Don't check types on the server when pushing schema",
@@ -228,7 +229,7 @@ program
 
 program
   .command("pull-schema")
-  .argument("[ID]")
+  .argument("[app-id]")
   .description("Generate instant.schema.ts from production")
   .action((appIdOrName) => {
     pullSchema(appIdOrName);
@@ -236,7 +237,7 @@ program
 
 program
   .command("pull-perms")
-  .argument("[ID]")
+  .argument("[app-id]")
   .description("Generate instant.perms.ts from production.")
   .action((appIdOrName) => {
     pullPerms(appIdOrName);
@@ -244,7 +245,7 @@ program
 
 program
   .command("pull")
-  .argument("[ID]")
+  .argument("[app-id]")
   .description(
     "Generate schema and perm files from from your production state.",
   )


### PR DESCRIPTION
- Made our subheadings dimbold.
- Updated our helper text for `[ID]` to be `[app-id]` 

Small changes but aesthetically more pleasing imo: 

**Before** 
<img width="924" alt="CleanShot 2024-11-20 at 13 39 33@2x" src="https://github.com/user-attachments/assets/ff0b1ef8-4b76-47dd-960c-efe561a7a5c5">

**After** 
<img width="929" alt="CleanShot 2024-11-20 at 13 44 09@2x" src="https://github.com/user-attachments/assets/eebd3d21-2946-4421-855e-2d3031258a51">

@dwwoelfel @nezaj 