### PR TITLE
$default permissions

### DIFF
--- a/client/www/components/docs/Layout.jsx
+++ b/client/www/components/docs/Layout.jsx
@@ -221,6 +221,7 @@ export function Layout({ children, title, tableOfContents }) {
           <div
             className="overflow-auto px-4 pb-6 pt-4"
             ref={scrollContainerRef}
+            key={router.pathname}
           >
             <AppPicker {...{ apps, selectedAppData, updateSelectedAppId }} />
             <article>

--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -93,6 +93,67 @@ a user executes, they’ll _only_ see data that they are allowed to see.
 Similarly, for each object in a transaction, we make sure to evaluate the respective `create`, `update`, and `delete` rule.
 Transactions will fail if a user does not have adequate permission.
 
+### Default permissions
+
+By default, all permissions are considered to be `"true"`. To change that, use `"$default"` key. This:
+
+```json
+"todos": {
+  "allow": {
+    "$default": "false"
+  }
+}
+```
+
+is equivalent to this:
+
+```json
+"todos": {
+  "allow": {
+    "view": "false",
+    "create": "false",
+    "update": "false",
+    "delete": "false",
+  }
+}
+```
+
+Specific keys can override defaults:
+
+```json
+"todos": {
+  "allow": {
+    "$default": "false",
+    "view": "true"
+  }
+}
+```
+
+You can use `$default` as the namespace:
+
+```json
+"$default": {
+  "allow": {
+    "view": false
+  }
+},
+"todos": {
+  "allow": {
+    "view": "true"
+  }
+}
+```
+
+Finally, the ultimate default:
+
+```json
+"$default": {
+  "allow": {
+    "$default": false
+  }
+}
+```
+
 ## Attrs
 
 Attrs are a special kind of namespace for creating new types of data on the fly.

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -78,7 +78,11 @@
         expr)))
 
 (defn get-expr [rule etype action]
-  (get-in rule [etype "allow" action]))
+  (or
+    (get-in rule [etype "allow" action])
+    (get-in rule [etype "allow" "$default"])
+    (get-in rule ["$default" "allow" action])
+    (get-in rule ["$default" "allow" "$default"])))
 
 (defn extract [rule etype action]
   (when-let [expr (get-in rule [etype "allow" action])]


### PR DESCRIPTION
I think `"$default"` is more consistent with other places where you have “special case” things. Also easier to google/ask questions about