### PR TITLE
[bugfix][cli] remove null && 

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1124,7 +1124,7 @@ async function readLocalPermsFile() {
   });
 
   return {
-    perms: null && config,
+    perms: config,
     path: sources.at(0),
   };
 }


### PR DESCRIPTION
Had a stray `null &&` in there, which I was using to test error messages. 

@dwwoelfel @nezaj 