### PR TITLE
[db-upgrade 3/3] Update connection string helper to point to new db

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -89,12 +89,12 @@ prod-psql:
 	@DATABASE_URL=$$(./scripts/prod_connection_string.sh); \
 	echo "[IMPORTANT] Connecting to prod db -- are you sure you want to do this? [y/N]" && \
 		read ans && [ $$ans = y ] && \
-		psql $${DATABASE_URL}
+		psql "$${DATABASE_URL}"
 
 psql-dump:
 	@DATABASE_URL=$$(./scripts/prod_connection_string.sh); \
 	echo "Exporting prod db..." && \
-	pg_dump $${DATABASE_URL} -f dump.sql
+	pg_dump "$${DATABASE_URL}" --schema-only -f dump.sql
 
 tail-web:
 	aws logs tail /aws/elasticbeanstalk/Instant-docker-prod-env-2/var/log/eb-docker/containers/eb-current-app/stdouterr.log --follow

--- a/server/scripts/prod_connection_string.sh
+++ b/server/scripts/prod_connection_string.sh
@@ -2,4 +2,18 @@
 
 set -euo pipefail
 
-aws secretsmanager get-secret-value --secret-id instant-aurora-1-pass --query 'SecretString' --output text | jq -r '"postgresql://\(.username):\(.password)@\(.host):\(.port)/instant"'
+cluster_id='instant-aurora-8'
+
+cluster_info=$(aws rds describe-db-clusters --db-cluster-identifier $cluster_id --query 'DBClusters[0].{host: Endpoint, port: Port, secretArn: MasterUserSecret.SecretArn, dbname: DatabaseName}')
+
+host=$(jq -r '.host' <<< $cluster_info)
+secret_arn=$(jq -r '.secretArn' <<< $cluster_info)
+port=$(jq -r '.port' <<< $cluster_info)
+dbname=$(jq -r '.dbname' <<< $cluster_info)
+
+secret_info=$(aws secretsmanager get-secret-value --secret-id $secret_arn --query 'SecretString' --output text)
+
+username=$(jq -r '.username' <<< $secret_info)
+password=$(jq -r '.password | @uri' <<< $secret_info)
+
+echo "postgresql://$username:$password@$host:$port/$dbname"


### PR DESCRIPTION

Updates the db connection string script. To update in the future, we'll just need to update the `cluster_id` var in the script.

