### PR TITLE
Calculate hostname once

### DIFF
--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -8,12 +8,13 @@
    (java.net InetAddress)
    (java.util UUID)))
 
-(defn get-hostname []
-  (try
-    (.getHostName (InetAddress/getLocalHost))
-    (catch Exception e
-      (log/error "Error getting hostname" e)
-      "unknown")))
+(defonce hostname
+  (delay
+    (try
+      (.getHostName (InetAddress/getLocalHost))
+      (catch Exception e
+        (log/error "Error getting hostname" e)
+        "unknown"))))
 
 (defn get-env []
   (if (= "true" (System/getenv "PRODUCTION"))
@@ -103,7 +104,7 @@
 
 (defn get-aurora-config []
   (let [application-name (uri/query-encode (format "%s, %s"
-                                                   (get-hostname)
+                                                   @hostname
                                                    @process-id))
         url (or (System/getenv "DATABASE_URL")
                 (some-> @config-map :database-url crypt-util/secret-value)
@@ -113,7 +114,7 @@
 
 (defn get-next-aurora-config []
   (let [application-name (uri/query-encode (format "%s, %s"
-                                                   (get-hostname)
+                                                   @hostname
                                                    @process-id))
         url (or (System/getenv "NEXT_DATABASE_URL")
                 (some-> @config-map :next-database-url crypt-util/secret-value))]

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -86,7 +86,7 @@
   (let [thread (Thread/currentThread)
         {:keys [code-ns code-line code-file]} source
         default-attributes (cond-> @last-calculated-metrics
-                             true (assoc "host.name" (config/get-hostname)
+                             true (assoc "host.name" @config/hostname
                                          "process-id" @config/process-id)
                              thread (assoc "thread.name"
                                            (.getName thread)


### PR DESCRIPTION
I think this might fix the issue identified in https://github.com/instantdb/instant/pull/670, where we see random pauses in between spans.

[According to the docs](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/InetAddress.html#getHostName()), `getHostName` can do some i/o.

We might be pausing in `with-span` while we look up the hostname. The hostname shouldn't ever change, so it's better to just calculate it once in the delay, and then always use the same value.