### PR TITLE
gzip honeycomb traces

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -41,9 +41,15 @@
         pjstadig/humane-test-output {:mvn/version "0.11.0"}
         com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}
         org.clj-commons/claypoole {:mvn/version "1.2.2"}
-        io.honeycomb/honeycomb-opentelemetry-sdk {:mvn/version "1.5.2"}
-        dev.cel/cel {:mvn/version "0.5.2"}
+
+        ;; opentelemetry
+        io.opentelemetry/opentelemetry-api {:mvn/version "1.44.1"}
+        io.opentelemetry/opentelemetry-sdk {:mvn/version "1.44.1"}
+        io.opentelemetry/opentelemetry-exporter-otlp {:mvn/version "1.44.1"}
+        io.grpc/grpc-netty-shaded {:mvn/version "1.68.1"}
         com.github.steffan-westcott/clj-otel-api {:mvn/version "0.2.4-SNAPSHOT"}
+
+        dev.cel/cel {:mvn/version "0.5.2"}
         com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.6"}
         com.google.crypto.tink/tink {:mvn/version "1.12.0"}
         com.google.crypto.tink/tink-awskms {:mvn/version "1.9.1"}

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -12,7 +12,7 @@
    (io.opentelemetry.context Context)
    (io.opentelemetry.exporter.otlp.trace OtlpGrpcSpanExporter)
    (io.opentelemetry.sdk.resources Resource)
-   (io.opentelemetry.sdk.trace SdkTracerProvider)
+   (io.opentelemetry.sdk.trace SdkTracerProvider SdkTracer)
    (io.opentelemetry.sdk.trace.export BatchSpanProcessor SimpleSpanProcessor))
   (:gen-class))
 
@@ -23,7 +23,7 @@
 (def ^:dynamic *silence-exceptions?* nil)
 
 (defonce tracer (atom nil))
-(defn get-tracer []
+(defn get-tracer ^SdkTracer []
   (if-let [t @tracer]
     t
     (throw (Exception. "Call to trace before initialization."))))
@@ -31,6 +31,7 @@
 (defn make-log-only-sdk
   "Creates an opentelemetry sdk that logs to the console for use in tests
   and for Open Source when no Honeycomb API key is available."
+  ^OpenTelemetrySdk
   []
   (let [trace-provider-builder (SdkTracerProvider/builder)
         sdk-builder (OpenTelemetrySdk/builder)
@@ -40,7 +41,9 @@
         (.setTracerProvider (.build trace-provider-builder))
         (.build))))
 
-(defn make-honeycomb-sdk [honeycomb-api-key]
+(defn make-honeycomb-sdk
+  ^OpenTelemetrySdk
+  [honeycomb-api-key]
   (let [trace-provider-builder (SdkTracerProvider/builder)
         sdk-builder (OpenTelemetrySdk/builder)
         log-processor (SimpleSpanProcessor/create (logging-exporter/create))
@@ -212,7 +215,7 @@
   ([]
    (when *span*
      (span-uri *span*)))
-  ([span]
+  ([^Span span]
    (let [ctx (.getSpanContext span)
          trace-id (.getTraceId ctx)
          span-id (.getSpanId ctx)]


### PR DESCRIPTION
Compresses honeycomb traces with gzip. Should help us to transfer a lot less data between our instances. 

Tested locally talking both to the honeycomb API and a local refinery instance.