### PR TITLE
fix distinct-on with limit

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1136,7 +1136,7 @@
                                     page-pattern)
         prev-table (kw prefix (dec next-idx))
         entity-id-col (if (= order-col-type :created-at-timestamp)
-                        (kw table :-entity-id)
+                        (kw :entity-id)
                         (kw prev-table :-entity-id))
         sym-component-type (component-type-of-sym named-pattern order-sym)
         sym-triple-idx (get (set/map-invert idx->component-type)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1188,14 +1188,14 @@
                                                      :order-col-type order-col-type
                                                      :cursor after
                                                      :cursor-type :after
-                                                     :entity-id-col entity-id-col})
+                                                     :entity-id-col :entity-id})
                       before (add-cursor-comparisons {:direction direction
                                                       :sym-triple-idx sym-triple-idx
                                                       :order-col-name order-col-name
                                                       :order-col-type order-col-type
                                                       :cursor before
                                                       :cursor-type :before
-                                                      :entity-id-col entity-id-col}))
+                                                      :entity-id-col :entity-id}))
 
         first-row-table (kw table :-first)
         last-row-table (kw table :-last)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1135,7 +1135,9 @@
                                     false
                                     page-pattern)
         prev-table (kw prefix (dec next-idx))
-        entity-id-col (kw prev-table :-entity-id)
+        entity-id-col (if (= order-col-type :created-at-timestamp)
+                        (kw table :-entity-id)
+                        (kw prev-table :-entity-id))
         sym-component-type (component-type-of-sym named-pattern order-sym)
         sym-triple-idx (get (set/map-invert idx->component-type)
                             sym-component-type)
@@ -1172,7 +1174,7 @@
                    (if (= order-by-direction :desc)
                      (kw order-by-direction :-nulls-last)
                      (kw order-by-direction :-nulls-first))
-                   order-by-direction ]
+                   order-by-direction]
                   [entity-id-col
                    order-by-direction]]
 
@@ -1234,7 +1236,7 @@
                                                     :cursor [:cursor-row.e
                                                              :cursor-row.sym]
                                                     :cursor-type :after
-                                                    :entity-id-col entity-id-col}))
+                                                    :entity-id-col :entity-id}))
         has-previous-query (-> query
                                (assoc :order-by order-by)
                                (assoc :limit 1)
@@ -1253,9 +1255,11 @@
                                                         :cursor [:cursor-row.e
                                                                  :cursor-row.sym]
                                                         :cursor-type :before
-                                                        :entity-id-col entity-id-col}))
+                                                        :entity-id-col :entity-id}))
 
         last-table-name (kw prefix next-idx)]
+
+    (tool/def-locals)
     {:next-idx (inc next-idx)
      :query {:with (conj (:with (:query match-query))
                          [table paged-query]
@@ -1310,7 +1314,6 @@
                                                    app-id
                                                    additional-joins
                                                    page-info))
-
 
                         ctes (:with query)
 
@@ -1839,7 +1842,6 @@
           query-hash (or (:query-hash ctx)
                          (hash (first (hsql/format query))))
           _ (tracer/add-data! {:attributes {:query-hash query-hash}})
-
           query (when query
                   (update query
                           :with conj

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -4056,7 +4056,7 @@
                                          :value-type :blob
                                          :cardinality :one}]
                              [:add-attr {:id msg-convos-id
-                                         :forward-identity [(random-uuid) "messages" "conversations"]
+                                         :forward-identity [(random-uuid) "messages" "conversation"]
                                          :reverse-identity [(random-uuid) "conversations" "messages"]
                                          :unique? false
                                          :index? false
@@ -4113,7 +4113,6 @@
                     ctx
                     (iq/query ctx
                               {:conversations {:$ {:limit 2
-                                                   :order {:serverCreatedAt :desc}
                                                    :where {:messages.time {:$gte 0}}}}}))
                    (get "conversations")
                    count)))))))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -804,8 +804,7 @@
                                                                  :users/fullName
                                                                  :users/handle} _]
                                           [:ave #{"eid-nicole"} #{:users/handle} _]}
-                                :triples #{
-                                           ("eid-nicole" :users/id "eid-nicole")
+                                :triples #{("eid-nicole" :users/id "eid-nicole")
                                            --
                                            ("eid-nicole" :users/handle "nicolegf")
                                            ("eid-nicole" :users/fullName "Nicole")
@@ -857,8 +856,7 @@
                                                                  :users/fullName
                                                                  :users/handle} _]
                                           [:ave #{"eid-nicole"} #{:users/handle} _]}
-                                :triples #{
-                                           ("eid-nicole" :users/id "eid-nicole")
+                                :triples #{("eid-nicole" :users/id "eid-nicole")
                                            --
                                            ("eid-nicole" :users/handle "nicolegf")
                                            ("eid-nicole" :users/fullName "Nicole")
@@ -2847,7 +2845,6 @@
                    (get "bookshelves")
                    (#(map (fn [x] (get x "order")) %)))))))))
 
-
 (deftest order-by-with-ors-and-ands
   (with-zeneca-checked-data-app
     (fn [app r]
@@ -4021,6 +4018,105 @@
                                   {:books {}})
                    :books)
                []))))))
+
+(deftest ordering-with-where-and-limit
+  (with-empty-app
+    (fn [{app-id :id :as _app}]
+      (let [make-ctx (fn []
+                       (let [attrs (attr-model/get-by-app-id app-id)]
+                         {:db {:conn-pool (aurora/conn-pool)}
+                          :app-id app-id
+                          :attrs attrs}))
+
+            ;; Create conversations, messages
+            convo-id-aid (random-uuid)
+            msg-id-aid (random-uuid)
+            msg-time-aid (random-uuid)
+            msg-convos-id (random-uuid)
+            _ (tx/transact! (aurora/conn-pool)
+                            (attr-model/get-by-app-id app-id)
+                            app-id
+                            [[:add-attr {:id convo-id-aid
+                                         :forward-identity [(random-uuid) "conversations" "id"]
+                                         :unique? true
+                                         :index? true
+                                         :value-type :blob
+                                         :cardinality :one}]
+                             [:add-attr {:id msg-id-aid
+                                         :forward-identity [(random-uuid) "messages" "id"]
+                                         :unique? true
+                                         :index? true
+                                         :value-type :blob
+                                         :cardinality :one}]
+                             [:add-attr {:id msg-time-aid
+                                         :forward-identity [(random-uuid) "messages" "time"]
+                                         :unique? false
+                                         :index? true
+                                         :checked-data-type :number
+                                         :value-type :blob
+                                         :cardinality :one}]
+                             [:add-attr {:id msg-convos-id
+                                         :forward-identity [(random-uuid) "messages" "conversations"]
+                                         :reverse-identity [(random-uuid) "conversations" "messages"]
+                                         :unique? false
+                                         :index? false
+                                         :value-type :ref
+                                         :cardinality :one}]])
+
+            ;; add 3 conversations, with 5 messages each
+
+            add-conversation (fn [c-id]
+                               [[:add-triple c-id convo-id-aid (str c-id)]])
+
+            add-message (fn [convo-id m-id t]
+                          [[:add-triple m-id msg-id-aid m-id]
+                           [:add-triple m-id msg-time-aid t]
+                           [:add-triple m-id msg-convos-id convo-id]])
+
+            convo-msg-data (->> (repeatedly 3 random-uuid)
+                                (map-indexed (fn [idx c-id]
+                                               {:convo-id c-id
+                                                :convo-idx idx
+                                                :messages (map-indexed
+                                                           (fn [i m-id]
+                                                             {:msg-id m-id
+                                                              :msg-idx i})
+                                                           (repeatedly 20 random-uuid))})))
+
+            steps-of-steps (map
+                            (fn [{:keys [convo-id convo-idx messages]}]
+                              (concat (add-conversation convo-id)
+                                      (mapcat (fn [{:keys [msg-id msg-idx]}]
+                                                (add-message convo-id msg-id (+ convo-idx msg-idx)))
+                                              messages)))
+
+                            convo-msg-data)
+            _ (mapv
+               (fn [steps]
+                 (tx/transact! (aurora/conn-pool)
+                               (attr-model/get-by-app-id app-id)
+                               app-id
+                               steps))
+
+               steps-of-steps)
+            ctx (make-ctx)]
+        (is (= 3
+               (-> (instaql-nodes->object-tree
+                    ctx
+                    (iq/query ctx
+                              {:conversations {:$ {:where {:messages.time {:$gte 0}}}}}))
+                   (get "conversations")
+                   count)))
+
+        (is (= 2
+               (-> (instaql-nodes->object-tree
+                    ctx
+                    (iq/query ctx
+                              {:conversations {:$ {:limit 2
+                                                   :order {:serverCreatedAt :desc}
+                                                   :where {:messages.time {:$gte 0}}}}}))
+                   (get "conversations")
+                   count)))))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
## Context

Consider the following schema: 

```javascript
entities: {
    conversations: i.entity({
      // ...
    }),
    messages: i.entity({
      // ...
    }),
  },
  links: {
    messageConvo: {
      forward: { on: 'messages', has: 'one', label: 'conversation' }, 
      reverse: { on: 'conversations', has: 'many', label: 'messages' }
    },
  },
```

Say I create 3 convos, with 10 messages each.

## Problem

If I query:  

```edn
{:conversations {:$ {:limit 2 :where {:messages.time {:$gte 0}}}}}
```

**I will get _1_ result back, rather then 2** 

## Investigation 

This is because the datalog query looks something like: 

```
[?m :time (> t)] 
[?m :convo ?c] 
```

When we add our `order` information, we actually add it to `[?m :convo ?c]`: 


```sql
WITH match_0_0 AS MATERIALIZED (
  SELECT
    entity_id AS match_0_0_entity_id,
    attr_id AS match_0_0_attr_id,
    value AS match_0_0_value_blob,
    CASE
      WHEN eav THEN CAST(value ->> 0 AS UUID)
      ELSE null
    END AS match_0_0_value_uuid,
    created_at AS match_0_0_created_at
  FROM
    triples
  WHERE
    (
      app_id = 'fc10c06f-1a4c-496f-bb4d-a3b9ce252cb7' :: uuid
    )
    AND (ave = true)
    AND (
      attr_id = '70387671-fad8-416c-9e7f-226228794c05' :: uuid
    )
    AND (TRIPLES_EXTRACT_NUMBER_VALUE(value) >= 0)
    AND (
      checked_data_type = CAST('number' AS CHECKED_DATA_TYPE)
    )
),
match_0_1 AS MATERIALIZED (
  SELECT
    match_0_0.*,
    entity_id AS match_0_1_entity_id,
    attr_id AS match_0_1_attr_id,
    value AS match_0_1_value_blob,
    CASE
      WHEN eav THEN CAST(value ->> 0 AS UUID)
      ELSE null
    END AS match_0_1_value_uuid,
    created_at AS match_0_1_created_at
  FROM
    triples,
    match_0_0
  WHERE
    (
      app_id = 'fc10c06f-1a4c-496f-bb4d-a3b9ce252cb7' :: uuid
    )
    AND (eav = true)
    AND (
      attr_id = 'ea2bf36e-200a-4b55-a86c-bbfd623ed5da' :: uuid
    )
    AND (entity_id = match_0_0_entity_id)
),
match_0_2 AS MATERIALIZED (
  SELECT
    -- this makes ?m unique, rather than ?c
    DISTINCT ON(order_val, match_0_1_entity_id) CAST(created_at AS BIGINT) AS order_val, 
    match_0_1.*,
    entity_id AS match_0_2_entity_id,
    attr_id AS match_0_2_attr_id,
    value AS match_0_2_value_blob,
    CASE
      WHEN eav THEN CAST(value ->> 0 AS UUID)
      ELSE null
    END AS match_0_2_value_uuid,
    created_at AS match_0_2_created_at
  FROM
    match_0_1
    LEFT JOIN triples ON (
      app_id = 'fc10c06f-1a4c-496f-bb4d-a3b9ce252cb7' :: uuid
    )
    AND (ea = true)
    AND (
      attr_id = 'cdf7582a-4b07-4c36-ab28-5916539d8db4' :: uuid
    )
    AND (entity_id = match_0_1_value_uuid)
  ORDER BY
    order_val ASC NULLS FIRST,
    match_0_1_entity_id ASC
  LIMIT
    2
)
SELECT * FROM match_0_2;
```

## Possible Solution

It's a bit of hack, but here's what I do: 

I detect that _if_ we end up joining `curr-table-entity-id` on `prev-table-value-uuid`, then the `entity-id-col` must be prev-table-uuid. 

By doing this, all tests pass

@dwwoelfel @nezaj @tonsky 