### PR TITLE
[do-not-review] Enforce the type `Query` on InstaQLEntity and InstaQLResult 

### DIFF
--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -371,7 +371,6 @@ type EntityDefFromShape<Shape, K extends keyof Shape> = EntityDef<
 >;
 
 /**
- * @deprecated
  * If you were using the old `schema` types, you can use this to help you
  * migrate.
  *

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
@@ -163,10 +163,7 @@ let coreMessageWithCreator: CoreMessageWithCreator = 1 as any;
 coreMessageWithCreator.content;
 coreMessageWithCreator.creator?.email;
 
-type MessageCreatorResult = InstaQLResult<
-  AppSchema,
-  InstaQLParams<AppSchema>
->;
+type MessageCreatorResult = InstaQLResult<AppSchema, InstaQLParams<AppSchema>>;
 function subMessagesWithCreator(
   resultCB: (data: MessageCreatorResult) => void,
 ) {
@@ -177,6 +174,61 @@ function subMessagesWithCreator(
   });
 }
 
+// Test that the `Q` bit is typed
+type DeeplyNestedQueryWorks = InstaQLEntity<
+  AppSchema,
+  "messages",
+  { creator: { createdMessages: { creator: {} } } }
+>;
+let deeplyNestedQuery: DeeplyNestedQueryWorks = 1 as any;
+deeplyNestedQuery.creator?.createdMessages[0].creator?.email;
+
+type DeeplyNestedQueryWillFailsBadInput = InstaQLEntity<
+  AppSchema,
+  "messages",
+  // Type '{ foo: {}; }' has no properties in common with type 'InstaQLSubqueryParams<AppSchema, "messages">'
+  // @ts-expect-error
+  { creator: { createdMessages: { foo: {} } } }
+>;
+let deeplyNestedQueryFailed: DeeplyNestedQueryWillFailsBadInput = 1 as any;
+
+type DeeplyNestedResultWorks = InstaQLResult<
+  AppSchema,
+  {
+    messages: {
+      creator: {
+        createdMessages: {
+          creator: {};
+        };
+      };
+    };
+  }
+>;
+let deeplyNestedResult: DeeplyNestedResultWorks = 1 as any;
+deeplyNestedQuery.creator?.createdMessages[0].creator?.email;
+
+type DeeplyNestedResultFailsBadInput = InstaQLResult<
+  AppSchema,
+  // @ts-expect-error
+  {
+    messages: {
+      creator: {
+        createdMessages: {
+          // Type '{ foo: {}; }' is not assignable to type 
+          // '$Option | ($Option & InstaQLQuerySubqueryParams<AppSchema, "messages">) 
+          // | undefined'
+          foo: {};
+        };
+      };
+    };
+  }
+>;
+let deeplyNestedResultFailed: DeeplyNestedResultFailsBadInput = 1 as any;
+
 // to silence ts warnings
+deeplyNestedQueryFailed;
+deeplyNestedResultFailed;
 messagesQuery;
 subMessagesWithCreator;
+deeplyNestedQuery;
+deeplyNestedResult;


### PR DESCRIPTION
### Context

Given a schema like: `messages, users, messages.creator = users.createdMessages`

If you made a type in the 'first' level of your expansion:

```typescript
InstaQLEntity<AppSchema, 'messages', { creatorr: { } }>
InstaQLResult<AppSchema, { messagess: { } }>
```

TS would warn you.  _But_ as you went deeper, you would lose typesafety: 

```typescript
InstaQLEntity<AppSchema, 'messages', { creator: { createdMessagess: { } } }>
InstaQLResult<AppSchema, { messages: { creator: { createdMessagess: { } } }>
```

This is because we were really lax with how we typed `Query`.  

It used to be: 

```
```
