### PR TITLE
Use the order-eid to create the cursor when the order-val is null

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1287,10 +1287,7 @@
                            :symbol-fields {}
                            :pattern page-pattern
                            :page-info (assoc page-info
-                                             :eid-col (-> pattern-metas
-                                                          last
-                                                          :cte-cols
-                                                          first)
+                                             :eid-col "order_eid"
                                              :created-col (-> pattern-metas
                                                               last
                                                               :cte-cols
@@ -1526,7 +1523,7 @@
                                                ;; where the entity is missing a value.
                                                ;; We'll have to create a fake row with [e a nil t]
                                                (let [{:keys [eid-col created-col]} page-info]
-                                                 [(get row "order_eid")
+                                                 [(get row eid-col)
                                                   (:attr-id page-info)
                                                   nil
                                                   (get row created-col)])))]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1526,7 +1526,7 @@
                                                ;; where the entity is missing a value.
                                                ;; We'll have to create a fake row with [e a nil t]
                                                (let [{:keys [eid-col created-col]} page-info]
-                                                 [(get row eid-col)
+                                                 [(get row "order_eid")
                                                   (:attr-id page-info)
                                                   nil
                                                   (get row created-col)])))]


### PR DESCRIPTION
Fixes a bug where we could return a null eid in the `start-cursor` or `end-cursor`.