### PR TITLE
Add primary keys to all tables

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -54,7 +54,6 @@ make dev
 
 The instant server will run at [localhost:8888](http://localhost:8888) and you can connect to nrepl on port 6005.
 
-
 ### Config
 
 If you want to make any changes to your configuration, update the `resources/config/override.edn` file that was created when you ran `make docker-compose` or `make bootstrap-oss`. `src/config_edn.clj` has a spec that describes the data for the file, or you can look at `resources/config/dev.edn` for an example.

--- a/server/resources/migrations/41_primary_keys.down.sql
+++ b/server/resources/migrations/41_primary_keys.down.sql
@@ -1,0 +1,3 @@
+-- no down migration for adding back deprecated triples
+
+alter table instant_subscriptions drop column id;

--- a/server/resources/migrations/41_primary_keys.up.sql
+++ b/server/resources/migrations/41_primary_keys.up.sql
@@ -1,0 +1,3 @@
+drop table if exists deprecated_triples;
+
+alter table instant_subscriptions add column id uuid primary key default gen_random_uuid();


### PR DESCRIPTION
Drop the deprecated_triples table and add a `uuid` primary key to `instant_subscriptions`.

Doesn't require any code changes, postgres will automatically insert a random uuid as the id for the existing rows and for new rows.