### PR TITLE
[in-progress] Comparison operators on indexed+checked attrs

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/operators.tsx
+++ b/client/sandbox/react-nextjs/pages/play/operators.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import config from "../../config";
+import { init_experimental, tx, id, i } from "@instantdb/react";
+import { useRouter } from "next/router";
+
+const schema = i.graph(
+  {
+    comments: i.entity({
+      slug: i.string().unique().indexed(),
+      someString: i.string().indexed(),
+      date: i.date().indexed(),
+      order: i.number().indexed(),
+      bool: i.boolean().indexed(),
+    }),
+    $users: i.entity({
+      email: i.string().unique().indexed(),
+    }),
+  },
+  {
+    commentAuthors: {
+      forward: {
+        on: "comments",
+        has: "one",
+        label: "author",
+      },
+      reverse: {
+        on: "$users",
+        has: "many",
+        label: "authoredComments",
+      },
+    },
+  },
+);
+
+function randInt(max: number) {
+  return Math.floor(Math.random() * max);
+}
+
+const d = new Date();
+
+function Example({ appId }: { appId: string }) {
+  const router = useRouter();
+  const myConfig = { ...config, appId, schema };
+  const db = init_experimental(myConfig);
+
+  const { data } = db.useQuery({
+    comments: {
+      // XXX: Update client
+      $: { where: { date: { $lt: d } } },
+    },
+  });
+
+  return (
+    <div>
+      <div>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() =>
+            db.transact(
+              tx.comments[id()].update({
+                order: randInt(100),
+                date: new Date(),
+                someString: "a".repeat(randInt(20)),
+                bool: randInt(2) === 1,
+              }),
+            )
+          }
+        >
+          Create comment
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => {
+            window.location.href = router.pathname;
+          }}
+        >
+          Start over
+        </button>
+      </div>
+      <div className="p-2"></div>
+      <div className="flex">
+        <div className="p-2">
+          <details open>
+            <summary>All items ({data?.comments?.length || 0}):</summary>
+
+            {data?.comments?.map((item) => (
+              <div key={item.id}>
+                <button
+                  onClick={() => {
+                    db.transact([tx.items[item.id].delete()]);
+                  }}
+                >
+                  X
+                </button>{" "}
+                order = {item.order}
+              </div>
+            ))}
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+async function provisionEphemeralApp() {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: "Comparisons example",
+    }),
+  });
+
+  return r.json();
+}
+
+async function verifyEphemeralApp({ appId }: { appId: string }) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  return r.json();
+}
+
+function App({ urlAppId }: { urlAppId: string | undefined }) {
+  const router = useRouter();
+  const [appId, setAppId] = useState();
+
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (appId) {
+      return;
+    }
+    if (urlAppId) {
+      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
+        if (res.app) {
+          setAppId(res.app.id);
+        } else {
+          provisionEphemeralApp().then((res) => {
+            if (res.app) {
+              router.replace({
+                pathname: router.pathname,
+                query: { ...router.query, app: res.app.id },
+              });
+
+              setAppId(res.app.id);
+            } else {
+              console.log(res);
+              setError("Could not create app.");
+            }
+          });
+        }
+      });
+    } else {
+      provisionEphemeralApp().then((res) => {
+        if (res.app) {
+          router.replace({
+            pathname: router.pathname,
+            query: { ...router.query, app: res.app.id },
+          });
+
+          setAppId(res.app.id);
+        } else {
+          console.log(res);
+          setError("Could not create app.");
+        }
+      });
+    }
+  }, []);
+
+  if (error) {
+    return (
+      <div>
+        <p>There was an error</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!appId) {
+    return <div>Loading...</div>;
+  }
+  return <Example appId={appId} />;
+}
+
+function Page() {
+  const router = useRouter();
+  if (router.isReady) {
+    return <App urlAppId={router.query.app as string} />;
+  } else {
+    return <div>Loading...</div>;
+  }
+}
+
+export default Page;

--- a/server/resources/migrations/39_fix_extract_boolean.down.sql
+++ b/server/resources/migrations/39_fix_extract_boolean.down.sql
@@ -1,0 +1,1 @@
+-- no down migration

--- a/server/resources/migrations/39_fix_extract_boolean.up.sql
+++ b/server/resources/migrations/39_fix_extract_boolean.up.sql
@@ -1,0 +1,13 @@
+-- Had the wrong return type
+drop function triples_extract_boolean_value;
+
+create or replace function triples_extract_boolean_value(value jsonb)
+returns boolean as $$
+  begin
+    if jsonb_typeof(value) = 'boolean' then
+      return (value->>0)::boolean;
+    else
+      return null;
+    end if;
+  end;
+$$ language plpgsql immutable;

--- a/server/resources/migrations/40_checked_indexes.down.sql
+++ b/server/resources/migrations/40_checked_indexes.down.sql
@@ -1,0 +1,10 @@
+drop index triples_string_trgm_gist_idx;
+
+drop index triples_number_type_idx;
+
+drop index triples_boolean_type_idx;
+
+drop index triples_date_type_idx;
+
+drop extension btree_gist;
+drop extension pg_trgm;

--- a/server/resources/migrations/40_checked_indexes.up.sql
+++ b/server/resources/migrations/40_checked_indexes.up.sql
@@ -1,0 +1,39 @@
+-- TODO: Run in production with `create index concurrently` before running this migration
+
+create extension if not exists btree_gist;
+create extension if not exists pg_trgm;
+
+create index if not exists triples_string_trgm_gist_idx on triples using gist (
+    app_id,
+    attr_id,
+    triples_extract_string_value(value) gist_trgm_ops,
+    entity_id
+  )
+  where ave and checked_data_type = 'string';
+
+create index if not exists triples_number_type_idx on triples (
+    app_id,
+    attr_id,
+    triples_extract_number_value(value),
+    entity_id
+  )
+  where ave and checked_data_type = 'number';
+
+create index if not exists triples_boolean_type_idx on triples (
+    app_id,
+    attr_id,
+    triples_extract_boolean_value(value),
+    entity_id
+  )
+  where ave and checked_data_type = 'boolean';
+
+create index if not exists triples_date_type_idx on triples (
+    app_id,
+    attr_id,
+    triples_extract_date_value(value),
+    entity_id
+  )
+  where ave and checked_data_type = 'date';
+
+-- XXX: Should we even have the `eav_index` in the database after this?
+---     Need to filter that index at least

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -37,12 +37,21 @@
 
 (s/def ::$not where-value-valid?)
 (s/def ::$isNull boolean?)
+(s/def ::comparator (s/or :date-string string?
+                          :number number?))
+
+;; XXX: do we want to support aliases like :$greaterThan, :$greaterThanOrEqualTo
+(s/def ::$gt ::comparator)
+(s/def ::$gte ::comparator)
+(s/def ::$lt ::comparator)
+(s/def ::$lte ::comparator)
 
 (defn where-value-valid-keys? [m]
-  (every? #{:in :$in :$not :$isNull} (keys m)))
+  (every? #{:in :$in :$not :$isNull :$gt :$gte :$lt :$lte} (keys m)))
 
 (s/def ::where-args-map (s/and
-                         (s/keys :opt-un [::in ::$in ::$not ::$isNull])
+                         (s/keys :opt-un [::in ::$in ::$not ::$isNull
+                                          ::$gt ::$gte ::$lt ::$lte])
                          where-value-valid-keys?))
 
 (s/def ::where-v
@@ -489,8 +498,7 @@
             :args-map (let [[func args-map-val] (first v-value)]
                         (case func
                           (:$in :in) args-map-val
-                          :$not {:$not args-map-val}
-                          :$isNull {:$isNull args-map-val})))
+                          {func args-map-val})))
         [refs-path value-label] (ucoll/split-last path)
 
         [last-etype last-level ref-attr-pats referenced-etypes]


### PR DESCRIPTION
Adds `$gt`, `$lt`, `$gte`, and `$lte` comparison operators for indexed attrs with `date` or `number` checked types.

**How it works**
We add new partial indexes on the `triples` table that extracts the typed data from the json. This is the number index for example:

```sql
create index if not exists triples_number_type_idx on triples (
    app_id,
    attr_id,
    triples_extract_number_value(value),
    entity_id
  )
  where ave and checked_data_type = 'number';
```

Our comparison query uses the index we created:

```sql
select * from triples
where app_id = :app_id
  and ave
  and attr_id = :attr_id
  and checked_data_type = 'number'
  and triples_extract_boolean_value(value) > 10;
```

```sql
->  Index Scan using triples_number_type_idx on triples  (cost=0.27..8.30 rows=1 width=143) (actual time=0.027..0.226 rows=221 loops=1)
Index Cond: ((app_id = :app-id)
              AND (attr_id = :attr-id) 
              AND (triples_extract_number_value(value) > '10'::double precision))
```

Still TODO:
- [ ] Clean up error messages a bit
- [ ] Fix topics
- [ ] Tests
- [ ] Client
- [ ] Create a PR into Joe's $like PR


TODOS before deploy:
- [ ] Manually add all of the indexes with `create index concurrently` so that we don't lock up the db when running the migration
- [ ] Run the migration