### PR TITLE
Docs: AppSchema type export

### DIFF
--- a/client/www/pages/docs/schema.md
+++ b/client/www/pages/docs/schema.md
@@ -205,6 +205,6 @@ type _AppSchema = typeof _schema;
 interface AppSchema extends _AppSchema {}
 const schema: AppSchema = _schema;
 
-export { type AppSchema };
+export type { AppSchema };
 export default schema;
 ```


### PR DESCRIPTION
AppSchema type export, as described in https://biomejs.dev/linter/rules/use-export-type/ or https://typescript-eslint.io/rules/consistent-type-exports/ (was giving me an error in VSCode with Biome plugin)