### PR TITLE
New elastic beanstalk environment

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -97,12 +97,12 @@ psql-dump:
 	pg_dump $${DATABASE_URL} -f dump.sql
 
 tail-web:
-	aws logs tail /aws/elasticbeanstalk/Instant-docker-prod-env/var/log/eb-docker/containers/eb-current-app/stdouterr.log --follow
+	aws logs tail /aws/elasticbeanstalk/Instant-docker-prod-env-2/var/log/eb-docker/containers/eb-current-app/stdouterr.log --follow
 
 MINS?=30
 errors:
 	aws logs filter-log-events \
-		--log-group-name "/aws/elasticbeanstalk/Instant-docker-prod-env/var/log/eb-docker/containers/eb-current-app/stdouterr.log" \
+		--log-group-name "/aws/elasticbeanstalk/Instant-docker-prod-env-2/var/log/eb-docker/containers/eb-current-app/stdouterr.log" \
 		--start-time $$(expr `date -v-$(MINS)M +%s` \* 1000) \
 		--filter-pattern "ERROR" \
 	    --output text

--- a/server/refinery/.ebextensions/resources.config
+++ b/server/refinery/.ebextensions/resources.config
@@ -14,7 +14,7 @@ Resources:
       GroupDescription: "refinery auto scaling group"
       SecurityGroupIngress:
         - Description: "Inbound from prod"
-          SourceSecurityGroupId: "sg-051cfc0a20314d181"
+          SourceSecurityGroupId: "sg-04c436f7a3ea769cb"
           FromPort: '8082'
           ToPort: '8082'
           IpProtocol: tcp
@@ -72,7 +72,7 @@ Resources:
       VpcId: "vpc-00063e3a899656167"
       SecurityGroupIngress:
         - Description: "Inbound from prod"
-          SourceSecurityGroupId: "sg-051cfc0a20314d181"
+          SourceSecurityGroupId: "sg-04c436f7a3ea769cb"
           FromPort: '8082'
           ToPort: '8082'
           IpProtocol: tcp

--- a/server/scripts/eb_deploy.clj
+++ b/server/scripts/eb_deploy.clj
@@ -72,7 +72,7 @@
   (println "Deploying " (get version "VersionLabel") " " (get version "Description"))
   (Thread/sleep 500)
   (apply exec
-         (str "eb deploy instant-docker-prod-env --version " (get version "VersionLabel"))
+         (str "eb deploy Instant-docker-prod-env-2 --version " (get version "VersionLabel"))
          *command-line-args*))
 
 (defn main-loop []

--- a/server/scripts/eb_deploy.clj
+++ b/server/scripts/eb_deploy.clj
@@ -16,7 +16,7 @@
                {:out :string
                 :err :string
                 :continue true}
-               "aws elasticbeanstalk describe-environments --region us-east-1 --environment-name Instant-docker-prod-env"
+               "aws elasticbeanstalk describe-environments --region us-east-1 --environment-name Instant-docker-prod-env-2"
                *command-line-args*)]
     (when-not (string/blank? out)
       (-> (json/parse-string out)

--- a/server/scripts/manual_deploy.sh
+++ b/server/scripts/manual_deploy.sh
@@ -27,4 +27,4 @@ aws s3api put-object --region us-east-1 --bucket "$bucket" --key "$key" --body $
 
 aws elasticbeanstalk create-application-version --region us-east-1 --application-name instant-docker-prod --version-label "$application_version" --description "Manual deploy from $(hostname)" --source-bundle "S3Bucket=$bucket,S3Key=$key"
 
-eb deploy instant-docker-prod-env --version "$application_version"
+eb deploy Instant-docker-prod-env-2 --version "$application_version"

--- a/server/scripts/prod_ssh.sh
+++ b/server/scripts/prod_ssh.sh
@@ -9,7 +9,7 @@ done
 if [ -z "$instance_id" ]; then
   instance_id=$(
     aws ec2 describe-instances \
-      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env" \
+      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env-2" \
       --query "Reservations[].Instances[?State.Name == 'running'].InstanceId[]" \
       --output text
   )

--- a/server/scripts/prod_tunnel.sh
+++ b/server/scripts/prod_tunnel.sh
@@ -16,7 +16,7 @@ done
 if [ -z "$instance_id" ]; then
   instance_id=$(
     aws ec2 describe-instances \
-      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env" \
+      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env-2" \
       --query "Reservations[].Instances[?State.Name == 'running'].InstanceId[]" \
       --output text
   )

--- a/server/scripts/yourkit_tunnel.sh
+++ b/server/scripts/yourkit_tunnel.sh
@@ -16,7 +16,7 @@ done
 if [ -z "$instance_id" ]; then
   instance_id=$(
     aws ec2 describe-instances \
-      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env" \
+      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env-2" \
       --query "Reservations[].Instances[?State.Name == 'running'].InstanceId[]" \
       --output text
   )


### PR DESCRIPTION
The old elasticbeanstalk environment is stuck in an invalid state, so this updates us to use a new one.

The new environment is already running and everything looks good.

Deployment strategy:

1. Reduce number of instances in old env to 1 and wait for connections to drain
2. Update cloudflare to use the new environment
3. Reduce number of instances in old env to 0 and wait for connections to drain
4. Terminate old environment

There will be a split brain on session state while sessions transition to the new environment, but no worse than it was when we were on a single instance.