### PR TITLE
[Metrics] Add daily metrics job

### DIFF
--- a/server/resources/migrations/44_add_daily_app_transactions.down.sql
+++ b/server/resources/migrations/44_add_daily_app_transactions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE daily_app_transactions;

--- a/server/resources/migrations/44_add_daily_app_transactions.up.sql
+++ b/server/resources/migrations/44_add_daily_app_transactions.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE daily_app_transactions (
+   date date,
+   app_id uuid,
+   active_date timestamp without time zone,
+   is_active boolean,
+   count bigint,
+   UNIQUE (date, app_id, is_active)
+);

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -69,8 +69,8 @@
 (def discord-signups-channel-id
   "1235663275144908832")
 
-(def discord-metrics-channel-id
-  "1314360699685703751")
+(def discord-teams-channel-id
+  "1196584090552512592")
 
 (def discord-debug-channel-id
   "1235659966627582014")

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -69,6 +69,9 @@
 (def discord-signups-channel-id
   "1235663275144908832")
 
+(def discord-metrics-channel-id
+  "1314360699685703751")
+
 (def discord-debug-channel-id
   "1235659966627582014")
 

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -26,6 +26,7 @@
    [instant.reactive.store :as rs]
    [instant.runtime.routes :as runtime-routes]
    [instant.scripts.analytics :as analytics]
+   [instant.scripts.daily-metrics :as daily-metrics]
    [instant.session-counter :as session-counter]
    [instant.storage.routes :as storage-routes]
    [instant.stripe :as stripe]
@@ -186,6 +187,9 @@
   (when (= (config/get-env) :prod)
     (log/info "Starting analytics")
     (analytics/start))
+  (when (= (config/get-env) :prod)
+    (log/info "Starting daily metrics")
+    (daily-metrics/start))
   (start)
   (add-shutdown-hook))
 

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -1,0 +1,127 @@
+(ns instant.scripts.daily-metrics
+  "Job to ping discord with daily active metrics. We also use this job to
+  populate the daily_app_transactions table with new transactions."
+  (:require
+   [instant.jdbc.aurora :as aurora]
+   [instant.util.date :as date]
+   [clojure.tools.logging :as log]
+   [instant.discord :as discord]
+   [chime.core :as chime-core]
+   [instant.flags :refer [get-emails]]
+   [instant.config :as config]
+   [instant.jdbc.sql :as sql]
+   [instant.grab :as grab])
+  (:import
+   (java.time Period LocalDate)))
+
+(defn excluded-emails []
+  (let [{:keys [test team friend]} (get-emails)]
+    (vec (concat test team friend))))
+
+(defn get-daily-actives
+  "Returns the number of active devs and apps for a day"
+  ([date-str]
+   (get-daily-actives (aurora/conn-pool) date-str))
+  ([conn date-str]
+   (sql/select-one conn
+                   ["SELECT
+                  dat.date as date_start,
+                  COUNT(dat.count) AS total_transactions,
+                  COUNT(DISTINCT u.id) AS distinct_users,
+                  COUNT(DISTINCT a.id) AS distinct_apps
+                FROM daily_app_transactions dat
+                JOIN apps a ON dat.app_id = a.id
+                JOIN instant_users u ON a.creator_id = u.id
+                WHERE dat.is_active
+                  AND dat.date = DATE(?)
+                  AND u.email NOT IN (SELECT unnest(?::text[]))
+                GROUP BY 1
+                ORDER BY 1"
+                    date-str
+                    (with-meta (excluded-emails) {:pgtype "text[]"})])))
+
+(defn send-discord!
+  "Ping the discord channel with the metrics for a specific date"
+  [stats date-str]
+  (let [{:keys [distinct_users distinct_apps]} stats
+        message (str "🎯 Daily metrics for " date-str
+                     ": Active Devs: **" distinct_users
+                     "**, Active Apps: **" distinct_apps
+                     "**")]
+    (discord/send! config/discord-metrics-channel-id message)))
+
+(defn insert-new-activity
+  "Insert new transactions into the daily_app_transactions table.
+  This is intended to run daily to speed up monthly metrics generation."
+  ([] (insert-new-activity (aurora/conn-pool)))
+  ([conn]
+   (sql/do-execute! conn
+                    ["WITH date_range AS (
+                    SELECT
+                      COALESCE(MAX(date) + INTERVAL '1 day', '2022-01-01') AS last_seen_date,
+                      CURRENT_DATE - INTERVAL '1 day' AS max_date
+                    FROM daily_app_transactions
+                  ),
+                  earliest_transaction_per_app AS (
+                    SELECT
+                      app_id,
+                      MIN(created_at) AS earliest_date,
+                      MIN(created_at) + INTERVAL '7 days' AS earliest_date_plus_7
+                    FROM
+                      transactions
+                    GROUP BY
+                      app_id
+                  ),
+                  new_transactions AS (
+                    SELECT
+                       DATE(t.created_at) as date,
+                       t.app_id,
+                       eta.earliest_date_plus_7 as active_date,
+                       CASE  WHEN t.created_at > eta.earliest_date_plus_7 THEN true ELSE false END as is_active,
+                       count(*)
+                    FROM transactions t
+                    JOIN earliest_transaction_per_app eta ON t.app_id = eta.app_id
+                    CROSS JOIN date_range dr
+                    WHERE t.created_at > dr.last_seen_date and t.created_at < dr.max_date AND DATE(t.created_at) NOT IN ('2024-10-28')
+                    GROUP BY 1, 2, 3, 4
+                  )
+                  INSERT INTO daily_app_transactions (date, app_id, is_active, count)
+                  SELECT date, app_id, is_active, count
+                  FROM new_transactions;"])))
+
+(defn daily-job!
+  ([] (daily-job! (date/numeric-date-str (-> (LocalDate/now) (.minusDays 1)))))
+  ([date-str]
+   (grab/run-once!
+    (str "daily-metrics-" date-str)
+    (fn []
+      (insert-new-activity)
+      (let [stats (get-daily-actives date-str)]
+        (send-discord! stats date-str))))))
+
+(comment
+  (daily-job! "2024-10-04"))
+
+(defn period []
+  (let [now (date/pst-now)
+        nine-am-pst (-> now
+                        (.withHour 9)
+                        (.withMinute 0))
+        periodic-seq (chime-core/periodic-seq
+                      nine-am-pst
+                      (Period/ofDays 1))]
+
+    (->> periodic-seq
+         (filter (fn [x] (.isAfter x now))))))
+
+(defn start []
+  (log/info "Starting daily metrics daemon")
+  (def schedule (chime-core/chime-at (period) daily-job!)))
+
+(defn stop []
+  (when schedule
+    (.close schedule)))
+
+(defn restart []
+  (stop)
+  (start))

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -123,7 +123,7 @@
   (def schedule (chime-core/chime-at (period) daily-job!)))
 
 (defn stop []
-  (when schedule
+  (when (bound? #'schedule)
     (.close schedule)))
 
 (defn restart []

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -48,7 +48,7 @@
                      ": Active Devs: **" distinct_users
                      "**, Active Apps: **" distinct_apps
                      "**")]
-    (discord/send! config/discord-metrics-channel-id message)))
+    (discord/send! config/discord-teams-channel-id message)))
 
 (defn insert-new-activity
   "Insert new transactions into the daily_app_transactions table.
@@ -102,7 +102,7 @@
 
 (comment
   (def t1 (first (period)))
-  (def t2 (LocalDate/parse "2024-10-04"))
+  (def t2 (LocalDate/parse "2024-10-05"))
   (date/numeric-date-str t1)
   (daily-job! t2))
 

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -104,7 +104,7 @@
   (def t1 (first (period)))
   (def t2 (LocalDate/parse "2024-10-04"))
   (date/numeric-date-str t1)
-  (daily-job! "2024-10-04"))
+  (daily-job! t2))
 
 (defn period []
   (let [now (date/pst-now)

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -90,16 +90,20 @@
                   FROM new_transactions;"])))
 
 (defn daily-job!
-  ([] (daily-job! (date/numeric-date-str (-> (LocalDate/now) (.minusDays 1)))))
-  ([date-str]
-   (grab/run-once!
-    (str "daily-metrics-" date-str)
-    (fn []
-      (insert-new-activity)
-      (let [stats (get-daily-actives date-str)]
-        (send-discord! stats date-str))))))
+  ([] (daily-job! (-> (LocalDate/now) (.minusDays 1))))
+  ([date-obj]
+   (let [date-str (date/numeric-date-str date-obj)]
+     (grab/run-once!
+      (str "daily-metrics-" date-str)
+      (fn []
+        (insert-new-activity)
+        (let [stats (get-daily-actives date-str)]
+          (send-discord! stats date-str)))))))
 
 (comment
+  (def t1 (first (period)))
+  (def t2 (LocalDate/parse "2024-10-04"))
+  (date/numeric-date-str t1)
   (daily-job! "2024-10-04"))
 
 (defn period []

--- a/server/src/instant/scripts/metrics.clj
+++ b/server/src/instant/scripts/metrics.clj
@@ -1,7 +1,7 @@
 (ns instant.scripts.metrics
-  "Generate metrics for our updates
+  "Generate metrics for our monthly updates
   Usage:
-    1. Pull latest prod data to your local db or run dev with prod data
+    1. Run `make dev-with-prod` to connect to prod data
     2. Run `generate!` at the bottom generate metrics
     3. Run `open resources/metrics/*-usage.png` in the terminal from the /server directory to view the metrics
   
@@ -46,38 +46,17 @@
    (get-weekly-stats (aurora/conn-pool)))
   ([conn]
    (sql/select conn
-               ["WITH earliest_transaction_per_app AS (
-                  SELECT
-                    app_id,
-                    MIN(created_at) AS earliest_date,
-                    MIN(created_at) + INTERVAL '7 days' AS earliest_date_plus_7
-                  FROM transactions
-                  WHERE
-                    -- Exclude 10/28 since we migrated $users that day
-                    created_at < '2024-10-28' OR created_at >= '2024-10-29'
-                  GROUP BY app_id
-                ),
-                filtered_transactions AS (
-                  SELECT t.*
-                  FROM
-                    transactions t
-                    JOIN earliest_transaction_per_app eta ON t.app_id = eta.app_id
-                  WHERE
-                    t.created_at > eta.earliest_date_plus_7
-                    -- Exclude 10/28 since we migrated $users that day
-                    AND (t.created_at < '2024-10-28' OR t.created_at >= '2024-10-29')
-                )
-                SELECT
-                  TO_CHAR(DATE_TRUNC('week', ft.created_at), 'YYYY-MM-DD') AS date_start,
-                  COUNT(*) AS total_transactions,
+               ["SELECT
+                  TO_CHAR(DATE_TRUNC('week', dat.date), 'YYYY-MM-DD') AS date_start,
+                  COUNT(dat.count) AS total_transactions,
                   COUNT(DISTINCT u.id) AS distinct_users,
                   COUNT(DISTINCT a.id) AS distinct_apps
-                FROM filtered_transactions ft
-                JOIN apps a ON ft.app_id = a.id
+                FROM daily_app_transactions dat
+                JOIN apps a ON dat.app_id = a.id
                 JOIN instant_users u ON a.creator_id = u.id
-                WHERE u.email NOT IN (SELECT unnest(?::text[]))
+                WHERE dat.is_active AND u.email NOT IN (SELECT unnest(?::text[]))
                 GROUP BY 1
-                HAVING COUNT(DISTINCT DATE(ft.created_at)) = 7
+                HAVING COUNT(DISTINCT DATE(dat.date)) = 7
                 ORDER BY 1"
                 (with-meta (excluded-emails) {:pgtype "text[]"})])))
 
@@ -86,39 +65,17 @@
    (get-monthly-stats (aurora/conn-pool)))
   ([conn]
    (sql/select conn
-               ["WITH earliest_transaction_per_app AS (
-                  SELECT
-                    app_id,
-                    MIN(created_at) AS earliest_date,
-                    MIN(created_at) + INTERVAL '7 days' AS earliest_date_plus_7
-                  FROM transactions
-                  WHERE
-                    -- Exclude 10/28 since we migrated $users that day
-                    created_at < '2024-10-28' OR created_at >= '2024-10-29'
-                  GROUP BY
-                    app_id
-                ),
-                filtered_transactions AS (
-                  SELECT t.*
-                  FROM
-                    transactions t
-                    JOIN earliest_transaction_per_app eta ON t.app_id = eta.app_id
-                  WHERE
-                    t.created_at > eta.earliest_date_plus_7
-                    -- Exclude 10/28 since we migrated $users that day
-                    AND (t.created_at < '2024-10-28' OR t.created_at >= '2024-10-29')
-                )
-                SELECT
-                  TO_CHAR(DATE_TRUNC('month', ft.created_at), 'YYYY-MM-DD') AS date_start,
+               ["SELECT
+                  TO_CHAR(DATE_TRUNC('month', dat.date), 'YYYY-MM-DD') AS date_start,
                   COUNT(*) AS total_transactions,
                   COUNT(DISTINCT u.id) AS distinct_users,
                   COUNT(DISTINCT a.id) AS distinct_apps
-                FROM filtered_transactions ft
-                JOIN apps a ON ft.app_id = a.id
+                FROM daily_app_transactions dat
+                JOIN apps a ON dat.app_id = a.id
                 JOIN instant_users u ON a.creator_id = u.id
-                WHERE u.email NOT IN (SELECT unnest(?::text[]))
+                WHERE dat.is_active AND u.email NOT IN (SELECT unnest(?::text[]))
                 GROUP BY 1
-                HAVING COUNT(DISTINCT DATE(ft.created_at)) >= 14
+                HAVING COUNT(DISTINCT DATE(dat.date)) >= 14
                 ORDER BY 1"
                 (with-meta (excluded-emails) {:pgtype "text[]"})])))
 

--- a/server/src/instant/util/date.clj
+++ b/server/src/instant/util/date.clj
@@ -4,7 +4,11 @@
    (java.time.format DateTimeFormatter)
    (java.time.temporal TemporalAdjusters)))
 
+(def ^ZoneRegion pst-zone (ZoneId/of "America/Los_Angeles"))
 (def ^ZoneRegion est-zone (ZoneId/of "America/New_York"))
+
+(defn pst-now ^ZonedDateTime []
+  (ZonedDateTime/now pst-zone))
 
 (defn est-now ^ZonedDateTime []
   (ZonedDateTime/now est-zone))


### PR DESCRIPTION
This PR does two things 1) speeds up our monthly metrics job and 2) sends us a daily ping with active apps and devs.

**speeding up metrics**
I realized we could speed up our monthly metrics query by changing how we calculated daily app transaction counts. I also thought it would be nice to save these counts to a table to make our metrics generation even faster. Generating the metrics and bar charts is pretty instant now.

**daily metrics ping**
Stopa mentioned earlier that he wanted a more frequent feel for number of users/apps. I played around with sending images to discord, but they get cut off in the previews which makes it less fun to look at. Figured it would be nice to just send some plan numbers in a separate discord channel

**Next steps before merging**
- [x] Get stamp on PR
- [ ] Run CREATE statement in prod + migrate db