### PR TITLE
[cli] improve error messages

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -71,12 +71,13 @@ async function resolveBagAndAppWithErrorLogging(cmdName, arg, opts) {
   } else if (PUSH_PULL_OPTIONS.has(arg)) {
     bag = arg;
   } else {
-    console.error(
-      `Invalid argument: ${arg} must be one of ${Array.from(PUSH_PULL_OPTIONS).join(", ")}`,
+    error(
+      `${chalk.red(arg)} must be one of ${chalk.green(Array.from(PUSH_PULL_OPTIONS).join(", "))}`,
     );
+    return;
   }
   const appId = await getAppIdWithErrorLogging(opts.app);
-  if (!bag || !appId) return;
+  if (!appId) return;
   return [bag, appId];
 }
 
@@ -1315,14 +1316,14 @@ async function getAppIdWithErrorLogging(arg) {
       uuidAppId
     );
   }
-  const appId = null;
-  // const appId =
-  //   // finally, check .env
-  //   process.env.INSTANT_APP_ID ||
-  //   process.env.NEXT_PUBLIC_INSTANT_APP_ID ||
-  //   process.env.PUBLIC_INSTANT_APP_ID || // for Svelte
-  //   process.env.VITE_INSTANT_APP_ID ||
-  //   null;
+
+  const appId =
+    // finally, check .env
+    process.env.INSTANT_APP_ID ||
+    process.env.NEXT_PUBLIC_INSTANT_APP_ID ||
+    process.env.PUBLIC_INSTANT_APP_ID || // for Svelte
+    process.env.VITE_INSTANT_APP_ID ||
+    null;
 
   // otherwise, instruct the user to set one of these up
   if (!appId) {

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -942,9 +942,8 @@ async function pushSchema(appId, opts) {
 }
 
 async function pushPerms(appId) {
-  const { perms } = await readLocalPermsFile();
+  const perms = await readLocalPermsFileWithErrorLogging();
   if (!perms) {
-    console.error("Missing instant.perms file!");
     return;
   }
 
@@ -991,7 +990,7 @@ async function waitForAuthToken({ secret }) {
     } catch (error) {}
   }
 
-  console.error("Login timed out.");
+  error("Timed out waiting for authentication");
   return null;
 }
 
@@ -1127,9 +1126,19 @@ async function readLocalPermsFile() {
   });
 
   return {
-    perms: config,
+    perms: null && config,
     path: sources.at(0),
   };
+}
+
+async function readLocalPermsFileWithErrorLogging() {
+  const { perms } = await readLocalPermsFile();
+  if (!perms) {
+    error(
+      `We couldn't find your ${chalk.yellow("`instant.perms.ts`")} file. Make sure it's in the root directory.`,
+    );
+  }
+  return perms;
 }
 
 async function readLocalSchemaFile() {

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -451,13 +451,13 @@ async function init() {
   const id = randomUUID();
   const token = randomUUID();
 
-  const title = await input({
+  const _title = await input({
     message: "Enter a name for your app",
     required: true,
   }).catch(() => null);
-
+  const title = _title?.trim();
   if (!title) {
-    console.error("No name provided. Exiting.");
+    error("No name provided. Exiting.");
     return;
   }
 

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1054,14 +1054,14 @@ async function fetchJson({
 
     if (!res.ok) {
       if (withErrorLogging) {
-        console.error(errorMessage);
+        error(errorMessage);
         if (data?.message) {
-          console.error(data.message);
+          error(data.message);
         }
         if (Array.isArray(data?.hint?.errors)) {
-          for (const error of data.hint.errors) {
-            console.error(
-              `${error.in ? error.in.join("->") + ": " : ""}${error.message}`,
+          for (const err of data.hint.errors) {
+            error(
+              `${err.in ? err.in.join("->") + ": " : ""}${err.message}`,
             );
           }
         }
@@ -1080,11 +1080,11 @@ async function fetchJson({
   } catch (err) {
     if (withErrorLogging) {
       if (err.name === "AbortError") {
-        console.error(
-          `Timeout: It took more than ${timeoutMs / 60000} minutes to get the result!`,
+        error(
+          `Timeout: It took more than ${timeoutMs / 60000} minutes to get the result.`,
         );
       } else {
-        console.error(`Error: type: ${err.name}, message: ${err.message}`);
+        error(`Error: type: ${err.name}, message: ${err.message}`);
       }
     }
     return { ok: false, data: null };

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1060,13 +1060,11 @@ async function fetchJson({
         }
         if (Array.isArray(data?.hint?.errors)) {
           for (const err of data.hint.errors) {
-            error(
-              `${err.in ? err.in.join("->") + ": " : ""}${err.message}`,
-            );
+            error(`${err.in ? err.in.join("->") + ": " : ""}${err.message}`);
           }
         }
         if (!data) {
-          console.error("Failed to parse error response");
+          error("Failed to parse error response");
         }
       }
       return { ok: false, data };
@@ -1179,7 +1177,9 @@ async function readLocalSchemaFileWithErrorLogging() {
   const schema = await readLocalSchemaFile();
 
   if (!schema) {
-    console.error("Missing instant.schema file!");
+    error(
+      `We couldn't find your ${chalk.yellow("`instant.schema.ts`")} file. Make sure it's in the root directory.`,
+    );
     return;
   }
 

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -81,6 +81,15 @@ async function resolveBagAndAppWithErrorLogging(cmdName, arg, opts) {
   return [bag, appId];
 }
 
+async function packageDirectoryWithErrorLogging() {
+  const pkgDir = await packageDirectory();
+  if (!pkgDir) {
+    error("Couldn't find your root directory. Is there a package.json file?");
+    return;
+  }
+  return pkgDir;
+}
+
 // cli
 
 // Header -- this shows up in every command
@@ -426,9 +435,8 @@ async function login(options) {
 }
 
 async function init() {
-  const pkgDir = await packageDirectory();
+  const pkgDir = await packageDirectoryWithErrorLogging();
   if (!pkgDir) {
-    console.error("Failed to locate app root dir.");
     return;
   }
 
@@ -499,9 +507,8 @@ async function getInstantModuleName(pkgDir) {
 }
 
 async function pullSchema(appId) {
-  const pkgDir = await packageDirectory();
+  const pkgDir = await packageDirectoryWithErrorLogging();
   if (!pkgDir) {
-    console.error("Failed to locate app root dir.");
     return;
   }
   const instantModuleName = await getInstantModuleName(pkgDir);
@@ -581,12 +588,10 @@ async function pullSchema(appId) {
 
 async function pullPerms(appId) {
   console.log("Pulling perms...");
-  const pkgDir = await packageDirectory();
+  const pkgDir = await packageDirectoryWithErrorLogging();
   if (!pkgDir) {
-    console.error("Failed to locate app root dir.");
     return;
   }
-
   const authToken = await readConfigAuthToken();
   if (!authToken) {
     console.error("Unauthenticated.  Please log in with `login`!");

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -21,13 +21,26 @@ dotenv.config();
 const dev = Boolean(process.env.INSTANT_CLI_DEV);
 const verbose = Boolean(process.env.INSTANT_CLI_VERBOSE);
 
+// logs
+
+function warn(firstArg, ...rest) {
+  console.warn(chalk.yellow("[warning]") + " " + firstArg, ...rest);
+}
+
+function error(firstArg, ...rest) {
+  console.error(chalk.red("[error]") + " " + firstArg, ...rest);
+}
+
 // consts
 
 const noAppIdErrorMessage = `
-No app ID found.
-Add \`INSTANT_APP_ID=<ID>\` to your .env file.
-(Or \`NEXT_PUBLIC_INSTANT_APP_ID\`, \`VITE_INSTANT_APP_ID\`)
-Or provide an app ID via the CLI \`instant-cli pull schema <ID>\`.
+Couldn't find an app ID.
+
+You can either: 
+a. Set ${chalk.green("`INSTANT_APP_ID`")} in your .env file. [1]
+b. Or provide an app ID via the CLI: ${chalk.green("`instant-cli push|pull -a <app-id>`")}.
+
+[1] Alternatively, If you have ${chalk.green("`NEXT_PUBLIC_INSTANT_APP_ID`")}, ${chalk.green("`VITE_INSTANT_APP_ID`")}, we can detect those too!
 `.trim();
 
 const instantDashOrigin = dev
@@ -1289,9 +1302,9 @@ async function getAppIdWithErrorLogging(arg) {
     const uuidAppId = arg && isUUID(arg) ? arg : null;
 
     if (nameMatch && !namedAppId) {
-      console.error(`App ID for \`${arg}\` is not a valid UUID.`);
+      error(`Expected \`${arg}\` to point to a UUID, but got ${nameMatch.id}.`);
     } else if (!namedAppId && !uuidAppId) {
-      console.error(`The provided app ID is not a valid UUID.`);
+      error(`Expected App ID to be a UUID, but got: ${chalk.red(arg)}`);
     }
 
     return (
@@ -1302,17 +1315,18 @@ async function getAppIdWithErrorLogging(arg) {
       uuidAppId
     );
   }
-  const appId =
-    // finally, check .env
-    process.env.INSTANT_APP_ID ||
-    process.env.NEXT_PUBLIC_INSTANT_APP_ID ||
-    process.env.PUBLIC_INSTANT_APP_ID || // for Svelte
-    process.env.VITE_INSTANT_APP_ID ||
-    null;
+  const appId = null;
+  // const appId =
+  //   // finally, check .env
+  //   process.env.INSTANT_APP_ID ||
+  //   process.env.NEXT_PUBLIC_INSTANT_APP_ID ||
+  //   process.env.PUBLIC_INSTANT_APP_ID || // for Svelte
+  //   process.env.VITE_INSTANT_APP_ID ||
+  //   null;
 
   // otherwise, instruct the user to set one of these up
   if (!appId) {
-    console.error(noAppIdErrorMessage);
+    error(noAppIdErrorMessage);
   }
 
   return appId;

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -443,9 +443,8 @@ async function init() {
   const instantModuleName = await getInstantModuleName(pkgDir);
   const schema = await readLocalSchemaFile();
   const { perms } = await readLocalPermsFile();
-  const authToken = await readConfigAuthToken();
+  const authToken = await readConfigAuthTokenWithErrorLogging();
   if (!authToken) {
-    console.error("Unauthenticated.  Please log in with `instant-cli login`!");
     return;
   }
 
@@ -517,10 +516,8 @@ async function pullSchema(appId) {
       "Missing Instant dependency in package.json.  Please install `@instantdb/react` or `@instantdb/core`.",
     );
   }
-
-  const authToken = await readConfigAuthToken();
+  const authToken = await readConfigAuthTokenWithErrorLogging();
   if (!authToken) {
-    console.error("Unauthenticated.  Please log in with `login`!");
     return;
   }
 
@@ -592,9 +589,8 @@ async function pullPerms(appId) {
   if (!pkgDir) {
     return;
   }
-  const authToken = await readConfigAuthToken();
+  const authToken = await readConfigAuthTokenWithErrorLogging();
   if (!authToken) {
-    console.error("Unauthenticated.  Please log in with `login`!");
     return;
   }
 
@@ -1027,9 +1023,8 @@ async function fetchJson({
   const withErrorLogging = !noLogError;
   let authToken = null;
   if (withAuth) {
-    authToken = await readConfigAuthToken();
+    authToken = await readConfigAuthTokenWithErrorLogging();
     if (!authToken) {
-      console.error("Unauthenticated. Please log in with `instant-cli login`");
       return { ok: false, data: undefined };
     }
   }
@@ -1211,6 +1206,15 @@ async function readConfigAuthToken() {
   ).catch(() => null);
 
   return authToken;
+}
+async function readConfigAuthTokenWithErrorLogging() {
+  const token = await readConfigAuthToken();
+  if (!token) {
+    error(
+      `Looks like you are not logged in. Please log in with ${chalk.green("`instant-cli login`")}`,
+    );
+  }
+  return token;
 }
 
 async function saveConfigAuthToken(authToken) {

--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -23,6 +23,7 @@ const _graph = i.graph(
       },
     },
   },
+  
 );
 
 type _Graph = typeof _graph;


### PR DESCRIPTION
Our error messages were a bit meh for two reasons: 
1. Sometimes the message was written in a rushed way 
2. We didn't have any syntax highlighting, so it didn't look visually different from stdout in the terminal. 

Updated our error messages with an `error` helper, that adds some syntax highlighting. I also updated a few of the messages. 

![image](https://github.com/user-attachments/assets/019f9fa8-b1cc-4300-ae7e-0dc235ce5a19)
<img width="964" alt="CleanShot 2024-11-21 at 10 09 52@2x" src="https://github.com/user-attachments/assets/29b2facf-57f8-45cc-8fe6-2970c904dd9f">
<img width="953" alt="CleanShot 2024-11-21 at 10 11 27@2x" src="https://github.com/user-attachments/assets/3f0fc23f-2266-442f-aff4-b8457270ce11">
<img width="952" alt="CleanShot 2024-11-21 at 10 18 59@2x" src="https://github.com/user-attachments/assets/cf73f944-213d-4ed8-91a0-e7fca7c4275f">
<img width="916" alt="CleanShot 2024-11-21 at 10 21 43@2x" src="https://github.com/user-attachments/assets/8dc1a40b-a42d-4589-91d3-79fdcd769e4a">
<img width="921" alt="CleanShot 2024-11-21 at 10 38 40@2x" src="https://github.com/user-attachments/assets/0392ece9-ead8-47b0-8dd0-74c98449b85b">
<img width="944" alt="CleanShot 2024-11-21 at 10 42 12@2x" src="https://github.com/user-attachments/assets/5974851e-1f83-4dbe-a079-fc033bceeddb">
![image](https://github.com/user-attachments/assets/d7843387-808c-433f-b46e-0acd703c2dad)
<img width="973" alt="CleanShot 2024-11-21 at 10 48 54@2x" src="https://github.com/user-attachments/assets/da0cda9d-2692-4d7c-a0c0-ba7f067015db">

@dwwoelfel @nezaj 
