### PR TITLE
[lookups] support lookups in the `v` portion

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -572,7 +572,7 @@
         (list* :or
                (for [lookup v-set]
                  (if-not (value-lookup? lookup)
-                   [:= :value lookup]
+                   [:= :value (value->jsonb lookup)]
                    [:=
                     :value
                     {:select [[[:to_jsonb :entity-id]]]
@@ -580,7 +580,8 @@
                      :where [:and
                              [:= :app-id app-id]
                              [:= :value [:cast (->json (second lookup)) :jsonb]]
-                             [:= :attr-id [:cast (first lookup) :uuid]]]}])))
+                             [:= :attr-id [:cast (first lookup) :uuid]]
+                             :av]}])))
         (list* :or (map (fn [v]
                           [:and
                            [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
@@ -600,7 +601,8 @@
                     :where [:and
                             [:= :app-id app-id]
                             [:= :value [:cast (->json (second lookup)) :jsonb]]
-                            [:= :attr-id [:cast (first lookup) :uuid]]]}])))
+                            [:= :attr-id [:cast (first lookup) :uuid]]
+                            :av]}])))
     :a (in-or-eq :attr-id v)
     :v (in-or-eq-value idx app-id v)))
 

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -580,7 +580,8 @@
                      :where [:and
                              [:= :app-id app-id]
                              [:= :value [:cast (->json (second lookup)) :jsonb]]
-                             [:= :attr-id [:cast (first lookup) :uuid]]]}])))
+                             [:= :attr-id [:cast (first lookup) :uuid]]
+                             :av]}])))
         (list* :or (map (fn [v]
                           [:and
                            [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
@@ -600,7 +601,8 @@
                     :where [:and
                             [:= :app-id app-id]
                             [:= :value [:cast (->json (second lookup)) :jsonb]]
-                            [:= :attr-id [:cast (first lookup) :uuid]]]}])))
+                            [:= :attr-id [:cast (first lookup) :uuid]]
+                            :av]}])))
     :a (in-or-eq :attr-id v)
     :v (in-or-eq-value idx app-id v)))
 
@@ -1827,14 +1829,12 @@
 ;; -----
 ;; query
 
-(tool/copy  (tool/unsafe-hsql-format --query))
 (defn send-query-single
   "Sends a single query, returns the join rows."
   [_ctx conn app-id named-patterns]
   (tracer/with-span! {:name "datalog/send-query-single"}
     (let [{:keys [query pattern-metas]} (match-query :match-0- app-id named-patterns)
           sql-query (hsql/format query)
-          _ (def --query query)
           sql-res (sql/select-string-keys ::send-query-single conn sql-query)]
       (sql-result->result sql-res
                           pattern-metas

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -580,8 +580,7 @@
                      :where [:and
                              [:= :app-id app-id]
                              [:= :value [:cast (->json (second lookup)) :jsonb]]
-                             [:= :attr-id [:cast (first lookup) :uuid]]
-                             :av]}])))
+                             [:= :attr-id [:cast (first lookup) :uuid]]]}])))
         (list* :or (map (fn [v]
                           [:and
                            [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
@@ -601,8 +600,7 @@
                     :where [:and
                             [:= :app-id app-id]
                             [:= :value [:cast (->json (second lookup)) :jsonb]]
-                            [:= :attr-id [:cast (first lookup) :uuid]]
-                            :av]}])))
+                            [:= :attr-id [:cast (first lookup) :uuid]]]}])))
     :a (in-or-eq :attr-id v)
     :v (in-or-eq-value idx app-id v)))
 

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -385,21 +385,30 @@
 
 (deftest lookup-refs
   (testing "e side"
-    (let [person-name-aid (resolvers/->uuid @r :person/name)]
-      (is (= #{"Tina Turner" "1939-11-26T00:00:00Z"}
+    (let [movie-cast-aid (resolvers/->uuid @r :movie/cast)
+          movie-title-aid (resolvers/->uuid @r :movie/title)
+          person-name-aid (resolvers/->uuid @r :person/name)]
+      (is (= #{"Mad Max Beyond Thunderdome"}
              (->> (d/query
                    {:db {:conn-pool (aurora/conn-pool)}
                     :app-id  movies-app-id}
-                   [[:ea #{[person-name-aid "Tina Turner"]}]])
+                   [[:ea [movie-title-aid "Predator"]]])
+
                   :join-rows
                   (map (comp last drop-last last))
                   set)))))
   (testing "v side"
-    (let [person-name-aid (resolvers/->uuid @r :person/name)]
-      (->> (d/query
-            {:db {:conn-pool (aurora/conn-pool)}
-             :app-id  movies-app-id}
-            [[:ea '_ '_ #{[person-name-aid "Tina Turner"]}]])))))
-
+    (let [movie-cast-aid (resolvers/->uuid @r :movie/cast)
+          movie-title-aid (resolvers/->uuid @r :movie/title)
+          person-name-aid (resolvers/->uuid @r :person/name)]
+      (is (= #{"Mad Max Beyond Thunderdome"}
+             (->> (d/query
+                   {:db {:conn-pool (aurora/conn-pool)}
+                    :app-id  movies-app-id}
+                   [[:eav '?movie movie-cast-aid #{[person-name-aid "Tina Turner"]}]
+                    [:ea '?movie movie-title-aid '?title]])
+                  :join-rows
+                  (map (comp last drop-last last))
+                  set))))))
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -425,8 +425,10 @@
                       (("eid-joe-averbukh" :users/bookshelves "eid-2018")
                        ("eid-alex" :users/id "eid-alex")
                        ("eid-alex" :users/bookshelves "eid-short-stories")
-                       ("eid-stepan-parunashvili" :users/bookshelves "eid-worldview")
                        ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
+                       ("eid-stepan-parunashvili"
+                        :users/bookshelves
+                        "eid-the-way-of-the-gentleman")
                        ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
                        --
                        ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")


### PR DESCRIPTION
### Context

We can already write queries that have lookups in the `e` position: 

```edn
[[handle-aid "stopa"] :users/email ?email]
```

### Problem

However, we _cannot_ write lookups in the `v` position: 

```edn
[?bookshelf :bookshelves/owner [handle-aid "stopa"]]
```

We particularly need this in cel.clj, as we write a query with ids in the `v` position.

### Solution 

I added support for lookups on the `v` side of our query. 

### Notes 

There are two things of note:

**How we detect lookups in the `v` side** 

Technically, a user _could_ have any jsonb value on the `v` side (However, afaik we don't allow jsonb values in where clauses). Still, we detect a lookup by specifically checking that it is: a) a vector b) first element is a uuid and c) it is count 2. 

**adding a av check** 

Previously, our lookup subquery did a search for entity_id, but did not have the `av` flag. I added this flag, as otherwise the subquery would lead to a table scan. 

@dwwoelfel @nezaj @tonsky 





