### PR TITLE
[InstaQL] Add $like operator

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -114,6 +114,83 @@ test("Where in", () => {
   ).toEqual(["joe", "stopa"]);
 });
 
+test("Where %like%", () => {
+  expect(
+    query(
+      { store },
+      {
+        users: {
+          $: {
+            where: {
+              handle: { $like: "%o%" },
+            },
+          },
+        },
+      },
+    )
+      .data.users.map((x) => x.handle)
+      .sort(),
+  ).toEqual(["joe", "nicolegf", "stopa"]);
+});
+
+test("Where like equality", () => {
+  expect(
+    query(
+      { store },
+      {
+        users: {
+          $: {
+            where: {
+              handle: { $like: "joe" },
+            },
+          },
+        },
+      },
+    )
+      .data.users.map((x) => x.handle)
+      .sort(),
+  ).toEqual(["joe"]);
+});
+
+test("Where startsWith deep", () => {
+  expect(
+    query(
+      { store },
+      {
+        users: {
+          $: {
+            where: {
+              "bookshelves.books.title": { $like: "%Monte Cristo" },
+            },
+          },
+        },
+      },
+    )
+      .data.users.map((x) => x.handle)
+      .sort(),
+  ).toEqual(["nicolegf", "stopa"]);
+});
+
+test("Where endsWith deep", () => {
+  expect(
+    query(
+      { store },
+      {
+        users: {
+          $: {
+            where: {
+              "bookshelves.books.title": { $like: "Anti%" },
+            },
+          },
+        },
+      },
+    )
+      .data.users.map((x) => x.handle)
+      .sort(),
+  ).toEqual(["alex", "nicolegf", "stopa"]);
+});
+
+
 test("Where and", () => {
   expect(
     query(

--- a/client/packages/core/src/datalog.js
+++ b/client/packages/core/src/datalog.js
@@ -28,10 +28,10 @@ function matchWithArgMap(patternPart, triplePart, context) {
 
   if (
     patternPart.hasOwnProperty("$not") ||
-    patternPart.hasOwnProperty("$isNull")
+    patternPart.hasOwnProperty("$isNull") ||
+    patternPart.hasOwnProperty("$like")
   ) {
-    // If we use `$not` or `$isNull`, we've already done the filtering in
-    // `getTriples`
+    // We've already done the filtering in `getTriples`
     return context;
   }
   return null;

--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -112,6 +112,16 @@ function valueAttrPat(makeVar, store, valueEtype, valueLevel, valueLabel, v) {
     ];
   }
 
+  if (v?.hasOwnProperty("$like")) {
+    return [
+      makeVar(valueEtype, valueLevel),
+      attr.id,
+      { $like: v.$like },
+      wildcard("time"),
+    ];
+  }
+
+
   return [makeVar(valueEtype, valueLevel), attr.id, v, wildcard("time")];
 }
 

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -450,6 +450,15 @@ export function allMapValues(m, level, res = []) {
   return res;
 }
 
+function matchesLikePattern(value, pattern) {
+  if (typeof value !== 'string' || typeof pattern !== 'string') return false;
+  const regexPattern = pattern
+    .replace(/%/g, '.*')
+  const regex = new RegExp(`^${regexPattern}$`, 'i');
+  return regex.test(value);
+}
+
+
 function triplesByValue(store, m, v) {
   const res = [];
   if (v?.hasOwnProperty('$not')) {
@@ -469,6 +478,16 @@ function triplesByValue(store, m, v) {
       const isValNull =
         !aMap || aMap.get(candidate)?.get(null) || !aMap.get(candidate);
       if (isNull ? isValNull : !isValNull) {
+        res.push(m.get(candidate));
+      }
+    }
+    return res;
+  }
+
+  if (v?.hasOwnProperty('$like')) {
+    const pattern = v.$like;
+    for (const candidate of m.keys()) {
+      if (matchesLikePattern(candidate, pattern)) {
         res.push(m.get(candidate));
       }
     }

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -452,9 +452,8 @@ export function allMapValues(m, level, res = []) {
 
 function matchesLikePattern(value, pattern) {
   if (typeof value !== 'string' || typeof pattern !== 'string') return false;
-  const regexPattern = pattern
-    .replace(/%/g, '.*')
-  const regex = new RegExp(`^${regexPattern}$`, 'i');
+  const regexPattern = pattern.replace(/%/g, '.*')
+  const regex = new RegExp(`^${regexPattern}$`);
   return regex.test(value);
 }
 

--- a/client/sandbox/react-nextjs/pages/play/query-like.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-like.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useState } from "react";
+import config from "../../config";
+import { init, tx, id } from "@instantdb/react";
+import { useRouter } from "next/router";
+
+function Example({ appId }: { appId: string }) {
+  const router = useRouter();
+  const myConfig = { ...config, appId };
+  const db = init(myConfig);
+
+  const { data } = db.useQuery({ items: {} });
+
+  const { data: isEquality } = db.useQuery({
+    items: { $: { where: { val: { $like: "%Go Team Instant%" } } } },
+  });
+
+  const { data: isStartsWith } = db.useQuery({
+    items: { $: { where: { val: { $like: "%Go%" } } } },
+  });
+
+  const { data: isEndsWith } = db.useQuery({
+    items: { $: { where: { val: { $like: "%Instant%" } } } },
+  });
+
+  const { data: isContains } = db.useQuery({
+    items: { $: { where: { val: { $like: "%Team%" } } } },
+  });
+
+  const { data: isContainsLink } = db.useQuery({
+    items: { $: { where: { "link.val": { $like: "%moop%" } } } },
+  });
+
+  console.log({
+    data,
+    isEquality,
+    isStartsWith,
+    isEndsWith,
+    isContains,
+    isContainsLink,
+  });
+  return (
+    <div>
+      <div>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => db.transact(tx.items[id()].update({ val: "Go Team Instant" }))}
+        >
+          Create item with val = "Go Team Instant"
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => db.transact(tx.items[id()].update({ val: "Instant" }))}
+        >
+          Create item with val = "Instant"
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => db.transact(tx.items[id()].update({ val: null }))}
+        >
+          Create item with val = null
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => {
+            const linkId = id();
+            db.transact([
+              tx.link[linkId].update({ val: "super moop" }),
+              tx.items[id()].update({}).link({ link: linkId }),
+            ]);
+          }}
+        >
+          Create link with val = "super moop"
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => {
+            const linkId = id();
+            db.transact([
+              tx.link[linkId].update({ val: "womp" }),
+              tx.items[id()].update({}).link({ link: linkId }),
+            ]);
+          }}
+        >
+          Create link with val = "womp"
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => {
+            window.location.href = router.pathname;
+          }}
+        >
+          Start over
+        </button>
+      </div>
+      <div className="p-2"></div>
+      <div className="flex">
+        <div className="p-2">
+          <details open>
+            <summary>All items ({data?.items.length || 0}):</summary>
+
+            {data?.items.map((item) => (
+              <div key={item.id}>
+                <button
+                  onClick={() => {
+                    db.transact([tx.items[item.id].delete()]);
+                  }}
+                >
+                  X
+                </button>{" "}
+                val ={" "}
+                {item.val === undefined
+                  ? "undefined"
+                  : JSON.stringify(item.val)}
+              </div>
+            ))}
+          </details>
+        </div>
+        <div className="p-2">
+          <details open>
+            <summary>
+              equals 'Go Team Instant': ({isEquality?.items.length || 0}):
+            </summary>
+
+            {isEquality?.items.map((item) => (
+              <div key={item.id}>
+                <button
+                  onClick={() => {
+                    db.transact([tx.items[item.id].delete()]);
+                  }}
+                >
+                  X
+                </button>{" "}
+                val ={" "}
+                {item.val === undefined
+                  ? "undefined"
+                  : JSON.stringify(item.val)}
+              </div>
+            ))}
+          </details>
+        </div>
+        <div className="p-2">
+          <details open>
+            <summary>
+              starts with 'Go%' ({isStartsWith?.items.length || 0}):
+            </summary>
+
+            {isStartsWith?.items.map((item) => (
+              <div key={item.id}>
+                <button
+                  onClick={() => {
+                    db.transact([tx.items[item.id].delete()]);
+                  }}
+                >
+                  X
+                </button>{" "}
+                val ={" "}
+                {item.val === undefined
+                  ? "undefined"
+                  : JSON.stringify(item.val)}
+              </div>
+            ))}
+          </details>
+        </div>
+        <div className="p-2">
+          <details open>
+            <summary>ends with "Instant" ({isEndsWith?.items.length || 0}):</summary>
+
+            {isEndsWith?.items.map((item) => (
+              <div key={item.id}>
+                <button
+                  onClick={() => {
+                    db.transact([tx.items[item.id].delete()]);
+                  }}
+                >
+                  X
+                </button>{" "}
+                val ={" "}
+                {item.val === undefined
+                  ? "undefined"
+                  : JSON.stringify(item.val)}
+              </div>
+            ))}
+          </details>
+        </div>
+        <div className="p-2">
+          <details open>
+            <summary>
+              links like "%moop%" ({isContainsLink?.items.length || 0}):
+            </summary>
+
+            {isContainsLink?.items.map((item) => (
+              <div key={item.id}>
+                <button
+                  onClick={() => {
+                    db.transact([tx.items[item.id].delete()]);
+                  }}
+                >
+                  X
+                </button>{" "}
+                val ={" "}
+                {item.val === undefined
+                  ? "undefined"
+                  : JSON.stringify(item.val)}
+              </div>
+            ))}
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+async function provisionEphemeralApp() {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: "Query Like Sandbox",
+    }),
+  });
+
+  return r.json();
+}
+
+async function verifyEphemeralApp({ appId }: { appId: string }) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  return r.json();
+}
+
+function App({ urlAppId }: { urlAppId: string | undefined }) {
+  const router = useRouter();
+  const [appId, setAppId] = useState();
+
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (appId) {
+      return;
+    }
+    if (urlAppId) {
+      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
+        if (res.app) {
+          setAppId(res.app.id);
+        } else {
+          provisionEphemeralApp().then((res) => {
+            if (res.app) {
+              router.replace({
+                pathname: router.pathname,
+                query: { ...router.query, app: res.app.id },
+              });
+
+              setAppId(res.app.id);
+            } else {
+              console.log(res);
+              setError("Could not create app.");
+            }
+          });
+        }
+      });
+    } else {
+      provisionEphemeralApp().then((res) => {
+        if (res.app) {
+          router.replace({
+            pathname: router.pathname,
+            query: { ...router.query, app: res.app.id },
+          });
+
+          setAppId(res.app.id);
+        } else {
+          console.log(res);
+          setError("Could not create app.");
+        }
+      });
+    }
+  }, []);
+
+  if (error) {
+    return (
+      <div>
+        <p>There was an error</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!appId) {
+    return <div>Loading...</div>;
+  }
+  return <Example appId={appId} />;
+}
+
+function Page() {
+  const router = useRouter();
+  if (router.isReady) {
+    return <App urlAppId={router.query.app as string} />;
+  } else {
+    return <div>Loading...</div>;
+  }
+}
+
+export default Page;
+

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -763,6 +763,79 @@ console.log(data)
 }
 ```
 
+### $like
+
+The `where` clause supports `$like` queries that will return entities that match
+a case-insensitive substring of the provided value for the field. You can use
+`$like` to do queries like `contains`, `startsWith`, and `endsWith`.
+
+`{ $like: "%promoted!" }` looks for values that end with "promoted!".
+
+`{ $like: "Get%" }` looks for values that start with "Get".
+
+`{ $like: "%fit%" }` looks for values that contain "fit".
+
+
+```javascript
+// Find all goals that end with the word "promoted!"
+const query = {
+  goals: {
+    $: {
+      where: {
+        title: { $like: '%promoted!' },
+      },
+    },
+  },
+};
+const { isLoading, error, data } = db.useQuery(query);
+```
+
+```javascript
+console.log(data)
+{
+  "goals": [
+    {
+      "id": workId,
+      "title": "Get promoted!",
+    }
+  ]
+}
+```
+
+You can use `$like` in nested queries as well
+
+```javascript
+// Find goals that have todos with the word "standup" in their title
+const query = {
+  goals: {
+    $: {
+      where: {
+        'todos.title': { $like: '%standup%' },
+      },
+    },
+    todos: {},
+  },
+};
+const { isLoading, error, data } = db.useQuery(query);
+```
+
+Returns
+
+```javascript
+console.log(data)
+{
+  "goals": [
+    {
+      "id": workId,
+      "title": "Get promoted!",
+    }
+      ]
+    }
+  ]
+}
+```
+
+
 ## Query once
 
 Sometimes, you don't want a subscription, and just want to fetch data once. For example, you might want to fetch data before rendering a page or check whether a user name is available.

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -813,7 +813,6 @@ const query = {
         'todos.title': { $like: '%standup%' },
       },
     },
-    todos: {},
   },
 };
 const { isLoading, error, data } = db.useQuery(query);
@@ -828,8 +827,6 @@ console.log(data)
     {
       "id": workId,
       "title": "Get promoted!",
-    }
-      ]
     }
   ]
 }

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -332,13 +332,14 @@
       #{(-> v second :$isNull :attr-id)}
       '_]]
 
-    ;; Handle $like patterns by using wildcard for v
+    ;; There's probably a more clever way to invalidate against like
+    ;; values but this is a simple way for now
     (and (= :function (first v))
          (contains? (second v) :$like))
     [[idx
       (component->topic-component symbol-values :e e)
       (component->topic-component symbol-values :a a)
-      '_]] ;; Wildcard for v
+      '_]]
 
     :else
     [[idx

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -171,7 +171,6 @@
                     [:vae '?movie movie-director-aid '?director]
                     [:ea '?movie movie-title-aid '?title]]
 
-
         named-ps-1 (d/->named-patterns patterns-1)
 
         named-ps-2 (d/->named-patterns patterns-2)]
@@ -380,7 +379,6 @@
 
             (testing "we only make a single sql query for both d/query calls"
               (is (= @counts 1)))))))))
-
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -927,6 +927,124 @@
                   ("eid-joe-averbukh" :users/email "joe@instantdb.com")
                   ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637"))}))))
 
+(deftest where-$like
+  (testing "with no matches"
+    (is-pretty-eq?
+     (query-pretty
+      {:users {:$ {:where {:handle {:$like "%moop%"}}}}})
+     '({:topics ([:av _ #{:users/handle} _]), :triples (), :aggregate (nil)})))
+  (testing "with equality"
+    (is-pretty-eq?
+     (query-pretty
+      {:users {:$ {:where {:handle {:$like "joe"}}}}})
+     '({:topics
+        ([:av _ #{:users/handle} _]
+         --
+         [:ea
+          #{"eid-joe-averbukh"}
+          #{:users/bookshelves
+            :users/createdAt
+            :users/email
+            :users/id
+            :users/fullName
+            :users/handle}
+          _]),
+        :triples
+        (("eid-joe-averbukh" :users/handle "joe")
+         --
+         ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
+         ("eid-joe-averbukh" :users/email "joe@instantdb.com")
+         ("eid-joe-averbukh" :users/handle "joe")
+         ("eid-joe-averbukh" :users/fullName "Joe Averbukh")
+         ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637")),
+        :aggregate (nil nil)})))
+  (testing "like startsWith"
+    (is-pretty-eq?
+     (query-pretty
+      {:users {:$ {:where {:handle {:$like "al%"}}}}})
+     '({:topics
+        ([:av _ #{:users/handle} _]
+         --
+         [:ea
+          #{"eid-alex"}
+          #{:users/bookshelves
+            :users/createdAt
+            :users/email
+            :users/id
+            :users/fullName
+            :users/handle}
+          _]),
+        :triples
+        (("eid-alex" :users/handle "alex")
+         --
+         ("eid-alex" :users/id "eid-alex")
+         ("eid-alex" :users/fullName "Alex")
+         ("eid-alex" :users/email "alex@instantdb.com")
+         ("eid-alex" :users/handle "alex")
+         ("eid-alex" :users/createdAt "2021-01-09 18:53:07.993689")),
+        :aggregate (nil nil)})))
+  (testing "like endsWith deep"
+    (is-pretty-eq?
+     (query-pretty
+      {:users {:$ {:where {:bookshelves.books.title {:$like "%Monte Cristo"}}}}})
+     '({:topics
+        ([:ea _ #{:books/title} _]
+         [:vae _ #{:bookshelves/books} #{"eid-the-count-of-monte-cristo"}]
+         [:vae
+          _
+          #{:users/bookshelves}
+          #{"eid-the-way-of-the-gentleman" "eid-fiction"}]
+         --
+         [:ea
+          #{"eid-stepan-parunashvili"}
+          #{:users/bookshelves
+            :users/createdAt
+            :users/email
+            :users/id
+            :users/fullName
+            :users/handle}
+          _]
+         --
+         [:ea
+          #{"eid-nicole"}
+          #{:users/bookshelves
+            :users/createdAt
+            :users/email
+            :users/id
+            :users/fullName
+            :users/handle}
+          _]),
+        :triples
+        (("eid-the-count-of-monte-cristo"
+          :books/title
+          "The Count of Monte Cristo")
+         ("eid-the-count-of-monte-cristo"
+          :books/title
+          "The Count of Monte Cristo")
+         ("eid-nicole" :users/bookshelves "eid-fiction")
+         ("eid-fiction" :bookshelves/books "eid-the-count-of-monte-cristo")
+         ("eid-the-way-of-the-gentleman"
+          :bookshelves/books
+          "eid-the-count-of-monte-cristo")
+         ("eid-stepan-parunashvili"
+          :users/bookshelves
+          "eid-the-way-of-the-gentleman")
+         --
+         ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
+         ("eid-stepan-parunashvili"
+          :users/createdAt
+          "2021-01-07 18:50:43.447955")
+         ("eid-stepan-parunashvili" :users/fullName "Stepan Parunashvili")
+         ("eid-stepan-parunashvili" :users/handle "stopa")
+         ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
+         --
+         ("eid-nicole" :users/createdAt "2021-02-05 22:35:23.754264")
+         ("eid-nicole" :users/email "nicole@instantdb.com")
+         ("eid-nicole" :users/handle "nicolegf")
+         ("eid-nicole" :users/id "eid-nicole")
+         ("eid-nicole" :users/fullName "Nicole")),
+        :aggregate (nil nil nil)}))))
+
 (deftest where-$not
   (is-pretty-eq?
    (query-pretty
@@ -1361,7 +1479,6 @@
                  (map (fn [x] (get x "id")) %)
                  (set %))))
 
-
         (add-links [["eid-fwd-null" "eid-rev-b"]
                     ["eid-fwd-undefined" "eid-rev-c"]])
 
@@ -1438,7 +1555,6 @@
                  (get % "rev")
                  (map (fn [x] (get x "id")) %)
                  (set %))))
-
 
         (add-links [["eid-fwd-null" "eid-rev-b"]
                     ["eid-fwd-undefined" "eid-rev-c"]])
@@ -1517,7 +1633,6 @@
                  (map (fn [x] (get x "id")) %)
                  (set %))))
 
-
         (add-links [["eid-fwd-null" "eid-rev-b"]
                     ["eid-fwd-undefined" "eid-rev-c"]])
 
@@ -1595,7 +1710,6 @@
                  (get % "rev")
                  (map (fn [x] (get x "id")) %)
                  (set %))))
-
 
         (add-links [["eid-fwd-null" "eid-rev-b"]
                     ["eid-fwd-undefined" "eid-rev-c"]])


### PR DESCRIPTION
As part of the storage upgrade, I found myself on a side quest to implement `$like`

https://github.com/user-attachments/assets/bf2362a6-d7d3-462e-bde9-eb665014fb93

This PR does the following:

* Adds support for `$like` in instaql on the backend
* Updates our topic logic so `$like` queries can be properly refreshed
* Adds `$like` to instaql on the frontend
* Adds a sandbox app to play with it / verify behavior
* Adds some docs and tests!

<img width="505" alt="image" src="https://github.com/user-attachments/assets/234c98c8-368e-4b56-bbd5-03f575fed844">
