### PR TITLE
Coerce date data types when we use equality comparisons too

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -537,6 +537,17 @@
 (defn- value->jsonb [x]
   [:cast (->json x) :jsonb])
 
+(defn- not-eq-value [idx val]
+  (let [[tag idx-val] idx
+        data-type (case tag
+                    :keyword nil
+                    :map (:data-type idx-val))]
+    (if-not data-type
+      [:not= :value (value->jsonb val)]
+      [:and
+       [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
+       [:not= [(kw :triples_extract_ data-type :_value) :value] val]])))
+
 (defn- in-or-eq-value [idx v-set]
   (let [[tag idx-val] idx
         data-type (case tag
@@ -569,11 +580,11 @@
     :a (in-or-eq :attr-id v)
     :v (in-or-eq-value idx v)))
 
-(defn- value-function-clauses [[v-tag v-value]]
+(defn- value-function-clauses [idx [v-tag v-value]]
   (case v-tag
     :function (let [[func val] (first v-value)]
                 (case func
-                  :$not [[:not= :value (value->jsonb val)]]
+                  :$not [(not-eq-value idx val)]
                   :$isNull [[(if (:nil? val)
                                :not-in
                                :in)
@@ -602,7 +613,7 @@
     []))
 
 (defn- function-clauses [named-pattern]
-  (value-function-clauses (:v named-pattern)))
+  (value-function-clauses (:idx named-pattern) (:v named-pattern)))
 
 (defn- where-clause
   "

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -253,15 +253,18 @@
                       (json/->json value)
                       (json/json-type-of-clj value))}]))
 
-(defn throw-on-invalid-value-data-value!
-  "Validates an individual value"
+(defn coerce-value-data-value!
+  "Coerces an individual value"
   [state attr data-type v]
   (case data-type
-    :string (when-not (string? v)
+    :string (if (string? v)
+              v
               (throw-invalid-data-value! state attr data-type v))
-    :number (when-not (number? v)
+    :number (if (number? v)
+              v
               (throw-invalid-data-value! state attr data-type v))
-    :boolean (when-not (boolean? v)
+    :boolean (if (boolean? v)
+               v
                (throw-invalid-data-value! state attr data-type v))
     :date (cond (number? v)
                 (try
@@ -277,7 +280,7 @@
 
                 :else
                 (throw-invalid-data-value! state attr data-type v))
-    nil))
+    v))
 
 (defn assert-like-is-string! [state attr tag value]
   (when (not= tag :string)
@@ -306,14 +309,16 @@
       (throw-invalid-data-value! state attr attr-data-type value)
       value)))
 
-(defn validate-value-type! [state attr data-type v]
-  (doseq [v (if (set? v) v [v])
-          :let [v (if (and (map? v)
-                           (contains? v :$not))
-                    (:$not v)
-                    v)]]
-    (throw-on-invalid-value-data-value! state attr data-type v))
-  v)
+(defn coerce-v-single! [state attr data-type v]
+  (if (and (map? v)
+           (contains? v :$not))
+    (update v :$not coerce-value-data-value! state attr data-type)
+    (coerce-value-data-value! state attr data-type v)))
+
+(defn coerced-value-with-checked-type! [state attr data-type v]
+  (if (set? v)
+    (set (map (partial coerce-v-single! state attr data-type) v))
+    (coerce-v-single! state attr data-type v)))
 
 (defn coerce-value-for-typed-comparison!
   "Coerces the value for a typed comparison, throwing a validation error
@@ -334,13 +339,11 @@
             :value (coerced-type-comparison-value! state attr attr-data-type tag value)
             :data-type attr-data-type}})
 
-
         :else
         (if (and (:checked-data-type attr)
                  (not (:checking-data-type? attr)))
-          (validate-value-type! state attr (:checked-data-type attr) v)
+          (coerced-value-with-checked-type! state attr (:checked-data-type attr) v)
           v)))
-
 
 (defn ->value-attr-pat
   "Take the where-cond:

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -312,7 +312,7 @@
 (defn coerce-v-single! [state attr data-type v]
   (if (and (map? v)
            (contains? v :$not))
-    (update v :$not coerce-value-data-value! state attr data-type)
+    (update v :$not (partial coerce-value-data-value! state attr data-type))
     (coerce-value-data-value! state attr data-type v)))
 
 (defn coerced-value-with-checked-type! [state attr data-type v]

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -19,8 +19,8 @@
 ;; In the future, we may want to _retract_ the triple if the value is nil
 (defn value? [x]
   (or (string? x) (uuid? x) (number? x) (nil? x) (boolean? x)
-      (sequential? x) (associative? x)))
-
+      (sequential? x) (associative? x)
+      (instance? java.time.Instant x)))
 
 (s/def ::attr-id uuid?)
 (s/def ::entity-id uuid?)

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2110,6 +2110,7 @@
           (is (= #{"0" "1"} (run-query :string {:etype {:$ {:where {:string {:$lt "2"}}}}})))
           (is (= #{"0" "1" "2"} (run-query :string {:etype {:$ {:where {:string {:$lte "2"}}}}})))
           (is (= #{"1"} (run-query :string {:etype {:$ {:where {:string "1"}}}})))
+          (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
 
           (testing "uses index"
             (is (= "triples_string_trgm_gist_idx" (run-explain :string "2"))))
@@ -2123,6 +2124,7 @@
           (is (= #{0 1} (run-query :number {:etype {:$ {:where {:number {:$lt 2}}}}})))
           (is (= #{0 1 2} (run-query :number {:etype {:$ {:where {:number {:$lte 2}}}}})))
           (is (= #{1} (run-query :number {:etype {:$ {:where {:number 1}}}})))
+          (is (= #{0 2 3 4} (run-query :number {:etype {:$ {:where {:number {:$not 1}}}}})))
 
           (testing "uses index"
             (is (= "triples_number_type_idx" (run-explain :number 2)))))
@@ -2134,6 +2136,7 @@
           (is (= #{0 1 2} (run-query :date {:etype {:$ {:where {:date {:$lte 2}}}}})))
           (is (= #{1} (run-query :date {:etype {:$ {:where {:date 1}}}})))
           (is (= #{1} (run-query :date {:etype {:$ {:where {:date (.toString (Instant/ofEpochMilli 1))}}}})))
+          (is (= #{0 2 3 4} (run-query :date {:etype {:$ {:where {:date {:$not 1}}}}})))
 
           (testing "uses index"
             (is (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2))))))
@@ -2146,6 +2149,8 @@
           (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt true}}}}})))
           (is (= #{false true} (run-query :boolean {:etype {:$ {:where {:boolean {:$lte true}}}}})))
           (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean true}}}})))
+          (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$not true}}}}})))
+
           (testing "uses index"
             (is (= "triples_boolean_type_idx" (run-explain :boolean true)))))))))
 

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -75,15 +75,15 @@
    the set of topics and triples in the result"
   [pretty-a pretty-b]
   `(do
-    (testing "(topics is-pretty-eq?)"
-      (is (= (set (mapcat :topics ~pretty-a))
-             (set (mapcat :topics ~pretty-b)))))
-    (testing "(triples is-pretty-eq?)"
-      (is (= (set (mapcat :triples ~pretty-a))
-             (set (mapcat :triples ~pretty-b)))))
-    (testing "(aggregate is-pretty-eq?)"
-      (is (= (set (remove nil? (mapcat :aggregate ~pretty-a)))
-             (set (remove nil? (mapcat :aggregate ~pretty-b))))))))
+     (testing "(topics is-pretty-eq?)"
+       (is (= (set (mapcat :topics ~pretty-a))
+              (set (mapcat :topics ~pretty-b)))))
+     (testing "(triples is-pretty-eq?)"
+       (is (= (set (mapcat :triples ~pretty-a))
+              (set (mapcat :triples ~pretty-b)))))
+     (testing "(aggregate is-pretty-eq?)"
+       (is (= (set (remove nil? (mapcat :aggregate ~pretty-a)))
+              (set (remove nil? (mapcat :aggregate ~pretty-b))))))))
 
 (defn- query-pretty
   ([q]
@@ -2094,6 +2094,7 @@
                                      :value-type :blob
                                      :checked-data-type t
                                      :cardinality :one}])
+
                        (mapcat
                         (fn [i]
                           (let [id (random-uuid)]
@@ -2108,6 +2109,7 @@
           (is (= #{"2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$gte "2"}}}}})))
           (is (= #{"0" "1"} (run-query :string {:etype {:$ {:where {:string {:$lt "2"}}}}})))
           (is (= #{"0" "1" "2"} (run-query :string {:etype {:$ {:where {:string {:$lte "2"}}}}})))
+          (is (= #{"1"} (run-query :string {:etype {:$ {:where {:string "1"}}}})))
 
           (testing "uses index"
             (is (= "triples_string_trgm_gist_idx" (run-explain :string "2"))))
@@ -2120,6 +2122,7 @@
           (is (= #{2 3 4} (run-query :number {:etype {:$ {:where {:number {:$gte 2}}}}})))
           (is (= #{0 1} (run-query :number {:etype {:$ {:where {:number {:$lt 2}}}}})))
           (is (= #{0 1 2} (run-query :number {:etype {:$ {:where {:number {:$lte 2}}}}})))
+          (is (= #{1} (run-query :number {:etype {:$ {:where {:number 1}}}})))
 
           (testing "uses index"
             (is (= "triples_number_type_idx" (run-explain :number 2)))))
@@ -2129,6 +2132,8 @@
           (is (= #{2 3 4} (run-query :date {:etype {:$ {:where {:date {:$gte 2}}}}})))
           (is (= #{0 1} (run-query :date {:etype {:$ {:where {:date {:$lt 2}}}}})))
           (is (= #{0 1 2} (run-query :date {:etype {:$ {:where {:date {:$lte 2}}}}})))
+          (is (= #{1} (run-query :date {:etype {:$ {:where {:date 1}}}})))
+          (is (= #{1} (run-query :date {:etype {:$ {:where {:date (.toString (Instant/ofEpochMilli 1))}}}})))
 
           (testing "uses index"
             (is (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2))))))
@@ -2140,7 +2145,7 @@
           (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt false}}}}})))
           (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt true}}}}})))
           (is (= #{false true} (run-query :boolean {:etype {:$ {:where {:boolean {:$lte true}}}}})))
-
+          (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean true}}}})))
           (testing "uses index"
             (is (= "triples_boolean_type_idx" (run-explain :boolean true)))))))))
 
@@ -2899,9 +2904,9 @@
            (is
             (= ::ex/permission-evaluation-failed
                (::ex/type (instant-ex-data
-                            (pretty-perm-q
-                             {:app-id app-id :current-user {:handle "stopa"}}
-                             {:users {}})))))))))))
+                           (pretty-perm-q
+                            {:app-id app-id :current-user {:handle "stopa"}}
+                            {:users {}})))))))))))
 
 (deftest coarse-topics []
   (let [{:keys [patterns]}


### PR DESCRIPTION
I noticed a curious error in prod: 

https://ui.honeycomb.io/instantdb/environments/prod/datasets/instant-server/result/r4cm97gTDzi/trace/aAmj4xsbSfo?fields[]=s_name&fields[]=s_serviceName&span=432079d52cf13865

It was something along the lines of: 

```bash
clojure.lang.ExceptionInfo: [instant-exception] SQL Exception: undefined-function {:instant.util.exception/type :instant.util.exception/sql-exception, :instant.util.exception/message "SQL Exception: undefined-function", :instant.util.exception/hint {:table nil, :condition :undefined-function, :constraint nil}, :instant.util.exception/pg-error-data {:sql-state "42883", :condition :undefined-function, :table nil, :constraint nil, :server-message "operator does not exist: timestamp with time zone = character varying", :detail nil}
```

Looking into this, I realize it was because:
- The users passed in a date as a str in the query
- We use the value, and compare it to triples_extract_timestamp_value 
- But, the input is not casted as a timestamp 

This ends up breaking and throwing the error above. 

I noticed we _do_ coerce in the comparator case, so I went ahead and started to coerce in the equal case too. 

I am not 100% sure if this is the right approach, so all feedback welcome!

@dwwoelfel @nezaj @tonsky 
