### PR TITLE
[cli] use prettier to autoformat our exported files

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -21,6 +21,7 @@ import {
   getInstallCommand,
 } from "./src/util/packageManager.js";
 import { pathExists, readJsonFile } from "./src/util/fs.js";
+import prettier from 'prettier';
 
 const execAsync = promisify(exec);
 
@@ -603,6 +604,15 @@ async function detectOrCreateAppWithErrorLogging(opts) {
   return await promptImportAppOrCreateApp();
 }
 
+async function writeTypescript(path, content, encoding) { 
+  const prettierConfig = await prettier.resolveConfig(path);
+  const formattedCode = await prettier.format(content, {
+    ...prettierConfig,
+    parser: 'typescript',
+  });
+  return await writeFile(path, formattedCode, encoding);
+}
+
 async function handleCreatedApp(
   { pkgDir, instantModuleName },
   appId,
@@ -618,7 +628,7 @@ async function handleCreatedApp(
 
   if (!schema) {
     const schemaPath = join(pkgDir, "instant.schema.ts");
-    await writeFile(
+    await writeTypescript(
       schemaPath,
       instantSchemaTmpl(appTitle, appId, instantModuleName),
       "utf-8",
@@ -627,7 +637,7 @@ async function handleCreatedApp(
   }
 
   if (!perms) {
-    await writeFile(
+    await writeTypescript(
       join(pkgDir, "instant.perms.ts"),
       examplePermsTmpl,
       "utf-8",
@@ -719,7 +729,7 @@ async function pullSchema(appId, { pkgDir, instantModuleName }) {
   }
 
   const schemaPath = join(pkgDir, "instant.schema.ts");
-  await writeFile(
+  await writeTypescript(
     schemaPath,
     generateSchemaTypescriptFile(
       appId,
@@ -760,7 +770,7 @@ async function pullPerms(appId, { pkgDir }) {
   }
 
   const permsPath = join(pkgDir, "instant.perms.ts");
-  await writeFile(
+  await writeTypescript(
     permsPath,
     `export default ${JSON.stringify(pullRes.data.perms, null, "  ")};`,
     "utf-8",

--- a/client/packages/cli/package.json
+++ b/client/packages/cli/package.json
@@ -19,6 +19,7 @@
     "open": "^10.1.0",
     "ora": "^8.1.1",
     "pkg-dir": "^8.0.0",
+    "prettier": "^3.3.3",
     "terminal-link": "^3.0.0",
     "unconfig": "^0.5.5"
   }

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       pkg-dir:
         specifier: ^8.0.0
         version: 8.0.0
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
       terminal-link:
         specifier: ^3.0.0
         version: 3.0.0
@@ -14236,7 +14239,6 @@ packages:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
 
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}


### PR DESCRIPTION
Previously, the files we generated would be a bit off with formatting:
- Keys would be written out as strings, even rather than as symbols
- Spacing was off

Added prettier to the CLI. This makes it so we print a formatted file

@dwwoelfel @nezaj 