### PR TITLE
Fix instaql with reverse references

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -464,6 +464,47 @@ test("multiple connections", () => {
   ]);
 });
 
+test("query reverse references work with and without id", () => {
+  const stopa = query(
+    { store },
+    {
+      users: {
+        $: { where: { handle: "stopa" } },
+      },
+    },
+  ).data.users[0];
+
+  const stopaBookshelvesByHandle = query(
+    { store },
+    {
+      bookshelves: {
+        $: { where: { "users.handle": "stopa" } },
+      },
+    },
+  ).data.bookshelves;
+
+  const stopaBookshelvesById = query(
+    { store },
+    {
+      bookshelves: {
+        $: { where: { "users.id": stopa.id } },
+      },
+    },
+  ).data.bookshelves;
+
+  const stopaBookshelvesByLinkField = query(
+    { store },
+    {
+      bookshelves: {
+        $: { where: { users: stopa.id } },
+      },
+    },
+  ).data.bookshelves;
+
+  expect(stopaBookshelvesByHandle).toEqual(stopaBookshelvesById);
+  expect(stopaBookshelvesByHandle).toEqual(stopaBookshelvesByLinkField);
+});
+
 test("objects are created by etype", () => {
   const stopa = query(
     { store },
@@ -721,6 +762,22 @@ test("$isNull with relations", () => {
   ).data.users.map((x) => x.handle);
 
   expect(usersWithNullTitle).toEqual([...usersWithBook, "dww"]);
+});
+
+test("$isNull with reverse relations", () => {
+  const q = {
+    bookshelves: { $: { where: { "users.id": { $isNull: true } } }, users: {} },
+  };
+  expect(query({ store }, q).data.bookshelves.length).toBe(0);
+
+  const chunks = [
+    tx.bookshelves[randomUUID()].update({ name: "Lonely shelf" }),
+  ];
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunks);
+  const newStore = transact(store, txSteps);
+  expect(
+    query({ store: newStore }, q).data.bookshelves.map((x) => x.name),
+  ).toEqual(["Lonely shelf"]);
 });
 
 test("$not", () => {

--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -464,6 +464,38 @@ test("multiple connections", () => {
   ]);
 });
 
+test("query forward references work with and without id", () => {
+  const bookshelf = query(
+    { store },
+    {
+      bookshelves: {
+        $: { where: { "users.handle": "stopa" } },
+      },
+    },
+  ).data.bookshelves[0];
+
+  const usersByBookshelfId = query(
+    { store },
+    {
+      users: {
+        $: { where: { "bookshelves.id": bookshelf.id } },
+      },
+    },
+  ).data.users.map((x) => x.handle);
+
+  const usersByBookshelfLinkFIeld = query(
+    { store },
+    {
+      users: {
+        $: { where: { bookshelves: bookshelf.id } },
+      },
+    },
+  ).data.users.map((x) => x.handle);
+
+  expect(usersByBookshelfId).toEqual(["stopa"]);
+  expect(usersByBookshelfLinkFIeld).toEqual(["stopa"]);
+});
+
 test("query reverse references work with and without id", () => {
   const stopa = query(
     { store },
@@ -500,6 +532,8 @@ test("query reverse references work with and without id", () => {
       },
     },
   ).data.bookshelves;
+
+  expect(stopaBookshelvesByHandle.length).toBe(16);
 
   expect(stopaBookshelvesByHandle).toEqual(stopaBookshelvesById);
   expect(stopaBookshelvesByHandle).toEqual(stopaBookshelvesByLinkField);

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -452,7 +452,7 @@ export function allMapValues(m, level, res = []) {
 
 function triplesByValue(store, m, v) {
   const res = [];
-  if (v?.hasOwnProperty('$not')) {
+  if (v?.hasOwnProperty("$not")) {
     for (const candidate of m.keys()) {
       if (v.$not !== candidate) {
         res.push(m.get(candidate));
@@ -461,21 +461,32 @@ function triplesByValue(store, m, v) {
     return res;
   }
 
-  if (v?.hasOwnProperty('$isNull')) {
-    const { attrId, isNull } = v.$isNull;
+  if (v?.hasOwnProperty("$isNull")) {
+    const { attrId, isNull, reverse } = v.$isNull;
 
-    const aMap = store.aev.get(attrId);
-    for (const candidate of m.keys()) {
-      const isValNull =
-        !aMap || aMap.get(candidate)?.get(null) || !aMap.get(candidate);
-      if (isNull ? isValNull : !isValNull) {
-        res.push(m.get(candidate));
+    if (reverse) {
+      for (const candidate of m.keys()) {
+        const vMap = store.vae.get(candidate);
+        const isValNull =
+          !vMap || vMap.get(attrId)?.get(null) || !vMap.get(attrId);
+        if (isNull ? isValNull : !isValNull) {
+          res.push(m.get(candidate));
+        }
+      }
+    } else {
+      const aMap = store.aev.get(attrId);
+      for (const candidate of m.keys()) {
+        const isValNull =
+          !aMap || aMap.get(candidate)?.get(null) || !aMap.get(candidate);
+        if (isNull ? isValNull : !isValNull) {
+          res.push(m.get(candidate));
+        }
       }
     }
     return res;
   }
 
-  const values = v.in || v.$in ? (v.in || v.$in) : [v];
+  const values = v.in || v.$in ? v.in || v.$in : [v];
 
   for (const value of values) {
     const triple = m.get(value);
@@ -588,7 +599,7 @@ export function getPrimaryKeyAttr(store, etype) {
   if (fromPrimary) {
     return fromPrimary;
   }
-  return store.attrIndexes.forwardIdents.get(etype)?.get('id');
+  return store.attrIndexes.forwardIdents.get(etype)?.get("id");
 }
 
 export function transact(store, txSteps) {


### PR DESCRIPTION
Fixes Cam's `$isNull` bug.

We weren't handling reverse references correctly. Before this PR you can't use the linked field name in the where without the `.id`:

```clojure
{bookshelves: {$: {where: {users: myUserId}}}}
```
(`bookshelves.users` is the reverse link to `users.bookshelves`).

You could leave off the `.id` in the forward direction:

```clojure
{users: {$: {where: {bookshelves: bookshelfId}}}}
```

Now both directions are supported.

Also fixes how we check `$isNull` for reverse references, copying the same strategy we use on the server.

We actually patched this same issue on the server as part of the `isNull` PR https://github.com/instantdb/instant/pull/409, but didn't think to check if it was a problem on the client.