### PR TITLE
[types] add UpdateParams and LinkParams

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -45,6 +45,8 @@ import {
   type InstaQLEntity,
   type InstaQLResult,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 } from "@instantdb/core";
 
 import version from "./version";
@@ -951,4 +953,6 @@ export {
   type InstaQLEntity,
   type InstaQLResult,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 };

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -62,6 +62,8 @@ import type {
   ValueTypes,
   InstantUnknownSchema,
   BackwardsCompatibleSchema,
+  UpdateParams,
+  LinkParams,
 } from "./schemaTypes";
 
 const defaultOpenDevtool = true;
@@ -730,4 +732,6 @@ export {
   type IInstantDatabase,
   type BackwardsCompatibleSchema,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 };

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -1,4 +1,10 @@
-import type { DataAttrDef, IContainEntitiesAndLinks, InstantGraph, LinkAttrDef } from "./schemaTypes";
+import type {
+  DataAttrDef,
+  IContainEntitiesAndLinks,
+  InstantGraph,
+  LinkAttrDef,
+  UpdateParams,
+} from "./schemaTypes";
 
 type Action = "update" | "link" | "unlink" | "delete" | "merge";
 type EType = string;
@@ -7,24 +13,6 @@ type Args = any;
 type LookupRef = [string, any];
 type Lookup = string;
 export type Op = [Action, EType, Id | LookupRef, Args];
-
-type UpdateParams<
-  Schema extends IContainEntitiesAndLinks<any, any>,
-  EntityName extends keyof Schema["entities"],
-> = {
-  [AttrName in keyof Schema["entities"][EntityName]["attrs"]]?: Schema["entities"][EntityName]["attrs"][AttrName] extends DataAttrDef<
-    infer ValueType,
-    infer IsRequired
-  >
-    ? IsRequired extends true
-      ? ValueType
-      : ValueType | null
-    : never;
-} & (Schema extends IContainEntitiesAndLinks<any, any>
-  ? {}
-  : {
-      [attribute: string]: any;
-    });
 
 type LinkParams<
   Schema extends IContainEntitiesAndLinks<any, any>,

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -1,8 +1,6 @@
 import type {
-  DataAttrDef,
   IContainEntitiesAndLinks,
-  InstantGraph,
-  LinkAttrDef,
+  LinkParams,
   UpdateParams,
 } from "./schemaTypes";
 
@@ -13,20 +11,6 @@ type Args = any;
 type LookupRef = [string, any];
 type Lookup = string;
 export type Op = [Action, EType, Id | LookupRef, Args];
-
-type LinkParams<
-  Schema extends IContainEntitiesAndLinks<any, any>,
-  EntityName extends keyof Schema["entities"],
-> = {
-  [LinkName in keyof Schema["entities"][EntityName]["links"]]?: Schema["entities"][EntityName]["links"][LinkName] extends LinkAttrDef<
-    infer Cardinality,
-    any
-  >
-    ? Cardinality extends "one"
-      ? string
-      : string | string[]
-    : never;
-} & (Schema extends InstantGraph<any, any> ? {} : { [attribute: string]: any });
 
 export interface TransactionChunk<
   Schema extends IContainEntitiesAndLinks<any, any>,

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -466,3 +466,17 @@ export type UpdateParams<
     Schema["entities"][EntityName]["attrs"][AttrName]
   >;
 };
+
+export type LinkParams<
+  Schema extends IContainEntitiesAndLinks<any, any>,
+  EntityName extends keyof Schema["entities"],
+> = {
+  [LinkName in keyof Schema["entities"][EntityName]["links"]]?: Schema["entities"][EntityName]["links"][LinkName] extends LinkAttrDef<
+    infer Cardinality,
+    any
+  >
+    ? Cardinality extends "one"
+      ? string
+      : string | string[]
+    : never;
+};

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -462,9 +462,14 @@ export type UpdateParams<
   Schema extends IContainEntitiesAndLinks<any, any>,
   EntityName extends keyof Schema["entities"],
 > = {
-  [AttrName in keyof Schema["entities"][EntityName]["attrs"]]?: ExtractValueType<
-    Schema["entities"][EntityName]["attrs"][AttrName]
-  >;
+  [AttrName in keyof Schema["entities"][EntityName]["attrs"]]?: Schema["entities"][EntityName]["attrs"][AttrName] extends DataAttrDef<
+    infer ValueType,
+    infer IsRequired
+  >
+    ? IsRequired extends true
+      ? ValueType
+      : ValueType | null
+    : never;
 };
 
 export type LinkParams<

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -305,21 +305,21 @@ export class InstantSchemaDef<
 
   /**
    * @deprecated
-   * `withRoomSchema` is deprecated. Define your schema in `rooms` directly: 
-   * 
-   * @example 
-   * // Before: 
-   * const schema = i.schema({ 
+   * `withRoomSchema` is deprecated. Define your schema in `rooms` directly:
+   *
+   * @example
+   * // Before:
+   * const schema = i.schema({
    *   // ...
    * }).withRoomSchema<RoomSchema>()
-   * 
+   *
    * // After
    * const schema = i.schema({
    *  rooms: {
    *    // ...
    *  }
    * })
-   * 
+   *
    * @see https://instantdb.com/docs/presence-and-topics#typesafety
    */
   withRoomSchema<_RoomSchema extends RoomSchemaShape>() {
@@ -335,7 +335,7 @@ export class InstantSchemaDef<
 /**
  * @deprecated
  * `i.graph` is deprecated. Use `i.schema` instead.
- * 
+ *
  * @see https://instantdb.com/docs/modeling-data
  */
 export class InstantGraph<
@@ -457,3 +457,12 @@ export type InstantUnknownSchema = InstantSchemaDef<
   UnknownLinks<UnknownEntities>,
   UnknownRooms
 >;
+
+export type UpdateParams<
+  Schema extends IContainEntitiesAndLinks<any, any>,
+  EntityName extends keyof Schema["entities"],
+> = {
+  [AttrName in keyof Schema["entities"][EntityName]["attrs"]]?: ExtractValueType<
+    Schema["entities"][EntityName]["attrs"][AttrName]
+  >;
+};

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -51,6 +51,8 @@ import {
   type InstantSchemaDef,
   type InstantUnknownSchema,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 } from "@instantdb/core";
 
 /**
@@ -147,4 +149,6 @@ export {
   type InstantUnknownSchema,
   type BackwardsCompatibleSchema,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 };

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -40,6 +40,8 @@ import {
   type InstantSchemaDef,
   type BackwardsCompatibleSchema,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 } from "@instantdb/core";
 
 import InstantReactAbstractDatabase from "./InstantReactAbstractDatabase";
@@ -95,4 +97,6 @@ export {
   type InstantSchemaDef,
   type BackwardsCompatibleSchema,
   type InstantRules,
+  type UpdateParams,
+  type LinkParams,
 };

--- a/client/sandbox/strong-init-vite/src/typescript_test_abstract.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_test_abstract.tsx
@@ -1,4 +1,4 @@
-import { i, id, init, InstaQLEntity } from "@instantdb/admin";
+import { i, id, init, InstaQLEntity, UpdateParams } from "@instantdb/admin";
 
 const _schema = i.schema({ entities: { users: i.entity({ email: i.string() }) } });
 type _AppSchema = typeof _schema; 
@@ -13,11 +13,11 @@ const db = init({
 
 type Collection = keyof typeof schema.entities;
 
-type Entity<T extends Collection> = InstaQLEntity<typeof schema, T, {}>;
+type EntityUpdate<T extends Collection> = UpdateParams<typeof schema, T>;
 
 export const newEntity = async <T extends Collection>(
   type: T,
-  props: Omit<Entity<T>, "id">,
+  props: EntityUpdate<T>,
 ) => {
   const theId = id();
   await db.transact(db.tx[type][theId].update(props));
@@ -25,10 +25,15 @@ export const newEntity = async <T extends Collection>(
 };
 
 // seems good
-const alice = await newEntity("users", { email: "alice@gmail.com" });
+const existing_attr_works = await newEntity("users", { email: "alice@gmail.com" });
 
-// Should be a typing error but is not
-const bob = await newEntity("users", { blabla: "bob@gmail.com" });
+// @ts-expect-error
+const non_existing_attr_errors = await newEntity("users", { blabla: "bob@gmail.com" });
 
-// Should be a typing error but is not
-const eve = await newEntity("users", { email: 123 });
+// @ts-expect-error
+const wrong_type_errors = await newEntity("users", { email: 123 });
+
+// to silence ts warnings
+existing_attr_works;
+non_existing_attr_errors;
+wrong_type_errors;

--- a/client/sandbox/strong-init-vite/src/typescript_test_abstract.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_test_abstract.tsx
@@ -1,4 +1,4 @@
-import { i, id, init, InstaQLEntity, UpdateParams } from "@instantdb/admin";
+import { i, id, init, UpdateParams } from "@instantdb/admin";
 
 const _schema = i.schema({ entities: { users: i.entity({ email: i.string() }) } });
 type _AppSchema = typeof _schema; 

--- a/client/sandbox/strong-init-vite/src/typescript_test_abstract.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_test_abstract.tsx
@@ -1,0 +1,34 @@
+import { i, id, init, InstaQLEntity } from "@instantdb/admin";
+
+const _schema = i.schema({ entities: { users: i.entity({ email: i.string() }) } });
+type _AppSchema = typeof _schema; 
+interface AppSchema extends _AppSchema {} 
+const schema: AppSchema = _schema; 
+
+const db = init({
+  adminToken: "...",
+  appId: "...",
+  schema,
+});
+
+type Collection = keyof typeof schema.entities;
+
+type Entity<T extends Collection> = InstaQLEntity<typeof schema, T, {}>;
+
+export const newEntity = async <T extends Collection>(
+  type: T,
+  props: Omit<Entity<T>, "id">,
+) => {
+  const theId = id();
+  await db.transact(db.tx[type][theId].update(props));
+  return theId;
+};
+
+// seems good
+const alice = await newEntity("users", { email: "alice@gmail.com" });
+
+// Should be a typing error but is not
+const bob = await newEntity("users", { blabla: "bob@gmail.com" });
+
+// Should be a typing error but is not
+const eve = await newEntity("users", { email: 123 });


### PR DESCRIPTION
https://github.com/instantdb/instant/issues/493 

Uri mentioned issues trying to create generic functions for creating entities. 

I looked deeper into his repro, and the underlying issue was: 

```typescript
Omit<Entity<T>, 'id'>
```

Since technically `InstaQLEntity` can include links, this was not matching up with `UpdateParams`.  Perhaps we can hint better to typescript, that since we gave an empty object, `Entity` would have no links, and that _should_ pass for `UpdateParams`. 

For now I just exposed `UpdateParams` directly, and added Uri's example in our playground. 

@nezaj @dwwoelfel @tonsky 