### PR TITLE
Add a benchmark to the tests

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -52,6 +52,10 @@ jobs:
         working-directory: client
         run: pnpm run test
 
+      - name: Run benchmarks
+        working-directory: client
+        run: pnpm run bench
+
   detect_docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "build": "turbo run build --cache-dir=.turbo",
     "dev": "turbo run dev --parallel",
     "test": "turbo run test:ci",
+    "bench": "turbo run bench:ci",
     "format": "prettier --write --config ./.prettierrc \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "publish-packages": "turbo run publish-package --filter=\"./packages/*\"",
     "build-packages": "turbo run build --filter=\"./packages/*\" --cache-dir=.turbo",

--- a/client/packages/core/__tests__/src/instaql.bench.js
+++ b/client/packages/core/__tests__/src/instaql.bench.js
@@ -1,0 +1,29 @@
+import { bench } from "vitest";
+
+import zenecaAttrs from "./data/zeneca/attrs.json";
+import zenecaTriples from "./data/zeneca/triples.json";
+import { createStore } from "../../src/store";
+import query from "../../src/instaql";
+
+const zenecaIdToAttr = zenecaAttrs.reduce((res, x) => {
+  res[x.id] = x;
+  return res;
+}, {});
+
+const store = createStore(zenecaIdToAttr, zenecaTriples);
+
+bench("big query", () => {
+  query(
+    { store },
+    {
+      users: {
+        bookshelves: {
+          books: {},
+          users: {
+            bookshelves: {},
+          },
+        },
+      },
+    },
+  );
+});

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -8,7 +8,9 @@
   "unpkg": "standalone/index.umd.js",
   "scripts": {
     "test": "vitest",
+    "bench": "vitest bench",
     "test:ci": "vitest run",
+    "bench:ci": "vitest bench --run",
     "check": "tsc --noEmit",
     "build": "rm -rf dist; npm run build:main && npm run build:module && npm run build:standalone",
     "dev:main": "tsc -p tsconfig.json -w --skipLibCheck",

--- a/client/turbo.json
+++ b/client/turbo.json
@@ -16,6 +16,9 @@
     "test:ci": {
       "outputs": []
     },
+    "bench:ci": {
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Could potentially help us catch performance regressions. Outputs in the test output: https://github.com/instantdb/instant/actions/runs/12303534856/job/34339091865

<img width="786" alt="image" src="https://github.com/user-attachments/assets/0de4dc01-2214-4678-9361-1e7d11efddef" />
