### PR TITLE
[ts] make optional fields work if the key is ommited

### DIFF
--- a/client/sandbox/strong-init-vite/instant.schema.v2.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.v2.ts
@@ -4,6 +4,7 @@ const _schema = i.schema({
   entities: {
     messages: i.entity({
       content: i.string(),
+      createdAt: i.date().optional(),
     }),
     $users: i.entity({
       email: i.string().unique().indexed(),

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
@@ -151,6 +151,14 @@ const messagesQuery = {
 } satisfies InstaQLParams<AppSchema>;
 
 type CoreMessage = InstaQLEntity<AppSchema, "messages">;
+const mWithOptionalFieldWorks: CoreMessage = { 
+  id: '1', 
+  content: 'hello',
+};
+
+// to silence ts warnings
+mWithOptionalFieldWorks;
+
 let coreMessage: CoreMessage = 1 as any;
 coreMessage.content;
 


### PR DESCRIPTION
Uri pointed out an issue in https://github.com/instantdb/instant/issues/459 

If you have a `messages` entity like so:

```javascript
messages: i.entity({
  content: i.string(),
  createdAt: i.date().optional(),
}),
```

Then using `InstaQLEntity`: 

```typescript
type CoreMessage = InstaQLEntity<AppSchema, "messages">;

const mWithOptionalFieldWorks: CoreMessage = { 
  id: '1', 
  content: 'hello',
};
```

You end up having an error, because typescript _expects_ `createdAt` to be present, even though it's optional 

## Fix

I updated how we resolved attrs, so that instead of generating: `createdAt: Foo | undefined`, we generate: `createdAt?: Foo | undefined`

@nezaj @dwwoelfel @tonsky

