### PR TITLE
export InstantAdminDatabase

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -896,6 +896,7 @@ export {
   type TransactionChunk,
   type DebugCheckResult,
   type InstantAdmin,
+  type InstantAdminDatabase,
 
   // core types
   type User,


### PR DESCRIPTION
User reported that this type was missing. It's not longer _strictly_ necessary to export it, as all other types just take the Schema, but it's good to have. 

https://discord.com/channels/1031957483243188235/1280983629270487080/1310893036401856523

@dwwoelfel @nezaj 