### PR TITLE
[Docs] Fix permissions typos

### DIFF
--- a/client/packages/cli/index.js
+++ b/client/packages/cli/index.js
@@ -1571,7 +1571,7 @@ function generatePermsTypescriptFile(perms, instantModuleName) {
    *     update: "isOwner",
    *     delete: "isOwner",
    *   },
-   *   bind: ["isOwner", "data.creator == auth.uid"],
+   *   bind: ["isOwner", "auth.id != null && auth.id == data.ownerId"],
    * },
    */
 }

--- a/client/sandbox/react-native-expo/instant.perms.ts
+++ b/client/sandbox/react-native-expo/instant.perms.ts
@@ -16,7 +16,7 @@ const rules = {
    *     update: "isOwner",
    *     delete: "isOwner",
    *   },
-   *   bind: ["isOwner", "data.creator == auth.uid"],
+   *   bind: ["isOwner", "auth.id != null && auth.id == data.creatorId"],
    * },
    */
   $default: {

--- a/client/sandbox/react-nextjs/pages/play/stickers.tsx
+++ b/client/sandbox/react-nextjs/pages/play/stickers.tsx
@@ -211,7 +211,7 @@ const originalRules = {
     },
   },
   teams: {
-    bind: ["isOwner", "auth.id == data.user_id"],
+    bind: ["isOwner", "auth.id != null && auth.id == data.user_id"],
     allow: {
       view: "auth.id != null",
       create: "isOwner",
@@ -222,7 +222,7 @@ const originalRules = {
   users: {
     bind: [
       "isOwner",
-      "auth.id == data.id",
+      "auth.id != null && auth.id == data.id",
       "isPartOfUniverse",
       "auth.id in data.ref('universes.users.id')",
     ],

--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -18,7 +18,7 @@ const rules = {
       update: "isOwner",
       delete: "isOwner",
     },
-    bind: ["isOwner", "auth.id == data.creator"],
+    bind: ["isOwner", "auth.id != null && auth.id == data.creatorId"],
   },
 } satisfies InstantRules;
 
@@ -230,7 +230,7 @@ In `update`, you'll also have access to `newData`. This refers to the changes th
     "allow": {
       "create": "isOwner"
     },
-    "bind": ["isOwner", "auth.id == data.creatorId"]
+    "bind": ["isOwner", "auth.id != null && auth.id == data.creatorId"]
   }
 }
 ```
@@ -239,7 +239,7 @@ In `update`, you'll also have access to `newData`. This refers to the changes th
 {
   "todos": {
     "allow": {
-      "create": "auth.id == data.creatorId"
+      "create": "auth.id != null && auth.id == data.creatorId"
     }
   }
 }
@@ -255,7 +255,7 @@ In `update`, you'll also have access to `newData`. This refers to the changes th
     },
     "bind": [
       "isOwner",
-      "auth.id == data.creatorId",
+      "auth.id != null && auth.id == data.creatorId",
       "isAdmin",
       "auth.email in ['joe@instantdb.com', 'stopa@instantdb.com']"
     ]


### PR DESCRIPTION
@laurentpayot Noticed there was an error in our `isOwner` example where indeed an un-authed user could pass the `isOwner` example. Updating all references to these