### PR TITLE
[types] Expand should ignore builtins

### DIFF
--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -10,11 +10,15 @@ import type {
   ResolveEntityAttrs,
 } from "./schemaTypes";
 
-type Expand<T> = T extends object
-  ? T extends infer O
-    ? { [K in keyof O]: Expand<O[K]> }
-    : never
-  : T;
+type BuiltIn = Date | Function | Error | RegExp;
+
+type Expand<T> = T extends BuiltIn
+  ? T
+  : T extends object
+    ? T extends infer O
+      ? { [K in keyof O]: Expand<O[K]> }
+      : never
+    : T;
 
 // NonEmpty disallows {}, so that you must provide at least one field
 type NonEmpty<T> = {

--- a/client/sandbox/strong-init-vite/src/typescript_tests_backwards_compat_date.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_backwards_compat_date.tsx
@@ -1,0 +1,48 @@
+import { init, BackwardsCompatibleSchema } from "@instantdb/react";
+
+type Message = {
+  content: string;
+  createdAt: Date;
+};
+
+type User = {
+  email: string;
+};
+
+type Schema = {
+  messages: Message;
+  creator: User;
+};
+
+type EmojiName = "fire" | "wave" | "confetti" | "heart";
+
+type Rooms = {
+  chat: {
+    presence: {
+      name: string;
+      avatarURI: string;
+    };
+    topics: {
+      emoji: {
+        name: EmojiName;
+        rotationAngle: number;
+        directionAngle: number;
+      };
+    };
+  };
+};
+
+// ----
+// Core
+
+const db = init<BackwardsCompatibleSchema<Schema, Rooms>>({
+  appId: import.meta.env.VITE_INSTANT_APP_ID,
+});
+
+const res = db.useQuery({ messages: { creator: {} }})
+const m = res.data?.messages[0];
+// Hover over `m` to see that `m?.createdAt` and see that it says `Date`;
+m?.createdAt;
+
+
+


### PR DESCRIPTION
Nacho mentioned type issues when he put `Date` in his schema. 

I made an example with a `Date` type, and realized that our `Expand` utility broke out the type: 

I updated `Expand` to exclude builtin types, and my hope this will make Nacho's upgrade seamless. 

@dwwoelfel @nezaj @tonsky 