### PR TITLE
[delete-entity] make delete-entity use vae index for lookups

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -463,10 +463,7 @@
                                   :av
                                   [:= :attr-id (first id)]
                                   [:=
-                                   :value-md5
-                                   [:md5 [:cast
-                                          [:cast (->json (second id)) :jsonb]
-                                          :text]]]]}
+                                   :value [:cast (->json (second id)) :jsonb]]]}
                          id)]
                    (if etype
                      [[:and
@@ -485,7 +482,7 @@
                       [:and
                        ;; Delete ref triples where we're the value
                        :vae
-                       [:= :value-md5 [:md5 [:cast [:to_jsonb id] :text]]]
+                       [:= :value [:to_jsonb id]]
                        [:in
                         :attr-id
                         {:select :attrs.id
@@ -500,7 +497,7 @@
                      [[:= :entity-id id-lookup]
                       [:and
                        :vae
-                       [:= :value-md5 [:md5 [:cast [:to_jsonb [id-lookup]] :text]]]]])))
+                       [:= :value [:to_jsonb [id-lookup]]]]])))
                id+etypes)
         query {:delete-from :triples
                :where [:and [:= :app-id app-id]


### PR DESCRIPTION
Kosmik reported slow delete transactions. 

Looking into this, I realized it was because we compared to `value-md5`: 

```
;; Delete ref triples where we're the value
 :vae
 [:= :value-md5 [:md5 [:cast [:to_jsonb id] :text]]]
```

This worked, but would end up in a scanning all app triples. This is because our `vae` index actually works on the jsonb value, rather then the md5 value. By switching to the jsonb value, we could now use the `v` based indexes. 

```clojure
(time
   (do
     (permissioned-tx/transact!
      ctx
      (admin-model/->tx-steps!
       ctx
       (map (fn [sticker-id]
              ["delete" "stickers" sticker-id])
            sticker-ids)))
     :done))

;; Before 

; eval (current-form): (time (do (permissioned-tx/transact! ctx (admin-model/->tx-step...
; (out) "Elapsed time: 15090.590791 msecs"
:done

;; After

; eval (current-form): (time (do (permissioned-tx/transact! ctx (admin-model/->tx-step...
; (out) "Elapsed time: 111.3705 msecs"
:done
```

@dwwoelfel @nezaj @tonsky 