### PR TITLE
[strong-init][experimental] Expand

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -42,6 +42,8 @@ import {
   type ValueTypes,
   type InstantSchemaDef,
   type InstantUnknownSchema,
+  type InstaQLEntity,
+  type InstaQLResult,
 } from "@instantdb/core";
 
 import version from "./version";
@@ -926,4 +928,6 @@ export {
   type ValueTypes,
   type InstantSchemaDef,
   type InstantUnknownSchema,
+  type InstaQLEntity,
+  type InstaQLResult,
 };

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -10,6 +10,12 @@ import type {
   ResolveEntityAttrs,
 } from "./schemaTypes";
 
+type Expand<T> = T extends object
+  ? T extends infer O
+    ? { [K in keyof O]: Expand<O[K]> }
+    : never
+  : T;
+
 // NonEmpty disallows {}, so that you must provide at least one field
 type NonEmpty<T> = {
   [K in keyof T]-?: Required<Pick<T, K>>;
@@ -207,8 +213,10 @@ type InstaQLEntity<
   Schema extends IContainEntitiesAndLinks<EntitiesDef, any>,
   EntityName extends keyof Schema["entities"],
   Subquery extends InstaQLEntitySubquery<Schema, EntityName> = {},
-> = { id: string } & ResolveEntityAttrs<Schema["entities"][EntityName]> &
-  InstaQLEntitySubqueryResult<Schema, EntityName, Subquery>;
+> = Expand<
+  { id: string } & ResolveEntityAttrs<Schema["entities"][EntityName]> &
+    InstaQLEntitySubqueryResult<Schema, EntityName, Subquery>
+>;
 
 type InstaQLQueryEntityResult<
   Entities extends EntitiesDef,
@@ -243,11 +251,11 @@ type InstaQLQueryResult<
 type InstaQLResult<
   Schema extends IContainEntitiesAndLinks<EntitiesDef, any>,
   Query extends InstaQLParams<Schema>,
-> = {
+> = Expand<{
   [QueryPropName in keyof Query]: QueryPropName extends keyof Schema["entities"]
     ? InstaQLEntity<Schema, QueryPropName, Query[QueryPropName]>[]
     : never;
-};
+}>;
 
 type InstaQLEntitySubquery<
   Schema extends IContainEntitiesAndLinks<EntitiesDef, any>,

--- a/client/sandbox/strong-init-vite/src/typescript_tests_normal_as_experimental.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_normal_as_experimental.tsx
@@ -90,7 +90,6 @@ function ReactNormalApp() {
   }
   const { messages } = data;
   messages[0].content;
-
   // transactions
   reactDB.transact(
     reactDB.tx.messages[id()]


### PR DESCRIPTION
When we returned a query result type, it would look something like:

<img width="616" alt="CleanShot 2024-11-22 at 10 02 25@2x" src="https://github.com/user-attachments/assets/48320e2f-8086-43ad-a998-24f6d7d47acd">

This is not _too_ helpful, as it doesn't actually show what the result would look like. 

I added a `Expand` type, which tries to convert this to it's most concrete form: 

<img width="660" alt="CleanShot 2024-11-22 at 10 02 43@2x" src="https://github.com/user-attachments/assets/0e542b80-d129-45dc-812c-88eb852afca3">

This is a bit experimental, as I am not 100% sure how this will interact with other types in the real world. 

However, I thought, let's ship it and get some feedback. 

@dwwoelfel @nezaj 