### PR TITLE
fix: logick for next link in bottom article nav

### DIFF
--- a/client/www/components/docs/Layout.jsx
+++ b/client/www/components/docs/Layout.jsx
@@ -142,7 +142,7 @@ function getNextPage(allLinks, currentPath) {
     const [nextLink] = findLink(allLinks, link.nextHref);
     return nextLink;
   }
-  return allLinks[idx - 1];
+  return allLinks[idx + 1];
 }
 
 export function Layout({ children, title, tableOfContents }) {


### PR DESCRIPTION
now:

<img width="1085" alt="Screenshot 2025-01-10 at 12 58 50" src="https://github.com/user-attachments/assets/0f0c723a-6f55-44a5-85d7-ac8230f545af" />

after fix:

<img width="1111" alt="Screenshot 2025-01-10 at 12 57 34" src="https://github.com/user-attachments/assets/157e1c34-9e1b-4cc9-9bc2-fcf6b4c33111" />


