### PR TITLE
Remove placement group

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -186,9 +186,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    # if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
-    # needs: [ detect_clj ]
+    needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     # Publish to elastic beanstalk only if we pass the tests
     needs:
-      # - clj-check
+      - clj-check
       - publish-image
     permissions:
       id-token: write

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -186,9 +186,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    # if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
-    needs: [ detect_clj ]
+    # needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     # Publish to elastic beanstalk only if we pass the tests
     needs:
-      - clj-check
+      # - clj-check
       - publish-image
     permissions:
       id-token: write

--- a/server/.ebextensions/resources.config
+++ b/server/.ebextensions/resources.config
@@ -2,4 +2,4 @@ Resources:
   AWSEBAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      PlacementGroup: "Instant-docker-prod-placement-group"
+      #PlacementGroup: "Instant-docker-prod-placement-group"

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -38,8 +38,8 @@
 (declare handle-broadcast-message)
 
 (defn init-hz [store-conn {:keys [instance-name cluster-name]
-                           :or {instance-name "instant-hz-v2"
-                                cluster-name "instant-server"}}]
+                           :or {instance-name "instant-hz-v3"
+                                cluster-name "instant-server-v1"}}]
   (-> (java.util.logging.Logger/getLogger "com.hazelcast")
       (.setLevel java.util.logging.Level/WARNING))
   (System/setProperty "hazelcast.shutdownhook.enabled" "false")


### PR DESCRIPTION
Removes the placement group so that we can try deploying into another availability zone.

Tested in staging and it did appear to deploy an instance without a placement group.