### PR TITLE
Support ISO 8601 date formats, not just date time

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -41,7 +41,6 @@
             [instant.util.json :refer [->json]]
             [instant.util.string :refer [safe-name]])
   (:import (com.zaxxer.hikari HikariDataSource)
-           (java.time Instant)
            (java.util UUID)))
 
 ;; ---

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1056,10 +1056,7 @@
                              [(extract-value-fn order-col-type) cursor-val]
 
                              (= :date order-col-type)
-                             (cond (string? cursor-val)
-                                   (Instant/parse cursor-val)
-                                   (number? cursor-val)
-                                   (Instant/ofEpochMilli cursor-val))
+                             (triple-model/parse-date-value cursor-val)
 
                              :else
                              cursor-val)

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -274,7 +274,7 @@
 
                 (string? v)
                 (try
-                  (Instant/parse v)
+                  (triple-model/iso8601-date-str->instant v)
                   (catch Exception _e
                     (throw-invalid-date-string! state attr v)))
 
@@ -302,7 +302,7 @@
                       (catch Exception _e
                         (throw-invalid-timestamp! state attr value)))
             :string (try
-                      (Instant/parse value)
+                      (triple-model/iso8601-date-str->instant value)
                       (catch Exception _e
                         (throw-invalid-date-string! state attr value))))
     (if-not (= tag attr-data-type)

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -15,7 +15,7 @@
    [clojure.string :as string])
   (:import
    (java.util UUID)
-   (java.time Instant LocalDate ZoneOffset)))
+   (java.time Instant LocalDate ZonedDateTime ZoneOffset)))
 
 ;; (XXX): Currently we allow value to be nil
 ;; In the future, we may want to _retract_ the triple if the value is nil
@@ -711,7 +711,7 @@
 
 (defn iso8601-date-str->instant [x]
   (if (string/includes? x "T")
-    (Instant/parse x)
+    (.toInstant (ZonedDateTime/parse x))
     (-> (LocalDate/parse x)
         (.atStartOfDay)
         (.toInstant ZoneOffset/UTC))))
@@ -725,4 +725,5 @@
 
 (comment
   (parse-date-value "2025-01-01T00:00:00Z")
-  (parse-date-value "2025-01-01"))
+  (parse-date-value "2025-01-01")
+  (parse-date-value "2025-01-02T00:00:00-08"))

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -11,10 +11,11 @@
    [instant.util.json :refer [->json]]
    [instant.util.spec :as uspec]
    [instant.util.string :refer [multiline->single-line]]
-   [instant.util.tracer :as tracer])
+   [instant.util.tracer :as tracer]
+   [clojure.string :as string])
   (:import
    (java.util UUID)
-   (java.time Instant)))
+   (java.time Instant LocalDate ZoneOffset)))
 
 ;; (XXX): Currently we allow value to be nil
 ;; In the future, we may want to _retract_ the triple if the value is nil
@@ -708,8 +709,20 @@
       (tracer/add-data! {:attributes {:total-count @row-count}})
       {:row-count @row-count})))
 
+(defn iso8601-date-str->instant [x]
+  (if (string/includes? x "T")
+    (Instant/parse x)
+    (-> (LocalDate/parse x)
+        (.atStartOfDay)
+        (.toInstant ZoneOffset/UTC))))
+
 (defn parse-date-value [x]
   (cond (string? x)
-        (Instant/parse x)
+        (iso8601-date-str->instant x)
+
         (number? x)
         (Instant/ofEpochMilli x)))
+
+(comment
+  (parse-date-value "2025-01-01T00:00:00Z")
+  (parse-date-value "2025-01-01"))

--- a/server/src/instant/util/instaql.clj
+++ b/server/src/instant/util/instaql.clj
@@ -2,7 +2,8 @@
   (:require [instant.db.model.attr :as attr-model]
             [instant.db.model.attr-pat :as attr-pat]
             [instant.db.model.entity :as entity-model]
-            [instant.util.uuid :as uuid-util])
+            [instant.util.uuid :as uuid-util]
+            [instant.db.model.triple :as triple-model])
   (:import
    (java.time Instant)))
 
@@ -59,10 +60,7 @@
                          :checked-data-type)]
     (if (= checked-type :date)
       (fn [v]
-        (cond (string? v)
-              (Instant/parse v)
-              (number? v)
-              (Instant/ofEpochMilli v)))
+        (triple-model/parse-date-value v))
       identity)))
 
 (defn sort-entries [ctx etype option-map entries]

--- a/server/src/instant/util/instaql.clj
+++ b/server/src/instant/util/instaql.clj
@@ -3,9 +3,7 @@
             [instant.db.model.attr-pat :as attr-pat]
             [instant.db.model.entity :as entity-model]
             [instant.util.uuid :as uuid-util]
-            [instant.db.model.triple :as triple-model])
-  (:import
-   (java.time Instant)))
+            [instant.db.model.triple :as triple-model]))
 
 (declare instaql-ref-nodes->object-tree)
 


### PR DESCRIPTION
### Context

In postgres, we can save date values as strings:

```
SELECT triples_extract_date_value('"2025-01-03"');
```

### Problem

However, we weren't able to parse "2025-01-03" in java. We would get: 

```
; (err) Text '2025-01-03' could not be parsed at index 10
```

## Solution

This is because we used `java.time.Instant/parse`. I updated our codepath, so we now handle _both_ date time parsing, and date parsing. 

@dwwoelfel @nezaj @tonsky 