### PR TITLE
make sure we run `distinct-on` when paginating

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1080,12 +1080,16 @@
         order-by-direction (if last?
                              (reverse-direction direction)
                              direction)
-        order-by [[(kw table :- order-col-name)
-                   order-by-direction]
-                  [entity-id-col
-                   order-by-direction]]
+
+        order-col (kw table :- order-col-name)
+        order-by [[order-col order-by-direction]
+                  [entity-id-col order-by-direction]]
+        order-cols (map first order-by)
         paged-query (cond-> query
                       true (assoc :order-by order-by)
+                      true (dissoc :select)
+                      true (assoc :select-distinct-on (into [order-cols]
+                                                            (:select query)))
                       limit (assoc :limit limit)
                       offset (assoc :offset offset)
                       after (add-cursor-comparisons {:direction direction

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -327,6 +327,88 @@
                                  ("eid-joe-averbukh" :users/email "joe@instantdb.com")
                                  ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637")}})))
 
+  (testing "makes sure we use distinct"
+    (is-pretty-eq? (query-pretty {:users {:$ {:where {:bookshelves {:in
+                                                                    ;; this will cause 
+                                                                    ;; multiple matches for `stopa` 
+                                                                    [(resolvers/->uuid @r "eid-worldview")
+                                                                     (resolvers/->uuid @r "eid-the-way-of-the-gentleman")
+                                                                     (resolvers/->uuid @r "eid-short-stories")
+                                                                     (resolvers/->uuid @r "eid-2018")]}}
+                                              :limit 3
+                                              :order {:serverCreatedAt :asc}}}})
+
+                   '({:topics
+                      ([:vae
+                        _
+                        #{:users/bookshelves}
+                        #{"eid-the-way-of-the-gentleman"
+                          "eid-worldview"
+                          "eid-short-stories"
+                          "eid-2018"}]
+                       [:ea
+                        #{"eid-joe-averbukh" "eid-alex" "eid-stepan-parunashvili"}
+                        #{:users/id}
+                        _]
+                       --
+                       [:ea
+                        #{"eid-stepan-parunashvili"}
+                        #{:users/bookshelves
+                          :users/createdAt
+                          :users/email
+                          :users/id
+                          :users/fullName
+                          :users/handle}
+                        _]
+                       --
+                       [:ea
+                        #{"eid-joe-averbukh"}
+                        #{:users/bookshelves
+                          :users/createdAt
+                          :users/email
+                          :users/id
+                          :users/fullName
+                          :users/handle}
+                        _]
+                       --
+                       [:ea
+                        #{"eid-alex"}
+                        #{:users/bookshelves
+                          :users/createdAt
+                          :users/email
+                          :users/id
+                          :users/fullName
+                          :users/handle}
+                        _]),
+                      :triples
+                      (("eid-joe-averbukh" :users/bookshelves "eid-2018")
+                       ("eid-alex" :users/id "eid-alex")
+                       ("eid-alex" :users/bookshelves "eid-short-stories")
+                       ("eid-stepan-parunashvili" :users/bookshelves "eid-worldview")
+                       ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
+                       ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
+                       --
+                       ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
+                       ("eid-stepan-parunashvili"
+                        :users/createdAt
+                        "2021-01-07 18:50:43.447955")
+                       ("eid-stepan-parunashvili" :users/fullName "Stepan Parunashvili")
+                       ("eid-stepan-parunashvili" :users/handle "stopa")
+                       ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
+                       --
+                       ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
+                       ("eid-joe-averbukh" :users/email "joe@instantdb.com")
+                       ("eid-joe-averbukh" :users/handle "joe")
+                       ("eid-joe-averbukh" :users/fullName "Joe Averbukh")
+                       ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637")
+                       --
+                       ("eid-alex" :users/id "eid-alex")
+                       ("eid-alex" :users/fullName "Alex")
+                       ("eid-alex" :users/email "alex@instantdb.com")
+                       ("eid-alex" :users/handle "alex")
+                       ("eid-alex" :users/createdAt "2021-01-09 18:53:07.993689")),
+                      :aggregate (nil nil nil nil)})))
+
   (testing "offset"
     (is-pretty-eq? (query-pretty {:users {:$ {:offset 2
                                               :order {:serverCreatedAt :desc}}}})


### PR DESCRIPTION
Uri noticed an error when running a query like: 

```edn
 {:items
   {:$
    {:order {:serverCreatedAt "desc"},
     :limit 5,
     :where
     {:foo.bar {:$gte 5}}}}}
```

Because of the `foo.bar`, it was possible to get multiple instances of `item` entity ids repeating. When we updated the select statement to insert an `order-by` to the query, we could end up over-filtering. 

This is because of the CTE had:

```
entA
entA
entA 
entB 
```

With a `LIMIT` of 3, we would just return `entA`. 

To fix this, I updated `add-page-info`, to include a `select-distinct-on`

@dwwoelfel @nezaj 