### PR TITLE
[SDK] Add useConnectionStatus for init_experimental

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -749,6 +749,31 @@ class InstantCoreDatabase<Schema extends InstantSchemaDef<any, any, any>>
   }
 
   /**
+   * Listen for connection status changes to Instant. This is useful
+   * for building things like connectivity indicators
+   *
+   * @see https://www.instantdb.com/docs/patterns#connection-status
+   * @example
+   *   const unsub = db.subscribeConnectionStatus((status) => {
+   *     const connectionState =
+   *       status === 'connecting' || status === 'opened'
+   *         ? 'authenticating'
+   *       : status === 'authenticated'
+   *         ? 'connected'
+   *       : status === 'closed'
+   *         ? 'closed'
+   *       : status === 'errored'
+   *         ? 'errored'
+   *       : 'unexpected state';
+   *
+   *     console.log('Connection status:', connectionState);
+   *   });
+   */
+  subscribeConnectionStatus(cb: (status: ConnectionStatus) => void): UnsubscribeFn {
+    return this._reactor.subscribeConnectionStatus(cb);
+  }
+
+  /**
    * Join a room to publish and subscribe to topics and presence.
    *
    * @see https://instantdb.com/docs/presence-and-topics


### PR DESCRIPTION
One of our users inquired about `useConnectionStatus` for `init_experimental` and realized needed to integrate this into the `init_experimental` branch -- excited for init/init_experimental to become one soon!