### PR TITLE
Add a rate-limited flag for apps that are making too many requests

### DIFF
--- a/server/flags-config/instant.perms.ts
+++ b/server/flags-config/instant.perms.ts
@@ -6,6 +6,14 @@ const rules = {
       create: "false",
     },
   },
+  "rate-limited-apps": {
+    allow: {
+      view: "false",
+      create: "false",
+      delete: "false",
+      update: "false",
+    },
+  },
   "storage-whitelist": {
     allow: {
       view: "false",

--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -28,6 +28,9 @@ const graph = i.graph(
     "promo-emails": i.entity({
       email: i.string(),
     }),
+    "rate-limited-apps": i.entity({
+      appId: i.string().unique()
+    }),
     "storage-whitelist": i.entity({
       appId: i.string().unique().indexed(),
       email: i.string(),

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -14,7 +14,8 @@
             :test-emails {}
             :hazelcast {}
             :drop-refresh-spam {}
-            :promo-emails {}})
+            :promo-emails {}
+            :rate-limited-apps {}})
 
 (defn transform-query-result
   "Function that is called on the query result before it is stored in the
@@ -74,12 +75,17 @@
                                   default-value (get hz-flag "default-value" false)]
                               {:disabled-apps disabled-apps
                                :enabled-apps enabled-apps
-                               :default-value default-value}))]
+                               :default-value default-value}))
+        rate-limited-apps (reduce (fn [acc {:strs [appId]}]
+                                    (conj acc (parse-uuid appId)))
+                                  #{}
+                                  (get result "rate-limited-apps"))]
     {:emails emails
      :storage-enabled-whitelist storage-enabled-whitelist
      :hazelcast hazelcast
      :promo-code-emails promo-code-emails
-     :drop-refresh-spam drop-refresh-spam}))
+     :drop-refresh-spam drop-refresh-spam
+     :rate-limited-apps rate-limited-apps}))
 
 (def queries [{:query query :transform #'transform-query-result}])
 
@@ -137,3 +143,7 @@
             :else default-value))
     ;; Default false
     false))
+
+(defn app-rate-limited? [app-id]
+  (contains? (:rate-limited-apps (query-result))
+             app-id))

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -32,6 +32,7 @@
 
                 ::validation-failed
                 ::operation-timed-out
+                ::rate-limited
 
                 ::oauth-error
 
@@ -191,6 +192,13 @@
   (throw+ {::type ::operation-timed-out
            ::message (format "Operation timed out: %s" (name operation-name))
            ::hint {:timeout-ms timeout-ms}}))
+
+;; ----------
+;; Rate limit
+
+(defn throw-rate-limited! []
+  (throw+ {::type ::rate-limited
+           ::message "You're making too many requests. Please email support@instantdb.com or ask for help in the Discord."}))
 
 ;; -------
 ;; Sockets

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -74,6 +74,7 @@
         ::ex/record-check-violation
         ::ex/sql-raise
         ::ex/timeout
+        ::ex/rate-limited
 
         ::ex/permission-denied
         ::ex/permission-evaluation-failed
@@ -116,6 +117,12 @@
                               (= type ::ex/timeout)
                               (do (tracer/record-exception-span! e {:name "instant-ex/timeout"})
                                   (response/too-many-requests bad-request))
+
+                              (= type ::ex/rate-limited)
+                              (do
+                                ;; Don't throw an error or we'll overwhelm honeycomb
+                                (tracer/add-data! {:attributes {:rate-limited? true}})
+                                (response/too-many-requests bad-request))
 
                               :else
                               (do (tracer/record-exception-span! e {:name "instant-ex/bad-request"})


### PR DESCRIPTION
Adds a new `rate-limited-apps` namespace to instant-config where we can add apps that are making too many requests to ban them until they talk to us.

Error message looks like:

```
sandbox-nextjs:dev:  ⨯ {
sandbox-nextjs:dev:   status: 429,
sandbox-nextjs:dev:   body: {
sandbox-nextjs:dev:     type: 'rate-limited',
sandbox-nextjs:dev:     message: "You're making too many requests. Please email support@instantdb.com or ask for help in the Discord.",
sandbox-nextjs:dev:     hint: null
sandbox-nextjs:dev:   }
sandbox-nextjs:dev: }
```

Right now it just bans them from making admin requests, but we can add extra information to the row latter to be more specific about which actions we're limiting and even add rate info.