### PR TITLE
Track some wal latency metrics

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -181,7 +181,7 @@
     (stripe/init)
     (session/start)
     (inv/start-global)
-    (wal/init-cleanup)
+    (wal/init)
 
     (when-let [config-app-id (config/instant-config-app-id)]
       (flags-impl/init config-app-id


### PR DESCRIPTION
Tracks two latency metrics for the invalidator:

1. Queries the database every minute to calculate the difference in bytes between the last available wal entry and where our replication subscription is on the log. We'll send that metric with the rest of the `gauges`.
2. Calculates the number of milliseconds between when we process a transaction in the invalidator and when that transaction was created in the database.

There are still a lot of steps where latency could be introduced, but this gives us a little more insight into the system.