### PR TITLE
[cli] Make sure `instant-cli` login responds to `deny`

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -444,7 +444,7 @@ async function login(options) {
   if (!registerRes.ok) return;
 
   const { secret, ticket } = registerRes.data;
-
+  console.log("Let's log you in!");
   const ok = await promptOk(
     `This will open instantdb.com in your browser, OK to proceed?`,
   );
@@ -1279,7 +1279,9 @@ async function fetchJson({
     } catch {
       data = null;
     }
-
+    if (data) {
+      console.log(debugName, "json:", data);
+    }
     if (!res.ok) {
       if (withErrorLogging) {
         error(errorMessage);

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1200,26 +1200,25 @@ async function pushPerms(appId) {
 async function waitForAuthToken({ secret }) {
   for (let i = 1; i <= 120; i++) {
     await sleep(1000);
-
-    try {
-      const authCheckRes = await fetchJson({
-        method: "POST",
-        debugName: "Auth check",
-        errorMessage: "Failed to check auth status.",
-        path: "/dash/cli/auth/check",
-        body: { secret },
-        noAuth: true,
-        noLogError: true,
-      });
-
-      if (authCheckRes.ok) {
-        return authCheckRes.data;
-      }
-    } catch (error) {
-      throw error;
+    const authCheckRes = await fetchJson({
+      method: "POST",
+      debugName: "Auth check",
+      errorMessage: "Failed to check auth status.",
+      path: "/dash/cli/auth/check",
+      body: { secret },
+      noAuth: true,
+      noLogError: true,
+    });
+    if (authCheckRes.ok) {
+      return authCheckRes.data;
     }
+    if (authCheckRes.data?.hint.errors?.[0]?.issue === "waiting-for-user") {
+      continue;
+    }
+    error('Failed to authenticate ');
+    prettyPrintJSONErr(authCheckRes.data);
+    return;
   }
-
   error("Timed out waiting for authentication");
   return null;
 }
@@ -1287,17 +1286,7 @@ async function fetchJson({
     if (!res.ok) {
       if (withErrorLogging) {
         error(errorMessage);
-        if (data?.message) {
-          error(data.message);
-        }
-        if (Array.isArray(data?.hint?.errors)) {
-          for (const err of data.hint.errors) {
-            error(`${err.in ? err.in.join("->") + ": " : ""}${err.message}`);
-          }
-        }
-        if (!data) {
-          error("Failed to parse error response");
-        }
+        prettyPrintJSONErr(data);
       }
       return { ok: false, data };
     }
@@ -1318,6 +1307,20 @@ async function fetchJson({
       }
     }
     return { ok: false, data: null };
+  }
+}
+
+function prettyPrintJSONErr(data) {
+  if (data?.message) {
+    error(data.message);
+  }
+  if (Array.isArray(data?.hint?.errors)) {
+    for (const err of data.hint.errors) {
+      error(`${err.in ? err.in.join("->") + ": " : ""}${err.message}`);
+    }
+  }
+  if (!data) {
+    error("Failed to parse error response");
   }
 }
 

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1280,7 +1280,7 @@ async function fetchJson({
     } catch {
       data = null;
     }
-    if (data) {
+    if (verbose && data) {
       console.log(debugName, "json:", JSON.stringify(data));
     }
     if (!res.ok) {

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1215,7 +1215,9 @@ async function waitForAuthToken({ secret }) {
       if (authCheckRes.ok) {
         return authCheckRes.data;
       }
-    } catch (error) {}
+    } catch (error) {
+      throw error;
+    }
   }
 
   error("Timed out waiting for authentication");
@@ -1280,7 +1282,7 @@ async function fetchJson({
       data = null;
     }
     if (data) {
-      console.log(debugName, "json:", data);
+      console.log(debugName, "json:", JSON.stringify(data));
     }
     if (!res.ok) {
       if (withErrorLogging) {

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1124,11 +1124,8 @@
 
 (defn cli-auth-check-post [req]
   (let [secret (ex/get-param! req [:body :secret] uuid-util/coerce)
-        cli-auth (instant-cli-login-model/check! aurora/conn-pool {:secret secret})
+        cli-auth (instant-cli-login-model/use! aurora/conn-pool {:secret secret})
         user-id (:user_id cli-auth)
-        _ (ex/assert-valid! :cli-auth
-                            (:id cli-auth)
-                            (when-not user-id [{:message "Invalid CLI auth ticket"}]))
         refresh-token (instant-user-refresh-token-model/create! {:id (UUID/randomUUID) :user-id user-id})
         token (:id refresh-token)
         {email :email} (instant-user-model/get-by-id! {:id user-id})

--- a/server/src/instant/model/instant_cli_login.clj
+++ b/server/src/instant/model/instant_cli_login.clj
@@ -2,12 +2,10 @@
   (:require [instant.jdbc.aurora :as aurora]
             [instant.jdbc.sql :as sql]
             [instant.util.crypt :as crypt-util]
-            [instant.util.exception :as ex]
-            [next.jdbc :as next-jdbc])
+            [instant.util.exception :as ex])
   (:import
    (java.time Instant)
-   (java.time.temporal ChronoUnit)
-   (java.util UUID)))
+   (java.time.temporal ChronoUnit)))
 
 (defn create!
   ([params] (create! aurora/conn-pool params))


### PR DESCRIPTION
Previously, there were a few bugs with our `instant-cli login` flow: 
1. Once we entered the waitForAuthToken phase, we couldn't ctrl + c out of the program
   1. This was because we had a try catch over the fetch json, which swallowed everything
1. If a user clicked 'Deny' on the dashboard, the system would not exit
  1.  This was because there was no difference between a) a missing login request, a claimed one, or an expired one

I updated our backend, so we return more descriptive errors when we are waiting for authentication. If we are simply waiting for user input, we recurse. But, if there's any other error, we now exit. 

I also removed the high-level try catch. 

@dwwoelfel @nezaj 