### PR TITLE
Docs: Permissions: isOwner example

### DIFF
--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -15,7 +15,7 @@ Here’s an example ruleset below
       "update": "isOwner",
       "delete": "isOwner"
     },
-    "bind": ["isOwner", "auth.id == data.creatorId"]
+    "bind": ["isOwner", "auth.id != null && auth.id == data.creatorId"]
   }
 }
 ```


### PR DESCRIPTION
Added `auth.id != null` to the `isOwner` example clause to avoid granting permission when user is not signed-in and creatorId is set to null.