### PR TITLE
Fix how we do per-route middleware

### DIFF
--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -435,14 +435,14 @@
         (handler req)))))
 
 (defroutes routes
-  (with-rate-limiting
-    (POST "/admin/query" [] query-post))
-  (with-rate-limiting
-    (POST "/admin/transact" [] transact-post))
-  (with-rate-limiting
-    (POST "/admin/query_perms_check" [] query-perms-check))
-  (with-rate-limiting
-    (POST "/admin/transact_perms_check" [] transact-perms-check))
+  (POST "/admin/query" []
+    (with-rate-limiting query-post))
+  (POST "/admin/transact" []
+    (with-rate-limiting transact-post))
+  (POST "/admin/query_perms_check" []
+    (with-rate-limiting query-perms-check))
+  (POST "/admin/transact_perms_check" []
+    (with-rate-limiting transact-perms-check))
 
   (POST "/admin/sign_out" [] sign-out-post)
   (POST "/admin/refresh_tokens" [] refresh-tokens-post)
@@ -451,15 +451,16 @@
   (GET "/admin/users", [] app-users-get)
   (DELETE "/admin/users", [] app-users-delete)
 
-  (with-rate-limiting
-    (POST "/admin/storage/signed-upload-url" [] signed-upload-url-post))
-  (with-rate-limiting
-    (GET "/admin/storage/signed-download-url", [] signed-download-url-get))
-  (with-rate-limiting
-    (GET "/admin/storage/files" [] files-get))
-  (with-rate-limiting
-    (DELETE "/admin/storage/files" [] file-delete)) ;; single delete
-  (with-rate-limiting
-    (POST "/admin/storage/files/delete" [] files-delete)) ;; bulk delete
+  (POST "/admin/storage/signed-upload-url" []
+    (with-rate-limiting signed-upload-url-post))
+  (GET "/admin/storage/signed-download-url", []
+    (with-rate-limiting signed-download-url-get))
+
+  (GET "/admin/storage/files" []
+    (with-rate-limiting files-get))
+  (DELETE "/admin/storage/files" []
+    (with-rate-limiting file-delete)) ;; single delete
+  (POST "/admin/storage/files/delete" []
+    (with-rate-limiting files-delete)) ;; bulk delete
 
   (GET "/admin/schema" [] schema-get))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1208,11 +1208,9 @@
   (POST "/dash/apps/:app_id/oauth_clients" [] oauth-clients-post)
   (DELETE "/dash/apps/:app_id/oauth_clients/:id" [] oauth-clients-delete)
 
-  (wrap-cookies
-   (GET "/dash/oauth/start" [] oauth-start))
+  (GET "/dash/oauth/start" [] (wrap-cookies oauth-start))
 
-  (wrap-cookies
-   (GET "/dash/oauth/callback" [] oauth-callback))
+  (GET "/dash/oauth/callback" [] (wrap-cookies oauth-callback))
 
   (POST "/dash/oauth/token" [] oauth-token-callback)
 

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -599,15 +599,12 @@
   (POST "/runtime/auth/send_magic_code" [] send-magic-code-post)
   (POST "/runtime/auth/verify_magic_code" [] verify-magic-code-post)
   (POST "/runtime/auth/verify_refresh_token" [] verify-refresh-token-post)
-  (wrap-cookies
-   (GET "/runtime/oauth/start" [] oauth-start)
-   {:decoder parse-cookie})
-  (wrap-cookies
-   (GET "/runtime/:app_id/oauth/start" [] oauth-start)
-   {:decoder parse-cookie})
-  (wrap-cookies
-   (GET "/runtime/oauth/callback" [] oauth-callback)
-   {:decoder parse-cookie})
+  (GET "/runtime/oauth/start" [] (wrap-cookies oauth-start
+                                               {:decoder parse-cookie}))
+  (GET "/runtime/:app_id/oauth/start" [] (wrap-cookies oauth-start
+                                                       {:decoder parse-cookie}))
+  (GET "/runtime/oauth/callback" [] (wrap-cookies oauth-callback
+                                                  {:decoder parse-cookie}))
 
   (POST "/runtime/oauth/token" [] oauth-token-callback)
   (POST "/runtime/:app_id/oauth/token" [] oauth-token-callback)


### PR DESCRIPTION
If we wrap the `GET` or `POST` with the middleware, then it gets applied before any route matching is applied.

https://github.com/weavejester/compojure/blob/master/src/compojure/core.clj#L185

If I'm reading how `defroutes` works correctly, we try every handler until we get a match, so my middleware could run on every request (depending on ordering of the routes).

Also fixes how we wrap cookies. Tested the oauth login locally.