### PR TITLE
[server] add unique identifiers to d/query-nested

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1697,11 +1697,12 @@
                                                        nested-named-patterns)
           query-hash (hash (first query))
           _ (tracer/add-data! {:attributes {:query-hash query-hash}})
-          query (update query
-                        :with conj
-                        [:qid
-                         {:select [[[:inline app-id]]
-                                   [[:inline query-hash]]]}])
+          query (when query
+                  (update query
+                          :with conj
+                          [:qid
+                           {:select [[[:inline app-id]]
+                                     [[:inline query-hash]]]}]))
 
           sql-query (hsql/format query)
           sql-res (when query ;; we may not have a query if everything is missing attrs

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1571,14 +1571,14 @@
                      result (cond-> (sql-result->result rows transformed-pattern-metas true)
                               (:page-info group) (assoc-in [:page-info :has-next-page?]
                                                            (-> sql-res
-                                                             (get (name (has-next-tbl table)))
-                                                             first
-                                                             (get "exists")))
+                                                               (get (name (has-next-tbl table)))
+                                                               first
+                                                               (get "exists")))
                               (:page-info group) (assoc-in [:page-info :has-previous-page?]
                                                            (-> sql-res
-                                                             (get (name (has-prev-tbl table)))
-                                                             first
-                                                             (get "exists"))))
+                                                               (get (name (has-prev-tbl table)))
+                                                               first
+                                                               (get "exists"))))
                      datalog-query (if join-sym
                                      (replace-join-sym-in-datalog-query join-sym
                                                                         join-val
@@ -1695,6 +1695,14 @@
                                                        :match-0-
                                                        app-id
                                                        nested-named-patterns)
+          query-hash (hash (first query))
+          _ (tracer/add-data! {:attributes {:query-hash query-hash}})
+          query (update query
+                        :with conj
+                        [:qid
+                         {:select [[[:inline app-id]]
+                                   [[:inline query-hash]]]}])
+
           sql-query (hsql/format query)
           sql-res (when query ;; we may not have a query if everything is missing attrs
                     (->> (sql/select-arrays ::send-query-nested conn sql-query)


### PR DESCRIPTION
Right now it's hard to correlate our slow queries on postgres, to the originating datalog queries. 

Added a quick app-id, query-hash to the beginning of every one of our queries, which we can use as variables to correlate

@dwwoelfel @nezaj @tonsky 