### PR TITLE
Only delete slots that use wal2json to prevent killing replication slots

### DIFF
--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -133,7 +133,8 @@
 (defn get-inactive-replication-slots [conn]
   (sql/select conn ["select slot_name
                        from pg_replication_slots
-                      where active = false"]))
+                      where active = false
+                        and plugin = 'wal2json'"]))
 
 (defn cleanup-inactive-replication-slots [conn slot-names]
   (sql/select conn ["select slot_name, pg_drop_replication_slot(slot_name)


### PR DESCRIPTION
Prevent the wal cleanup from deleting replication slots that we're using for syncing the database.

Uses the `wal2json` plugin as the indicator that these are our invalidator's slots.