### PR TITLE
[mutations] apply mutations after transact-ok

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -449,13 +449,14 @@ export default class Reactor {
           return prev;
         })
 
-        this._finishTransaction("synced", eventId);
-
         const newAttrs = prevMutation["tx-steps"]
           .filter(([action, ..._args]) => action === "add-attr")
           .map(([_action, attr]) => attr)
           .concat(Object.values(this.attrs));
+        
         this._setAttrs(newAttrs);
+        
+        this._finishTransaction("synced", eventId);
         break;
       case "refresh-presence":
         const roomId = msg["room-id"];

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -325,23 +325,6 @@ export default class Reactor {
     });
   };
 
-  /**
-   * On refresh we clear out pending mutations that we know have been applied
-   * by the server and thus those mutations are applied in the instaql result
-   * returned by the server
-   */
-  _cleanPendingMutations(txId) {
-    this.pendingMutations.set((prev) => {
-      const copy = new Map(prev);
-      [...prev.entries()].forEach(([eventId, mut]) => {
-        if (mut["tx-id"] <= txId) {
-          copy.delete(eventId);
-        }
-      });
-      return copy;
-    });
-  }
-
   _flushEnqueuedRoomData(roomId) {
     const enqueuedUserPresence = this._presence[roomId]?.result?.user;
     const enqueuedBroadcasts = this._broadcastQueue[roomId];
@@ -388,8 +371,7 @@ export default class Reactor {
         this.notifyOneQueryOnce(weakHash(msg.q));
         break;
       case "add-query-ok":
-        const { q, result, "processed-tx-id": addQueryTxId } = msg;
-        this._cleanPendingMutations(addQueryTxId);
+        const { q, result } = msg;
         const hash = weakHash(q);
         const pageInfo = result?.[0]?.data?.["page-info"];
         const aggregate = result?.[0]?.data?.["aggregate"];
@@ -408,8 +390,7 @@ export default class Reactor {
         this.notifyOneQueryOnce(hash);
         break;
       case "refresh-ok":
-        const { computations, attrs, "processed-tx-id": refreshOkTxId } = msg;
-        this._cleanPendingMutations(refreshOkTxId);
+        const { computations, attrs } = msg;
         this._setAttrs(attrs);
         const updates = computations.map((x) => {
           const q = x["instaql-query"];
@@ -447,12 +428,26 @@ export default class Reactor {
           break;
         }
 
-        const mut = { ...prevMutation, "tx-id": txId };
-
+        // Now that this transaction is accepted, 
+        // We can delete it from our queue. 
         this.pendingMutations.set((prev) => {
-          prev.set(eventId, mut);
+          prev.delete(eventId);
           return prev;
         });
+        
+        // We apply this transaction to all our existing queries
+        const txStepsToApply = prevMutation["tx-steps"];
+        this.querySubs.set((prev) => {
+          for (const [hash, sub] of Object.entries(prev)) {
+            const store = sub?.result?.store;
+            if (!store) {
+              continue;
+            }
+            const newStore = s.transact(store, txStepsToApply);
+            prev[hash].result.store = newStore;
+          }
+          return prev;
+        })
 
         this._finishTransaction("synced", eventId);
 
@@ -1348,7 +1343,9 @@ export default class Reactor {
     this.connectionStatusCbs.push(cb);
 
     return () => {
-      this.connectionStatusCbs = this.connectionStatusCbs.filter((x) => x !== cb);
+      this.connectionStatusCbs = this.connectionStatusCbs.filter(
+        (x) => x !== cb,
+      );
     };
   }
 
@@ -1485,7 +1482,7 @@ export default class Reactor {
           appId: this.config.appId,
           refreshToken,
         });
-      } catch (e) { }
+      } catch (e) {}
     }
     await this.changeCurrentUser(null);
   }

--- a/client/packages/core/src/utils/PersistedObject.js
+++ b/client/packages/core/src/utils/PersistedObject.js
@@ -13,6 +13,8 @@
 // function to handle the merge of data from storage and memory
 // on load
 export class PersistedObject {
+  _subs = [];
+
   constructor(
     persister,
     key,
@@ -117,6 +119,18 @@ export class PersistedObject {
       this._loadedCbs.push(() => this._enqueuePersist(cb));
     } else {
       this._enqueuePersist(cb);
+    }
+    for (const sub of this._subs) {
+      sub(this.currentValue);
+    }
+  }
+  
+  subscribe(cb) { 
+    this._subs.push(cb);
+    cb(this.currentValue);
+
+    return () => {
+      this._subs = this._subs.filter((x) => x !== cb);
     }
   }
 }

--- a/client/sandbox/react-nextjs/pages/play/pending-transactions.tsx
+++ b/client/sandbox/react-nextjs/pages/play/pending-transactions.tsx
@@ -1,0 +1,71 @@
+import { init, id } from "@instantdb/react";
+import { useEffect, useState } from "react";
+import config from "../../config";
+
+const db = init(config);
+
+function App() {
+  return <Main />;
+}
+
+let n = 0;
+function Main() {
+  const query = db.useQuery({ stickers: {} });
+  const [pendingTxs, setPendingTxs] = useState<any>(null);
+  useEffect(() => {
+    const unsub = db._core._reactor.pendingMutations.subscribe((txs: any) => {
+      const copy = new Map(txs);
+      setPendingTxs(copy);
+    });
+    return unsub;
+  }, []);
+  const pendingTxToPrint = [...(pendingTxs?.values() || [])].map((x) => {
+    return x["tx-steps"][1][3];
+  });
+  return (
+    <div>
+      <ul>
+        <li> Add a `(Thread/sleep (rand-int 5000))` to handle-transact </li>
+        <li>
+          {" "}
+          Click `transact`, and make sure that we in fact _are_ processing
+          transactions in order
+        </li>
+      </ul>
+      <div className="space-x-2">
+        <button
+          className="bg-black text-white"
+          onClick={() => {
+            for (let i = 0; i < 100; i++) {
+              db.transact(db.tx.stickers[id()].update({ n: n++ }));
+            }
+          }}
+        >
+          Transact
+        </button>
+        <button
+          className="bg-black text-white"
+          onClick={() => {
+            db.transact(
+              query.data?.stickers.map((x) => db.tx.strickers[x.id].delete()) ?? [],
+            );
+          }}
+        >
+          clear
+        </button>
+      </div>
+      <div className="flex">
+        <div className="flex-1">
+          <strong>Query Result</strong>
+          <pre>{JSON.stringify(query, null, 2)}</pre>
+        </div>
+        <div className="flex-1">
+          <strong>Pending Transactions</strong>
+          <pre>{JSON.stringify(pendingTxToPrint, null, 2)}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default App;


### PR DESCRIPTION
## Context

Previously, transactions had 3 phases in the lifetime

**1. pending**

The transaction was created, but hasn't been processed by the server. 

We apply it right away to all queries.

**2. ok**

The server said this transaction was `ok`. We record this information, because we don't want to send it again.

**_However_, we can't delete the transaction from the queue yet**. 

Why? Because this transaction has not fully been reflected in active queries.

**3. refresh -> delete**

The server has refresh queries. At this point, we can delete pending mutations. 

## Problem 

The kosmik folks reported an edge case, where queries were missing pending mutations. This is because we were too eager about _when_ we removed pending transactions. We removed them _even_ during add-query-ok, which mean some queries may not have refreshed yet. 

## Solution 

I got rid of cleanPendingMutations entirely. Instead, we apply the mutation onto every active query, during `transact-ok`. 

@dwwoelfel @nezaj 