### PR TITLE
Ordering fix

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1107,6 +1107,13 @@
 (defn has-prev-tbl [table]
   (kw table :-has-prev))
 
+(defn flatten-symbol-map-values [vs]
+  (mapcat (fn [v]
+            (if (set? v)
+              (mapcat flatten-symbol-map-values v)
+              [v]))
+          vs))
+
 (defn add-page-info
   "Updates the cte with pagination constraints."
   [{:keys [next-idx
@@ -1122,6 +1129,7 @@
            direction
            named-pattern
            order-sym
+           eid-sym
            order-col-type
            before
            after]
@@ -1136,13 +1144,11 @@
                                     page-pattern)
         prev-table (kw prefix (dec next-idx))
 
-        entity-id-col (if (= :created-at-timestamp order-col-type)
-                        :entity-id
-                        (kw prev-table :-entity-id))
-
-        entity-id-col-full-name (if (= :created-at-timestamp order-col-type)
-                                  (kw table :-entity-id)
-                                  (kw prev-table :-entity-id))
+        entity-id-col (list* :coalesce
+                             (map (fn [x]
+                                    (let [[cte-idx pat-idx] x]
+                                      (last (join-cols prefix cte-idx [:e (idx->component-type pat-idx)]))))
+                                  (flatten-symbol-map-values (get symbol-map eid-sym))))
         sym-component-type (component-type-of-sym named-pattern order-sym)
         sym-triple-idx (get (set/map-invert idx->component-type)
                             sym-component-type)
@@ -1168,11 +1174,12 @@
 
                   ;; Make sure we're getting each entity once
                   (dissoc :select)
-                  (assoc :select-distinct-on (list* [:order-val entity-id-col]
+                  (assoc :select-distinct-on (list* [:order-val :order-eid]
                                                     [(if (= order-col-type :created-at-timestamp)
                                                        [:cast order-col-name :bigint]
                                                        [(extract-value-fn order-col-type) order-col-name])
                                                      :order-val]
+                                                    [entity-id-col :order-eid]
                                                     (:select query))))
 
         order-by [[:order-val
@@ -1180,7 +1187,7 @@
                      (kw order-by-direction :-nulls-last)
                      (kw order-by-direction :-nulls-first))
                    order-by-direction]
-                  [entity-id-col
+                  [:order-eid
                    order-by-direction]]
 
         paged-query (cond-> query
@@ -1205,14 +1212,14 @@
         first-row-table (kw table :-first)
         last-row-table (kw table :-last)
         first-row-cte [first-row-table
-                       {:select [[entity-id-col-full-name :e]
+                       {:select [[:order-eid :e]
                                  [(kw table :- (if (= :value order-col-name)
                                                  :value-blob
                                                  order-col-name)) :sym]]
                         :from table
                         :limit 1}]
         last-row-cte [last-row-table
-                      {:select [[entity-id-col-full-name :e]
+                      {:select [[:order-eid :e]
                                 [(kw table :- (if (= :value order-col-name)
                                                 :value-blob
                                                 order-col-name)) :sym]]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -747,7 +747,7 @@
     ;; ordering on the frontend.
     (when (or limit first last offset before after order)
       (let [{:keys [k direction]} (or order default-order)
-            etype-sym (attr-pat/default-level-sym etype level)
+            eid-sym (attr-pat/default-level-sym etype level)
             order-sym (if (= "serverCreatedAt" k)
                         (symbol (str "?t-" level))
                         (attr-pat/default-level-sym k level))
@@ -820,14 +820,15 @@
          :offset offset
          :direction direction
          :order-sym order-sym
+         :eid-sym eid-sym
          :order-col-type (if (= k "serverCreatedAt")
                            :created-at-timestamp
                            (:checked-data-type order-attr))
          :pattern (if (= "serverCreatedAt" k)
-                    [:ea etype-sym (:id order-attr) '_ order-sym]
+                    [:ea eid-sym (:id order-attr) '_ order-sym]
                     [{:idx-key :ave
                       :data-type (:checked-data-type order-attr)}
-                     etype-sym
+                     eid-sym
                      (:id order-attr)
                      order-sym])
          :attr-id (:id order-attr)


### PR DESCRIPTION
Generalizes @stopachka's fix in https://github.com/instantdb/instant/pull/647 to work with ordering on arbitrary fields.

With this change we'll use the symbol map to look up the entity id that we need to use as our secondary ordering key. We could look it up from the page-pattern, but I passed it in directly (as `eid-sym`) to make things a little more explicit.