### PR TITLE
Add support for case-insensitive like

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -191,6 +191,29 @@ test("Where endsWith deep", () => {
   ).toEqual(["alex", "nicolegf", "stopa"]);
 });
 
+test("like case sensitivity", () => {
+  function runQuery(where) {
+    return query(
+      { store },
+      {
+        users: {
+          $: {
+            where: {
+              fullName: where,
+            },
+          },
+        },
+      },
+    )
+      .data.users.map((x) => x.fullName)
+      .sort();
+  }
+  expect(runQuery({ $like: "%O%" })).toEqual([]);
+  expect(runQuery({ $ilike: "%O%" })).toEqual(["Joe Averbukh", "Nicole"]);
+  expect(runQuery({ $like: "%j%" })).toEqual([]);
+  expect(runQuery({ $ilike: "%j%" })).toEqual(["Joe Averbukh"]);
+});
+
 test("Where and", () => {
   expect(
     query(

--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -32,6 +32,7 @@ type WhereArgs = {
   $gte?: string | number | boolean;
   $lte?: string | number | boolean;
   $like?: string;
+  $ilike?: string;
 };
 
 type WhereClauseValue = string | number | boolean | NonEmpty<WhereArgs>;

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -895,7 +895,11 @@ console.log(data)
 
 The `where` clause supports `$like` on fields that are indexed with a checked `string` type.
 
-`$like` queries will return entities that match a **case sensitive** substring of the provided value for the field. Here's how you can do queries like `startsWith`, `endsWith` and `includes`.
+`$like` queries will return entities that match a **case sensitive** substring of the provided value for the field.
+
+For **case insensitive** matching use `$ilike` in place of `$like`.
+
+Here's how you can do queries like `startsWith`, `endsWith` and `includes`.
 
 | Example                   | Description           | JS equivalent |
 | :-----------------------: | :-------------------: | :-----------: |
@@ -956,8 +960,39 @@ console.log(data)
 {
   "goals": [
     {
-      "id": workId,
-      "title": "Get promoted!",
+      "id": standupId,
+      "title": "Perform standup!",
+    }
+  ]
+}
+```
+
+Case-insensitive matching with `$ilike`:
+
+```javascript
+const query = {
+  goals: {
+    $: {
+      where: {
+        'todos.title': { $ilike: '%stand%' },
+      },
+    },
+  },
+};
+const { isLoading, error, data } = db.useQuery(query);
+```
+
+```javascript
+console.log(data)
+{
+  "goals": [
+    {
+      "id": standupId,
+      "title": "Perform standup!",
+    },
+    {
+      "id": standId,
+      "title": "Stand up a food truck.",
     }
   ]
 }

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -57,7 +57,7 @@
 (s/def ::nil? boolean?)
 (s/def ::$isNull (s/keys :req-un [::attr-id ::nil?]))
 
-(s/def ::op #{:$gt :$gte :$lt :$lte :$like})
+(s/def ::op #{:$gt :$gte :$lt :$lte :$like :$ilike})
 (s/def ::data-type #{:string :number :date :boolean})
 (s/def ::value any?)
 (s/def ::$comparator (s/keys :req-un [::op ::data-type ::value]))
@@ -612,7 +612,8 @@
                                      :$gte :>=
                                      :$lt :<
                                      :$lte :<=
-                                     :$like :like)
+                                     :$like :like
+                                     :$ilike :ilike)
                                    [(extract-value-fn data-type)
                                     :value]
                                    value]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -50,17 +50,18 @@
 (s/def ::$lt ::comparator)
 (s/def ::$lte ::comparator)
 (s/def ::$like ::comparator)
+(s/def ::$ilike ::comparator)
 
 (defn where-value-valid-keys? [m]
   (every? #{:in :$in
             :$not :$isNull
             :$gt :$gte :$lt :$lte
-            :$like}
+            :$like :$ilike}
           (keys m)))
 
 (s/def ::where-args-map (s/and
                          (s/keys :opt-un [::in ::$in ::$not ::$isNull
-                                          ::$gt ::$gte ::$lt ::$lte ::$like])
+                                          ::$gt ::$gte ::$lt ::$lte ::$like ::$ilike])
                          where-value-valid-keys?))
 
 (s/def ::where-v
@@ -1149,6 +1150,10 @@
 
                                  (contains? (second v) :$like)
                                  (when-let [like-val (:$like (second v))]
+                                   like-val)
+
+                                 (contains? (second v) :$ilike)
+                                 (when-let [like-val (:$ilike (second v))]
                                    like-val)))]
 
     (if (< 1 (count path))
@@ -1192,7 +1197,10 @@
                                          :<
 
                                          (contains? (second v) :$like)
-                                         :like))]
+                                         :like
+
+                                         (contains? (second v) :$ilike)
+                                         :ilike))]
         {:sql-conds (list* :or
                            (for [value values]
                              [comparison field [:cast value field-type]]))

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -328,11 +328,12 @@
 
         (and (map? v)
              (= (count v) 1)
-             (contains? #{:$gt :$gte :$lt :$lte :$like} (ffirst v)))
+             (contains? #{:$gt :$gte :$lt :$lte :$like :$ilike} (ffirst v)))
         (let [[op [tag value]] (first v)
               attr-data-type (assert-checked-attr-data-type! state attr)
               state (update state :in conj op)]
-          (when (= op :$like)
+          (when (or (= op :$like)
+                    (= op :$ilike))
             (assert-like-is-string! state attr tag value))
           {:$comparator
            {:op op

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -436,12 +436,19 @@
             false
             small)))
 
-(defn like-match? [text pattern]
+(defn make-like-match? [case-insensitive? text pattern]
   (let [regex-pattern (-> pattern
                           (string/replace "_" ".")
                           (string/replace "%" ".*")
-                          (#(str "^" % "$")))]
+                          (#(str (when case-insensitive?
+                                   "(?i)")
+                                 "^"
+                                 %
+                                 "$")))]
     (re-matches (re-pattern regex-pattern) text)))
+
+(def like-match? (partial make-like-match? false))
+(def ilike-match? (partial make-like-match? true))
 
 (defn- match-topic-part? [iv-part dq-part]
   (cond
@@ -456,7 +463,8 @@
                 :$gte >=
                 :$lt <
                 :$lte <=
-                :$like like-match?)]
+                :$like like-match?
+                :$ilike ilike-match?)]
         (some (fn [v]
                 (f v value))
               iv-part))


### PR DESCRIPTION
Adds support for `ilike`, which is just like `like`, but it's case-insensitive.

Example:

```javascript
const query = {
  goals: {
    $: {
      where: {
        'todos.title': { $ilike: '%stand%' },
      },
    },
  },
};
const { isLoading, error, data } = db.useQuery(query);
console.log(data)
{
  "goals": [
    {
      "id": standupId,
      "title": "Perform standup!",
    },
    {
      "id": standId,
      "title": "Stand up a food truck.",
    }
  ]
}
```