### PR TITLE
Include hint in query error

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -530,6 +530,10 @@ export default class Reactor {
       message: msg.message || "Uh-oh, something went wrong. Ping Joe & Stopa.",
     };
 
+    if (msg.hint) {
+      errorMessage.hint = msg.hint;
+    }
+
     if (prevMutation) {
       // This must be a transaction error
       const errDetails = {

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -659,23 +659,6 @@ console.log(data)
 }
 ```
 
-### Comparison operators
-
-The `where` clause supports comparison operators on fields that are indexed and have checked types.
-
-{% callout %}
-Add indexes and checked types to your attributes from the [Explorer on the the Instant dashboard](/dash?t=explorer) or from the [cli with Schema-as-code](/docs/schema).
-{% /callout %}
-
-| Operator |       Description        | JS equivalent |
-| :------: | :----------------------: | :-----------: |
-|  `$gt`   |       greater than       |      `>`      |
-|  `$lt`   |        less than         |      `<`      |
-|  `$gte`  | greater than or equal to |     `>=`      |
-|  `$lte`  |  less than or equal to   |     `<=`      |
-
-
-
 ### $not
 
 The `where` clause supports `$not` queries that will return entities that don't

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -659,6 +659,23 @@ console.log(data)
 }
 ```
 
+### Comparison operators
+
+The `where` clause supports comparison operators on fields that are indexed and have checked types.
+
+{% callout %}
+Add indexes and checked types to your attributes from the [Explorer on the the Instant dashboard](/dash?t=explorer) or from the [cli with Schema-as-code](/docs/schema).
+{% /callout %}
+
+| Operator |       Description        | JS equivalent |
+| :------: | :----------------------: | :-----------: |
+|  `$gt`   |       greater than       |      `>`      |
+|  `$lt`   |        less than         |      `<`      |
+|  `$gte`  | greater than or equal to |     `>=`      |
+|  `$lte`  |  less than or equal to   |     `<=`      |
+
+
+
 ### $not
 
 The `where` clause supports `$not` queries that will return entities that don't


### PR DESCRIPTION
We get a lot of people in the discord who are confused about query errors because all they see is "Validation failed for query" in the error message. This passes along the hint so that they can identify the problem.

**Before**

```json
{
    "message": "Validation failed for query"
}
```

**After**
```json
{
    "message": "Validation failed for query",
    "hint": {
        "data-type": "query",
        "input": {
            "comments": {
                "$": {
                    "where": {
                        "someField": {
                            "$gt": 50
                        }
                    }
                }
            }
        },
        "errors": [
            {
                "expected?": "indexed?",
                "in": [
                    "comments",
                    "$",
                    "where",
                    "someField"
                ],
                "message": "The `comments.someField` attribute must be indexed to use comparison operators."
            }
        ]
    }
}
```