### PR TITLE
[cli][sm] remove extraneous printDotEnvInfo

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -403,12 +403,11 @@ program.parse(process.argv);
 async function handlePush(bag, opts) {
   const pkgAndAuthInfo = await resolvePackageAndAuthInfoWithErrorLogging();
   if (!pkgAndAuthInfo) return;
-  const { ok, appId, source } = await detectOrCreateAppAndWriteToEnv(
+  const { ok, appId } = await detectOrCreateAppAndWriteToEnv(
     pkgAndAuthInfo,
     opts,
   );
   if (!ok) return;
-  printDotEnvInfo(source, appId);
   await push(bag, appId, opts);
 }
 


### PR DESCRIPTION
This ended up printing twice in the push case. 

Removing.

@dwwoelfel @nezaj 