### PR TITLE
Log how much data we're sending over websockets per app

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1151,7 +1151,7 @@
     {:undertow/websocket
      {:on-open (fn [{:keys [channel]}]
                  (tracer/with-span! {:name "ws-play/on-open" :attributes {:id id}}
-                   (ws/send-json! (format "[%s] ok" id) channel)))
+                   (ws/send-json! nil (format "[%s] ok" id) channel)))
       :on-message (fn [{:keys [^WebSocketChannel channel data]}]
                     (tracer/with-span! {:name "ws-play/on-message" :attributes {:id id :data data}}
                       (condp = (string/trim data)
@@ -1161,8 +1161,8 @@
                         "throw-err"
                         (tracer/with-span! {:name "ws-play/throw-err" :attributes {:id id}}
                           (do (.close channel)
-                              (ws/send-json! "this can't send" channel)))
-                        (ws/send-json! (format "[%s] received %s" id data) channel))))
+                              (ws/send-json! nil "this can't send" channel)))
+                        (ws/send-json! nil (format "[%s] received %s" id data) channel))))
 
       :on-close (fn [_]
                   (tracer/record-info! {:name  "ws-play/on-close" :attributes {:id id}}))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -184,6 +184,7 @@
             :when q]
       (receive-queue/enqueue->receive-q q
                                         {:op :refresh-presence
+                                         :app-id (:app-id room-key)
                                          :room-id room-id
                                          :data room-data
                                          :session-id sess-id}))))
@@ -214,6 +215,7 @@
                   :when q]
             (receive-queue/enqueue->receive-q q
                                               {:op :refresh-presence
+                                               :app-id app-id
                                                :room-id room-id
                                                :data room-data
                                                :session-id sess-id})))))))

--- a/server/src/instant/session_counter.clj
+++ b/server/src/instant/session_counter.clj
@@ -36,7 +36,7 @@
        (into {})))
 
 (defn send-report! [report ws]
-  (ws/send-json! {:op :report :report report} ws))
+  (ws/send-json! nil {:op :report :report report} ws))
 
 ;; ------- 
 ;; Reporter 
@@ -83,8 +83,8 @@
                       (if (= token api-key)
                         (do (add-websocket-listener! ws-id channel)
                             (send-report! (store->report @rs/store-conn) channel))
-                        (ws/send-json! {:op :error
-                                        :message "Invalid token"}
+                        (ws/send-json! nil {:op :error
+                                            :message "Invalid token"}
                                        channel))))
       :on-error (fn [{throwable :error}]
                   (remove-websocket-listener! ws-id)

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -120,12 +120,14 @@
 (def exclude-span?
   (if (= :prod (config/get-env))
     (fn [span]
-      (let [attrs (.getAttributes span)]
-        (when-let [op (.get attrs op-attr-key)]
-          (or (= op ":set-presence")
-              (= op ":refresh-presence")
-              (= op ":server-broadcast")
-              (= op ":client-broadcast")))))
+      (let [name (.getName span)
+            attrs (.getAttributes span)]
+        (or (= name "ws/send-json!")
+            (when-let [op (.get attrs op-attr-key)]
+              (or (= op ":set-presence")
+                  (= op ":refresh-presence")
+                  (= op ":server-broadcast")
+                  (= op ":client-broadcast"))))))
     (fn [_span]
       false)))
 

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -59,7 +59,7 @@
               *eph-store-atom* eph-store-atom]
       (with-redefs [receive-queue/receive-q receive-q
                     eph/room-refresh-ch room-refresh-ch
-                    ws/send-json! (fn [msg fake-ws-conn]
+                    ws/send-json! (fn [_app-id msg fake-ws-conn]
                                     (a/>!! fake-ws-conn msg))
 
                     rq/instaql-query-reactive!


### PR DESCRIPTION
Adds a trace to log how much data we're sending over the websockets. This way we can get a better idea of how much different apps are contributing to network usage.

Ignores the span in prod for the console log so that we don't spike our cloudwatch costs.