### PR TITLE
[perf] skip `optimize-attr-pats` for child queries

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -685,7 +685,11 @@
          referenced-etypes :referenced-etypes}
         (if where-conds
           (where-conds->patterns (assoc ctx
-                                        :skip-optimize? false) form where-conds)
+                                        :skip-optimize?
+                                        (if join-attr-pat
+                                            true
+                                            false))
+                                 form where-conds)
           {:pats nil
            :referenced-etypes #{}})
         with-join (cond-> []

--- a/server/src/instant/scratch/backtest.clj
+++ b/server/src/instant/scratch/backtest.clj
@@ -111,12 +111,9 @@
              (mapv (partial compare! prod-conn))))))
 
   (tool/copy
-   (with-out-str (pprint/pprint
-                  (map (fn [x]
-                         (-> x
-                             (select-keys [:improvement :same? :same-same?])
-                             (assoc :new-result-error? (-> x :new-result-error boolean))
-                             (assoc :old-result-error? (-> x :old-result-error boolean)))) runs))))
+   (with-out-str (clojure.pprint/print-table
+                  [:same? :improvement :old-ms :new-ms]
+                  runs)))
 
   (defn avg [coll]
     (/ (reduce + coll) (count coll)))


### PR DESCRIPTION
I was looking into one of Palette's slow queries. I saw that the query took about 5 seconds to complete. 

Looking at how we built our joins, I noticed there were a few places where we created connected a CTE, without an explicit join condition. 

This was because we were running `optimize-attr-pats` over child queries. When those queries we re-ordered, we would lose the joined condition to the previous CTE. 

I updated the code to only run-optimize-attr-pats at the top level. 

Running a backtest, there are a few queries that register large improvements, while the rest show a neglible change. 

@dwwoelfel @nezaj @tonsky 



| :same? |         :improvement |     :old-ms |     :new-ms |
|--------|----------------------|-------------|-------------|
|   true |   -770.9051669999999 |    1724.245 | 2495.150167 |
|   true |   -693.8365419999999 |  880.320292 | 1574.156834 |
|   true |   -438.4742920000001 | 1625.332291 | 2063.806583 |
|   true |          -405.974749 |   72.603334 |  478.578083 |
|   true |  -356.49837499999995 |  450.060125 |    806.5585 |
|   true |          -354.310958 |  190.280084 |  544.591042 |
|   true |   -311.3532499999999 | 1782.316083 | 2093.669333 |
|   true |  -227.60979099999997 |   70.390709 |    298.0005 |
|   true |  -227.12358299999983 |   1069.5195 | 1296.643083 |
|   true |  -199.26183300000002 |  316.405125 |  515.666958 |
|   true |  -196.54483200000004 | 2632.284584 | 2828.829416 |
|   true |  -179.55945800000006 |  751.466333 |  931.025791 |
|   true |          -154.881333 |   69.841625 |  224.722958 |
|   true |          -153.240791 |   72.494042 |  225.734833 |
|   true |          -147.774541 |  578.815709 |   726.59025 |
|   true |  -136.63766700000002 |   93.691333 |     230.329 |
|   true |  -134.78025100000002 |  497.093083 |  631.873334 |
|   true |  -119.09866699999975 | 2479.197125 | 2598.295792 |
|   true |  -118.28058300000001 |   72.020959 |  190.301542 |
|   true |  -113.72454100000004 |  511.126125 |  624.850666 |
|   true |  -112.13529200000005 |  791.448958 |   903.58425 |
|   true |           -77.517042 |   102.40625 |  179.923292 |
|   true |  -60.075874999999996 |   69.462209 |  129.538084 |
|   true |  -58.694248999999985 |   70.044792 |  128.739041 |
|   true |           -53.236333 |   68.878125 |  122.114458 |
|   true |  -45.539083000000005 |   69.499792 |  115.038875 |
|   true |   -38.60479200000002 |  127.790083 |  166.394875 |
|   true |  -29.048416000000003 |  133.766834 |   162.81525 |
|   true |  -24.941583000000037 |    1028.629 | 1053.570583 |
|   true |  -24.479332999999997 |   68.699833 |   93.179166 |
|   true |  -23.249333000000007 |   69.913292 |   93.162625 |
|   true |           -18.175792 |   68.853125 |   87.028917 |
|   true |   -17.97041799999988 | 5234.916041 | 5252.886459 |
|   true |             -11.5685 |   72.364625 |   83.933125 |
|   true |   -10.12191700000001 |   69.892333 |    80.01425 |
|   true |  -4.0703749999999985 |   69.284583 |   73.354958 |
|   true |  -2.2436659999999904 |   69.685167 |   71.928833 |
|   true |   -1.869458999999992 |   73.556791 |    75.42625 |
|   true |  -1.8100000000000023 |  329.907292 |  331.717292 |
|   true |   -1.765709000000001 |   72.105791 |     73.8715 |
|   true |  -1.6752919999999998 |    1.411667 |    3.086959 |
|   true |  -1.4920419999999979 |   69.865375 |   71.357417 |
|   true |  -1.3542499999999933 |   70.667375 |   72.021625 |
|   true |  -1.3150419999999912 |      69.977 |   71.292042 |
|   true |  -0.9815830000000005 |   69.148042 |   70.129625 |
|   true |  -0.3451249999999959 |   71.306375 |     71.6515 |
|   true |  -0.3295000000000101 |   69.642625 |   69.972125 |
|   true | -0.30066599999999255 |   70.065959 |   70.366625 |
|   true | -0.23312499999997272 | 1015.084334 | 1015.317459 |
|   true | -0.07354100000000585 |   70.615417 |   70.688958 |
|   true |   0.1545420000000064 |   71.232875 |   71.078333 |
|   true |  0.16783399999999915 |    69.15875 |   68.990916 |
|   true |   0.3361250000000098 |    69.61825 |   69.282125 |
|   true |    0.378499000000005 |   72.830166 |   72.451667 |
|   true |  0.47562499999999375 |     70.6835 |   70.207875 |
|   true |   0.6348339999999979 |   70.486834 |      69.852 |
|   true |   1.3526250000000033 |   70.199375 |    68.84675 |
|   true |   1.4529579999999953 |     71.7055 |   70.252542 |
|   true |    2.101957999999996 |   73.151625 |   71.049667 |
|   true |             2.598917 |   71.799292 |   69.200375 |
|   true |    4.560749999999999 |    73.89625 |     69.3355 |
|   true |    6.393332999999984 |  457.134542 |  450.741209 |
|   true |   15.231375000000014 |  129.120583 |  113.889208 |
|   true |            17.222791 |  131.916708 |  114.693917 |
|   true |   21.729083000000003 |   92.207958 |   70.478875 |
|   true |   23.699081999999976 |  478.282916 |  454.583834 |
|   true |   25.902124999999998 |  131.175375 |   105.27325 |
|   true |    34.87120900000001 |  106.137917 |   71.266708 |
|   true |    35.39812500000001 |  105.621125 |      70.223 |
|   true |    40.56141699999999 |   111.22425 |   70.662833 |
|   true |    48.70775099999997 |  531.241417 |  482.533666 |
|   true |   54.400499999999994 |  123.747333 |   69.346833 |
|   true |    54.64041699999996 |  379.998792 |  325.358375 |
|   true |     64.1619169999999 | 1690.705792 | 1626.543875 |
|   true |               64.257 |  138.271625 |   74.014625 |
|   true |    78.83129100000002 |  473.325958 |  394.494667 |
|   true |    79.42487600000004 | 1129.581834 | 1050.156958 |
|   true |            79.664667 |   148.97125 |   69.306583 |
|   true |            80.283667 |     150.213 |   69.929333 |
|   true |            84.919124 |  158.775083 |   73.855959 |
|   true |    92.76912400000002 |  162.961833 |   70.192709 |
|   true |           114.895166 |  187.056541 |   72.161375 |
|   true |   125.34808299999997 |  664.661333 |   539.31325 |
|   true |   151.54899999999998 | 1742.971917 | 1591.422917 |
|   true |   156.31483400000002 | 1237.976792 | 1081.661958 |
|   true |   158.55991699999998 |  231.289792 |   72.729875 |
|   true |   160.79920900000002 |  232.204292 |   71.405083 |
|   true |   165.97783400000003 | 1102.744709 |  936.766875 |
|   true |           185.695375 | 1687.129125 |  1501.43375 |
|   true |   245.75462500000003 | 3600.233875 |  3354.47925 |
|   true |    285.4537909999999 | 1144.001791 |     858.548 |
|   true |   289.76837500000005 |  617.190542 |  327.422167 |
|   true |    323.8368340000002 | 2473.584167 | 2149.747333 |
|   true |           401.372458 |  825.914666 |  424.542208 |
|   true |   418.25300000000004 | 1300.971958 |  882.718958 |
|   true |           499.824875 | 1481.567583 |  981.742708 |
|   true |    517.3279579999999 | 2098.809708 |  1581.48175 |
|   true |    697.8347090000002 | 3465.671875 | 2767.837166 |
|   true |    804.3213330000001 | 2803.295458 | 1998.974125 |
|   true |   3150.1921249999996 | 5602.883792 | 2452.691667 |


**Second run**

| :same? |         :improvement | :old-ms | :new-ms |
|--------|----------------------|---------|---------|
|   true |   -869.4820009999999 |         |         |
|   true |   -734.5542069999999 |         |         |
|   true |   -697.3230409999996 |         |         |
|   true |   -641.8545000000001 |         |         |
|   true |          -484.476459 |         |         |
|   true |   -461.4432079999999 |         |         |
|   true |  -422.88045799999963 |         |         |
|   true |  -387.90866600000004 |         |         |
|   true |  -343.25229199999967 |         |         |
|   true |  -290.65983400000005 |         |         |
|   true |   -283.3768329999998 |         |         |
|   true |          -203.717083 |         |         |
|   true |   -200.2779169999999 |         |         |
|   true |  -178.45808399999999 |         |         |
|   true |  -160.62395800000002 |         |         |
|   true |          -157.657458 |         |         |
|   true |          -157.558291 |         |         |
|   true |          -141.443583 |         |         |
|   true |          -136.834042 |         |         |
|   true |   -118.4381249999999 |         |         |
|   true |          -117.978459 |         |         |
|   true |  -117.50429199999999 |         |         |
|   true |          -105.150916 |         |         |
|   true |  -104.72924900000001 |         |         |
|   true |   -88.08841699999999 |         |         |
|   true |   -76.85079200000001 |         |         |
|   true |   -71.49787400000002 |         |         |
|   true |   -70.73045900000011 |         |         |
|   true |   -61.49975100000006 |         |         |
|   true |   -61.45150000000001 |         |         |
|   true |   -60.51270800000002 |         |         |
|   true |   -59.75787500000001 |         |         |
|   true |   -59.23658399999999 |         |         |
|   true |  -58.300584000000015 |         |         |
|   true |           -45.529917 |         |         |
|   true |   -45.50562500000001 |         |         |
|   true |   -39.21962500000001 |         |         |
|   true |           -33.167958 |         |         |
|   true |  -29.336666000000008 |         |         |
|   true |   -25.89166700000004 |         |         |
|   true |  -17.791166999999973 |         |         |
|   true |   -16.51741600000001 |         |         |
|   true |   -9.187374999999989 |         |         |
|   true |  -4.0378749999999854 |         |         |
|   true |  -3.0154580000000095 |         |         |
|   true |  -2.7622499999999945 |         |         |
|   true |  -2.4604580000000027 |         |         |
|   true |   -2.411958999999996 |         |         |
|   true |  -2.0685410000000104 |         |         |
|   true |   -1.966417000000007 |         |         |
|   true |   -1.578084000000004 |         |         |
|   true |  -1.5739580000000046 |         |         |
|   true |  -1.5697509999999966 |         |         |
|   true |  -0.9838329999999997 |         |         |
|   true |  -0.8519160000000028 |         |         |
|   true |  -0.7982499999998254 |         |         |
|   true |  -0.4311659999999904 |         |         |
|   true | 0.061792999999994436 |         |         |
|   true |   0.4286249999999967 |         |         |
|   true |  0.44104200000001015 |         |         |
|   true |   0.5218339999999984 |         |         |
|   true |   0.5380420000000044 |         |         |
|   true |   0.6227499999999964 |         |         |
|   true |   0.6765000000000043 |         |         |
|   true |   0.7997919999999965 |         |         |
|   true |   0.8571249999999964 |         |         |
|   true |   1.8572080000000142 |         |         |
|   true |     6.12445799999999 |         |         |
|   true |    8.077708999999999 |         |         |
|   true |    9.794249999999977 |         |         |
|   true |   10.470541000000026 |         |         |
|   true |   13.697000000000116 |         |         |
|   true |   14.109750000000005 |         |         |
|   true |   14.478166000000002 |         |         |
|   true |               16.039 |         |         |
|   true |   17.246542000000005 |         |         |
|   true |   20.979708000000002 |         |         |
|   true |            21.996375 |         |         |
|   true |   27.005209000000008 |         |         |
|   true |   39.854457999999966 |         |         |
|   true |            44.761375 |         |         |
|   true |    51.87704100000019 |         |         |
|   true |   52.473124999999996 |         |         |
|   true |   52.972334000000004 |         |         |
|   true |            68.764208 |         |         |
|   true |    83.33954099999998 |         |         |
|   true |            86.701376 |         |         |
|   true |    93.67962500000002 |         |         |
|   true |    99.34870899999999 |         |         |
|   true |   117.54820900000001 |         |         |
|   true |   126.73066700000015 |         |         |
|   true |   141.12900100000002 |         |         |
|   true |             165.0765 |         |         |
|   true |   239.24800000000005 |         |         |
|   true |   272.68687499999993 |         |         |
|   true |   276.91712600000005 |         |         |
|   true |   314.57745799999987 |         |         |
|   true |             333.8415 |         |         |
|   true |           409.048166 |         |         |
|   true |   1275.5743750000001 |         |         |
