### PR TITLE
Add script to check data on replica

### DIFF
--- a/server/.clj-kondo/hooks/defsql.clj
+++ b/server/.clj-kondo/hooks/defsql.clj
@@ -7,6 +7,7 @@
         conn-token (api/token-node 'conn)
         query-token (api/token-node 'query)
         tag-token (api/token-node '_tag)
+        additional-opts-token (api/token-node '_additional-opts)
         new-node (api/list-node
                   (list
                    (api/token-node 'defn)
@@ -18,5 +19,9 @@
                    (api/list-node
                     (list
                      (api/vector-node [tag-token conn-token query-token])
+                     (api/list-node (list query-fn conn-token query-token opts))))
+                   (api/list-node
+                    (list
+                     (api/vector-node [tag-token conn-token query-token additional-opts-token])
                      (api/list-node (list query-fn conn-token query-token opts))))))]
     {:node new-node}))

--- a/server/src/instant/jdbc/failover.clj
+++ b/server/src/instant/jdbc/failover.clj
@@ -232,7 +232,7 @@
 
 (defn recheck-missing [primary-conn
                        replica-conn
-                       {:keys [tbl primary-key] :as config}
+                       {:keys [tbl primary-key]}
                        rows]
   (println (format "Rechecking missing from %s (%d rows)" tbl (count rows)))
   (reduce (fn [acc row]

--- a/server/src/instant/jdbc/failover.clj
+++ b/server/src/instant/jdbc/failover.clj
@@ -1,8 +1,15 @@
 (ns instant.jdbc.failover
-  (:require [instant.config :as config]
-            [instant.db.model.transaction :as transaction-model]
-            [instant.jdbc.sql :as sql]
-            [instant.jdbc.aurora :as aurora]))
+  (:require
+   [honey.sql :as hsql]
+   [instant.config :as config]
+   [instant.db.model.transaction :as transaction-model]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.util.crypt :refer [bytes->hex-string]]
+   [next.jdbc :as next-jdbc]
+   [next.jdbc.result-set :as rs])
+  (:import
+   (java.sql ResultSet ResultSetMetaData)))
 
 (defn start-new-pool [aurora-config]
   (let [conn-pool-size (config/get-connection-pool-size)]
@@ -78,3 +85,212 @@
     (println "NEXT STEPS:")
     (println "  1. Put the old database to sleep so that it doesn't accidentally get written to.")
     (println "  2. Update the config so that old db is now new db and redeploy")))
+
+;; ----------------
+;; Validate replica
+
+(def fetch-size 1000)
+
+;; Generate the tbl-configs with:
+;; WITH primary_keys AS (
+;;     SELECT
+;;         kcu.table_name,
+;;         array_agg(kcu.column_name) AS primary_key_columns
+;;     FROM
+;;         information_schema.table_constraints tc
+;;     JOIN
+;;         information_schema.key_column_usage kcu
+;;     ON
+;;         tc.constraint_name = kcu.constraint_name
+;;         AND tc.table_schema = kcu.table_schema
+;;     WHERE
+;;         tc.constraint_type = 'PRIMARY KEY'
+;;     GROUP BY
+;;         kcu.table_name
+;; )
+;; SELECT
+;;     json_agg(
+;;         json_build_object(
+;;             'tbl', t.table_name,
+;;             'primary-key', COALESCE(pk.primary_key_columns, ARRAY[]::text[])
+;;         )
+;;     ) AS result
+;; FROM
+;;     information_schema.tables t
+;; LEFT JOIN
+;;     primary_keys pk ON t.table_name = pk.table_name
+;; WHERE
+;;     t.table_schema = 'public'
+;;     AND t.table_type = 'BASE TABLE';
+
+(def tbl-configs [{:tbl :apps,
+                   :primary-key [:id]}
+                  {:tbl :indexing_jobs
+                   :primary-key [:id]}
+                  {:tbl :schema_migrations
+                   :primary-key [:version]}
+                  {:tbl :instant_oauth_redirects
+                   :primary-key [:lookup_key]}
+                  {:tbl :grabs
+                   :primary-key [:id]}
+                  {:tbl :app_authorized_redirect_origins
+                   :primary-key [:id]}
+                  {:tbl :instant_users
+                   :primary-key [:id]}
+                  {:tbl :app_email_senders
+                   :primary-key [:id]}
+                  {:tbl :app_email_templates
+                   :primary-key [:id]}
+                  {:tbl :app_member_invites
+                   :primary-key [:id]}
+                  {:tbl :app_members
+                   :primary-key [:id]}
+                  {:tbl :app_oauth_service_providers
+                   :primary-key [:id]}
+                  {:tbl :app_oauth_codes
+                   :primary-key [:lookup_key]}
+                  {:tbl :app_users
+                   :primary-key [:id]}
+                  {:tbl :app_oauth_redirects
+                   :primary-key [:lookup_key]}
+                  {:tbl :app_user_oauth_links
+                   :primary-key [:id]}
+                  {:tbl :deprecated_transaction_counters
+                   :primary-key [:app_id]}
+                  {:tbl :triples
+                   :primary-key [:value_md5
+                                 :app_id
+                                 :attr_id
+                                 :entity_id]}
+                  {:tbl :app_admin_tokens
+                   :primary-key [:token]}
+                  {:tbl :app_user_refresh_tokens
+                   :primary-key [:id]}
+                  {:tbl :instant_user_refresh_tokens
+                   :primary-key [:id]}
+                  {:tbl :instant_user_magic_codes
+                   :primary-key [:id]}
+                  {:tbl :instant_user_outreaches
+                   :primary-key [:user_id]}
+                  {:tbl :app_user_magic_codes
+                   :primary-key [:id]}
+                  {:tbl :idents
+                   :primary-key [:id]}
+                  {:tbl :instant_oauth_codes
+                   :primary-key [:lookup_key]}
+                  {:tbl :instant_profiles
+                   :primary-key [:id]}
+                  {:tbl :instant_stripe_customers
+                   :primary-key [:id]}
+                  {:tbl :instant_subscription_types
+                   :primary-key [:id]}
+                  {:tbl :rules
+                   :primary-key [:app_id]}
+                  {:tbl :transactions
+                   :primary-key [:id]}
+                  {:tbl :app_oauth_clients
+                   :primary-key [:id]}
+                  {:tbl :attrs
+                   :primary-key [:id]}
+                  {:tbl :instant_subscriptions
+                   :primary-key [:id]}
+                  {:tbl :instant_cli_logins
+                   :primary-key [:id]}
+                  {:tbl :config
+                   :primary-key [:k]}
+                  {:tbl :instant_personal_access_tokens
+                   :primary-key [:id]}])
+
+(def bytes-class (Class/forName "[B"))
+
+(defn bytes-column-reader
+  "Converts byte arrays into hex strings so that we can compare them."
+  [^ResultSet rs ^ResultSetMetaData _ ^Integer i]
+  (when-let [value (.getObject rs i)]
+    (if (instance? bytes-class value)
+      ;; This lets us use the field as a primary key component
+      [:decode (bytes->hex-string value) [:inline "hex"]]
+      value)))
+
+(def row-builder (rs/as-maps-adapter
+                  rs/as-unqualified-maps
+                  bytes-column-reader))
+
+(defn find-missing-rows [replica-conn batch {:keys [tbl primary-key]}]
+  (let [q (hsql/format
+           {:select :*
+            :from tbl
+            :where (list* :or
+                          (map (fn [row]
+                                 (list* :and
+                                        (map (fn [[k v]]
+                                               [:= k v])
+                                             (select-keys row primary-key))))
+                               batch))})
+        replica-rows (sql/select ::fetch-by-id replica-conn q {:builder-fn row-builder})]
+    (apply disj (set batch) replica-rows)))
+
+(defn recheck-missing [primary-conn
+                       replica-conn
+                       {:keys [tbl primary-key] :as config}
+                       rows]
+  (tool/def-locals)
+  (println (format "Rechecking missing from %s (%d rows)" tbl (count rows)))
+  (reduce (fn [acc row]
+            (let [q (hsql/format
+                     {:select :*
+                      :from tbl
+                      :where (list* :and
+                                    (map (fn [[k v]]
+                                           [:= k v])
+                                         (select-keys row primary-key)))})
+                  primary-row (sql/select-one ::fetch-by-id primary-conn q {:builder-fn row-builder})]
+              (tool/def-locals)
+              (if (not= primary-row row)
+                (do
+                  (println "Row didn't match on primary" (select-keys row primary-key))
+                  acc)
+                (let [replica-row (sql/select-one ::fetch-by-id replica-conn q {:builder-fn row-builder})]
+                  (if (not= primary-row replica-row)
+                    (conj acc row)
+                    acc)))))
+          []
+          rows))
+
+(defn validate-replica-data [primary-conn replica-conn]
+  (reduce (fn [results {:keys [tbl] :as config}]
+            (println "Validating" tbl)
+            (time (let [{:keys [batch invalid]}
+                        (reduce (fn [{:keys [invalid batch]} row]
+                                  (let [next-batch (conj batch (into {} row))]
+                                    (if (> fetch-size (count next-batch))
+                                      {:invalid invalid
+                                       :batch next-batch}
+                                      {:batch []
+                                       :invalid (into invalid
+                                                      (find-missing-rows replica-conn next-batch config))})))
+                                {:invalid []
+                                 :batch []}
+                                (with-open [conn (next-jdbc/get-connection
+                                                  primary-conn
+                                                  ;; required to make postgres stream results
+                                                  {:auto-commit false})]
+                                  (next-jdbc/plan conn
+                                                  (hsql/format {:select :*
+                                                                :from tbl})
+                                                  {:builder-fn row-builder
+                                                   ;; required to make postgres stream results
+                                                   :fetch-size fetch-size
+                                                   :concurrency :read-only
+                                                   :cursors :close
+                                                   :result-type :forward-only})))
+
+                        invalid (if (seq batch)
+                                  (into invalid (find-missing-rows replica-conn batch config))
+                                  invalid)
+                        invalid (if (seq invalid)
+                                  (recheck-missing primary-conn replica-conn config invalid)
+                                  invalid)]
+                    (assoc results tbl {:invalid invalid}))))
+          {}
+          tbl-configs))

--- a/server/src/instant/jdbc/failover.clj
+++ b/server/src/instant/jdbc/failover.clj
@@ -234,7 +234,6 @@
                        replica-conn
                        {:keys [tbl primary-key] :as config}
                        rows]
-  (tool/def-locals)
   (println (format "Rechecking missing from %s (%d rows)" tbl (count rows)))
   (reduce (fn [acc row]
             (let [q (hsql/format
@@ -245,7 +244,6 @@
                                            [:= k v])
                                          (select-keys row primary-key)))})
                   primary-row (sql/select-one ::fetch-by-id primary-conn q {:builder-fn row-builder})]
-              (tool/def-locals)
               (if (not= primary-row row)
                 (do
                   (println "Row didn't match on primary" (select-keys row primary-key))

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -204,12 +204,15 @@
        ([~'conn ~'query]
         (~name nil ~'conn ~'query))
        ([~'tag ~'conn ~'query]
+        (~name nil ~'conn ~'query nil))
+       ([~'tag ~'conn ~'query ~'additional-opts]
         (tracer/with-span! {:name ~span-name
                             :attributes (span-attrs ~'conn ~'query ~'tag)}
           (try
             (io/tag-io
               (let [create-connection?# (not (instance? Connection ~'conn))
                     opts# (merge ~opts
+                                 ~'additional-opts
                                  {:timeout *query-timeout-seconds*})
                     ^Connection c# (if create-connection?#
                                      (next-jdbc/get-connection ~'conn)

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -219,10 +219,13 @@
      ;; with-redefs rebinds globally, this binding trick will make sure
      ;; anything happening in parallel doesn't affect our count
      (binding [*count-atom* ~count-atom]
-       (with-redefs [sql/select-arrays (fn [tag# conn# query#]
-                                         (when *count-atom*
-                                           (swap! *count-atom* inc))
-                                         (select-arrays# tag# conn# query#))]
+       (with-redefs [sql/select-arrays (fn
+                                         ([tag# conn# query#]
+                                          (sql/select-arrays tag# conn# query# nil))
+                                         ([tag# conn# query# opts#]
+                                          (when *count-atom*
+                                            (swap! *count-atom* inc))
+                                          (select-arrays# tag# conn# query# opts#)))]
          ~@body))))
 
 (deftest queries


### PR DESCRIPTION
Adds a script that will run a check that all of the data in the primary is also in the replica.

Right now it takes about an hour or two to run--as the db grows, we may have to do a spot check instead of checking everything.