### PR TITLE
Make sure we use the `:av` index on lookup triples

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -189,6 +189,7 @@
                                             [:= :app-id app-id]
                                             (list* :or (for [[a v] lookup-refs]
                                                          [:and
+                                                          :av
                                                           [:= :attr-id a]
                                                           [:= :value [:cast (->json v) :jsonb]]]))]}]}]])
                   [[[:input-triples
@@ -323,6 +324,7 @@
                                                 [:= :app-id app-id]
                                                 (list* :or (for [[a v] lookup-refs]
                                                              [:and
+                                                              :av
                                                               [:= :attr-id a]
                                                               [:= :value [:cast (->json v) :jsonb]]]))]}]}]])
                       [[[:input-triples
@@ -356,6 +358,7 @@
                                                                   {:select :entity-id
                                                                    :from :triples
                                                                    :where [:and
+                                                                           :av
                                                                            [:= :app-id app-id]
                                                                            [:= :attr-id (first v)]
                                                                            [:= :value [:cast (->json (second v)) :jsonb]]]}]}
@@ -363,6 +366,7 @@
                                                    [[{:select :entity-id
                                                       :from :triples
                                                       :where [:and
+                                                              :av
                                                               [:= :app-id app-id]
                                                               [:= :attr-id (first v)]
                                                               [:= :value [:cast (->json (second v)) :jsonb]]]}


### PR DESCRIPTION
Small improvement for lookups--make sure we're looking at the `av` index when we search for the triple value.

*Note* I discovered we don't handle reverse link lookups properly, so we'll probably have to update this to use the `vae` index on reverse lookups. I'm surprised nobody has complained about this, but I guess they're only looking up in the forward direction or they gave up on lookups.