### PR TITLE
[ts] improve the AuthState type

### DIFF
--- a/client/packages/core/src/clientTypes.ts
+++ b/client/packages/core/src/clientTypes.ts
@@ -7,7 +7,7 @@ export type AuthResult =
 export type AuthState =
   | { isLoading: true; error: undefined; user: undefined }
   | { isLoading: false; error: { message: string }; user: undefined }
-  | { isLoading: false; error: undefined; user: User | undefined };
+  | { isLoading: false; error: undefined; user: User | null };
 
 export type ConnectionStatus =
   | "connecting"

--- a/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_tests_experimental_v2.tsx
@@ -53,6 +53,11 @@ const reactDB = react_init({
 });
 
 function ReactNormalApp() {
+  // auth
+  const authInfo = reactDB.useAuth();
+  if (!authInfo.error && !authInfo.isLoading) {
+    const { user } = authInfo; 
+  }
   // rooms
   const reactRoom = reactDB.room("chat");
   const reactPresence = reactRoom.usePresence({ keys: ["name"] });


### PR DESCRIPTION
Uri mentioned that the typing for `useAuth` was incorrect: 

https://github.com/instantdb/instant/issues/471

In the case where isLoading: false and error: null, `user` should be typed as `User | null` rather than `User | undefined` 

@nezaj @dwwoelfel @tonsky 