### PR TITLE
[invalidator] fix topic error from date insert

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -13,7 +13,8 @@
    [instant.util.string :refer [multiline->single-line]]
    [instant.util.tracer :as tracer])
   (:import
-   (java.util UUID)))
+   (java.util UUID)
+   (java.time Instant)))
 
 ;; (XXX): Currently we allow value to be nil
 ;; In the future, we may want to _retract_ the triple if the value is nil
@@ -706,3 +707,9 @@
                        (inc i)))))))
       (tracer/add-data! {:attributes {:total-count @row-count}})
       {:row-count @row-count})))
+
+(defn parse-date-value [x]
+  (cond (string? x)
+        (Instant/parse x)
+        (number? x)
+        (Instant/ofEpochMilli x)))

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -14,7 +14,8 @@
    [instant.reactive.store :as rs]
    [instant.util.async :as ua]
    [instant.util.json :refer [<-json]]
-   [instant.util.tracer :as tracer])
+   [instant.util.tracer :as tracer]
+   [instant.db.model.triple :as triple-model])
   (:import (java.util UUID)))
 
 (declare wal-opts)
@@ -43,10 +44,13 @@
         e (UUID/fromString (:entity_id m))
         a (UUID/fromString (:attr_id m))
         v-parsed (<-json (:value m))
-        v (if (:eav m)
+        v (cond
+            (:eav m)
             (UUID/fromString v-parsed)
+            (= (:checked_data_type m) "date")
+            (triple-model/parse-date-value v-parsed)
+            :else
             v-parsed)
-
         ks (->> #{:ea :eav :av :ave :vae}
                 (filter m))]
     (map (fn [k] [k #{e} #{a} #{v}])


### PR DESCRIPTION
I saw a [few bugs](https://ui.honeycomb.io/instantdb/environments/prod/datasets/instant-server/result/iNdPFYRibPW?tab=traces) in our logs, with the error: 

```bash
class java.time.Instant cannot be cast to class java.lang.Number (java.time.Instant and java.lang.Number are in module java.base of loader 'bootstrap')
```

## Root cause

In datalog, we convert values for checked-data-type = date into java.time.Instant 

```edn
topicFromQuery [:ea eid aid java.time.Instant<...>]
```

When we generate `topics-for-triple-insert`, we keep the underlying number value: 

```edn
topicFromInvalidator [:ea eid aid 1735658560430]
```

This means that when we run `match` on the topic, this causes a type mismatch 

## Solution 

I went ahead and updated `topics-for-triple-insert`, to convert dates to java.time.Instant

## Further work 

Right now I realize tests for this flow are a bit cumbersome to write. Noting to look into a future PR, which could make writing something like a) Make a query, b) Make a transaction, c) see that the correct query updates, a bit easier to write

@dwwoelfel @nezaj @tonsky 