### PR TITLE
Add replica id to metrics

### DIFF
--- a/server/resources/migrations/47_add_replica_id_to_daily_metrics.down.sql
+++ b/server/resources/migrations/47_add_replica_id_to_daily_metrics.down.sql
@@ -1,0 +1,7 @@
+-- Remove the replica identity setting
+ALTER TABLE daily_app_transactions REPLICA IDENTITY DEFAULT;
+
+-- Allow columns to be nullable again
+ALTER TABLE daily_app_transactions ALTER COLUMN is_active DROP NOT NULL;
+ALTER TABLE daily_app_transactions ALTER COLUMN app_id DROP NOT NULL;
+ALTER TABLE daily_app_transactions ALTER COLUMN date DROP NOT NULL;

--- a/server/resources/migrations/47_add_replica_id_to_daily_metrics.up.sql
+++ b/server/resources/migrations/47_add_replica_id_to_daily_metrics.up.sql
@@ -1,0 +1,8 @@
+-- Ensure all columns in the unique index are non-nullable
+ALTER TABLE daily_app_transactions ALTER COLUMN date SET NOT NULL;
+ALTER TABLE daily_app_transactions ALTER COLUMN app_id SET NOT NULL;
+ALTER TABLE daily_app_transactions ALTER COLUMN is_active SET NOT NULL;
+
+-- Set the replica identity to use the unique index
+ALTER TABLE daily_app_transactions
+REPLICA IDENTITY USING INDEX daily_app_transactions_date_app_id_is_active_key;


### PR DESCRIPTION
We had another migration on 12-06 and wanted to delete some inflated data from this metrics table but got an error due to no replica id being set. This PR enables it!