### PR TITLE
[Refinery] use DynamicSampler

### DIFF
--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -15,8 +15,8 @@ Samplers:
           - Name: default rule
             Sampler:
               EMAThroughputSampler:
-                # With one server, that's about 65MM/month
                 GoalThroughputPerSec: 25
                 UseClusterSize: true
                 FieldList:
-                  - name
+                  - root.name
+                  - root.op


### PR DESCRIPTION
We tried using `name` as a sample key but this wasn't working as expected -- refinery was concatenating the span names of the parent traces. Found this in the [refinery docs though](https://docs.honeycomb.io/manage-data-volume/sample/honeycomb-refinery/sampling-methods/#fieldlist)

> As of Refinery 2.8.0, the root. prefix can be used to limit the field value to that of the root span. For example, root.http.response.status_code will only consider the http.response.status_code field from the root span rather than a combination of all the spans in the trace. This is useful when you want to sample based on the root span’s properties rather than the entire trace, and helps to reduce the cardinality of the sampler key. 

So now we use `root.name` instead of `name` -- @dwwoelfel also suggested we use `root.op` so we get enough data for less frequents ops.