### PR TITLE
[cli] Add a type helper to rules

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -44,6 +44,7 @@ import {
   type InstantUnknownSchema,
   type InstaQLEntity,
   type InstaQLResult,
+  type InstantRules,
 } from "@instantdb/core";
 
 import version from "./version";
@@ -931,4 +932,5 @@ export {
   type InstantUnknownSchema,
   type InstaQLEntity,
   type InstaQLResult,
+  type InstantRules,
 };

--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -720,7 +720,7 @@ async function pullSchema(appId, { pkgDir, instantModuleName }) {
   return true;
 }
 
-async function pullPerms(appId, { pkgDir }) {
+async function pullPerms(appId, { pkgDir, instantModuleName }) {
   console.log("Pulling perms...");
 
   const pullRes = await fetchJson({
@@ -742,7 +742,7 @@ async function pullPerms(appId, { pkgDir }) {
   const permsPath = join(pkgDir, "instant.perms.ts");
   await writeTypescript(
     permsPath,
-    generatePermsTypescriptFile(pullRes.data.perms || {}),
+    generatePermsTypescriptFile(pullRes.data.perms || {}, instantModuleName),
     "utf-8",
   );
 
@@ -1478,7 +1478,7 @@ function appDashUrl(id) {
   return `${instantDashOrigin}/dash?s=main&t=home&app=${id}`;
 }
 
-function generatePermsTypescriptFile(perms) {
+function generatePermsTypescriptFile(perms, instantModuleName) {
   const rulesTxt = Object.keys(perms).length
     ? JSON.stringify(perms, null, 2)
     : `
@@ -1504,7 +1504,9 @@ function generatePermsTypescriptFile(perms) {
   return `
 // Docs: https://www.instantdb.com/docs/permissions
 
-const rules = ${rulesTxt};
+import { type InstantRules } from "${instantModuleName ?? "@instantdb/core"}";
+
+const rules = ${rulesTxt} satisfies InstantRules;
 
 export default rules;
   `.trim();

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -834,6 +834,19 @@ function init_experimental<
   return client;
 }
 
+type InstantRules = {
+  [EntityName: string]: {
+    allow: {
+      view?: string;
+      create?: string;
+      update?: string;
+      delete?: string;
+    };
+    bind?: string[];
+  };
+};
+
+
 export {
   // bada bing bada boom
   init,
@@ -915,4 +928,5 @@ export {
   type InstantUnknownSchema,
   type IInstantDatabase,
   type BackwardsCompatibleSchema,
+  type InstantRules,
 };

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -50,6 +50,7 @@ import {
   type InstantConfig,
   type InstantSchemaDef,
   type InstantUnknownSchema,
+  type InstantRules,
 } from "@instantdb/core";
 
 /**
@@ -146,4 +147,5 @@ export {
   type InstantSchemaDef,
   type InstantUnknownSchema,
   type BackwardsCompatibleSchema,
+  type InstantRules,
 };

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -37,6 +37,7 @@ import {
   type InstantUnknownSchema,
   type InstantSchemaDef,
   type BackwardsCompatibleSchema,
+  type InstantRules,
 } from "@instantdb/core";
 
 import { InstantReact } from "./InstantReact";
@@ -94,4 +95,5 @@ export {
   type InstantUnknownSchema,
   type InstantSchemaDef,
   type BackwardsCompatibleSchema,
+  type InstantRules,
 };

--- a/client/sandbox/strong-init-vite/instant.perms.ts
+++ b/client/sandbox/strong-init-vite/instant.perms.ts
@@ -8,27 +8,6 @@ const rules = {
       create: "false",
     },
   },
-  posts: {
-    bind: [
-      "isAdmin",
-      "auth.email == 'stepan.p@gmail.com'",
-      "isOwner",
-      "auth.uid == data.author",
-    ],
-    allow: {
-      create: "isAdmin || isOwner",
-      delete: "isAdmin || isOwner",
-      update: "isAdmin || isOwner",
-    },
-  },
-  postBodies: {
-    bind: ["isAdmin", "auth.email == 'stepan.p@gmail.com'"],
-    allow: {
-      create: "isAdmin",
-      delete: "isAdmin",
-      update: "isAdmin",
-    },
-  },
 } satisfies InstantRules;
 
 export default rules;

--- a/client/sandbox/strong-init-vite/instant.perms.ts
+++ b/client/sandbox/strong-init-vite/instant.perms.ts
@@ -1,9 +1,22 @@
+type InstantRules = {
+  [EntityName: string]: {
+    allow: {
+      view?: string;
+      create?: string;
+      update?: string;
+      delete?: string;
+    };
+    bind?: string[];
+  };
+};
+
 const rules = {
   attrs: {
     allow: {
       create: "false",
     },
+    bind: ["admin", "foo", "bar", "biz"],
   },
-};
+} satisfies InstantRules;
 
 export default rules;

--- a/client/sandbox/strong-init-vite/instant.perms.ts
+++ b/client/sandbox/strong-init-vite/instant.perms.ts
@@ -1,21 +1,33 @@
-type InstantRules = {
-  [EntityName: string]: {
-    allow: {
-      view?: string;
-      create?: string;
-      update?: string;
-      delete?: string;
-    };
-    bind?: string[];
-  };
-};
+// Docs: https://www.instantdb.com/docs/permissions
+
+import { type InstantRules } from "@instantdb/react";
 
 const rules = {
   attrs: {
     allow: {
       create: "false",
     },
-    bind: ["admin", "foo", "bar", "biz"],
+  },
+  posts: {
+    bind: [
+      "isAdmin",
+      "auth.email == 'stepan.p@gmail.com'",
+      "isOwner",
+      "auth.uid == data.author",
+    ],
+    allow: {
+      create: "isAdmin || isOwner",
+      delete: "isAdmin || isOwner",
+      update: "isAdmin || isOwner",
+    },
+  },
+  postBodies: {
+    bind: ["isAdmin", "auth.email == 'stepan.p@gmail.com'"],
+    allow: {
+      create: "isAdmin",
+      delete: "isAdmin",
+      update: "isAdmin",
+    },
   },
 } satisfies InstantRules;
 


### PR DESCRIPTION
Previously, rules had no type information. This made it a bit annoying to write it out, because you would get no intellisense. 

I made an `InstantRules` type, which helps with autocomplete when writing out the rules. 

<img width="1013" alt="CleanShot 2024-11-26 at 15 51 39@2x" src="https://github.com/user-attachments/assets/56816c1a-d083-41ec-bca0-82ac35857765">

@dwwoelfel @nezaj 