### PR TITLE
[cli][schema] use checked-types when creating new attrs, show rev ident

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1238,7 +1238,7 @@ async function fetchJson({
       data = null;
     }
     if (verbose && data) {
-      console.log(debugName, "json:", JSON.stringify(data));
+      console.log(debugName, "json:", JSON.stringify(data, null, 2));
     }
     if (!res.ok) {
       if (withErrorLogging) {
@@ -1246,10 +1246,6 @@ async function fetchJson({
         prettyPrintJSONErr(data);
       }
       return { ok: false, data };
-    }
-
-    if (verbose) {
-      console.log(debugName, "data:", data);
     }
 
     return { ok: true, data };
@@ -1462,7 +1458,7 @@ function attrFwdName(attr) {
 }
 
 function attrRevName(attr) {
-  if (attr["reverse-entity"]) {
+  if (attr["reverse-identity"]) {
     return `${attrRevEtype(attr)}.${attrRevLabel(attr)}`;
   }
 }

--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -10,12 +10,29 @@ const _schema = i.schema({
     $users: i.entity({
       email: i.string().unique().indexed(),
     }),
+    posts: i.entity({
+      title: i.string(),
+      body: i.string(),
+    }),
   },
   // You can define links here.
   // For example, if `posts` should have many `comments`.
   // More in the docs:
   // https://www.instantdb.com/docs/schema#defining-links
-  links: {},
+  links: {
+    postsOwner: {
+      forward: {
+        on: "posts",
+        has: "one",
+        label: "owner",
+      },
+      reverse: {
+        on: "$users",
+        has: "many",
+        label: "ownedPosts",
+      },
+    },
+  },
   rooms: {
     chat: {
       presence: i.entity({

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -44,12 +44,14 @@
                                 (cond
                                   name-id? nil
                                   new-attr? [[:add-attr
-                                              {:value-type :blob
-                                               :cardinality :one
-                                               :id (UUID/randomUUID)
-                                               :forward-identity [(UUID/randomUUID) (name ns-name) (name attr-name)]
-                                               :unique? (:unique? new-attr)
-                                               :index? (:index? new-attr)}]]
+                                              (cond-> {:value-type :blob
+                                                       :cardinality :one
+                                                       :id (UUID/randomUUID)
+                                                       :forward-identity [(UUID/randomUUID) (name ns-name) (name attr-name)]
+                                                       :unique? (:unique? new-attr)
+                                                       :index? (:index? new-attr)}
+                                                (and check-types? (:checked-data-type new-attr))
+                                                (assoc :checked-data-type (:checked-data-type new-attr)))]]
                                   :else (concat (when (and attr-changed?
                                                            (not background-updates?))
                                                   [[:update-attr


### PR DESCRIPTION
- I realized we can set the checked types for when we create attrs too
- I also fixed up a few bugs in cli (we were printing json twice in verbose mode), and had a bug in `attrRevName`

@dwwoelfel @nezaj 