### PR TITLE
docs(permissions): fix InstantRules not typed as string

### DIFF
--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -138,7 +138,7 @@ You can use `$default` as the namespace:
 ```json
 "$default": {
   "allow": {
-    "view": false
+    "view": "false"
   }
 },
 "todos": {
@@ -153,7 +153,7 @@ Finally, the ultimate default:
 ```json
 "$default": {
   "allow": {
-    "$default": false
+    "$default": "false"
   }
 }
 ```


### PR DESCRIPTION
The current permission examples for the `$default` namespace don't work since the rules are incorrectly defined as `boolean`. InstantRules requires permissions to be defined as `string`.

Updated the example to ensure compatibility and prevent confusion.