### PR TITLE
Send less log data to cloudfront in production

### DIFF
--- a/server/src/instant/reactive/query.clj
+++ b/server/src/instant/reactive/query.clj
@@ -74,24 +74,23 @@
   "Filters datalog results to only keys that the client will use and
  dedupes the triples."
   [instaql-results]
-  (tracer/with-span! {:name "collect-instaql-results-for-client"}
-    (let [{:keys [triples page-info aggregate]}
-          (reduce (fn [acc instaql-result]
-                    (let [{:keys [triples page-info aggregate]} (collect-triples instaql-result)]
-                      (-> acc
-                          (update :triples into triples)
-                          (update :page-info merge page-info)
-                          (update :aggregate merge aggregate))))
-                  {:triples #{}
-                   :page-info {}
-                   :aggregate {}}
-                  instaql-results)]
-      [{:data (merge {:datalog-result {:join-rows [triples]}}
-                     (when (seq page-info)
-                       {:page-info page-info})
-                     (when (seq aggregate)
-                       {:aggregate aggregate}))
-        :child-nodes []}])))
+  (let [{:keys [triples page-info aggregate]}
+        (reduce (fn [acc instaql-result]
+                  (let [{:keys [triples page-info aggregate]} (collect-triples instaql-result)]
+                    (-> acc
+                        (update :triples into triples)
+                        (update :page-info merge page-info)
+                        (update :aggregate merge aggregate))))
+                {:triples #{}
+                 :page-info {}
+                 :aggregate {}}
+                instaql-results)]
+    [{:data (merge {:datalog-result {:join-rows [triples]}}
+                   (when (seq page-info)
+                     {:page-info page-info})
+                   (when (seq aggregate)
+                     {:aggregate aggregate}))
+      :child-nodes []}]))
 
 (defn instaql-query-reactive!
   "Returns the result of an instaql query while producing book-keeping side

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -120,27 +120,27 @@
 (def exclude-span?
   (if (= :prod (config/get-env))
     (fn [span]
-      (or (case (.getName span)
-            ("ws/send-json!"
-             "handle-refresh/send-event!"
-             "store/record-datalog-query-finish!"
-             "store/record-datalog-query-start!"
-             "store/swap-datalog-cache-delay!"
-             "store/bump-instaql-version!"
-             "store/add-instaql-query!") true
+      (case (.getName span)
+        ("ws/send-json!"
+         "handle-refresh/send-event!"
+         "store/record-datalog-query-finish!"
+         "store/record-datalog-query-start!"
+         "store/swap-datalog-cache-delay!"
+         "store/bump-instaql-version!"
+         "store/add-instaql-query!") true
 
-            ("receive-worker/handle-event"
-             "receive-worker/handle-receive")
-            (case (-> (.getAttributes span)
-                      (.get op-attr-key))
-              (":set-presence"
-               ":refresh-presence"
-               ":server-broadcast"
-               ":client-broadcast") true
+        ("receive-worker/handle-event"
+         "receive-worker/handle-receive")
+        (case (-> (.getAttributes span)
+                  (.get op-attr-key))
+          (":set-presence"
+           ":refresh-presence"
+           ":server-broadcast"
+           ":client-broadcast") true
 
-              false)
+          false)
 
-            false)))
+        false))
     (fn [_span]
       false)))
 


### PR DESCRIPTION
Removes one span entirely. I don't think the `collect-instaql-results-for-client` span was really helpful for anything.

Stops logging a few more spans to cloudfront in production:
- handle-refresh/send-event!
- store/record-datalog-query-finish!
- store/record-datalog-query-start!
- store/swap-datalog-cache-delay!
- store/bump-instaql-version!
- store/add-instaql-query!