### PR TITLE
[strong-init][cli] make i.schema the default

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -752,12 +752,7 @@ async function pullSchema(appId, { pkgDir, instantModuleName }) {
   const schemaPath = join(pkgDir, "instant.schema.ts");
   await writeTypescript(
     schemaPath,
-    generateSchemaTypescriptFile(
-      appId,
-      pullRes.data.schema,
-      pullRes.data["app-title"],
-      instantModuleName,
-    ),
+    generateSchemaTypescriptFile(pullRes.data.schema, instantModuleName),
     "utf-8",
   );
 
@@ -1529,12 +1524,12 @@ function generatePermsTypescriptFile(perms, instantModuleName) {
     ? JSON.stringify(perms, null, 2)
     : `
 {
-  /** 
+  /**
    * Welcome to Instant's permission system!
    * Right now your rules are empty. To start filling them in, check out the docs:
    * https://www.instantdb.com/docs/permissions
-   * 
-   * Here's an example to give you a feel: 
+   *
+   * Here's an example to give you a feel:
    * posts: {
    *   allow: {
    *     view: "true",
@@ -1558,7 +1553,7 @@ export default rules;
   `.trim();
 }
 
-function generateSchemaTypescriptFile(id, schema, title, instantModuleName) {
+function generateSchemaTypescriptFile(schema, instantModuleName) {
   const entitiesEntriesCode = sortedEntries(schema.blobs)
     .map(([name, attrs]) => {
       // a block of code for each entity
@@ -1596,7 +1591,7 @@ function generateSchemaTypescriptFile(id, schema, title, instantModuleName) {
 
   const entitiesObjCode = `{\n${entitiesEntriesCode}\n}`;
 
-  const linksEntriesCode = Object.fromEntries(
+  const linksEntries = Object.fromEntries(
     sortedEntries(schema.refs).map(([_name, config]) => {
       const [, fe, flabel] = config["forward-identity"];
       const [, re, rlabel] = config["reverse-identity"];
@@ -1618,38 +1613,52 @@ function generateSchemaTypescriptFile(id, schema, title, instantModuleName) {
       ];
     }),
   );
+  const linksEntriesCode = JSON.stringify(linksEntries, null, "  ");
 
-  return `
-// ${appDashUrl(id)}
-// Docs: https://www.instantdb.com/docs/schema
-
-import { i } from "${instantModuleName ?? "@instantdb/core"}";
-
-const graph = i.graph(
-${
-  Object.keys(schema.blobs).length === 1 &&
-  Object.keys(schema.blobs)[0] === "$users"
+  const etypes = Object.keys(schema.blobs);
+  const hasOnlyUserTable = etypes.length === 1 && etypes[0] === "$users";
+  const entitiesComment = hasOnlyUserTable
     ? `
 // This section lets you define entities: think \`posts\`, \`comments\`, etc
 // Take a look at the docs to learn more:
 // https://www.instantdb.com/docs/schema#defining-entities
 `.trim()
-    : ""
-}
-${indentLines(entitiesObjCode, 1)},
-${
-  Object.keys(schema.refs).length === 0
+    : "";
+  const hasNoLinks = Object.keys(linksEntries).length === 0;
+  const linksComment = hasNoLinks
     ? `
-// You can define links here.
-// For example, if \`posts\` should have many \`comments\`.
-// More in the docs:
-// https://www.instantdb.com/docs/schema#defining-links
-`.trim()
-    : ""
-}
-${indentLines(JSON.stringify(linksEntriesCode, null, "  "), 1)}
-);
+  // You can define links here.
+  // For example, if \`posts\` should have many \`comments\`.
+  // More in the docs:
+  // https://www.instantdb.com/docs/schema#defining-links
+  `.trim()
+    : "";
 
-export default graph;
+  const roomsComment = `
+// If you use presence, you can define a room schema here
+// https://www.instantdb.com/docs/schema#defining-rooms
+  `.trim();
+
+  return `
+// Docs: https://www.instantdb.com/docs/schema
+
+import { i } from "${instantModuleName ?? "@instantdb/core"}";
+
+const _schema = i.schema({
+  ${entitiesComment}
+  entities: ${entitiesObjCode},
+  ${linksComment}
+  links: ${linksEntriesCode},
+  ${roomsComment}
+  rooms: {}
+});
+
+// This helps Typescript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
+
+export { type AppSchema }
+export default schema;
 `;
 }

--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -703,14 +703,14 @@ test("it doesn't create duplicate ref attrs", () => {
 });
 
 test("Schema: uses info in `attrs` and `links`", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       comments: i.entity({
         slug: i.string().unique().indexed(),
       }),
       books: i.entity({}),
     },
-    {
+    links: {
       commentBooks: {
         forward: {
           on: "comments",
@@ -724,7 +724,8 @@ test("Schema: uses info in `attrs` and `links`", () => {
         },
       },
     },
-  );
+    rooms: {},
+  });
 
   const commentId = uuid();
   const bookId = uuid();
@@ -794,12 +795,12 @@ test("Schema: uses info in `attrs` and `links`", () => {
 });
 
 test("Schema: doesn't create duplicate ref attrs", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       comments: i.entity({}),
       books: i.entity({}),
     },
-    {
+    links: {
       commentBooks: {
         forward: {
           on: "comments",
@@ -813,7 +814,8 @@ test("Schema: doesn't create duplicate ref attrs", () => {
         },
       },
     },
-  );
+    rooms: {},
+  });
 
   const commentId = uuid();
   const bookId = uuid();
@@ -862,14 +864,15 @@ test("Schema: doesn't create duplicate ref attrs", () => {
 });
 
 test("Schema: lookup creates unique attrs for custom lookups", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       users: i.entity({
         nickname: i.string().unique().indexed(),
       }),
     },
-    {},
-  );
+    links: {},
+    rooms: {},
+  });
 
   const ops = instatx.tx.users[instatx.lookup("nickname", "stopanator")].update(
     {
@@ -909,14 +912,14 @@ test("Schema: lookup creates unique attrs for custom lookups", () => {
 });
 
 test("Schema: lookup creates unique attrs for lookups in link values", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       posts: i.entity({
         slug: i.string().unique().indexed(),
       }),
       users: i.entity({}),
     },
-    {
+    links: {
       postUsers: {
         forward: {
           on: "users",
@@ -930,7 +933,8 @@ test("Schema: lookup creates unique attrs for lookups in link values", () => {
         },
       },
     },
-  );
+    rooms: {},
+  });
 
   const uid = uuid();
   const ops = instatx.tx.users[uid]
@@ -990,14 +994,14 @@ test("Schema: lookup creates unique attrs for lookups in link values", () => {
 });
 
 test("Schema: lookup creates unique attrs for lookups in link values with arrays", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       posts: i.entity({
         slug: i.string().unique().indexed(),
       }),
       users: i.entity({}),
     },
-    {
+    links: {
       postUsers: {
         forward: {
           on: "users",
@@ -1011,7 +1015,8 @@ test("Schema: lookup creates unique attrs for lookups in link values with arrays
         },
       },
     },
-  );
+    rooms: {},
+  });
 
   const uid = uuid();
   const ops = instatx.tx.users[uid].update({}).link({
@@ -1084,12 +1089,12 @@ test("Schema: lookup creates unique attrs for lookups in link values with arrays
 });
 
 test("Schema: lookup creates unique ref attrs for ref lookup", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       users: i.entity({}),
       user_prefs: i.entity({}),
     },
-    {
+    links: {
       user_user_prefs: {
         forward: {
           on: "user_prefs",
@@ -1103,7 +1108,8 @@ test("Schema: lookup creates unique ref attrs for ref lookup", () => {
         },
       },
     },
-  );
+    rooms: {},
+  });
 
   const uid = uuid();
   const ops = [
@@ -1167,12 +1173,12 @@ test("Schema: lookup creates unique ref attrs for ref lookup", () => {
 });
 
 test("Schema: lookup creates unique ref attrs for ref lookup in link value", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       users: i.entity({}),
       user_prefs: i.entity({}),
     },
-    {
+    links: {
       user_user_prefs: {
         forward: {
           on: "users",
@@ -1186,7 +1192,8 @@ test("Schema: lookup creates unique ref attrs for ref lookup in link value", () 
         },
       },
     },
-  );
+    rooms: {},
+  });
   const uid = uuid();
   const ops = [
     instatx.tx.users[uid]
@@ -1239,8 +1246,8 @@ test("Schema: lookup creates unique ref attrs for ref lookup in link value", () 
 });
 
 test("Schema: populates checked-data-type", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       comments: i.entity({
         s: i.string(),
         n: i.number(),
@@ -1250,8 +1257,9 @@ test("Schema: populates checked-data-type", () => {
         j: i.json(),
       }),
     },
-    {},
-  );
+    links: {},
+    rooms: {},
+  });
 
   const commentId = uuid();
   const ops = instatx.tx.comments[commentId].update({

--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -191,7 +191,6 @@ test("Where endsWith deep", () => {
   ).toEqual(["alex", "nicolegf", "stopa"]);
 });
 
-
 test("Where and", () => {
   expect(
     query(
@@ -913,8 +912,8 @@ test("$not", () => {
 });
 
 test("comparators", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       tests: i.entity({
         string: i.string().indexed(),
         number: i.number().indexed(),
@@ -922,8 +921,9 @@ test("comparators", () => {
         boolean: i.boolean().indexed(),
       }),
     },
-    {},
-  );
+    links: {},
+    rooms: {},
+  });
 
   const txSteps = [];
   for (let i = 0; i < 5; i++) {

--- a/client/packages/core/__tests__/src/instaqlInference.test.js
+++ b/client/packages/core/__tests__/src/instaqlInference.test.js
@@ -5,18 +5,19 @@ import { i, id } from "../../src";
 import { createLinkIndex } from "../../src/utils/linkIndex";
 
 test("many-to-many with inference", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       posts: i.entity({}),
       tags: i.entity({}),
     },
-    {
+    links: {
       postsTags: {
         forward: { on: "posts", has: "many", label: "tags" },
         reverse: { on: "tags", has: "many", label: "posts" },
       },
     },
-  );
+    rooms: {},
+  });
 
   const ids = {
     postsTagsLink: id(),
@@ -82,18 +83,19 @@ test("many-to-many with inference", () => {
 });
 
 test("one-to-one with inference", () => {
-  const schema = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       users: i.entity({}),
       profiles: i.entity({}),
     },
-    {
+    links: {
       postsTags: {
         forward: { on: "users", has: "one", label: "profile" },
         reverse: { on: "profiles", has: "one", label: "user" },
       },
     },
-  );
+    rooms: {},
+  });
 
   const ids = {
     usersProfilesLink: id(),

--- a/client/packages/core/__tests__/src/schema.test.ts
+++ b/client/packages/core/__tests__/src/schema.test.ts
@@ -1,11 +1,11 @@
 import { test } from "vitest";
 
 import { i } from "../../src";
-import type { InstaQLQueryResult } from "../../src/queryTypes";
+import type { InstaQLQueryResult, InstaQLResult } from "../../src/queryTypes";
 
 test("runs without exception", () => {
-  const graph = i.graph(
-    {
+  const schema = i.schema({
+    entities: {
       users: i.entity({
         name: i.string(),
         email: i.string().indexed().unique(),
@@ -23,7 +23,7 @@ test("runs without exception", () => {
         body: i.string(),
       }),
     },
-    {
+    links: {
       usersPosts: {
         forward: {
           on: "users",
@@ -73,7 +73,8 @@ test("runs without exception", () => {
         },
       },
     },
-  );
+    rooms: {},
+  });
 
   const demoQuery = {
     users: {
@@ -88,11 +89,11 @@ test("runs without exception", () => {
     },
   };
 
-  type Graph = typeof graph;
+  type Schema = typeof schema;
 
   // Explore derived types
-  type Test1 = Graph["entities"]["users"]["links"]["_friends"]["entityName"];
-  type Test2 = Graph["entities"]["users"]["links"]["_friends"]["cardinality"];
+  type Test1 = Schema["entities"]["users"]["links"]["_friends"]["entityName"];
+  type Test2 = Schema["entities"]["users"]["links"]["_friends"]["cardinality"];
 
   // Demo time!!!  Notice:
   // - everything is typed
@@ -103,11 +104,7 @@ test("runs without exception", () => {
   // - referrer is NOT an array (because cardinality is 'one')
   // - posts is not an array (because `$first`)
   const queryResult: DemoQueryResult = null as any;
-  type DemoQueryResult = InstaQLQueryResult<
-    Graph["entities"],
-    typeof demoQuery,
-    true
-  >;
+  type DemoQueryResult = InstaQLResult<Schema, typeof demoQuery>;
   queryResult?.users[0].friends[0]._friends[0].bio;
   queryResult?.users[0].posts[0].author?.junk;
 });

--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -13,37 +13,19 @@ import {
 // ==========
 // API
 
-
 /**
- * Accepts entities and links and merges them into a single graph definition.
+ * @deprecated
+ * `i.graph` is deprecated. Use `i.schema` instead.
  *
- * @see https://instantdb.com/docs/schema#defining-entities
  * @example
- *   export default i.graph(
- *     {
- *       posts: i.entity({
- *         title: i.string(),
- *         body: i.string(),
- *       }),
- *       comments: i.entity({
- *         body: i.string(),
- *       }),
- *     },
- *     {
- *       postsComments: {
- *         forward: {
- *           on: "posts",
- *           has: "many",
- *           label: "comments",
- *         },
- *         reverse: {
- *           on: "comments",
- *           has: "one",
- *           label: "post",
- *         },
- *       },
- *     },
- *   );
+ * // Before
+ * i.graph(entities, links).withRoomSchema<RoomType>();
+ *
+ * // After
+ * i.schema({ entities, links, rooms })
+ *
+ * @see
+ * https://instantdb.com/docs/schema
  */
 function graph<
   EntitiesWithoutLinks extends EntitiesDef,
@@ -153,7 +135,21 @@ type LinksIndex = Record<
 >;
 
 /**
- * TODO
+ * Lets you define a schema for your database.
+ *
+ * You can define entities, links between entities, and if you use
+ * presence, you can define rooms.
+ *
+ * You can push this schema to your database with the CLI,
+ * or use it inside `init_experimental`, to get typesafety and autocompletion.
+ *
+ * @see https://instantdb.com/docs/schema
+ * @example
+ *   i.schema({
+ *     entities: { },
+ *     links: { },
+ *     rooms: { }
+ *   });
  */
 function schema<
   EntitiesWithoutLinks extends EntitiesDef,

--- a/client/sandbox/admin-sdk-express/src/with-schema.ts
+++ b/client/sandbox/admin-sdk-express/src/with-schema.ts
@@ -8,8 +8,8 @@ import fs from "fs";
 
 dotenv.config();
 
-const schema = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     goals: i.entity({
       title: i.string(),
       creatorId: i.string(),
@@ -17,7 +17,7 @@ const schema = i.graph(
     }),
     todos: i.entity({ title: i.string(), creatorId: i.string() }),
   },
-  {
+  links: {
     goalsTodos: {
       forward: {
         on: "goals",
@@ -31,7 +31,8 @@ const schema = i.graph(
       },
     },
   },
-);
+  rooms: {},
+});
 
 const db = init_experimental({
   apiURI: "http://localhost:8888",

--- a/client/sandbox/cli-nodejs/instant.schema.ts
+++ b/client/sandbox/cli-nodejs/instant.schema.ts
@@ -1,7 +1,7 @@
 import { i } from "@instantdb/core";
 
-const graph = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     authors: i.entity({
       name: i.any(),
       userId: i.any(),
@@ -14,7 +14,7 @@ const graph = i.graph(
       label: i.any(),
     }),
   },
-  {
+  links: {
     authorsPosts: {
       forward: {
         on: "authors",
@@ -40,6 +40,7 @@ const graph = i.graph(
       },
     },
   },
-);
+  rooms: {},
+});
 
-export default graph;
+export default schema;

--- a/client/sandbox/react-native-expo/app/play/colors-schema.js
+++ b/client/sandbox/react-native-expo/app/play/colors-schema.js
@@ -3,14 +3,15 @@ import { View, Text, Button, StyleSheet } from "react-native";
 
 import config from "../config";
 
-const schema = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     colors: i.entity({
       color: i.string(),
     }),
   },
-  {},
-);
+  links: {},
+  rooms: {},
+});
 
 const { useQuery, transact, tx } = init_experimental({
   appId: config.appId,

--- a/client/sandbox/react-nextjs/pages/play/color-schema.tsx
+++ b/client/sandbox/react-nextjs/pages/play/color-schema.tsx
@@ -4,14 +4,15 @@ import config from "../../config";
 
 const db = init_experimental({
   ...config,
-  schema: i.graph(
-    {
+  schema: i.schema({
+    entities: {
       colors: i.entity({
         color: i.string().indexed(),
       }),
     },
-    {},
-  ),
+    links: {},
+    rooms: {},
+  }),
 });
 
 function App() {

--- a/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
+++ b/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
@@ -3,8 +3,8 @@ import config from "../../config";
 import { init, init_experimental, tx, id, i } from "@instantdb/react";
 import { useRouter } from "next/router";
 
-const schema = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     comments: i.entity({
       slug: i.string().unique().indexed(),
     }),
@@ -12,7 +12,7 @@ const schema = i.graph(
       email: i.string().unique().indexed(),
     }),
   },
-  {
+  links: {
     commentAuthors: {
       forward: {
         on: "comments",
@@ -26,7 +26,8 @@ const schema = i.graph(
       },
     },
   },
-);
+  rooms: {},
+});
 
 function Example({ appId, useSchema }: { appId: string; useSchema: boolean }) {
   const myConfig = { ...config, appId };

--- a/client/sandbox/react-nextjs/pages/play/operators.tsx
+++ b/client/sandbox/react-nextjs/pages/play/operators.tsx
@@ -3,8 +3,8 @@ import config from "../../config";
 import { init_experimental, tx, id, i } from "@instantdb/react";
 import { useRouter } from "next/router";
 
-const schema = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     comments: i.entity({
       slug: i.string().unique().indexed(),
       someString: i.string().indexed(),
@@ -16,7 +16,7 @@ const schema = i.graph(
       email: i.string().unique().indexed(),
     }),
   },
-  {
+  links: {
     commentAuthors: {
       forward: {
         on: "comments",
@@ -30,7 +30,8 @@ const schema = i.graph(
       },
     },
   },
-);
+  rooms: {},
+});
 
 function randInt(max: number) {
   return Math.floor(Math.random() * max);

--- a/client/sandbox/react-nextjs/pages/play/query-like.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-like.tsx
@@ -3,8 +3,8 @@ import config from "../../config";
 import { init_experimental, tx, id, i } from "@instantdb/react";
 import { useRouter } from "next/router";
 
-const schema = i.graph(
-  {
+const schema = i.schema({
+  entities: {
     items: i.entity({
       val: i.string().indexed(),
     }),
@@ -12,7 +12,7 @@ const schema = i.graph(
       val: i.string().indexed(),
     }),
   },
-  {
+  links: {
     valLink: {
       forward: {
         on: "items",
@@ -26,7 +26,8 @@ const schema = i.graph(
       },
     },
   },
-);
+  rooms: {},
+});
 
 function Example({ appId }: { appId: string }) {
   const router = useRouter();

--- a/client/sandbox/react-nextjs/pages/play/strong-todos.tsx
+++ b/client/sandbox/react-nextjs/pages/play/strong-todos.tsx
@@ -3,13 +3,12 @@ import {
   init_experimental,
   InstaQLEntity,
   type InstaQLParams,
-  type InstaQLResult,
 } from "@instantdb/react";
 
 import config from "../../config";
 
-const schema = i.graph(
-  {
+const _schema = i.schema({
+  entities: {
     todos: i.entity({
       text: i.string(),
       completed: i.boolean(),
@@ -18,7 +17,7 @@ const schema = i.graph(
       name: i.string(),
     }),
   },
-  {
+  links: {
     todosOwner: {
       forward: {
         on: "todos",
@@ -32,11 +31,12 @@ const schema = i.graph(
       },
     },
   },
-);
-type _Schema = typeof schema;
-// This is a little hack that makes
-// Typescript intellisense look a lot cleaner
-interface Schema extends _Schema {}
+  rooms: {},
+});
+// This helps Typescript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
 
 const db = init_experimental({
   ...config,
@@ -47,9 +47,9 @@ const todosQuery = {
   todos: {
     owner: {},
   },
-} satisfies InstaQLParams<Schema>;
+} satisfies InstaQLParams<AppSchema>;
 
-export type Todo = InstaQLEntity<Schema, "todos">;
+export type Todo = InstaQLEntity<AppSchema, "todos">;
 
 export default function TodoApp() {
   const result = db.useQuery(todosQuery);

--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -1,33 +1,30 @@
+// Docs: https://www.instantdb.com/docs/schema
+
 import { i } from "@instantdb/react";
 
-const _graph = i.graph(
-  {
-    messages: i.entity({
-      content: i.string(),
-    }),
+const _schema = i.schema({
+  // This section lets you define entities: think `posts`, `comments`, etc
+  // Take a look at the docs to learn more:
+  // https://www.instantdb.com/docs/schema#defining-entities
+  entities: {
     $users: i.entity({
       email: i.string().unique().indexed(),
     }),
   },
-  {
-    messageCreator: {
-      forward: {
-        on: "messages",
-        has: "one",
-        label: "creator",
-      },
-      reverse: {
-        on: "$users",
-        has: "many",
-        label: "createdMessages",
-      },
-    },
-  },
-  
-);
+  // You can define links here.
+  // For example, if `posts` should have many `comments`.
+  // More in the docs:
+  // https://www.instantdb.com/docs/schema#defining-links
+  links: {},
+  // If you use presence, you can define a room schema here
+  // https://www.instantdb.com/docs/schema#defining-rooms
+  rooms: {},
+});
 
-type _Graph = typeof _graph;
+// This helps Typescript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
 
-export interface Graph extends _Graph {};
-const graph: Graph = _graph;
-export default graph;
+export { type AppSchema };
+export default schema;

--- a/client/sandbox/vanilla-js-vite/src/schema.ts
+++ b/client/sandbox/vanilla-js-vite/src/schema.ts
@@ -16,14 +16,15 @@ document.body.appendChild(buttonEl);
 
 const db = init_experimental({
   appId: APP_ID,
-  schema: i.graph(
-    {
+  schema: i.schema({
+    entities: {
       todos: i.entity({
         title: i.string(),
       }),
     },
-    {},
-  ),
+    links: {},
+    rooms: {},
+  }),
 });
 
 db.subscribeQuery(

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -50,7 +50,7 @@ Note, this command will open Instant's dashboard in a browser window and prompt 
 npx instant-cli init
 ```
 
-Similar to `git init`, running `instant-cli init` will generate a new app id and add `instant.schema.ts` and `instant.perms.ts` files if none are present in your project's root directory.
+Running `instant-cli init` will help you generate your `instant.schema.ts` and `instant.perms.ts` files. You can either create a new Instant app, or an import an existing one through this flow.
 
 ### Push schema
 
@@ -58,7 +58,7 @@ Similar to `git init`, running `instant-cli init` will generate a new app id and
 npx instant-cli push schema
 ```
 
-`push schema` evals your `instant.schema.ts` file and applies it your app's production database. [Read more about schema as code](/docs/schema).
+`push schema` evaluates your `instant.schema.ts` file and applies it your app's production database. [Read more about schema as code](/docs/schema).
 
 Note, to avoid accidental data loss, `push schema` does not delete entities or fields you've removed from your schema. You can manually delete them in the [Explorer](https://www.instantdb.com/dash?s=main&t=explorer).
 
@@ -67,8 +67,8 @@ Here's an example `instant.schema.ts` file.
 ```ts
 import { i } from '@instantdb/core';
 
-const graph = i.graph(
-  {
+const _schema = i.schema({
+  entities: {
     authors: i.entity({
       userId: i.string(),
       name: i.string(),
@@ -78,7 +78,7 @@ const graph = i.graph(
       content: i.string(),
     }),
   },
-  {
+  links: {
     authorPosts: {
       forward: {
         on: 'authors',
@@ -91,10 +91,23 @@ const graph = i.graph(
         label: 'author',
       },
     },
+  },
+  rooms: {
+    chat: { 
+      presence: i.entity({
+        nickname: i.string()
+      })
+    }
   }
 );
 
-export default graph;
+// This helps Typescript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
+
+export { type AppSchema };
+export default schema;
 ```
 
 ### Push perms
@@ -103,15 +116,16 @@ export default graph;
 npx instant-cli push perms
 ```
 
-`push perms` evals your `instant.perms.ts` file and applies it your app's production database. `instant.perms.ts` should export an object implementing Instant's standard permissions CEL+JSON format. [Read more about permissions in Instant](/docs/permissions).
+`push perms` evaluates your `instant.perms.ts` file and applies it your app's production database. `instant.perms.ts` should export an object implementing Instant's standard permissions CEL+JSON format. [Read more about permissions in Instant](/docs/permissions).
 
 Here's an example `instant.perms.ts` file.
 
 ```ts
-export default {
+import { type InstantRules } from "@instantdb/react";
+const rules = {
   allow: {
     posts: {
-      bind: ['isAuthor', "auth.id in data.ref('authors.userId')"],
+      bind: ['isAuthor', "auth.id in data.ref('author.id')"],
       allow: {
         view: 'true',
         create: 'isAuthor',
@@ -120,7 +134,9 @@ export default {
       },
     },
   },
-};
+} satisfies InstantRules;
+
+export default rules;
 ```
 
 ### Pull: migrating from the dashboard

--- a/client/www/pages/docs/patterns.md
+++ b/client/www/pages/docs/patterns.md
@@ -43,8 +43,8 @@ permissions. Here's an example of limiting a user to creating at most 2 todos.
 // Here we define users, todos, and a link between them.
 import { i } from '@instantdb/core';
 
-const graph = i.graph(
-  {
+const _schema = i.schema({
+  entities: {
     users: i.entity({
       email: i.string(),
     }),
@@ -52,7 +52,7 @@ const graph = i.graph(
       label: i.string(),
     }),
   },
-  {
+  links: {
     userTodos: {
       forward: {
         on: 'users',
@@ -65,25 +65,35 @@ const graph = i.graph(
         label: 'owner',
       },
     },
-  }
+  },
+  rooms: {}
 );
 
-export default graph;
+// This helps Typescript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
+
+export { type AppSchema };
+export default schema;
 ```
 
 ```typescript
-// instant.schema.ts
+import { type InstantRules } from "@instantdb/core";
+// instant.perms.ts
 // And now we reference the `owner` link for todos to check the number
 // of todos a user has created.
 // (Note): Make sure the `owner` link is already defined in the schema.
 // before you can reference it in the permissions.
-export {
-  "todos": {
-    "allow": {
-      "create": "size(data.ref('owner.todos.id')) <= 2",
+const rules = {
+  todos: {
+    allow: {
+      create: "size(data.ref('owner.todos.id')) <= 2",
     }
   }
-}
+} satisfies InstantRules;
+
+export default rules;
 ```
 
 ## Listen to InstantDB connection status.

--- a/client/www/pages/docs/strong-init.md
+++ b/client/www/pages/docs/strong-init.md
@@ -65,25 +65,6 @@ const author = firstUser.author[0];
 const author = firstUser.author; // no more array! 🎉
 ```
 
-## Rooms support
-
-Rooms are still expressed in pure TypeScript. You can type rooms with `schema.withRoomSchema<R>`. Here's how it looks:
-
-```ts
-type RoomSchema = {
-  room: {
-    presence: {
-      example: number;
-    };
-  };
-};
-
-const db = init_experimental({
-  appId: '__APP_ID__',
-  schema: schema.withRoomSchema<RoomSchema>(),
-});
-```
-
 ## Reusable types
 
 Sometimes, you'll want to abstract out your query and result types. For example, a query's result might be consumed across multiple React components, each with their own prop types. For such cases, we provide `InstaQLParams` and `InstaQLResult`.
@@ -112,7 +93,8 @@ You can specify links relative to the entity, too:
 type TodoWithOwner = InstantEntity<
   typeof schema, 
   'todos', 
-  { owner: {} }>;
+  { owner: {} }
+>;
 ```
 
 [Here's a full example](https://github.com/instantdb/instant/blob/main/client/sandbox/react-nextjs/pages/play/strong-todos.tsx) demonstrating reusable query types in a React app.

--- a/client/www/pages/docs/users.md
+++ b/client/www/pages/docs/users.md
@@ -56,10 +56,10 @@ new namespace and link it to `$users`.
 
 ```javascript
 // Use the Instant CLI tool to create an app with this schema!
-import { i } from "@instantdb/react";
+import { i } from '@instantdb/react';
 
-const graph = i.graph(
-  {
+const _schema = i.schema({
+  entities: {
     $users: i.entity({
       email: i.any().unique().indexed(),
     }),
@@ -76,48 +76,55 @@ const graph = i.graph(
       completed: i.boolean(),
     }),
   },
-  {
+  links: {
     // `$users` is in the reverse direction for all these links!
     todoOwner: {
       reverse: {
-        on: "$users",
-        has: "many",
-        label: "todos"
+        on: '$users',
+        has: 'many',
+        label: 'todos',
       },
       forward: {
-        on: "todos",
-        has: "one",
-        label: "owner"
-      }
+        on: 'todos',
+        has: 'one',
+        label: 'owner',
+      },
     },
     userRoles: {
       reverse: {
-        on: "$users",
-        has: "one",
-        label: "role"
+        on: '$users',
+        has: 'one',
+        label: 'role',
       },
       forward: {
-        on: "roles",
-        has: "many",
-        label: "users"
+        on: 'roles',
+        has: 'many',
+        label: 'users',
       },
-    }
+    },
     userProfiles: {
       reverse: {
-        on: "$users",
-        has: "one",
-        label: "profile"
+        on: '$users',
+        has: 'one',
+        label: 'profile',
       },
       forward: {
-        on: "profiles",
-        has: "one",
-        label: "user"
+        on: 'profiles',
+        has: 'one',
+        label: 'user',
       },
-    }
-  }
-);
+    },
+  },
+  rooms: {},
+});
 
-export default graph;
+// This helps Typescript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
+
+export { type AppSchema };
+export default schema;
 ```
 
 You can then create links between users on the client side like so:


### PR DESCRIPTION
This PR: 
- Deprecates `i.graph` in favor of `i.schema`
- Uses `i.schema` throughout our codebase
- Updates cli's `pull` schema to create a file with `i.schema` rather than i.graph

**Some stuff punted** 

I am punting a few pieces of work in strong init, for a future release: 

1. Better format for links
  a. I was not 100% sure it would be a good idea to remove link names. They indeed aren't necessary, but it would make migrating from i.graph more cumbersome, and it's not clear to me that `links: Array<link>` is the better approach. I think we can look into this as a separate project later
2. Better typing for `where`
  a. @dwwoelfel (and our users) pointed out that right now `where` does not use type info. I think we _can_ make it use type info. I'm thinking we ship this as a separate unit of work 

**Some stuff coming soon**

Right now, if the user does `pull` twice, their room schema will wipe out. I am going to do a follow-on PR, where we make a best effort to keep the existing schema. In the meantime, the user always has git, so they can quickly add it back in.

Once cli stuff is finished, I'll push a new PR, which makes strong init the default.

@dwwoelfel @nezaj 