### PR TITLE
Send one span for all `invalidator/send-refresh`

### DIFF
--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -304,10 +304,8 @@
               (let [sockets (invalidate! store-conn wal-record)]
                 (tracer/add-data! {:attributes {:num-sockets (count sockets)}})
                 (doseq [{:keys [id]} sockets]
-                  (tracer/with-span! {:name "invalidator/send-refresh"
-                                      :attributes {:session-id id}}
-                    (receive-queue/enqueue->receive-q {:op :refresh
-                                                       :session-id id}))))
+                  (receive-queue/enqueue->receive-q {:op :refresh
+                                                     :session-id id})))
               (catch Throwable t
                 (def -wal-record wal-record)
                 (def -store-value @store-conn)
@@ -320,10 +318,8 @@
       (let [sockets (invalidate-byop! table-info app-id store-conn record)]
         (tracer/add-data! {:attributes {:num-sockets (count sockets)}})
         (doseq [{:keys [id]} sockets]
-          (tracer/with-span! {:name "invalidator/send-refresh"
-                              :session-id id}
-            (receive-queue/enqueue->receive-q {:op :refresh
-                                               :session-id id}))))
+          (receive-queue/enqueue->receive-q {:op :refresh
+                                             :session-id id})))
       (catch Throwable t
         (def -wal-record wal-record)
         (def -store-value @store-conn)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -303,9 +303,10 @@
             (try
               (let [sockets (invalidate! store-conn wal-record)]
                 (tracer/add-data! {:attributes {:num-sockets (count sockets)}})
-                (doseq [{:keys [id]} sockets]
-                  (receive-queue/enqueue->receive-q {:op :refresh
-                                                     :session-id id})))
+                (tracer/with-span! {:name "invalidator/send-refreshes"}
+                  (doseq [{:keys [id]} sockets]
+                    (receive-queue/enqueue->receive-q {:op :refresh
+                                                       :session-id id}))))
               (catch Throwable t
                 (def -wal-record wal-record)
                 (def -store-value @store-conn)
@@ -317,9 +318,10 @@
     (try
       (let [sockets (invalidate-byop! table-info app-id store-conn record)]
         (tracer/add-data! {:attributes {:num-sockets (count sockets)}})
-        (doseq [{:keys [id]} sockets]
-          (receive-queue/enqueue->receive-q {:op :refresh
-                                             :session-id id})))
+        (tracer/with-span! {:name "invalidator/send-refreshes"}
+          (doseq [{:keys [id]} sockets]
+            (receive-queue/enqueue->receive-q {:op :refresh
+                                               :session-id id}))))
       (catch Throwable t
         (def -wal-record wal-record)
         (def -store-value @store-conn)


### PR DESCRIPTION
Follow-up to https://github.com/instantdb/instant/pull/670, where we noticed that `invalidator/work` is randomly pausing between some `invalidator/send-refresh` calls.

It doesn't appear to be caused by the garbage collector. The only other thing that happens between the calls to `send-refresh` is that we log the span. I've reduced it to a single `send-refreshes` span for all of the `:refresh` messages we enqueue instead of one per message. We'll see if this removes the unaccounted-for time.