### PR TITLE
Support exact matches and <, > in filter input

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -72,7 +72,6 @@ function parseSearchQuery(s: string): ParsedQueryPart[] {
     }
     if ((OPERATORS as readonly string[]).includes(c)) {
       if (currentPart && valueStart != null) {
-        // XXX: Probably fails if there is no space before?
         currentPart.value = s.substring(valueStart, fieldStart).trim();
         parts.push(currentPart);
       }

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -1,10 +1,16 @@
 import { id, tx } from '@instantdb/core';
 import { InstantReactWebDatabase } from '@instantdb/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { isObject, debounce } from 'lodash';
+import { isObject, debounce, last } from 'lodash';
 import produce from 'immer';
 import clsx from 'clsx';
 import CopyToClipboard from 'react-copy-to-clipboard';
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+} from '@headlessui/react';
 
 import * as Tooltip from '@radix-ui/react-tooltip';
 import {
@@ -36,75 +42,326 @@ import { DBAttr, SchemaAttr, SchemaNamespace } from '@/lib/types';
 import { useIsOverflow } from '@/lib/hooks/useIsOverflow';
 import { useClickOutside } from '@/lib/hooks/useClickOutside';
 import { isTouchDevice } from '@/lib/config';
-import { useSchemaQuery, useNamespacesQuery } from '@/lib/hooks/explorer';
+import {
+  useSchemaQuery,
+  useNamespacesQuery,
+  SearchFilter,
+} from '@/lib/hooks/explorer';
 import { EditNamespaceDialog } from '@/components/dash/explorer/EditNamespaceDialog';
 import { EditRowDialog } from '@/components/dash/explorer/EditRowDialog';
 import { useRouter } from 'next/router';
 
-function searchWhereFilters(
-  attrs: Array<SchemaAttr>,
-  query: string,
-): [string, string, string][] {
-  if (!query) {
-    return [];
-  }
-  const q = `%${query}%`;
-  // Use case-insensitive if the query is all lower-case
-  const op = query.toLowerCase() === query ? '$ilike' : '$like';
-  const wheres = [];
-  for (const attr of attrs) {
-    if (attr.sortable && attr.checkedDataType === 'string') {
-      const filter: [string, string, string] = [attr.name, op, q];
-      wheres.push(filter);
+const OPERATORS = [':', '>', '<'] as const;
+type ParsedQueryPart = {
+  field: string;
+  operator: (typeof OPERATORS)[number];
+  value: string;
+};
+function parseSearchQuery(s: string): ParsedQueryPart[] {
+  let fieldStart = 0;
+  let currentPart: ParsedQueryPart | undefined;
+  let valueStart;
+  const parts: ParsedQueryPart[] = [];
+  let i = -1;
+  for (const c of s) {
+    i++;
+
+    if (c === ' ' && !(OPERATORS as readonly string[]).includes(s[i + 1])) {
+      fieldStart = i + 1;
+      continue;
+    }
+    if ((OPERATORS as readonly string[]).includes(c)) {
+      if (currentPart && valueStart != null) {
+        // XXX: Probably fails if there is no space before?
+        currentPart.value = s.substring(valueStart, fieldStart).trim();
+        parts.push(currentPart);
+      }
+      currentPart = {
+        field: s.substring(fieldStart, i).trim(),
+        operator: c as (typeof OPERATORS)[number],
+        value: '',
+      };
+
+      valueStart = i + 1;
+      continue;
     }
   }
-  return wheres;
+  if (currentPart && valueStart != null) {
+    currentPart.value = s.substring(valueStart).trim();
+    // Might push twice here...
+    parts.push(currentPart);
+  }
+  return parts;
+}
+
+function opToInstaqlOp(op: ':' | '<' | '>'): '=' | '$gt' | '$lt' {
+  switch (op) {
+    case ':':
+      // Not really an instaql op, but we have special handling in
+      // explorer.tsx to turn `=` into {k: v}
+      return '=';
+    case '<':
+      return '$lt';
+    case '>':
+      return '$gt';
+    default:
+      throw new Error('what kind of op is this? ' + op);
+  }
+}
+
+function queryToFilters({
+  query,
+  attrsByName,
+  stringIndexed,
+}: {
+  query: string;
+  attrsByName: { [key: string]: SchemaAttr };
+  stringIndexed: SchemaAttr[];
+}): SearchFilter[] {
+  if (!query.trim()) {
+    return [];
+  }
+  const parsed = parseSearchQuery(query);
+  const parts: SearchFilter[] = parsed.flatMap(
+    (part: ParsedQueryPart): SearchFilter[] => {
+      const attr = attrsByName[part.field];
+      if (!attr || !part.value) {
+        return [];
+      }
+      const res: SearchFilter[] = [];
+      if (attr.checkedDataType && attr.isIndex) {
+        if (attr.checkedDataType === 'string') {
+          const val = part.value;
+          return [
+            [
+              part.field,
+              val === val.toLowerCase() ? '$ilike' : '$like',
+              `%${part.value}%`,
+            ],
+          ];
+        }
+        if (attr.checkedDataType === 'number') {
+          try {
+            return [
+              [
+                part.field,
+                opToInstaqlOp(part.operator),
+                JSON.parse(part.value),
+              ],
+            ];
+          } catch (e) {}
+        }
+        if (attr.checkedDataType === 'date') {
+          try {
+            return [
+              [
+                part.field,
+                opToInstaqlOp(part.operator),
+                JSON.parse(part.value),
+              ],
+            ];
+          } catch (e) {
+            // Might be a string date
+            return [[part.field, opToInstaqlOp(part.operator), part.value]];
+          }
+        }
+      }
+      for (const inferredType of attr.inferredTypes || ['json']) {
+        switch (inferredType) {
+          case 'boolean':
+          case 'number': {
+            try {
+              res.push([
+                part.field,
+                opToInstaqlOp(part.operator),
+                JSON.parse(part.value),
+              ]);
+            } catch (e) {}
+            break;
+          }
+          default: {
+            res.push([part.field, opToInstaqlOp(part.operator), part.value]);
+            break;
+          }
+        }
+      }
+      return res;
+    },
+  );
+
+  if (!parsed.length && query.trim() && stringIndexed.length) {
+    for (const a of stringIndexed) {
+      parts.push([
+        a.name,
+        query.toLowerCase() === query ? '$ilike' : '$like',
+        `%${query.trim()}%`,
+      ]);
+    }
+  }
+  return parts;
+}
+
+function sameFilters(
+  oldFilters: [string, string, string][],
+  newFilters: [string, string, string][],
+): boolean {
+  if (newFilters.length === oldFilters.length) {
+    for (let i = 0; i < newFilters.length; i++) {
+      for (let j = 0; j < 3; j++) {
+        if (newFilters[i][j] !== oldFilters[i][j]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+  return false;
 }
 
 function SearchInput({
-  initialValue,
   onSearchChange,
   attrs,
 }: {
-  initialValue: string;
-  onSearchChange: (filters: [string, string, string][]) => void;
+  onSearchChange: (filters: SearchFilter[]) => void;
   attrs?: SchemaAttr[];
 }) {
-  const [value, setValue] = useState(initialValue);
+  const [query, setQuery] = useState('');
 
-  const filterableAttrs = useMemo(
-    () => attrs?.filter((a) => a.sortable && a.checkedDataType === 'string'),
-    [attrs],
-  );
+  const lastFilters = useRef<[string, string, string][]>([]);
+
+  const { attrsByName, stringIndexed } = useMemo(() => {
+    const byName: { [key: string]: SchemaAttr } = {};
+    const stringIndexed = [];
+    for (const attr of attrs || []) {
+      byName[attr.name] = attr;
+      if (attr.isIndex && attr.checkedDataType === 'string') {
+        stringIndexed.push(attr);
+      }
+    }
+    return { attrsByName: byName, stringIndexed };
+  }, [attrs]);
 
   const searchDebounce = useCallback(
-    debounce(
-      (search) => {
-        if (filterableAttrs) {
-          onSearchChange(searchWhereFilters(filterableAttrs, search));
-        }
-      },
-      80,
-      { maxWait: 3000 },
-    ),
-    [filterableAttrs],
+    debounce((query) => {
+      const filters = queryToFilters({ query, attrsByName, stringIndexed });
+      if (!sameFilters(lastFilters.current, filters)) {
+        lastFilters.current = filters;
+        onSearchChange(filters);
+      }
+    }, 80),
+    [attrsByName, stringIndexed, lastFilters],
   );
 
-  if (!filterableAttrs?.length) {
-    return null;
+  const lastQuerySegment =
+    query.indexOf(':') !== -1 ? last(query.split(' ')) : query;
+
+  const comboOptions: { field: string; operator: string; display: string }[] = (
+    attrs || []
+  ).flatMap((a) => {
+    if (a.type === 'ref') {
+      return [];
+    }
+    const ops = [];
+
+    const opCandidates = [];
+    opCandidates.push({
+      field: a.name,
+      operator: ':',
+      display: `${a.name}:`,
+    });
+    if (
+      a.isIndex &&
+      (a.checkedDataType === 'number' || a.checkedDataType === 'date')
+    ) {
+      const base = {
+        field: a.name,
+        query: null,
+      };
+      opCandidates.push({ ...base, operator: '<', display: `${a.name}<` });
+      opCandidates.push({ ...base, operator: '>', display: `${a.name}>` });
+    }
+
+    for (const op of opCandidates) {
+      if (
+        !lastQuerySegment ||
+        (op.display.startsWith(lastQuerySegment) &&
+          op.display !== lastQuerySegment)
+      ) {
+        ops.push(op);
+      }
+    }
+    return ops;
+  });
+
+  const activeOption = useRef<(typeof comboOptions)[0] | null>(null);
+
+  function completeQuery(optionDisplay: string) {
+    let q;
+    if (lastQuerySegment && optionDisplay.startsWith(lastQuerySegment)) {
+      q = `${query}${optionDisplay.substring(lastQuerySegment.length)}`;
+    } else {
+      q = `${query.trim()} ${optionDisplay}`;
+    }
+    setQuery(q);
+    searchDebounce(q);
   }
 
   return (
-    <TextInput
-      className="text-content py-0 text-sm flex-1 flex-shrink-0"
-      placeholder="Filter..."
-      value={value}
-      onChange={(v) => {
-        setValue(v);
-        searchDebounce.cancel();
-        searchDebounce(v);
+    <Combobox
+      value={query}
+      onChange={(option) => {
+        if (option) {
+          completeQuery(option);
+        }
       }}
-    />
+      immediate={true}
+    >
+      <ComboboxInput
+        size={32}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          searchDebounce(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          // Prevent the combobox's default action that inserts
+          // the active option and tabs out of the input.
+          // Inserting the option doesn't work in our case, because
+          // it's just the start of a query, you still need to add
+          // the value
+          if (e.key === 'Tab' && comboOptions.length) {
+            e.preventDefault();
+
+            const active = activeOption.current || comboOptions[0];
+            if (active) {
+              completeQuery(active.display);
+            }
+          }
+        }}
+        placeholder="Filter..."
+      ></ComboboxInput>
+      <ComboboxOptions
+        anchor="bottom start"
+        modal={false}
+        className="mt-1 w-[var(--input-width)] overflow-auto rounded-md bg-white shadow-lg z-10 border border-gray-300 divide-y"
+      >
+        {comboOptions.map((o, i) => (
+          <ComboboxOption
+            key={i}
+            value={o.display}
+            className={clsx('px-3 py-1 data-[focus]:bg-blue-100', {})}
+          >
+            {({ focus }) => {
+              if (focus) {
+                activeOption.current = o;
+              }
+              return <span>{o.display}</span>;
+            }}
+          </ComboboxOption>
+        ))}
+      </ComboboxOptions>
+    </Combobox>
   );
 }
 
@@ -128,6 +385,8 @@ export function Explorer({
   const [addItemDialogOpen, setAddItemDialogOpen] = useState(false);
   const nsRef = useRef<HTMLDivElement>(null);
 
+  const [searchFilters, setSearchFilters] = useState<SearchFilter[]>([]);
+
   // nav
   const router = useRouter();
   const selectedNamespaceId = router.query.ns as string;
@@ -143,6 +402,7 @@ export function Explorer({
   function nav(s: ExplorerNav[]) {
     _setNavStack(s);
     setCheckedIds({});
+    setSearchFilters([]);
 
     const current = s[s.length - 1];
     const ns = current.namespace;
@@ -195,10 +455,6 @@ export function Explorer({
 
   const sortAttr = currentNav?.sortAttr || 'serverCreatedAt';
   const sortAsc = currentNav?.sortAsc ?? true;
-
-  const [searchFilters, setSearchFilters] = useState<
-    [string, string, string][]
-  >([]);
 
   const { itemsRes, allCount } = useNamespacesQuery(
     db,
@@ -470,7 +726,7 @@ export function Explorer({
                   Edit Schema
                 </Button>
                 <SearchInput
-                  initialValue=""
+                  key={selectedNamespaceId}
                   onSearchChange={(filters) => setSearchFilters(filters)}
                   attrs={selectedNamespace?.attrs}
                 />

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -339,7 +339,7 @@ function SearchInput({
           }
         }}
         placeholder="Filter..."
-      ></ComboboxInput>
+      />
       <ComboboxOptions
         anchor="bottom start"
         modal={false}

--- a/client/www/lib/hooks/explorer.tsx
+++ b/client/www/lib/hooks/explorer.tsx
@@ -3,9 +3,12 @@ import { useEffect, useState } from 'react';
 import { DBAttr, SchemaNamespace } from '@/lib/types';
 import { dbAttrsToExplorerSchema } from '@/lib/schema';
 
+export type SearchFilterOp = '=' | '$ilike' | '$like' | '$gt' | '$lt';
+export type SearchFilter = [string, SearchFilterOp, any];
+
 function makeWhere(
   navWhere: null | undefined | [string, any],
-  searchFilters: null | undefined | [string, string, string][],
+  searchFilters: null | undefined | SearchFilter[],
 ) {
   const where: { [key: string]: any } = {};
   if (navWhere) {
@@ -13,7 +16,12 @@ function makeWhere(
   }
   if (searchFilters?.length) {
     where.or = searchFilters.map(([attr, op, val]) => {
-      return { [attr]: { [op]: val } };
+      switch (op) {
+        case '=':
+          return { [attr]: val };
+        default:
+          return { [attr]: { [op]: val } };
+      }
     });
   }
   return where;
@@ -24,7 +32,7 @@ export function useNamespacesQuery(
   db: InstantReactWebDatabase<any>,
   selectedNs?: SchemaNamespace,
   navWhere?: [string, any],
-  searchFilters?: [string, string, string][],
+  searchFilters?: SearchFilter[],
   limit?: number,
   offset?: number,
   sortAttr?: string,


### PR DESCRIPTION
In addition to free-form searching for string-indexed attributes, we also support exact search and (for indexed numbers or dates) `<`, `>` comparison attrs:

https://github.com/user-attachments/assets/4a98b790-7418-44d5-9d2c-00a7dbd8b092

Potential improvements:

It might not be obvious to people what the `:` operator means? If we gave them some examples using real data, e.g. show `pageCount:100, pageCount>100` in the dropdown, maybe that would help? It was a little too complex for me to tackle just now.

We're pretty permissive in the parsing. For example, if you type `number: number:hello number:100`, we'll ignore the incomplete `number:` and the invalid `number:hello` and just show you `number = 100`. Some better error handling so that we could show you where the query is invalid would be nice.

Support negation.

Support AND (we only do OR right now). 

Support free-form search and exact search at the same time.