### PR TITLE
Don't override name in gc span

### DIFF
--- a/server/src/instant/gauges.clj
+++ b/server/src/instant/gauges.clj
@@ -122,7 +122,7 @@
                        ^CompositeData (.getUserData notification))]
           (tracer/record-info!
            {:name "gc"
-            :attributes {:name (.getGcName gc-info)
+            :attributes {:gc-name (.getGcName gc-info)
                          :action (.getGcAction gc-info)
                          :cause (.getGcCause gc-info)
                          :duration-ms (.getDuration (.getGcInfo gc-info))}})


### PR DESCRIPTION
Setting `name` in attributes overrode the `name` field, so we weren't seeing any "name=gc" events.