### PR TITLE
[cli] if no instant module found in package.json, prompt to install one

### DIFF
--- a/client/packages/cli/src/util/fs.js
+++ b/client/packages/cli/src/util/fs.js
@@ -1,0 +1,23 @@
+import { readFile, stat } from "fs/promises";
+
+export async function pathExists(f) {
+  try {
+    await stat(f);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readJsonFile(path) {
+  if (!pathExists(path)) {
+    return null;
+  }
+
+  try {
+    const data = await readFile(path, "utf-8");
+    return JSON.parse(data);
+  } catch (error) {}
+
+  return null;
+}

--- a/client/packages/cli/src/util/packageManager.js
+++ b/client/packages/cli/src/util/packageManager.js
@@ -1,3 +1,7 @@
+// Note: 
+// Extracted the main logic for `detectPackageManager` from:
+// https://github.com/vercel/vercel/blob/eb7fe8a9266563cfeaf275cd77cd9fad3f17c92b/packages/build-utils/src/fs/run-user-scripts.ts
+
 import { pathExists, readJsonFile } from './fs.js';
 import path from 'path';
 

--- a/client/packages/cli/src/util/packageManager.js
+++ b/client/packages/cli/src/util/packageManager.js
@@ -1,21 +1,19 @@
-// Note: 
+// Note:
 // Extracted the main logic for `detectPackageManager` from:
 // https://github.com/vercel/vercel/blob/eb7fe8a9266563cfeaf275cd77cd9fad3f17c92b/packages/build-utils/src/fs/run-user-scripts.ts
 
-import { pathExists, readJsonFile } from './fs.js';
-import path from 'path';
+import { pathExists, readJsonFile } from "./fs.js";
+import path from "path";
 
 async function detectPackageManager(destPath) {
   const lockfileNames = {
-    'yarn.lock': 'yarn',
-    'package-lock.json': 'npm',
-    'pnpm-lock.yaml': 'pnpm',
-    'bun.lockb': 'bun',
+    "yarn.lock": "yarn",
+    "package-lock.json": "npm",
+    "pnpm-lock.yaml": "pnpm",
+    "bun.lockb": "bun",
   };
 
-  // Start from destPath and traverse upwards
   for (const dir of traverseUpDirectories(destPath)) {
-    // Check for lockfiles
     for (const [lockfileName, cliType] of Object.entries(lockfileNames)) {
       const lockfilePath = path.join(dir, lockfileName);
       if (await pathExists(lockfilePath)) {
@@ -23,26 +21,25 @@ async function detectPackageManager(destPath) {
       }
     }
 
-    // Check for package.json
-    const packageJsonPath = path.join(dir, 'package.json');
+    const packageJsonPath = path.join(dir, "package.json");
     if (await pathExists(packageJsonPath)) {
       const packageJson = await readJsonFile(packageJsonPath);
       if (packageJson.packageManager) {
-        const corepackPackageManager = parsePackageManagerField(packageJson.packageManager);
+        const corepackPackageManager = parsePackageManagerField(
+          packageJson.packageManager,
+        );
         if (corepackPackageManager) {
           return corepackPackageManager.packageName;
         }
       }
     }
 
-    // If at root directory, stop
     if (dir === path.parse(dir).root) {
       break;
     }
   }
 
-  // Default to 'npm' if nothing found
-  return 'npm';
+  return "npm";
 }
 
 function* traverseUpDirectories(start) {
@@ -59,7 +56,7 @@ function* traverseUpDirectories(start) {
 
 function parsePackageManagerField(packageManager) {
   if (!packageManager) return null;
-  const atIndex = packageManager.lastIndexOf('@');
+  const atIndex = packageManager.lastIndexOf("@");
   if (atIndex <= 0) return null; // '@' at position 0 is invalid
   const packageName = packageManager.slice(0, atIndex);
   const packageVersion = packageManager.slice(atIndex + 1);
@@ -69,17 +66,6 @@ function parsePackageManagerField(packageManager) {
   return { packageName, packageVersion };
 }
 
-async function runCommand(command, cwd) {
-  try {
-    await execAsync(command, { cwd });
-  } catch (error) {
-    throw new Error(
-      `Error installing package: ${error.stderr || error.message}`,
-    );
-  }
-}
-
-
 function getInstallCommand(packageManager, moduleName) {
   if (packageManager === "npm") {
     return `npm install ${moduleName}`;
@@ -88,11 +74,4 @@ function getInstallCommand(packageManager, moduleName) {
   }
 }
 
-
-export {
-  detectPackageManager,
-  getInstallCommand,
-}
-
-
-
+export { detectPackageManager, getInstallCommand };

--- a/client/packages/cli/src/util/packageManager.js
+++ b/client/packages/cli/src/util/packageManager.js
@@ -1,0 +1,94 @@
+import { pathExists, readJsonFile } from './fs.js';
+import path from 'path';
+
+async function detectPackageManager(destPath) {
+  const lockfileNames = {
+    'yarn.lock': 'yarn',
+    'package-lock.json': 'npm',
+    'pnpm-lock.yaml': 'pnpm',
+    'bun.lockb': 'bun',
+  };
+
+  // Start from destPath and traverse upwards
+  for (const dir of traverseUpDirectories(destPath)) {
+    // Check for lockfiles
+    for (const [lockfileName, cliType] of Object.entries(lockfileNames)) {
+      const lockfilePath = path.join(dir, lockfileName);
+      if (await pathExists(lockfilePath)) {
+        return cliType;
+      }
+    }
+
+    // Check for package.json
+    const packageJsonPath = path.join(dir, 'package.json');
+    if (await pathExists(packageJsonPath)) {
+      const packageJson = await readJsonFile(packageJsonPath);
+      if (packageJson.packageManager) {
+        const corepackPackageManager = parsePackageManagerField(packageJson.packageManager);
+        if (corepackPackageManager) {
+          return corepackPackageManager.packageName;
+        }
+      }
+    }
+
+    // If at root directory, stop
+    if (dir === path.parse(dir).root) {
+      break;
+    }
+  }
+
+  // Default to 'npm' if nothing found
+  return 'npm';
+}
+
+function* traverseUpDirectories(start) {
+  let current = path.resolve(start);
+  while (true) {
+    yield current;
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+}
+
+function parsePackageManagerField(packageManager) {
+  if (!packageManager) return null;
+  const atIndex = packageManager.lastIndexOf('@');
+  if (atIndex <= 0) return null; // '@' at position 0 is invalid
+  const packageName = packageManager.slice(0, atIndex);
+  const packageVersion = packageManager.slice(atIndex + 1);
+  if (!packageName || !packageVersion) {
+    return null;
+  }
+  return { packageName, packageVersion };
+}
+
+async function runCommand(command, cwd) {
+  try {
+    await execAsync(command, { cwd });
+  } catch (error) {
+    throw new Error(
+      `Error installing package: ${error.stderr || error.message}`,
+    );
+  }
+}
+
+
+function getInstallCommand(packageManager, moduleName) {
+  if (packageManager === "npm") {
+    return `npm install ${moduleName}`;
+  } else {
+    return `${packageManager} add ${moduleName}`;
+  }
+}
+
+
+export {
+  detectPackageManager,
+  getInstallCommand,
+}
+
+
+


### PR DESCRIPTION
**Context** 
When we generate files for the user, we need some instant module to exist. This is because in schema.ts for example, we need to generate an import statement like: 

```typescript
import { i } from '@instantdb/react'
```

Previously: 
1. We only detected instantdb/react or instantdb/core. 
2. We would fail if they weren't there

This PR makes the CLI more helpful, by: 
1. Detecting react, core, react-native, and admin
2. If none are detected, prodding the user to choose one and installing it for them.


## When a module is detected:
<img width="760" alt="CleanShot 2024-11-21 at 12 59 52@2x" src="https://github.com/user-attachments/assets/a0dcb641-05b1-4b5e-8a39-24ef00b43449">

## If no module is detected:
<img width="904" alt="CleanShot 2024-11-21 at 13 01 43@2x" src="https://github.com/user-attachments/assets/6cadd34b-3d34-49b8-8442-9160541cf984">
<img width="901" alt="CleanShot 2024-11-21 at 13 01 12@2x" src="https://github.com/user-attachments/assets/0cac9b29-3056-4a49-9f9b-86cd8006150f">

@dwwoelfel @nezaj 