### PR TITLE
Trigger connection status on network change

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -189,6 +189,9 @@ export default class Reactor {
         this._isOnline = isOnline;
         if (this._isOnline) {
           this._startSocket();
+        } else {
+          log.info("Changing status from", this.status, "to", STATUS.CLOSED);
+          this._setStatus(STATUS.CLOSED)
         }
       });
     });


### PR DESCRIPTION
One of our users pointed out that `useConnectionStatus` wasn't updating when directly turning off wifi. Was able to confirm that doing so doesn't trigger the websocket onclose event. This should do the trick!