### PR TITLE
Don't filter spam if the attrs changed

### DIFF
--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -522,7 +522,8 @@
   (seekById [this id])
   (seekByFwdIdentName [this fwd-ident])
   (seekByRevIdentName [this revIdent])
-  (attrIdsForEtype [this etype]))
+  (attrIdsForEtype [this etype])
+  (unwrap [this]))
 
 ;; Creates a wrapper over attrs. Makes them act like a regular list, but
 ;; we can also index them on demand so that our access patterns will be
@@ -570,7 +571,9 @@
   (attrIdsForEtype [_this etype]
     (-> @cache
         :ids-by-etype
-        (get etype #{}))))
+        (get etype #{})))
+  (unwrap [_this]
+    elements))
 
 (defn wrap-attrs [attrs]
   (Attrs. attrs (delay (index-attrs attrs))))

--- a/server/src/instant/reactive/query.clj
+++ b/server/src/instant/reactive/query.clj
@@ -13,8 +13,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.reactive.store :as rs]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
-   [instant.util.tracer :as tracer]
-   [taoensso.nippy :as nippy])
+   [instant.util.tracer :as tracer])
   (:import
    (org.apache.commons.codec.digest DigestUtils)))
 
@@ -113,8 +112,8 @@
                                   :record-datalog-query-finish! (partial rs/record-datalog-query-finish! store-conn ctx))))))
 
             instaql-result (iq/permissioned-query ctx instaql-query)
-            result-hash (DigestUtils/md5Hex (nippy/fast-freeze {:instaql-result instaql-result
-                                                                :attrs (attr-model/unwrap attrs)}))
+            result-hash (hash {:instaql-result instaql-result
+                               :attrs (attr-model/unwrap attrs)})
             {:keys [result-changed?]} (rs/add-instaql-query! store-conn ctx result-hash)]
         {:instaql-result (case return-type
                            :join-rows (collect-instaql-results-for-client instaql-result)

--- a/server/src/instant/reactive/query.clj
+++ b/server/src/instant/reactive/query.clj
@@ -13,9 +13,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.reactive.store :as rs]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
-   [instant.util.tracer :as tracer])
-  (:import
-   (org.apache.commons.codec.digest DigestUtils)))
+   [instant.util.tracer :as tracer]))
 
 (defn- datalog-query-cached!
   "Returns the result of a datalog query. Leverages atom and

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -46,7 +46,7 @@
                               :db/index true}
    :instaql-query/stale? {:db/type :db.type/boolean}
    :instaql-query/version {:db/type :db.type/integer}
-   :instaql-query/hash {:db/type :db.type/string}
+   :instaql-query/hash {:db/type :db.type/number}
    ;; This would be easier if we had a store per app
    :instaql-query/session-id+query
    {:db/tupleAttrs [:instaql-query/session-id :instaql-query/query]


### PR DESCRIPTION
The spam filter is preventing the `useSchemaQuery` on the dashboard from catching changes to attributes.

When you add a namespace or index an attr, you won't see the changes on the dashboard until you refresh.

The PR fixes that problem by embedding the attrs into the query hash we use to determine if the query result changed.