### PR TITLE
Fixes `Invalid semver version null` errors

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -325,6 +325,7 @@
       :nop
 
       (and edits
+           version
            (pos? (semver/compare-semver version "v0.17.5"))
            (flags/use-patch-presence? app-id))
       (rs/send-event! store-conn app-id sess-id


### PR DESCRIPTION
Some older clients won't send the `version` field