### PR TITLE
Don't treat isNull as a constant

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -95,8 +95,6 @@
 (def variable? (fn [x]
                  (and (symbol? x) (not= x '_))))
 
-(def constant? (comp not symbol?))
-
 (def named-variable? (partial uspec/tagged-as? :variable))
 (def named-constant? (partial uspec/tagged-as? :constant))
 

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -48,6 +48,10 @@
                 )]
     (if v-actualized? v-idx e-idx)))
 
+(defn constant-component? [component]
+  (and (not (symbol? component))
+       (not (:$isNull component))))
+
 (defn component-actualized?
   "A component is actualized if:
    a. It is a constant
@@ -57,7 +61,7 @@
     [?bookshelves books-attr ?books]] ;; ?bookshelves is actualized (it's been bound)
   "
   [seen component]
-  (or (d/constant? component)
+  (or (constant-component? component)
       (seen component)))
 
 (defn attr-by-id


### PR DESCRIPTION
When we do an `$isNull` query, we put something like `{:$isNull {:attr-id aid}}` in the value position. The pattern looks something like `[?e aid {:$isNull {:attr-id aid}}}]`.

When we choose the triples index to look at, we use the `av` index if we have a constant value for an indexed attr. Normally a non-constant is a symbol, e.g. `?v` in `[?e aid ?v]`. We saw a map for `$isNull` instead of a symbol, so we thought it was a constant value and we used the `av` index where the value wasn't actually known.

Now we'll check for `$isNull` before we say something is a constant.



