### PR TITLE
Extend the query hash

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1695,8 +1695,10 @@
                                                        :match-0-
                                                        app-id
                                                        nested-named-patterns)
-          query-hash (hash (first query))
+          query-hash (or (:query-hash ctx)
+                         (hash (first (hsql/format query))))
           _ (tracer/add-data! {:attributes {:query-hash query-hash}})
+
           query (when query
                   (update query
                           :with conj

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -960,17 +960,17 @@
 (defn query-normal
   "Generates and runs a nested datalog query, then collects the results into nodes."
   [ctx o]
-  (tracer/with-span! {:name "instaql/query-nested"
-                      :attributes {:app-id (:app-id ctx)
-                                   :forms o
-                                   :query-hash (forms-hash o)}}
-    (let [datalog-query-fn (or (:datalog-query-fn ctx)
-                               #'d/query)
-          {:keys [patterns forms]} (instaql-query->patterns ctx o)
-          query-hash (forms-hash o)
-          datalog-result (datalog-query-fn (assoc ctx :query-hash query-hash)
-                                           patterns)]
-      (collect-query-results (:data datalog-result) forms))))
+  (let [query-hash (forms-hash o)]
+    (tracer/with-span! {:name "instaql/query-nested"
+                        :attributes {:app-id (:app-id ctx)
+                                     :forms o
+                                     :query-hash query-hash}}
+      (let [datalog-query-fn (or (:datalog-query-fn ctx)
+                                 #'d/query)
+            {:keys [patterns forms]} (instaql-query->patterns ctx o)
+            datalog-result (datalog-query-fn (assoc ctx :query-hash query-hash)
+                                             patterns)]
+        (collect-query-results (:data datalog-result) forms)))))
 
 ;; BYOP InstaQL
 


### PR DESCRIPTION
We forgot to call `hsql/format` on the query, so the hash was including the variables in it.

This PR does the hash on the instaql forms, replacing the specific values in the where clause with their type. For example:

```clj
{:users {:$ {:where {:name "Daniel"}}}}
=> {:users {:$ {:where {:name :string}}}}
```

That way we can more easily figure out which query generated the hash.

If we're calling datalog/query from outside instaql, then we'll fall back to calling `hash` on the result of the parametrized  first arg from `(hsql/format query)`.

