### PR TITLE
Protect datalog cache from early cancellation

### DIFF
--- a/server/src/instant/jdbc/failover.clj
+++ b/server/src/instant/jdbc/failover.clj
@@ -41,7 +41,7 @@
     (Thread/sleep 2500)
     (println "Canceling in-progress transactions"
              (count @(:stmts sql/default-statement-tracker)))
-    (sql/cancel-in-progress @(:stmts sql/default-statement-tracker))
+    (sql/cancel-in-progress sql/default-statement-tracker)
     ;; Create a transaction we can use as a proxy for everything syncing over to
     ;; the new instance
     (let [tx (transaction-model/create! aurora/-conn-pool

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -167,8 +167,22 @@
                (when remove (remove rw cancelable)))
      :stmts stmts}))
 
-(defn cancel-in-progress [stmts]
-  (doseq [stmt stmts]
+(defn make-top-level-statement-tracker
+  "Creates a statement tracker that ignores all intermediate trackers, except
+   for the top-level default tracker."
+  []
+  (let [{:keys [add remove]} default-statement-tracker
+        stmts (atom #{})]
+    {:add (fn [rw cancelable]
+            (swap! stmts conj cancelable)
+            (when add (add rw cancelable)))
+     :remove (fn [rw cancelable]
+               (swap! stmts disj cancelable)
+               (when remove (remove rw cancelable)))
+     :stmts stmts}))
+
+(defn cancel-in-progress [{:keys [stmts]}]
+  (doseq [stmt @stmts]
     (cancel stmt)))
 
 (defn register-in-progress

--- a/server/src/instant/reactive/query.clj
+++ b/server/src/instant/reactive/query.clj
@@ -19,9 +19,7 @@
   "Returns the result of a datalog query. Leverages atom and
   delay to ensure queries are only run once in the face of concurrent requests."
   [store-conn {:keys [app-id] :as ctx} datalog-query]
-  (let [delayed-call (delay (d/query ctx datalog-query))
-        delayed (rs/swap-datalog-cache-delay! store-conn app-id datalog-query delayed-call)]
-    @delayed))
+  (rs/swap-datalog-cache! store-conn app-id d/query ctx datalog-query))
 
 (comment
   (def ctx {:db {:conn-pool (aurora/conn-pool)}

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -22,8 +22,7 @@
    [instant.util.async :as ua]
    [instant.util.coll :as ucoll]
    [instant.util.exception :as ex]
-   [instant.util.tracer :as tracer]
-   [medley.core :refer [dissoc-in]])
+   [instant.util.tracer :as tracer])
   (:import
    (java.lang InterruptedException)
    (java.util.concurrent CancellationException)))
@@ -421,7 +420,7 @@
                                        (Exception. "Did not deliver promise!")})
                              (deliver (:cancel-signal @result-delay)
                                       false)))))
-            cancel-fut (binding [ua/*child-vfutures* nil]
+            _cancel-fut (binding [ua/*child-vfutures* nil]
                          (ua/vfuture
                            (when @(:cancel-signal @result-delay)
                              (sql/cancel-in-progress stmt-tracker)

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -431,9 +431,7 @@
         ;; The work is already done, so we don't need to listen for cancellation
         (unwrap-result)
         ;; Start a tracked future to watch for cancelation
-        (let [wait-fut
-              (ua/vfuture
-                (unwrap-result))]
+        (let [wait-fut (ua/vfuture (unwrap-result))]
           (try
             @wait-fut
             (catch Throwable t

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -125,7 +125,7 @@
          "handle-refresh/send-event!"
          "store/record-datalog-query-finish!"
          "store/record-datalog-query-start!"
-         "store/swap-datalog-cache-delay!"
+         "store/swap-datalog-cache!"
          "store/bump-instaql-version!"
          "store/add-instaql-query!") true
 

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -20,7 +20,7 @@
                   1000)
         (is (= 1 (count @(:stmts in-progress))))
         (is (not (future-done? query)))
-        (sql/cancel-in-progress @(:stmts in-progress))
+        (sql/cancel-in-progress in-progress)
         (wait-for (fn []
                     (future-done? query))
                   1000)

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -1,7 +1,8 @@
 (ns instant.reactive.store-test
   (:require
-   [clojure.test :as test :refer [deftest is]]
-   [instant.reactive.store :as rs]))
+   [clojure.test :as test :refer [deftest is testing]]
+   [instant.reactive.store :as rs]
+   [instant.util.async :as ua]))
 
 (deftest match-topic?
   (is (true?
@@ -20,6 +21,111 @@
        (rs/match-topic?
         '[:eav #{3} _ _]
         '[:eav #{1} #{2} #{3}]))))
+
+(deftest swap-datalog-cache!
+  (let [store (rs/init-store)
+        app-id (random-uuid)]
+    (testing "store returns cached data"
+      (let [q [[:ea (random-uuid)]]]
+        (is (= :a (rs/swap-datalog-cache! store
+                                          app-id
+                                          (fn [_ctx _query]
+                                            :a)
+                                          nil
+                                          q)))
+        (is (= :a (rs/swap-datalog-cache! store
+                                          app-id
+                                          (fn [_ctx _query]
+                                            :b)
+                                          nil
+                                          q)))))
+
+    (testing "store returns cached data with delay"
+      (let [q [[:ea (random-uuid)]]]
+        (is (= :a (rs/swap-datalog-cache! store
+                                          app-id
+                                          (fn [_ctx _query]
+                                            (Thread/sleep 100)
+                                            :a)
+                                          nil
+                                          q)))
+        (is (= :a (rs/swap-datalog-cache! store
+                                          app-id
+                                          (fn [_ctx _query]
+                                            :b)
+                                          nil
+                                          q)))))
+
+    (testing "work is canceled with no listeners"
+      (let [q [[:ea (random-uuid)]]
+            err (promise)
+            started (promise)
+            f1 (ua/vfuture (rs/swap-datalog-cache! store
+                                                   app-id
+                                                   (fn [_ctx _query]
+                                                     (try
+                                                       (deliver started true)
+                                                       @(promise)
+                                                       (catch Throwable t
+                                                         (deliver err t))))
+                                                   nil
+                                                   q))]
+        @started
+        (future-cancel f1)
+        (is (instance? java.lang.InterruptedException @err))))
+
+    (dotimes [x 100]
+      (testing "work isn't canceled if there are still listeners"
+        (let [q [[:ea (random-uuid)]]
+              err (promise)
+              started (promise)
+              wait (promise)
+              f1 (ua/vfuture (try (rs/swap-datalog-cache! store
+                                                          app-id
+                                                          (fn [_ctx _query]
+                                                            (deliver started true)
+                                                            ;; It looks like the promise is getting canceled somehow?
+                                                            @wait)
+                                                          nil
+                                                          q)
+                                  (catch Throwable t
+                                    (deliver err t))))
+              _ @started
+              f2 (ua/vfuture (rs/swap-datalog-cache! store
+                                                     app-id
+                                                     (fn [_ctx _query]
+                                                       @wait)
+                                                     nil
+                                                     q))]
+          (future-cancel f1)
+          (is (or (instance? java.lang.InterruptedException @err)
+                  (instance? java.util.concurrent.CancellationException @err)))
+          (Thread/sleep 10)
+          (deliver wait :a)
+          (is (= @f2 :a))
+          @wait)))
+
+    (testing "propagates failures"
+      (let [q [[:ea (random-uuid)]]
+            r1 (try (rs/swap-datalog-cache! store
+                                            app-id
+                                            (fn [_ctx _query]
+                                              (throw (Exception. "oops")))
+                                            nil
+                                            q)
+                    (catch Exception e
+                      e))]
+
+        (is (instance? Exception
+                       r1))
+
+        (is (thrown? Exception
+                     (rs/swap-datalog-cache! store
+                                             app-id
+                                             (fn [_ctx _query]
+                                               :shouldn't-be-executed)
+                                             nil
+                                             q)))))))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -72,7 +72,7 @@
                                                    q))]
         @started
         (future-cancel f1)
-        (is (instance? java.lang.InterruptedException @err))))
+        (is (instance? java.lang.InterruptedException (deref err 100 :timeout)))))
 
     (dotimes [x 100]
       (testing "work isn't canceled if there are still listeners"
@@ -98,12 +98,11 @@
                                                      nil
                                                      q))]
           (future-cancel f1)
-          (is (or (instance? java.lang.InterruptedException @err)
-                  (instance? java.util.concurrent.CancellationException @err)))
+          (is (or (instance? java.lang.InterruptedException (deref err 100 :timeout))
+                  (instance? java.util.concurrent.CancellationException (deref err 100 :timeout))))
           (Thread/sleep 10)
           (deliver wait :a)
-          (is (= @f2 :a))
-          @wait)))
+          (is (= (deref f2 100 :timeout) :a)))))
 
     (testing "propagates failures"
       (let [q [[:ea (random-uuid)]]


### PR DESCRIPTION
This prevents in-progress datalog queries from getting cancelled when there are multiple sessions waiting on the query.

Previously, we could get into a situation like this:

1. user-1 opens a session and runs query-a
2. user-2 opens a session and runs query-a
3. user-1 closes their session
4. we cancel all in-progress queries, including query-a
5. user-2 gets an error for query-a because the query was cancelled

This PR moves the query execution to a separate call stack where it won't get canceled if the parent is canceled. 

To keep the behavior where we cancel queries that exceed the `handle-receive-timeout-ms`, we add another future that is in the call stack. If it gets canceled and there are no other threads waiting on the query, then it will cancel the query.