### PR TITLE
Remove entity_id from some indexes

### DIFF
--- a/server/resources/migrations/45_remove_entity_id_from_indexes.down.sql
+++ b/server/resources/migrations/45_remove_entity_id_from_indexes.down.sql
@@ -29,6 +29,7 @@ create index triples_boolean_type_idx on triples (
   where ave and checked_data_type = 'boolean';
 drop index triples_boolean_type_no_e_idx;
 
+alter index triples_date_type_idx rename to triples_date_type_no_e_idx;
 create index triples_date_type_idx on triples (
     app_id,
     attr_id,
@@ -36,6 +37,7 @@ create index triples_date_type_idx on triples (
     entity_id
   )
   where ave and checked_data_type = 'date';
+drop index triples_date_type_no_e_idx;
 
 alter index ave_index rename to ave_no_e_idx;
 create index ave_index

--- a/server/resources/migrations/45_remove_entity_id_from_indexes.down.sql
+++ b/server/resources/migrations/45_remove_entity_id_from_indexes.down.sql
@@ -1,0 +1,44 @@
+alter index triples_string_trgm_gist_idx rename to triples_string_trgm_gist_no_e_idx;
+create index triples_string_trgm_gist_idx on triples using gist (
+    app_id,
+    attr_id,
+    triples_extract_string_value(value) gist_trgm_ops,
+    entity_id
+  )
+  where ave and checked_data_type = 'string';
+drop index triples_string_trgm_gist_no_e_idx;
+
+alter index triples_number_type_idx rename to triples_number_type_no_e_idx;
+create index triples_number_type_idx on triples (
+    app_id,
+    attr_id,
+    triples_extract_number_value(value),
+    entity_id
+  )
+  where ave and checked_data_type = 'number';
+drop index triples_number_type_no_e_idx;
+
+
+alter index triples_boolean_type_idx rename to triples_boolean_type_no_e_idx;
+create index triples_boolean_type_idx on triples (
+    app_id,
+    attr_id,
+    triples_extract_boolean_value(value),
+    entity_id
+  )
+  where ave and checked_data_type = 'boolean';
+drop index triples_boolean_type_no_e_idx;
+
+create index triples_date_type_idx on triples (
+    app_id,
+    attr_id,
+    triples_extract_date_value(value),
+    entity_id
+  )
+  where ave and checked_data_type = 'date';
+
+alter index ave_index rename to ave_no_e_idx;
+create index ave_index
+  on triples(app_id, attr_id, value, entity_id)
+  where ave;
+drop index ave_no_e_idx;

--- a/server/resources/migrations/45_remove_entity_id_from_indexes.up.sql
+++ b/server/resources/migrations/45_remove_entity_id_from_indexes.up.sql
@@ -1,0 +1,42 @@
+-- Create these concurrently before running the migration in production and run `analyze`
+create index if not exists triples_string_trgm_gist_idx_no_e on triples using gist (
+    app_id,
+    attr_id,
+    triples_extract_string_value(value) gist_trgm_ops
+  )
+  where ave and checked_data_type = 'string';
+drop index triples_string_trgm_gist_idx;
+alter index triples_string_trgm_gist_idx_no_e rename to triples_string_trgm_gist_idx;
+
+create index if not exists triples_number_type_idx_no_e on triples (
+    app_id,
+    attr_id,
+    triples_extract_number_value(value)
+  )
+  where ave and checked_data_type = 'number';
+drop index triples_number_type_idx;
+alter index triples_number_type_idx_no_e rename to triples_number_type_idx;
+
+create index if not exists triples_boolean_type_idx_no_e on triples (
+    app_id,
+    attr_id,
+    triples_extract_boolean_value(value)
+  )
+  where ave and checked_data_type = 'boolean';
+drop index triples_boolean_type_idx;
+alter index triples_boolean_type_idx_no_e rename to triples_boolean_type_idx;
+
+create index if not exists triples_date_type_idx_no_e on triples (
+    app_id,
+    attr_id,
+    triples_extract_date_value(value)
+  )
+  where ave and checked_data_type = 'date';
+drop index triples_date_type_idx;
+alter index triples_date_type_idx_no_e rename to triples_date_type_idx;
+
+create index ave_index_no_e
+  on triples(app_id, attr_id, value)
+  where ave;
+drop index ave_index;
+alter index ave_index_no_e rename to ave_index;


### PR DESCRIPTION
@stopachka found that this improves the performance of some queries that use the `ave` indexes with nested loop joins when there are multiple `e` in the index. The loop causes postgres to do a bunch of inefficient index scans, slowing down the query. When we take the `e` out of the index, postgres no longer tries to use it in a nested loop.

More context on the underlying issue in @stopachka's stackoverflow post: https://dba.stackexchange.com/questions/344103/postgres-graph-query-gets-slow-because-of-a-nested-loop-join

Ran a backtest and we see some major improvements for a few queries and basically no change for the rest of the queries:

<img width="788" alt="image" src="https://github.com/user-attachments/assets/764f81a8-6565-4f62-8162-b319a717c173">

Deployment process:
1. Add all indexes concurrently:
```sql
create index concurrently triples_string_trgm_gist_idx_no_e on triples using gist (
    app_id,
    attr_id,
    triples_extract_string_value(value) gist_trgm_ops
  )
  where ave and checked_data_type = 'string';

create index concurrently triples_number_type_idx_no_e on triples (
    app_id,
    attr_id,
    triples_extract_number_value(value)
  )
  where ave and checked_data_type = 'number';

create index concurrently triples_boolean_type_idx_no_e on triples (
    app_id,
    attr_id,
    triples_extract_boolean_value(value)
  )
  where ave and checked_data_type = 'boolean';

create index concurrently triples_date_type_idx_no_e on triples (
    app_id,
    attr_id,
    triples_extract_date_value(value)
  )
  where ave and checked_data_type = 'date';

create index concurrently ave_index_no_e
  on triples(app_id, attr_id, value)
  where ave;
```

2. Run the migration.

