### PR TITLE
[Metrics] Daily metrics sm

### DIFF
--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -26,7 +26,6 @@
    (sql/select-one conn
                    ["SELECT
                   dat.date as date_start,
-                  COUNT(dat.count) AS total_transactions,
                   COUNT(DISTINCT u.id) AS distinct_users,
                   COUNT(DISTINCT a.id) AS distinct_apps
                 FROM daily_app_transactions dat

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -12,7 +12,7 @@
    [instant.jdbc.sql :as sql]
    [instant.grab :as grab])
   (:import
-   (java.time Instant Period LocalDate)))
+   (java.time Instant Period LocalDate DayOfWeek)))
 
 (defn excluded-emails []
   (let [{:keys [test team friend]} (get-emails)]
@@ -119,9 +119,14 @@
         periodic-seq (chime-core/periodic-seq
                       nine-am-pst
                       (Period/ofDays 1))]
-
     (->> periodic-seq
-         (filter (fn [x] (.isAfter x now))))))
+         (filter (fn [x] (.isAfter x now)))
+         ;; Only run on weekdays
+         (filter (fn [x]
+                   (let [day-of-week (.getDayOfWeek x)]
+                     (and
+                      (not= day-of-week java.time.DayOfWeek/SATURDAY)
+                      (not= day-of-week java.time.DayOfWeek/SUNDAY))))))))
 
 (defn start []
   (log/info "Starting daily metrics daemon")

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -125,8 +125,8 @@
          (filter (fn [x]
                    (let [day-of-week (.getDayOfWeek x)]
                      (and
-                      (not= day-of-week java.time.DayOfWeek/SATURDAY)
-                      (not= day-of-week java.time.DayOfWeek/SUNDAY))))))))
+                      (not= day-of-week DayOfWeek/SATURDAY)
+                      (not= day-of-week DayOfWeek/SUNDAY))))))))
 
 (defn start []
   (log/info "Starting daily metrics daemon")


### PR DESCRIPTION
Metrics had an off by one issue where the job runs at date X but we only have date for date X - 1. This PR fixes that, I also removed an unused transaction count and figured we should just run this on the weekdays to not ping #team on the weekends