### PR TITLE
Log when the garbage collector runs

### DIFF
--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -141,8 +141,8 @@
           false)
 
         false))
-    (fn [_span]
-      false)))
+    (fn [span]
+      (= (.getName span) "gc"))))
 
 (defn log-spans [spans]
   (doseq [span spans


### PR DESCRIPTION
We're seeing some odd spans in `invalidator/work` where there are long pauses between calls to `invalidator/send-refresh!`. It should be very fast, so I'm wondering if we might be hitting a gc pause there: https://ui.honeycomb.io/instantdb/environments/prod/datasets/instant-server/result/cvi3aghpm6F/trace/xWunNWZ1aNq?fields[]=s_name&fields[]=s_serviceName&span=e1c074bcfec331e2

With this change, we'll both log the gc events and update the gauges on any gc event. 

If garbage collection is causing the pauses, then we should should see an increase in the `gc.count` attribute between the two spans. We wouldn't see that before because we only collect the gauges every second.