### PR TITLE
[datalog] use `IN` for value comparison

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -555,11 +555,6 @@
        [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
        [:not= [(extract-value-fn data-type) :value] val]])))
 
-(defn- value-lookup? [x]
-  (and (vector? x)
-       (uuid? (first x))
-       (= (count x) 2)))
-
 (defn- in-or-eq-value [idx app-id v-set]
   (let [[tag idx-val] idx
         data-type (case tag
@@ -568,19 +563,8 @@
     (if (empty? v-set)
       [:= 0 1]
       (if-not data-type
-        (list* :or
-               (for [lookup v-set]
-                 (if-not (value-lookup? lookup)
-                   [:= :value (value->jsonb lookup)]
-                   [:=
-                    :value
-                    {:select [[[:to_jsonb :entity-id]]]
-                     :from :triples
-                     :where [:and
-                             [:= :app-id app-id]
-                             [:= :value [:cast (->json (second lookup)) :jsonb]]
-                             [:= :attr-id [:cast (first lookup) :uuid]]
-                             :av]}])))
+        (in-or-eq :value (map value->jsonb v-set))
+
         (list* :or (map (fn [v]
                           [:and
                            [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -555,7 +555,7 @@
        [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
        [:not= [(extract-value-fn data-type) :value] val]])))
 
-(defn- in-or-eq-value [idx app-id v-set]
+(defn- in-or-eq-value [idx v-set]
   (let [[tag idx-val] idx
         data-type (case tag
                     :keyword nil
@@ -587,7 +587,7 @@
                             [:= :attr-id [:cast (first lookup) :uuid]]
                             :av]}])))
     :a (in-or-eq :attr-id v)
-    :v (in-or-eq-value idx app-id v)))
+    :v (in-or-eq-value idx v)))
 
 (defn- value-function-clauses [idx [v-tag v-value]]
   (case v-tag

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -398,19 +398,7 @@
                        [[:ea [handle-aid "alex"] name-aid '?name]])
                       :join-rows
                       (map (comp last drop-last last))
-                      set)))))
-      (testing "v side"
-        (let [isbn13-aid (resolvers/->uuid r :books/isbn13)
-              bookshelves-books-aid (resolvers/->uuid r :bookshelves/books)
-              bookshelves-name-aid (resolvers/->uuid r :bookshelves/name)]
-          (is (= #{"Worldview"}
-                 (->> (d/query
-                       {:db {:conn-pool (aurora/conn-pool)}
-                        :app-id (:id app)}
-                       [[:eav '?b  bookshelves-books-aid [isbn13-aid "9780425284636"]]
-                        [:ea '?b bookshelves-name-aid '?title]])
-                      :join-rows
-                      (map (comp last drop-last last))
                       set))))))))
+
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -425,10 +425,8 @@
                       (("eid-joe-averbukh" :users/bookshelves "eid-2018")
                        ("eid-alex" :users/id "eid-alex")
                        ("eid-alex" :users/bookshelves "eid-short-stories")
+                       ("eid-stepan-parunashvili" :users/bookshelves "eid-worldview")
                        ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
-                       ("eid-stepan-parunashvili"
-                        :users/bookshelves
-                        "eid-the-way-of-the-gentleman")
                        ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
                        --
                        ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")


### PR DESCRIPTION
A user mentioned that some of his queries got slower. The query looked something like: 

```edn
{:conversations 
  {:$ {:order {:serverCreatedAt "desc"}, :limit 100, 
         :where {:groups "...", :messages.time {:$gte ...}}}, 
  :messages {}}}
```

After investigating, the problem was like so: 

`messages` expanded out to about 16000 entities. When we tried to resolve permissions, we would do a batched query, which would include all 16K uuids. 

When datalog generated the list of `:or` conditions,  it would take postgres about a minute and a half, just to parse the query. 

Changing the condition to an `IN` improved the perf to under 5 seconds. 

@dwwoelfel @nezaj @tonsky 