### PR TITLE
Set the `unique?` flag on attrs when they're created

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -843,7 +843,7 @@ function NewNamespaceDialog({
       'forward-identity': [id(), name, 'id'],
       'value-type': 'blob',
       cardinality: 'one',
-      'unique?': false,
+      'unique?': true,
       'index?': false,
     };
 

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -27,7 +27,7 @@
                                            :cardinality :one
                                            :id (UUID/randomUUID)
                                            :forward-identity [(UUID/randomUUID) (name ns-name) "id"]
-                                           :unique? false
+                                           :unique? true
                                            :index? false}])) new-blobs)
         blob-ops (mapcat
                   (fn [[ns-name attrs]]


### PR DESCRIPTION
We weren't making ids unique when they were generated from a cli push or when you created a new namespace from the UI. This PR fixes both.