### PR TITLE
Run the receive-queue workers without bindings

### DIFF
--- a/server/src/instant/util/async.clj
+++ b/server/src/instant/util/async.clj
@@ -78,7 +78,8 @@
         (.cancel fut interrupt?)))))
 
 (defmacro worker-vfuture
-  "Creates a "
+  "Creates a vfuture that does not propagate bindings and does not
+   track immediate children. Useful for starting a background worker."
   [^ExecutorService executor & body]
   `(worker-vfuture-call ~executor (^{:once true} fn* [] ~@body)))
 


### PR DESCRIPTION
I noticed that our traces for `invalidator/work` were including a lot of extra spans past the end of the top-level trace. This happens because we start the worker in an `on-add` callback to `grouped-queue/put!`, so it was inheriting the parent span from the bindings.

Now we have a new type of virtual future that doesn't propagate bindings. That gives our workers a bit more isolation. I also gave them their own virtual thread executor--doesn't do much now, but it would let us more thoroughly "shutdown" a grouped-queue in the future.

Much easier to review with whitespace off: https://github.com/instantdb/instant/pull/709/files?w=1