### PR TITLE
Reset the number of receive-workers

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -44,7 +44,7 @@
 (declare receive-q-stop-signal)
 (def handle-receive-timeout-ms 5000)
 
-(def num-receive-workers (* 256 (delay/cpu-count)))
+(def num-receive-workers (* 100 (delay/cpu-count)))
 
 ;; ------
 ;; handlers


### PR DESCRIPTION
We saw a spike in timeouts after the increase. Need to figure that out before increasing.