### PR TITLE
[lookups] improve how lookups work with perms

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -391,7 +391,7 @@
                  patterns
                  results))))
 
-(def auth-ref-validator ^CelAstValidator 
+(def auth-ref-validator ^CelAstValidator
   (reify CelAstValidator
     (validate [_this ast _cel issues-factory]
       (doseq [^CelNavigableExpr node (-> ast

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as string]
    [clojure.test :as test :refer [are deftest is testing]]
-   [instant.admin.model :as admin-model]
+   [instant.db.cel :as cel]
    [instant.data.bootstrap :as bootstrap]
    [instant.data.constants :refer [test-user-id]]
    [instant.data.resolvers :as resolvers]
@@ -94,7 +94,7 @@
               (testing "attr is deleted"
                 (is (= #{"name"}
                        (->> (attr-model/get-by-app-id app-id)
-                           (filter #(not= :system (:catalog %)))
+                            (filter #(not= :system (:catalog %)))
                             (map :forward-identity)
                             (map last)
                             set))))
@@ -419,11 +419,11 @@
           (is
            (= ::ex/record-not-unique
               (::ex/type (instant-ex-data
-                           (tx/transact!
-                            (aurora/conn-pool)
-                            (attr-model/get-by-app-id app-id)
-                            app-id
-                            [[:add-triple joe-eid email-attr-id "test2@instantdb.com"]]))))))))))
+                          (tx/transact!
+                           (aurora/conn-pool)
+                           (attr-model/get-by-app-id app-id)
+                           app-id
+                           [[:add-triple joe-eid email-attr-id "test2@instantdb.com"]]))))))))))
 
 (deftest tx-ref-many-to-many
   (with-empty-app
@@ -493,21 +493,21 @@
           (is
            (= :invalid-text-representation
               (->  (instant-ex-data
-                     (tx/transact!
-                      (aurora/conn-pool)
-                      (attr-model/get-by-app-id app-id)
-                      app-id
-                      [[:add-triple stopa-eid tag-attr-id "Foo"]]))
+                    (tx/transact!
+                     (aurora/conn-pool)
+                     (attr-model/get-by-app-id app-id)
+                     app-id
+                     [[:add-triple stopa-eid tag-attr-id "Foo"]]))
                    ::ex/hint
                    :condition)))
           (is
            (= "Check Violation: ref_values_are_uuid"
               (-> (instant-ex-data
-                    (tx/transact!
-                     (aurora/conn-pool)
-                     (attr-model/get-by-app-id app-id)
-                     app-id
-                     [[:add-triple stopa-eid tag-attr-id {:foo "bar"}]]))
+                   (tx/transact!
+                    (aurora/conn-pool)
+                    (attr-model/get-by-app-id app-id)
+                    app-id
+                    [[:add-triple stopa-eid tag-attr-id {:foo "bar"}]]))
                   ::ex/hint
                   :errors
                   first
@@ -722,13 +722,13 @@
                                        ctx
                                        (iq/query ctx {:bookshelves {:$ {:where {:name "Nonfiction"}}
                                                                     :books {:$ {:where {:isbn13 feynman-isbn}}}}}))
-                                    %
-                                    (get % "bookshelves")
-                                    (first %)
-                                    (get % "books")
-                                    (filter (fn [b] (= feynman-isbn (get b "isbn13"))) %)
-                                    (first %)
-                                    (get % "isbn13"))))
+                                      %
+                                  (get % "bookshelves")
+                                  (first %)
+                                  (get % "books")
+                                  (filter (fn [b] (= feynman-isbn (get b "isbn13"))) %)
+                                  (first %)
+                                  (get % "isbn13"))))
 
             ;; check retract
             (tx/transact! (aurora/conn-pool)
@@ -740,10 +740,10 @@
                                ctx
                                (iq/query ctx {:bookshelves {:$ {:where {:name "Nonfiction"}}
                                                             :books {:$ {:where {:isbn13 feynman-isbn}}}}}))
-                            %
-                            (get % "bookshelves")
-                            (first %)
-                            (get % "books"))))
+                              %
+                          (get % "bookshelves")
+                          (first %)
+                          (get % "books"))))
 
             ;; check adding back
             (tx/transact! (aurora/conn-pool)
@@ -755,14 +755,13 @@
                                        ctx
                                        (iq/query ctx {:bookshelves {:$ {:where {:name "Nonfiction"}}
                                                                     :books {:$ {:where {:isbn13 feynman-isbn}}}}}))
-                                    %
-                                    (get % "bookshelves")
-                                    (first %)
-                                    (get % "books")
-                                    (filter (fn [b] (= feynman-isbn (get b "isbn13"))) %)
-                                    (first %)
-                                    (get % "isbn13"))))))
-
+                                      %
+                                  (get % "bookshelves")
+                                  (first %)
+                                  (get % "books")
+                                  (filter (fn [b] (= feynman-isbn (get b "isbn13"))) %)
+                                  (first %)
+                                  (get % "isbn13"))))))
 
         (testing "value lookup refs are ignored for regular attributes"
           (tx/transact! (aurora/conn-pool)
@@ -1013,7 +1012,6 @@
                     (map :handle)
                     set))))))))
 
-
 (deftest write-perms
   (doseq [[title get-lookup] [[" with eid" (fn [r] (resolvers/->uuid r "eid-stepan-parunashvili"))]
                               [" with lookup ref" (fn [r] [(resolvers/->uuid r :users/email) "stopa@instantdb.com"])]]]
@@ -1233,15 +1231,15 @@
              {:app-id app-id :code {:attrs {:allow {:create "false"}}}})
             (is
              (perm-err?
-               (permissioned-tx/transact!
-                (make-ctx)
-                [[:add-attr
-                  {:id (UUID/randomUUID)
-                   :forward-identity [(UUID/randomUUID) "users" "favoriteColor"]
-                   :value-type :blob
-                   :cardinality :one
-                   :unique? false
-                   :index? false}]]))))
+              (permissioned-tx/transact!
+               (make-ctx)
+               [[:add-attr
+                 {:id (UUID/randomUUID)
+                  :forward-identity [(UUID/randomUUID) "users" "favoriteColor"]
+                  :value-type :blob
+                  :cardinality :one
+                  :unique? false
+                  :index? false}]]))))
           (testing (str "attr update/delete blocks unless admin" title)
             (is
              (perm-err?
@@ -1335,6 +1333,64 @@
                   (permissioned-tx/transact! (make-ctx)
                                              [[:delete-entity delete-id]])))))))))))
 
+(deftest lookup-perms
+  (with-zeneca-app
+    (fn [{app-id :id} r]
+      (let [attrs (attr-model/get-by-app-id app-id)
+            rule-with-ref "'Worldview' in data.ref('bookshelves.name')"
+            _ (rule-model/put!
+               (aurora/conn-pool)
+               {:app-id app-id
+                :code {:users {:allow
+                               {:create rule-with-ref
+                                :update rule-with-ref
+                                :delete rule-with-ref
+                                :view rule-with-ref}}}})
+
+            rules (rule-model/get-by-app-id {:app-id app-id})
+            ctx {:db {:conn-pool (aurora/conn-pool)}
+                 :app-id app-id
+                 :attrs attrs
+                 :datalog-query-fn d/query
+                 :rules rules}
+            user-id-aid (resolvers/->uuid r :users/id)
+            user-handle-aid (resolvers/->uuid r :users/handle)
+            user-fullname-aid (resolvers/->uuid r :users/fullName)
+            user-bookshelves-aid (resolvers/->uuid r :users/bookshelves)
+            bookshelves-name-aid (resolvers/->uuid r :bookshelves/name)
+            new-bookshelf-id (random-uuid)]
+
+        (testing "Update uses preload-refs"
+          (with-redefs [cel/get-ref (fn [& _args]
+                                      (throw (IllegalAccessError. "Should not be called")))]
+
+            (permissioned-tx/transact!
+             ctx
+             [[:add-triple [user-handle-aid "stopa"] user-fullname-aid "Stopachka"]])
+            (is
+             (perm-err?
+              (permissioned-tx/transact!
+               ctx
+               [[:add-triple [user-handle-aid "alex"] user-fullname-aid "Stopachka"]])))))
+
+        (testing "Create uses preload refs"
+          (with-redefs [cel/get-ref (fn [& _args]
+                                      (throw (IllegalAccessError. "Should not be called")))]
+            (permissioned-tx/transact!
+             ctx
+             [[:add-triple [user-handle-aid "alyssa"] user-fullname-aid "Alyssa P Hacker"]
+              [:add-triple [user-handle-aid "alyssa"] user-id-aid [user-handle-aid "alyssa"]]
+              [:add-triple [user-handle-aid "alyssa"] user-bookshelves-aid new-bookshelf-id]
+              [:add-triple new-bookshelf-id bookshelves-name-aid "Worldview"]])
+
+            (is (perm-err?
+                 (permissioned-tx/transact!
+                  ctx
+                  [[:add-triple [user-handle-aid "ben"] user-fullname-aid "Ben BitDiddle"]
+                   [:add-triple [user-handle-aid "ben"] user-id-aid [user-handle-aid "ben"]]
+                   [:add-triple [user-handle-aid "ben"] user-bookshelves-aid new-bookshelf-id]
+                   [:add-triple new-bookshelf-id bookshelves-name-aid "Nonfiction"]])))))))))
+
 (deftest rejects-bad-lookups
   (with-zeneca-app
     (fn [{app-id :id :as _app} r]
@@ -1350,9 +1406,9 @@
          {:app-id app-id :code {}})
         (testing "Can't use a lookup attr from one namespace with attrs from another"
           (is (validation-err?
-                (permissioned-tx/transact!
-                 (make-ctx)
-                 [[:add-triple lookup (resolvers/->uuid r :books/title) "Title"]]))))))))
+               (permissioned-tx/transact!
+                (make-ctx)
+                [[:add-triple lookup (resolvers/->uuid r :books/title) "Title"]]))))))))
 
 (defn validation-err [input]
   (try
@@ -1485,10 +1541,10 @@
                                                       :attr-id (str email-attr-id)
                                                       :entity-id (str eid)}}]}}
                    (instant-ex-data
-                     (tx/transact! (aurora/conn-pool)
-                                   (attr-model/get-by-app-id app-id)
-                                   app-id
-                                   [[:add-triple eid email-attr-id 10]]))))))))))
+                    (tx/transact! (aurora/conn-pool)
+                                  (attr-model/get-by-app-id app-id)
+                                  app-id
+                                  [[:add-triple eid email-attr-id 10]]))))))))))
 
 (deftest rejects-large-values-for-indexed-data
   (with-empty-app
@@ -1534,10 +1590,10 @@
                                                       :entity-id (str eid)
                                                       :value-too-large? true}}]}}
                    (instant-ex-data
-                     (tx/transact! (aurora/conn-pool)
-                                   (attr-model/get-by-app-id app-id)
-                                   app-id
-                                   [[:add-triple eid email-attr-id (apply str (repeat 1000000 "a"))]]))))))
+                    (tx/transact! (aurora/conn-pool)
+                                  (attr-model/get-by-app-id app-id)
+                                  app-id
+                                  [[:add-triple eid email-attr-id (apply str (repeat 1000000 "a"))]]))))))
         (testing "returns a friendly error message for unique data"
           (let [eid (random-uuid)]
             (is (= #:instant.util.exception{:type
@@ -1554,10 +1610,10 @@
                                                       :entity-id (str eid)
                                                       :value-too-large? true}}]}}
                    (instant-ex-data
-                     (tx/transact! (aurora/conn-pool)
-                                   (attr-model/get-by-app-id app-id)
-                                   app-id
-                                   [[:add-triple eid unique-attr-id (apply str (repeat 1000000 "a"))]]))))))))))
+                    (tx/transact! (aurora/conn-pool)
+                                  (attr-model/get-by-app-id app-id)
+                                  app-id
+                                  [[:add-triple eid unique-attr-id (apply str (repeat 1000000 "a"))]]))))))))))
 
 (deftest deep-merge-existing-object
   (with-empty-app
@@ -1896,39 +1952,39 @@
 (deftest inferred-types []
   (testing "inferred types update on triple save"
     (are [value inferred-types]
-        (with-empty-app
-          (fn [{app-id :id}]
-            (let [attr-id (random-uuid)
-                  target-eid (random-uuid)]
-              (try (tx/transact!
-                    (aurora/conn-pool)
-                    (attr-model/get-by-app-id app-id)
-                    app-id
-                    [[:add-attr
-                      {:id attr-id
-                       :forward-identity [(random-uuid) "namespace" "field"]
-                       :value-type :blob
-                       :cardinality :one
-                       :unique? false
-                       :index? false}]
-                     [:add-triple target-eid attr-id value]])
-                   (catch Exception e
-                     (is (not e))))
-              (testing (format "(%s -> %s)" value inferred-types)
-                (attr-model/evict-app-id-from-cache app-id)
-                (is (= inferred-types
-                       (->> (attr-model/get-by-app-id app-id)
-                            (attr-model/seek-by-id attr-id)
-                            :inferred-types)))))))
-        1 #{:number}
-        2.0 #{:number}
-        "2" #{:string}
-        "s" #{:string}
-        true #{:boolean}
-        false #{:boolean}
-        (random-uuid) #{:string}
-        {:hello "world"} #{:json}
-        ["array of stuff", 2] #{:json}))
+         (with-empty-app
+           (fn [{app-id :id}]
+             (let [attr-id (random-uuid)
+                   target-eid (random-uuid)]
+               (try (tx/transact!
+                     (aurora/conn-pool)
+                     (attr-model/get-by-app-id app-id)
+                     app-id
+                     [[:add-attr
+                       {:id attr-id
+                        :forward-identity [(random-uuid) "namespace" "field"]
+                        :value-type :blob
+                        :cardinality :one
+                        :unique? false
+                        :index? false}]
+                      [:add-triple target-eid attr-id value]])
+                    (catch Exception e
+                      (is (not e))))
+               (testing (format "(%s -> %s)" value inferred-types)
+                 (attr-model/evict-app-id-from-cache app-id)
+                 (is (= inferred-types
+                        (->> (attr-model/get-by-app-id app-id)
+                             (attr-model/seek-by-id attr-id)
+                             :inferred-types)))))))
+      1 #{:number}
+      2.0 #{:number}
+      "2" #{:string}
+      "s" #{:string}
+      true #{:boolean}
+      false #{:boolean}
+      (random-uuid) #{:string}
+      {:hello "world"} #{:json}
+      ["array of stuff", 2] #{:json}))
 
   (testing "inferred types accumulate"
     (with-empty-app
@@ -1995,16 +2051,15 @@
   (with-empty-app
     (fn [{app-id :id}]
       (validation-err?
-        (tx/transact! (aurora/conn-pool)
-                      (attr-model/get-by-app-id app-id)
-                      app-id
-                      [[:add-attr {:id (random-uuid)
-                                   :forward-identity [(random-uuid) "$users" "id"]
-                                   :value-type :blob
-                                   :cardinality :one
-                                   :unique? false
-                                   :index? false}]])))))
-
+       (tx/transact! (aurora/conn-pool)
+                     (attr-model/get-by-app-id app-id)
+                     app-id
+                     [[:add-attr {:id (random-uuid)
+                                  :forward-identity [(random-uuid) "$users" "id"]
+                                  :value-type :blob
+                                  :cardinality :one
+                                  :unique? false
+                                  :index? false}]])))))
 
 (deftest perms-rejects-writes-to-users-table
   (with-empty-app
@@ -2018,19 +2073,19 @@
                              :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
                              :current-user nil})]
         (validation-err?
-          (permissioned-tx/transact! (make-ctx)
-                                     [[:add-triple id (resolvers/->uuid r :$users/id) (str id)]]))
+         (permissioned-tx/transact! (make-ctx)
+                                    [[:add-triple id (resolvers/->uuid r :$users/id) (str id)]]))
         (validation-err?
-          (permissioned-tx/transact! (make-ctx)
-                                     [[:retract-triple id (resolvers/->uuid r :$users/id) (str id)]]))
+         (permissioned-tx/transact! (make-ctx)
+                                    [[:retract-triple id (resolvers/->uuid r :$users/id) (str id)]]))
 
         (validation-err?
-          (permissioned-tx/transact! (make-ctx)
-                                     [[:deep-merge-triple id (resolvers/->uuid r :$users/id) {:hello :world}]]))
+         (permissioned-tx/transact! (make-ctx)
+                                    [[:deep-merge-triple id (resolvers/->uuid r :$users/id) {:hello :world}]]))
 
         (validation-err?
-          (permissioned-tx/transact! (make-ctx)
-                                     [[:delete-entity id "$users"]]))))))
+         (permissioned-tx/transact! (make-ctx)
+                                    [[:delete-entity id "$users"]]))))))
 
 (deftest perms-accepts-writes-to-reverse-links-to-users-table
   (with-empty-app
@@ -2062,8 +2117,8 @@
                       [:add-triple book-id book-id-attr-id book-id]
                       [:add-triple book-id book-creator-attr-id user-id]]]
         (app-user-model/create! (aurora/conn-pool) {:app-id app-id
-                                                  :id user-id
-                                                  :email "test@example.com"})
+                                                    :id user-id
+                                                    :email "test@example.com"})
         (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
         (is (permissioned-tx/transact! (assoc (make-ctx)
                                               :current-user {:id user-id}) tx-steps))))))
@@ -2109,8 +2164,8 @@
                 [:add-triple book-id book-id-attr-id book-id]
                 [:add-triple book-id book-isbn-attr-id "1234"]])
             _ (app-user-model/create! (aurora/conn-pool) {:app-id app-id
-                                                        :id user-id
-                                                        :email "test@example.com"})
+                                                          :id user-id
+                                                          :email "test@example.com"})
             tx-steps [[:add-triple
                        [book-isbn-attr-id "1234"]
                        book-creator-attr-id
@@ -2154,8 +2209,6 @@
         (is (empty? (app-user-model/get-by-email {:app-id app-id
                                                   :email "test@example.com"})))))))
 
-
-
 (deftest auth-refs-requires-users
   (with-empty-app
     (fn [{app-id :id :as app}]
@@ -2186,8 +2239,8 @@
                              :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
                              :current-user nil})
             user (app-user-model/create! (aurora/conn-pool) {:app-id app-id
-                                                           :id user-id
-                                                           :email "test@example.com"})
+                                                             :id user-id
+                                                             :email "test@example.com"})
             _ (tx/transact!
                (aurora/conn-pool)
                (attr-model/get-by-app-id app-id)
@@ -2226,11 +2279,11 @@
 
         (let [tx-steps [[:add-triple book-id book-title-attr-id "Free Land"]]]
           (perm-err?
-            (permissioned-tx/transact! (make-ctx)
-                                       tx-steps))
+           (permissioned-tx/transact! (make-ctx)
+                                      tx-steps))
           (perm-err?
-            (permissioned-tx/transact! (assoc (make-ctx) :current-user {:id (random-uuid)})
-                                       tx-steps))
+           (permissioned-tx/transact! (assoc (make-ctx) :current-user {:id (random-uuid)})
+                                      tx-steps))
           (permissioned-tx/transact! (assoc (make-ctx) :current-user user)
                                      tx-steps)
 
@@ -2297,7 +2350,6 @@
                      [:add-triple user-id user-id-attr-id user-id]
                      [:add-triple book-id book-creator-attr-id user-id]])]
 
-
         (testing "setup worked"
           (is (= #{{:triple
                     [book-id
@@ -2341,7 +2393,6 @@
             [:add-triple book-id book-id-attr-id book-id]
             [:add-triple book-id book-creator-attr-id user-id]])
 
-
           (is (= [{:triple
                    [user-id
                     user-id-attr-id
@@ -2367,8 +2418,6 @@
                        (aurora/conn-pool)
                        app-id
                        [[:= :attr-id user-id-attr-id]])))))))))
-
-
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
# Setup 

Consider a zeneca app, with perms like: 

```json
{ 
   "users": { 
        "allow":  {
           "*":  "'Worldview' in data.ref('bookshelves.name')"
       }
    }
}
```

# Problems

We found three issues with how lookups and perms work together. 

## issue 1: updates cause a warn-io in preload-refs

If we tried to run an update to an existing entity:

```js
tx.users[lookup('handle', 'stopa')].update({fullName: "Stopa"})
```

The permission check would run, but we would end up getting a `io` warning. 

### reason: preload-refs has lookup, ref-fn has uuuid

The reason was that `preload-refs` would keep a mapping of: 

```edn
{ eid: [handle-uuid "stopa"]
  ... }
```

While `ref-fn` would contain the actual uuid for the object. 

This would cause us to skip preload-refs, and make a direct query. 

## issue 2: the create perm check would cause an error

If we used a lookup to create a new entity: 

```js
tx.users[lookup('handle', 'idontexist')].update({fullName: "Idonte Xist"})
```

The transaction would throw an error. 

### reason: parse-uuid in persistent vector

The reason this happened was because in `ref-fn`, we expected the `id` to be a string, but instead we got a vector lookup. This would throw when we tried to do: `(parse-uuid id)`

## issue 3: batch fn broken for lookups

You would think we _could_ fix issue 2, by simply handling the case where `id` is a lookup differently. Something like: 

```clj
parsed-id (if (sequential? id) (parse-lookup id) (parse-uuid id))
```

However, doing this would break our batch functions

### reason: no way to tie lookups to join rows

`get-ref-many` and our preload ref fn take a set of ids, and make a single query for them. We then partition the join rows for each id. 

However, if the input id is a lookup, and the child id is a uuid, there would be no way for us to to associate them together. This caused all batch-fns that included lookups to return empty results. 

## Solution

At a high level, I made the following changes: 

**For Updates: We use `preload-triples` to replace lookups with ids** 

Since we already have triples for all update and delete transactions, we replace the `lookup` eid in the check to the actual uuid. 

By doing this, preload-refs will now work.

**For creates: We query for the ids of all the lookups**

For creates, we run a separate query after insertion, to get all the uuids for the lookups. We then run the same code to replace the `eid` with the uuid. 

In order to do this, I made a change to how our `check` works. Instead of each `check` having an anonymous function, I moved the function out. This way, when we are replacing the `lookup` with the `uuid`, we don't have to worry about closures. 

## Alternatives considered

### alternative 1: have `transact!` return lookup-refs

I considered having `transact!` return all the lookups that were involved. However, if we did this we would need to make the change across insert, merge, and delete. I wasn't sure the efficieny win would be worth it, but can be convinced otherwise! 

### larger alternative: resolve lookups early

Another alternative I considered, was to do the 'resolution' step early. For example, right in the beginning of the transaction, we could 'eagerly' get all lookup uuids, and create the lookups if they don't exist. 

From there, we could map over tx-steps, and replace all lookups with those ids. 

There's some danger here: we would be creating data before running the permission check. However, I _think_ that is fine, as we run create checks after we insert data anyways. 

Ultimately I chose to go against this option, as it would require a much larger change. We would need to insert attrs before triples, and we would need to do the same kind of logic in `transact!`. 

Maybe at some point it could make sense to look into this, but just to fix this bug I don't think it was worth it. 

--- 

@dwwoelfel @nezaj @tonsky 
