### PR TITLE
[cli] merge all `pull` file creation into one path

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -401,7 +401,7 @@ async function push(bag, appId, opts) {
 
 function printDotEnvInfo(source, appId) {
   if (source === "imported" || source === "created") {
-    console.log(`\nPicked app ${chalk.green(appId)}! \n`);
+    console.log(`\nPicked app ${chalk.green(appId)}!\n`);
     console.log(
       `To use this app automatically from now on, update your ${chalk.green("`.env`")} file:`,
     );
@@ -409,8 +409,8 @@ function printDotEnvInfo(source, appId) {
     console.log(`  ${chalk.green(catchall)}=${appId}`);
     const otherEnvs = Object.values(rest);
     otherEnvs.sort();
-    const otherEnvStr = otherEnvs.map((x) => chalk.green(x)).join("\n ");
-    console.log(`Alternative names: \n ${otherEnvStr}`);
+    const otherEnvStr = otherEnvs.map((x) => "  " + chalk.green(x)).join("\n");
+    console.log(`Alternative names: \n${otherEnvStr}`);
     console.log(terminalLink("Dashboard", appDashUrl(appId)));
   }
 }
@@ -567,6 +567,9 @@ async function promptImportAppOrCreateApp() {
     if (!ok) return { ok: false };
     return await promptCreateApp();
   }
+
+  apps.sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at));
+
   const choice = await select({
     message: "Which app would you like to import?",
     choices: res.data.apps.map((app) => {
@@ -965,7 +968,7 @@ async function pushSchema(appId, opts) {
   if (!planRes.ok) return;
 
   if (!planRes.data.steps.length) {
-    console.log("No schema changes detected.  Exiting.");
+    console.log("No schema changes detected. Exiting.");
     return;
   }
 
@@ -1550,8 +1553,9 @@ function generateSchemaTypescriptFile(id, schema, title, instantModuleName) {
     }),
   );
 
-  return `// ${title}
+  return `
 // ${appDashUrl(id)}
+// Docs: https://www.instantdb.com/docs/schema
 
 import { i } from "${instantModuleName ?? "@instantdb/core"}";
 


### PR DESCRIPTION
**Context** 

Previously, we had a separate flow, where if you used `init` and chose to create an app, we would make some empty files for you. 

However, those files had a few issues: 
1. The default state was filled with data that wasn't actually in the production app. This felt a bit confusing
2. There wasn't _much_ explanation. For example, the `rules` file just had some example rules, but nothing more

We also had unique behavior when pulling an app: 
1. If there were no perms in an app, we would not create a perms file 

**This PR** 

Now, whether you 'create' an app or not, we will go through the same `pull` flow. 

In this new pull flow, we detect: 
1. If the schema does not have any entities defined, we add a comment explaining what they are 
2. If the schema does not have links defined, we add a comment explaining what they are 
3. If the perms are empty, we still make a perms file, but add a little description 

**Coming up**

I still have more to do, to make these files look better (i.schema instead of graph for schema, intellisense for perms, comparing previous files). But, we'll get to it soon 🔥

--- 

<img width="909" alt="CleanShot 2024-11-25 at 17 03 50@2x" src="https://github.com/user-attachments/assets/46d0dc0f-07c2-4009-bba2-9ff18963a63f">

<img width="852" alt="CleanShot 2024-11-25 at 17 04 07@2x" src="https://github.com/user-attachments/assets/309fa26c-1048-4653-a96e-0a86700c1c2c">

<img width="803" alt="CleanShot 2024-11-25 at 17 04 21@2x" src="https://github.com/user-attachments/assets/23be75e0-5176-4d7a-8898-f4cadbae8da7">

@dwwoelfel @nezaj 