### PR TITLE
[RFC] Attempt to also print out query in handle-receive-timeout exception

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -476,7 +476,7 @@
                                     ;; If false, then canceling the queries let
                                     ;; the future complete before we could cancel it
                                     :future-cancel-result cancel-res}}))
-              (ex/throw-operation-timeout! :handle-receive handle-receive-timeout-ms)))
+              (ex/throw-operation-timeout! :handle-receive handle-receive-timeout-ms :in-progress-stmts in-progress-stmts)))
 
           (catch CancellationException _e
             ;; We must have cancelled this in the on-close, so don't try to do any

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -187,10 +187,10 @@
 ;; --------
 ;; Timeouts
 
-(defn throw-operation-timeout! [operation-name timeout-ms]
+(defn throw-operation-timeout! [operation-name timeout-ms & {:as additional-hints}]
   (throw+ {::type ::operation-timed-out
            ::message (format "Operation timed out: %s" (name operation-name))
-           ::hint {:timeout-ms timeout-ms}}))
+           ::hint (merge {:timeout-ms timeout-ms} additional-hints)}))
 
 ;; -------
 ;; Sockets


### PR DESCRIPTION
timeout exception is not helpful currently:

```
 (NOBRIDGE) ERROR  Operation timed out: handle-receive {"client-event-id": null, "op": "error", "original-event": {"op": "refresh", "session-id": "673f84f9-ef42-4572-bccc-d7e85b3aa2e7", "total-delay-ms": 65, "ws-ping-latency-ms": 0}, "status": 500, "type": "operation-timed-out"}
 (NOBRIDGE) ERROR  This error comes with some debugging information. Here it is:
 {"timeout-ms": 5000}
 ```

with regards to the actual Clojure change, I need that FB macro meme "I have no idea what I'm doing". and I would suspect attempting to print `in-progress-stmts` would not actually show anything useful. But not sure how to access the original query passed in from the client