### PR TITLE
[script] nab the first instance from prod_tunnel.sh

### DIFF
--- a/server/scripts/prod_tunnel.sh
+++ b/server/scripts/prod_tunnel.sh
@@ -17,7 +17,7 @@ if [ -z "$instance_id" ]; then
   instance_id=$(
     aws ec2 describe-instances \
       --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env-2" \
-      --query "Reservations[].Instances[?State.Name == 'running'].InstanceId[]" \
+      --query "Reservations[].Instances[?State.Name == 'running'].InstanceId[] | [0]" \
       --output text
   )
 fi


### PR DESCRIPTION
I wanted to ssh into prod to diagnose some query issues. I noticed that prod_tunnel.sh was failing, as we now have multiple instances. 

I updated the script to grab the first instance. 

@dwwoelfel @nezaj @tonsky 