### PR TITLE
[cli] persist `rooms` info across pulls

### DIFF
--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -16,9 +16,21 @@ const _schema = i.schema({
   // More in the docs:
   // https://www.instantdb.com/docs/schema#defining-links
   links: {},
-  // If you use presence, you can define a room schema here
-  // https://www.instantdb.com/docs/schema#defining-rooms
-  rooms: {},
+  rooms: {
+    chat: {
+      presence: i.entity({
+        color: i.string(),
+        nickname: i.string(),
+      }),
+      topics: {
+        emote: i.entity({
+          emoji: i.string(),
+          x: i.number(),
+          y: i.number(),
+        }),
+      },
+    },
+  },
 });
 
 // This helps Typescript display nicer intellisense


### PR DESCRIPTION
**Context** 

We write `rooms` schema inside schema.ts. However, the backend doesn't currently store this schema. 

This could lead a problem, where if the user does a `pull` and chooses to overwrite, they will lose their `rooms` info. 

**Fix** 

We keep the existing schema file, and re-create the 'rooms' section if it's possible.


**Longer-term** 

It's still not 100% ideal, the user would lose comments, or if they wrote particular types, like: 

```typescript
i.entity<MyTypeOverride>(...)
``` 

In the future, we may want to use something like https://github.com/benjamn/recast to modify the code as an ast. But for now, this already an improvement.

@dwwoelfel @nezaj 