### PR TITLE
Qualify internal pg function calls with schema

### DIFF
--- a/server/resources/migrations/43_specify_public.down.sql
+++ b/server/resources/migrations/43_specify_public.down.sql
@@ -44,6 +44,42 @@ CREATE OR REPLACE FUNCTION public.is_jsonb_valid_timestamp(value jsonb) RETURNS 
   end;
 $$;
 
+CREATE OR REPLACE FUNCTION public.jsonb_deep_merge(obj1 jsonb, obj2 jsonb) RETURNS jsonb
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+declare
+    key text;
+    value jsonb;
+begin
+        if
+          obj1 isnull
+          or obj2 isnull
+          or jsonb_typeof(obj1) != 'object'
+          or jsonb_typeof(obj2) != 'object'
+        then
+          return obj2;
+        end if;
+
+    -- iterate over each key in obj2
+    for key, value in select * from jsonb_each(obj2) loop
+      obj1 := case
+        -- check if the key exists in obj1 and if both values are objects
+        when obj1 ? key and jsonb_typeof(obj1->key) = 'object' and jsonb_typeof(value) = 'object'
+          -- merge the nested objects
+          then jsonb_set(obj1, array[key], jsonb_deep_merge(obj1->key, value))
+        -- handle null case
+        when jsonb_typeof(value) = 'null'
+          then obj1 - key
+        else
+          -- set the value from obj2 to obj1
+          jsonb_set(obj1, array[key], value)
+      end;
+    end loop;
+
+    return obj1;
+end;
+$$;
+
 CREATE OR REPLACE FUNCTION public.jsonb_deep_merge_many(base jsonb, objs jsonb) RETURNS jsonb
     LANGUAGE plpgsql
     AS $$

--- a/server/resources/migrations/43_specify_public.down.sql
+++ b/server/resources/migrations/43_specify_public.down.sql
@@ -1,0 +1,92 @@
+CREATE OR REPLACE FUNCTION public.is_jsonb_valid_datestring(value jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+  declare
+    timestamp_check timestamp with time zone;
+    valid boolean;
+  begin
+    begin
+      if jsonb_typeof(value) = 'string' then
+        timestamp_check := triples_extract_date_value(value);
+        valid := true;
+      else
+        valid := false;
+      end if;
+    exception when others then
+      valid := false;
+    end;
+
+    return valid;
+  end;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.is_jsonb_valid_timestamp(value jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+  declare
+    timestamp_check timestamp with time zone;
+    valid boolean;
+  begin
+    begin
+      if (jsonb_typeof(value) = 'number') then
+        timestamp_check := triples_extract_date_value(value);
+        valid := true;
+      else
+        valid := false;
+      end if;
+
+    exception when others then
+      valid := false;
+    end;
+
+    return valid;
+  end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.jsonb_deep_merge_many(base jsonb, objs jsonb) RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $$
+  declare
+    accum jsonb;
+    idx int;
+  begin
+    accum := base;
+    idx := 0;
+    -- loops over the array of objects
+    -- and deep-merges them into the accumulator
+    while idx < jsonb_array_length(objs) loop
+      accum := jsonb_deep_merge(accum, objs->idx);
+      idx := idx + 1;
+    end loop;
+    return accum;
+  end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.triples_valid_value(data_type public.checked_data_type, value jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+  begin
+    case data_type
+      when 'string' then
+        return jsonb_typeof(value) in ('string', 'null');
+      when 'number' then
+        return jsonb_typeof(value) in ('number', 'null');
+      when 'boolean' then
+        return jsonb_typeof(value) in ('boolean', 'null');
+      when 'date' then
+        case jsonb_typeof(value)
+          when 'null' then
+            return true;
+          when 'number' then
+            return is_jsonb_valid_timestamp(value);
+          when 'string' then
+            return is_jsonb_valid_datestring(value);
+          else
+            return false;
+        end case;
+      else
+        return data_type is null;
+    end case;
+  end;
+$$;

--- a/server/resources/migrations/43_specify_public.up.sql
+++ b/server/resources/migrations/43_specify_public.up.sql
@@ -44,6 +44,43 @@ CREATE OR REPLACE FUNCTION public.is_jsonb_valid_timestamp(value jsonb) RETURNS 
   end;
 $$;
 
+CREATE OR REPLACE FUNCTION public.jsonb_deep_merge(obj1 jsonb, obj2 jsonb) RETURNS jsonb
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+declare
+    key text;
+    value jsonb;
+begin
+        if
+          obj1 isnull
+          or obj2 isnull
+          or jsonb_typeof(obj1) != 'object'
+          or jsonb_typeof(obj2) != 'object'
+        then
+          return obj2;
+        end if;
+
+    -- iterate over each key in obj2
+    for key, value in select * from jsonb_each(obj2) loop
+      obj1 := case
+        -- check if the key exists in obj1 and if both values are objects
+        when obj1 ? key and jsonb_typeof(obj1->key) = 'object' and jsonb_typeof(value) = 'object'
+          -- merge the nested objects
+          then jsonb_set(obj1, array[key], public.jsonb_deep_merge(obj1->key, value))
+        -- handle null case
+        when jsonb_typeof(value) = 'null'
+          then obj1 - key
+        else
+          -- set the value from obj2 to obj1
+          jsonb_set(obj1, array[key], value)
+      end;
+    end loop;
+
+    return obj1;
+end;
+$$;
+
+
 CREATE OR REPLACE FUNCTION public.jsonb_deep_merge_many(base jsonb, objs jsonb) RETURNS jsonb
     LANGUAGE plpgsql
     AS $$

--- a/server/resources/migrations/43_specify_public.up.sql
+++ b/server/resources/migrations/43_specify_public.up.sql
@@ -1,0 +1,92 @@
+CREATE OR REPLACE FUNCTION public.is_jsonb_valid_datestring(value jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+  declare
+    timestamp_check timestamp with time zone;
+    valid boolean;
+  begin
+    begin
+      if jsonb_typeof(value) = 'string' then
+        timestamp_check := public.triples_extract_date_value(value);
+        valid := true;
+      else
+        valid := false;
+      end if;
+    exception when others then
+      valid := false;
+    end;
+
+    return valid;
+  end;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.is_jsonb_valid_timestamp(value jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+  declare
+    timestamp_check timestamp with time zone;
+    valid boolean;
+  begin
+    begin
+      if (jsonb_typeof(value) = 'number') then
+        timestamp_check := public.triples_extract_date_value(value);
+        valid := true;
+      else
+        valid := false;
+      end if;
+
+    exception when others then
+      valid := false;
+    end;
+
+    return valid;
+  end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.jsonb_deep_merge_many(base jsonb, objs jsonb) RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $$
+  declare
+    accum jsonb;
+    idx int;
+  begin
+    accum := base;
+    idx := 0;
+    -- loops over the array of objects
+    -- and deep-merges them into the accumulator
+    while idx < jsonb_array_length(objs) loop
+      accum := public.jsonb_deep_merge(accum, objs->idx);
+      idx := idx + 1;
+    end loop;
+    return accum;
+  end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.triples_valid_value(data_type public.checked_data_type, value jsonb) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+  begin
+    case data_type
+      when 'string' then
+        return jsonb_typeof(value) in ('string', 'null');
+      when 'number' then
+        return jsonb_typeof(value) in ('number', 'null');
+      when 'boolean' then
+        return jsonb_typeof(value) in ('boolean', 'null');
+      when 'date' then
+        case jsonb_typeof(value)
+          when 'null' then
+            return true;
+          when 'number' then
+            return public.is_jsonb_valid_timestamp(value);
+          when 'string' then
+            return public.is_jsonb_valid_datestring(value);
+          else
+            return false;
+        end case;
+      else
+        return data_type is null;
+    end case;
+  end;
+$$;


### PR DESCRIPTION
We're having an issue during restore and during logical replication where postgres can't find the inner function in the `triples_value_valid_value` check. 

It seems to be an issue with the search_path--I can fix it by adding `SET search_path = public;` to the top of the dump file. I found [this on the mailing list](https://www.postgresql.org/message-id/flat/D2B9F2A20670C84685EF7D183F2949E2373D64%40gigant.nidsa.net#8132cc2fa455dd1f1bb02c63cdd04678) that basically says this is the expected behavior and you shouldn't set the search path.

To fix it, we can just specify `public.our_function` when calling functions inside of functions.

I did a `pg_dump --schema-only` on production and copied all functions that use internal functions and prefixed those with `public` for the `up` migration. The `down` migration just sets those functions back to the way they were.

Here's the diff

```diff
~/projects/instant-private/server(public) $ diff resources/migrations/43_specify_public.down.sql resources/migrations/43_specify_public.up.sql 
10c10
10c10
<         timestamp_check := triples_extract_date_value(value);
---
>         timestamp_check := public.triples_extract_date_value(value);
33c33
<         timestamp_check := triples_extract_date_value(value);
---
>         timestamp_check := public.triples_extract_date_value(value);
69c69
<           then jsonb_set(obj1, array[key], jsonb_deep_merge(obj1->key, value))
---
>           then jsonb_set(obj1, array[key], public.jsonb_deep_merge(obj1->key, value))
82a83
> 
95c96
<       accum := jsonb_deep_merge(accum, objs->idx);
---
>       accum := public.jsonb_deep_merge(accum, objs->idx);
118c119
<             return is_jsonb_valid_timestamp(value);
---
>             return public.is_jsonb_valid_timestamp(value);
120c121
<             return is_jsonb_valid_datestring(value);
---
>             return public.is_jsonb_valid_datestring(value);
```

Doing a dump and restore of my database locally now works after applying the migration. I'm hoping this means that logical replication will work too.