### PR TITLE
[cli] prompt for an app selector rather than pasting an id

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -566,7 +566,7 @@ async function promptForAppId(pkgAndAuthInfo) {
   }
   const { apps } = res.data;
   if (!apps.length) {
-    const ok = await "You don't have any apps. Want to create a new one?";
+    const ok = await promptOk("You don't have any apps. Want to create a new one?");
     if (!ok) return;
     await createApp(pkgAndAuthInfo);
     return;

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -574,7 +574,7 @@ async function promptForAppId(pkgAndAuthInfo) {
   const choice = await select({
     message: "Which app would you like to import?",
     choices: res.data.apps.map((app) => {
-      return { name: app.title, value: app.id };
+      return { name: `${app.title} (${app.id})`, value: app.id };
     }),
   });
   if (!choice) return;


### PR DESCRIPTION
Previously, we prompted for an app id. That's kind of a sadder experience though. Instead, we now fetch apps and let the user select: 

![image](https://github.com/user-attachments/assets/7345d552-12da-404d-86a7-2da7c7b60ca0)
