### PR TITLE
[cli] use inferred-types when using pull schema

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1591,6 +1591,13 @@ export default rules;
   `.trim();
 }
 
+function inferredType(config) {
+  const inferredList = config['inferred-types'];
+  const hasJustOne = inferredList?.length === 1;
+  if (!hasJustOne) return null;
+  return inferredList[0];
+}
+
 function schemaBlobToCodeStr(name, attrs) {
   // a block of code for each entity
   return [
@@ -1604,7 +1611,8 @@ function schemaBlobToCodeStr(name, attrs) {
     sortedEntries(attrs)
       .filter(([name]) => name !== "id")
       .map(([name, config]) => {
-        const type = config["checked-data-type"] || "any";
+        console.log(config);
+        const type = config["checked-data-type"] || inferredType(config) ||  "any";
 
         return [
           `    `,


### PR DESCRIPTION
**Context**

When existing apps pull schema, we're going to write out all attributes as `any`. 

This is a bit frustrating as an upgrade experience, as now developers need to manually update every column with it's actual type. 

**Potential solution** 

Well, one thing we _do_ have is inferred types. This PR makes it so if we detect an attribute that has just _one_ inferred type, then we choose that when someone writes `pull` schema. 

**Some tradeoffs in doing this** 

Mainly, it's a bit surprising that we _use_ the inferred type.

1. The user will have to write `push` schema, to actually enforce these types. The user may not know this 
  a. Perhaps it's not too big a deal though, as eventually they _will_ write push schema and see it. 
2. What if the user _intentionally_ wanted to leave an attribute untyped? Right now if they only have strings we'll keep telling him to type it
  a. Maybe this isn't too big a deal too, because as the user has heterogeneous data, we will stop doing it. 

The two tradeoffs do make me worry, but I think it would lead to a much better upgrade experience if we used inferred types

@dwwoelfel @nezaj @tonsky 