### PR TITLE
remove run opts for backtest

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -6,10 +6,6 @@ dev:
 	@echo "Booting up backend w/ local db..."
 	clojure -M:dev:run
 
-dev-backtest: 
-	@echo "Booting into instant.scratch.backtest..."
-	clojure -M:dev:into-backtest
-
 bootstrap-oss:
 	clojure -X:dev:oss-bootstrap
 

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -82,8 +82,6 @@
                             "-Dclojure.main.report=stderr"
                             "-Dclojure.server.repl={:port 6006 :accept clojure.core.server/repl}"]}
 
-           :into-backtest {:main-opts ["-m" "instant.scratch.backtest"]}
-
            :storm {:extra-deps {com.github.flow-storm/clojure {:mvn/version "1.11.2-4"}
                                 com.github.flow-storm/flow-storm-dbg {:mvn/version "3.14.0"}}
                    :override-deps {org.clojure/clojure nil}

--- a/server/src/instant/scratch/backtest.clj
+++ b/server/src/instant/scratch/backtest.clj
@@ -7,10 +7,6 @@
    3. We try to find discrepencies or degredations."
   (:require
    [instant.config :as config]
-   [instant.nrepl :as nrepl]
-   [instant.util.async :as ua]
-   [instant.util.crypt :as crypt-util]
-   [instant.util.tracer :as tracer]
    [instant.util.json :refer [<-json]]
    [clojure.java.io :as io]
    [instant.util.uuid :as uuid-util]
@@ -24,18 +20,6 @@
    [instant.util.instaql :as iq-util]
    [instant.scratch.backtest-vars :as backtest-vars]
    [clojure.pprint :as pprint]))
-
-(defn -main [& _args]
-  (let [{:keys [aead-keyset]} (config/init)]
-    (crypt-util/init aead-keyset))
-
-  (tracer/init)
-
-  (tracer/record-info! {:name "uncaught-exception-handler/set"})
-  (Thread/setDefaultUncaughtExceptionHandler
-   (ua/logging-uncaught-exception-handler))
-
-  (nrepl/start))
 
 (defn honeycomb-row->input! [[idx row]]
   (let [app-id (ex/get-param! row ["app_id"] uuid-util/coerce)


### PR DESCRIPTION
I originally wrote this thinking we would spin up a prod db instance. But I realize this is not needed, and can be done in comments. 

In which case, no need for a separate command. 

@dwwoelfel @nezaj @tonsky 