### PR TITLE
Trace invalidation from start to finish

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/color.tsx
+++ b/client/sandbox/react-nextjs/pages/play/color.tsx
@@ -5,7 +5,7 @@ import config from "../../config";
 const schema = i.schema({
   entities: {
     colors: i.entity({ color: i.string() }),
-  }
+  },
 });
 
 const db = init({ ...config, schema });
@@ -15,6 +15,16 @@ function App() {
 }
 
 const selectId = "4d39508b-9ee2-48a3-b70d-8192d9c5a059";
+
+const colorOptions = ["green", "blue", "purple"];
+
+function nextColor(c: string): string {
+  const i = colorOptions.indexOf(c);
+  if (i === -1) {
+    return colorOptions[0];
+  }
+  return colorOptions[(i + 1) % colorOptions.length];
+}
 
 function Main() {
   useEffect(() => {
@@ -35,7 +45,7 @@ function Main() {
       <div className="space-y-4">
         <h1>Hi! pick your favorite color</h1>
         <div className="space-x-4">
-          {["green", "blue", "purple"].map((c) => {
+          {colorOptions.map((c) => {
             return (
               <button
                 onClick={() => {
@@ -48,6 +58,16 @@ function Main() {
               </button>
             );
           })}
+          <button
+            className={`bg-white p-2`}
+            onClick={() => {
+              db.transact(
+                tx.colors[selectId].update({ color: nextColor(color) }),
+              );
+            }}
+          >
+            Cycle
+          </button>
         </div>
       </div>
     </div>

--- a/server/flags-config/instant.perms.ts
+++ b/server/flags-config/instant.perms.ts
@@ -6,92 +6,9 @@ const rules = {
       create: "false",
     },
   },
-  "rate-limited-apps": {
+  $default: {
     allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "storage-whitelist": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "friend-emails": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "view-checks": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "power-user-emails": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "test-emails": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "promo-emails": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "use-patch-presence": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "drop-refresh-spam": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  custodian: {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
-    },
-  },
-  "team-emails": {
-    allow: {
-      view: "false",
-      create: "false",
-      delete: "false",
-      update: "false",
+      $default: "false",
     },
   },
 };

--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -8,6 +8,9 @@ const graph = i.graph(
     $users: i.entity({
       email: i.string().unique().indexed(),
     }),
+    "e2e-logging": i.entity({
+      "invalidator-rate": i.number(),
+    }),
     "drop-refresh-spam": i.entity({
       "default-value": i.boolean(),
       "disabled-apps": i.any(),
@@ -29,7 +32,7 @@ const graph = i.graph(
       email: i.string(),
     }),
     "rate-limited-apps": i.entity({
-      appId: i.string().unique()
+      appId: i.string().unique(),
     }),
     "storage-whitelist": i.entity({
       appId: i.string().unique().indexed(),
@@ -47,7 +50,7 @@ const graph = i.graph(
   // For example, if `posts` should have many `comments`.
   // More in the docs:
   // https://www.instantdb.com/docs/schema#defining-links
-  {},
+  {}
 );
 
 export default graph;

--- a/server/flags-config/package.json
+++ b/server/flags-config/package.json
@@ -10,7 +10,7 @@
     "dev:push": "INSTANT_CLI_DEV=1 instant-cli push"
   },
   "dependencies": {
-    "@instantdb/core": "^0.14.29",
-    "instant-cli": "^0.14.29"
+    "@instantdb/core": "^0.17.7",
+    "instant-cli": "^0.17.7"
   }
 }

--- a/server/flags-config/pnpm-lock.yaml
+++ b/server/flags-config/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@instantdb/core':
-    specifier: ^0.14.29
-    version: 0.14.29
+    specifier: ^0.17.7
+    version: 0.17.7
   instant-cli:
-    specifier: ^0.14.29
-    version: 0.14.29
+    specifier: ^0.17.7
+    version: 0.17.7
 
 packages:
 
@@ -234,6 +234,12 @@ packages:
     dev: false
     optional: true
 
+  /@ewoudenberg/difflib@0.1.0:
+    resolution: {integrity: sha512-OU5P5mJyD3OoWYMWY+yIgwvgNS9cFAU10f+DDuvtogcWQOoJIsQ4Hy2McSfUfhKjq8L0FuWVb4Rt7kgA+XK86A==}
+    dependencies:
+      heap: 0.2.7
+    dev: false
+
   /@inquirer/checkbox@2.5.0:
     resolution: {integrity: sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==}
     engines: {node: '>=18'}
@@ -251,6 +257,25 @@ packages:
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
+    dev: false
+
+  /@inquirer/core@9.0.10:
+    resolution: {integrity: sha512-TdESOKSVwf6+YWDz8GhS6nKscwzkIyakEzCLJ5Vh6O3Co2ClhCJ0A4MG909MUWfaWdpJm7DE45ii51/2Kat9tA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/figures': 1.0.7
+      '@inquirer/type': 1.5.5
+      '@types/mute-stream': 0.0.4
+      '@types/node': 22.7.6
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
     dev: false
 
   /@inquirer/core@9.2.1:
@@ -319,6 +344,22 @@ packages:
       ansi-escapes: 4.3.2
     dev: false
 
+  /@inquirer/prompts@5.3.8:
+    resolution: {integrity: sha512-b2BudQY/Si4Y2a0PdZZL6BeJtl8llgeZa7U2j47aaJSCeAl1e4UI7y8a9bSkO3o/ZbZrgT5muy/34JbsjfIWxA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/checkbox': 2.5.0
+      '@inquirer/confirm': 3.2.0
+      '@inquirer/editor': 2.2.0
+      '@inquirer/expand': 2.3.0
+      '@inquirer/input': 2.3.0
+      '@inquirer/number': 1.1.0
+      '@inquirer/password': 2.2.0
+      '@inquirer/rawlist': 2.3.0
+      '@inquirer/search': 1.1.0
+      '@inquirer/select': 2.5.0
+    dev: false
+
   /@inquirer/prompts@5.5.0:
     resolution: {integrity: sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==}
     engines: {node: '>=18'}
@@ -379,8 +420,8 @@ packages:
       mute-stream: 1.0.0
     dev: false
 
-  /@instantdb/core@0.14.29:
-    resolution: {integrity: sha512-GyWnNa07QJXy5pdR9lr/xdfoDHJJVe2WYyLHAXeZhn9Fiik6ErxyKmwjvcT8c07jQilwdicR7dbJ9SMh1iQR9g==}
+  /@instantdb/core@0.17.7:
+    resolution: {integrity: sha512-5JaBEryf9MFCwoRFX5vNu850n93nbbW+urPc85hpUFZR4M4pU9f7d1qxnvlrDreqNobdzN8VvP+8Yv9uFT7/4Q==}
     dependencies:
       mutative: 1.0.11
       uuid: 9.0.1
@@ -487,6 +528,11 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: false
 
+  /colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
+    dev: false
+
   /commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -529,6 +575,13 @@ packages:
   /dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
+    dev: false
+
+  /dreamopt@0.8.0:
+    resolution: {integrity: sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      wordwrap: 1.0.0
     dev: false
 
   /emoji-regex@10.4.0:
@@ -614,6 +667,10 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /heap@0.2.7:
+    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
+    dev: false
+
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -649,19 +706,23 @@ packages:
       rxjs: 7.8.1
     dev: false
 
-  /instant-cli@0.14.29:
-    resolution: {integrity: sha512-GnYov/Q8jUjFN96rMd91Eg6ucxGd6jQCJnM/MqbeEOPu1KsCWNw5jc+fwfTplyYGlUSGnrbY5SYiJ8EuubwgGQ==}
+  /instant-cli@0.17.7:
+    resolution: {integrity: sha512-USNFUD4tK49dqqjBUpIJObyBsYad6ElMUr9V0pZA+QIM8kwbo2By7MJwLXLLWSxpgy0NOXeAlZtPQI77DRB/3A==}
     hasBin: true
     dependencies:
-      '@inquirer/prompts': 5.5.0
+      '@inquirer/core': 9.0.10
+      '@inquirer/prompts': 5.3.8
+      ansi-escapes: 4.3.2
       chalk: 5.3.0
       commander: 12.1.0
       dotenv: 16.4.5
       env-paths: 3.0.0
       inquirer: 10.2.2
+      json-diff: 1.0.6
       open: 10.1.0
       ora: 8.1.1
       pkg-dir: 8.0.0
+      prettier: 3.4.2
       terminal-link: 3.0.0
       unconfig: 0.5.5
     transitivePeerDependencies:
@@ -717,6 +778,15 @@ packages:
   /jiti@2.0.0-beta.3:
     resolution: {integrity: sha512-pmfRbVRs/7khFrSAYnSiJ8C0D5GvzkE4Ey2pAvUcJsw1ly/p+7ut27jbJrjY79BpAJQJ4gXYFtK6d1Aub+9baQ==}
     hasBin: true
+    dev: false
+
+  /json-diff@1.0.6:
+    resolution: {integrity: sha512-tcFIPRdlc35YkYdGxcamJjllUhXWv4n2rK9oJ2RsAzV4FBkuV4ojKEDgcZ+kpKxDmJKv+PFK65+1tVVOnSeEqA==}
+    hasBin: true
+    dependencies:
+      '@ewoudenberg/difflib': 0.1.0
+      colors: 1.4.0
+      dreamopt: 0.8.0
     dev: false
 
   /load-tsconfig@0.2.5:
@@ -797,6 +867,12 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       find-up-simple: 1.0.0
+    dev: false
+
+  /prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: false
 
   /resolve-pkg-maps@1.0.0:
@@ -945,6 +1021,10 @@ packages:
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+    dev: false
+
+  /wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: false
 
   /wrap-ansi@6.2.0:

--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -20,3 +20,4 @@ Samplers:
                 FieldList:
                   - root.name
                   - root.op
+                  - root.entropy

--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -10,6 +10,7 @@
    [instant.system-catalog :refer [system-catalog-app-id]]
    [instant.util.coll :as coll]
    [instant.util.exception :as ex]
+   [instant.util.e2e-tracer :as e2e-tracer]
    [instant.util.tracer :as tracer]
    [next.jdbc :as next-jdbc]))
 
@@ -206,6 +207,10 @@
 
            results-with-on-deletes (enforce-on-deletes conn attrs app-id results)
            tx (transaction-model/create! conn {:app-id app-id})]
+       (tool/def-locals)
+       (e2e-tracer/start-invalidator-tracking! {:tx-id (:id tx)})
+       (e2e-tracer/invalidator-tracking-step! {:tx-id (:id tx)
+                                               :name "transact"})
        (assoc tx :results results-with-on-deletes)))))
 
 (defn transact!

--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -207,7 +207,6 @@
 
            results-with-on-deletes (enforce-on-deletes conn attrs app-id results)
            tx (transaction-model/create! conn {:app-id app-id})]
-       (tool/def-locals)
        (e2e-tracer/start-invalidator-tracking! {:tx-id (:id tx)})
        (e2e-tracer/invalidator-tracking-step! {:tx-id (:id tx)
                                                :name "transact"})

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -156,7 +156,7 @@
   (contains? (:rate-limited-apps (query-result))
              app-id))
 
-(defn e2e-encourage-honeycomb-publish? [^Long tx-id]
+(defn e2e-should-honeycomb-publish? [^Long tx-id]
   (zero? (mod tx-id (or (get-in (query-result)
                                 [:e2e-logging :invalidator-every-n])
                         10000))))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -84,7 +84,7 @@
         e2e-logging (when-let [flag (-> (get result "e2e-logging")
                                         first)]
                       {:invalidator-every-n (try (/ 1 (get flag "invalidator-rate"))
-                                                 (catch Exception e
+                                                 (catch Exception _e
                                                    10000))})]
     {:emails emails
      :storage-enabled-whitelist storage-enabled-whitelist

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -157,6 +157,7 @@
              app-id))
 
 (defn e2e-should-honeycomb-publish? [^Long tx-id]
-  (zero? (mod tx-id (or (get-in (query-result)
-                                [:e2e-logging :invalidator-every-n])
-                        10000))))
+  (and tx-id
+       (zero? (mod tx-id (or (get-in (query-result)
+                                     [:e2e-logging :invalidator-every-n])
+                             10000)))))

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -10,6 +10,7 @@
   (:refer-clojure :exclude [send])
   (:require [ring.adapter.undertow.headers :refer [set-headers]]
             [instant.util.json :refer [->json]]
+            [instant.util.e2e-tracer :as e2e-tracer]
             [instant.util.tracer :as tracer]
             [instant.util.delay :as delay])
   (:import
@@ -30,6 +31,7 @@
    [ring.adapter.undertow Util]
    [clojure.lang IPersistentMap]
    [io.undertow.websockets.extensions PerMessageDeflateHandshake]
+   [java.util.concurrent ScheduledFuture]
    [java.util.concurrent.locks ReentrantLock]
    [java.util.concurrent.atomic AtomicLong]
    [java.io IOException]
@@ -43,7 +45,9 @@
 
    See `ws-callback` for more details."
   [{:keys [on-message on-close-message on-error channel-wrapper
-           atomic-last-received-at atomic-last-ping-at set-ping-latency-nanos]}]
+           ^AtomicLong atomic-last-received-at
+           ^AtomicLong atomic-last-ping-at
+           set-ping-latency-nanos]}]
   (let [on-message       (or on-message (constantly nil))
         on-error         (or on-error (constantly nil))
         on-close-message (or on-close-message (constantly nil))]
@@ -76,7 +80,7 @@
 
 (defn try-send-ping-blocking
   "Tries to send a ping-message. Ignores closed channel exceptions."
-  [channel]
+  [^WebSocketChannel channel]
   (try
     (WebSockets/sendPingBlocking
      (ByteBuffer/allocate 0)
@@ -158,25 +162,25 @@
 
     (reify WebSocketConnectionCallback
       (^void onConnect [_ ^WebSocketHttpExchange exchange ^WebSocketChannel channel]
-        (let [ping-job (delay/repeat-fn
-                        ping-pool
-                        ping-interval-ms
-                        (fn []
-                          (straight-jacket-run-ping-job channel
-                                                        atomic-last-received-at
-                                                        atomic-last-ping-at
-                                                        idle-timeout-ms)))
+       (let [^ScheduledFuture ping-job (delay/repeat-fn
+                                        ping-pool
+                                        ping-interval-ms
+                                        (fn []
+                                          (straight-jacket-run-ping-job channel
+                                                                        atomic-last-received-at
+                                                                        atomic-last-ping-at
+                                                                        idle-timeout-ms)))
 
-              close-task (reify ChannelListener
-                           (handleEvent [_this channel]
-                             (.cancel ping-job false)
-                             (on-close (channel-wrapper channel))))]
-          (.set atomic-last-received-at (System/currentTimeMillis))
-          (on-open {:exchange exchange
-                    :channel (channel-wrapper channel)})
-          (.addCloseTask channel close-task)
-          (.set (.getReceiveSetter channel) listener)
-          (.resumeReceives channel))))))
+             close-task (reify ChannelListener
+                          (handleEvent [_this channel]
+                            (.cancel ping-job false)
+                            (on-close (channel-wrapper channel))))]
+         (.set atomic-last-received-at (System/currentTimeMillis))
+         (on-open {:exchange exchange
+                   :channel (channel-wrapper channel)})
+         (.addCloseTask channel close-task)
+         (.set (.getReceiveSetter channel) listener)
+         (.resumeReceives channel))))))
 
 (defn ws-request [^HttpServerExchange exchange ^IPersistentMap headers ^WebSocketConnectionCallback callback]
   (let [handler (->  (WebSocketProtocolHandshakeHandler. callback)
@@ -187,32 +191,35 @@
 
 (defn send-json!
   "Serializes `obj` to json, and sends over a websocket."
-  [app-id obj {:keys [websocket-stub undertow-websocket send-lock]}]
+  [app-id obj {:keys [websocket-stub undertow-websocket ^ReentrantLock send-lock]}]
+  (tool/def-locals)
   ;; Websockets/sendText _should_ be thread-safe
   ;; But, t becomes thread-unsafe when we use per-message-deflate
   ;; Using a `send-lock` to make `send-json!` thread-safe
   (if websocket-stub
     (websocket-stub obj)
     (let [obj-json (->json obj)
-          p (promise)
-          _ (try
-              (tracer/with-span! {:name "ws/send-json!"
-                                  :attributes {:size (count obj-json)
-                                               :app-id app-id
-                                               :send-lock.queue-length (.getQueueLength send-lock)
-                                               :send-lock.is-locked (.isLocked send-lock)
-                                               :send-lock.held-by-current-thread (.isHeldByCurrentThread send-lock)}}
-                (.lock send-lock)
-                (WebSockets/sendText
-                 ^String obj-json
-                 ^WebSocketChannel undertow-websocket
-                 (proxy [WebSocketCallback] []
-                   (complete [ws-conn context]
-                     (deliver p nil))
-                   (onError [ws-conn context throwable]
-                     (deliver p throwable)))))
-              (finally
-                (.unlock send-lock)))
-          ret @p]
-      (when (instance? Throwable ret)
-        (throw ret)))))
+          p (promise)]
+      (tracer/with-span! {:name "ws/send-json!"
+                          :attributes {:app-id app-id
+                                       :size (count obj-json)}}
+        (try
+          (.lock send-lock)
+          (WebSockets/sendText
+           ^String obj-json
+           ^WebSocketChannel undertow-websocket
+           (proxy [WebSocketCallback] []
+             (complete [ws-conn context]
+               (deliver p nil))
+             (onError [ws-conn context throwable]
+               (deliver p throwable))))
+          (finally
+            (.unlock send-lock)))
+        (let [ret @p]
+          (when-let [tx-id (-> obj meta :tx-id)]
+            (e2e-tracer/invalidator-tracking-step!
+             {:tx-id tx-id
+              :name "send-json-delivered"
+              :attributes {:session-id (-> obj meta :session-id)}}))
+          (when (instance? Throwable ret)
+            (throw ret)))))))

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -192,7 +192,6 @@
 (defn send-json!
   "Serializes `obj` to json, and sends over a websocket."
   [app-id obj {:keys [websocket-stub undertow-websocket ^ReentrantLock send-lock]}]
-  (tool/def-locals)
   ;; Websockets/sendText _should_ be thread-safe
   ;; But, t becomes thread-unsafe when we use per-message-deflate
   ;; Using a `send-lock` to make `send-json!` thread-safe

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -31,6 +31,7 @@
    [instant.util.exception :as ex]
    [instant.util.json :refer [<-json]]
    [instant.util.semver :as semver]
+   [instant.util.e2e-tracer :as e2e-tracer]
    [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util]
    [lambdaisland.uri :as uri])
@@ -167,7 +168,10 @@
      :instaql-result instaql-result
      :result-changed? result-changed?}))
 
-(defn- handle-refresh! [store-conn sess-id _event debug-info]
+(defn- handle-refresh! [store-conn sess-id event debug-info]
+  (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id event)
+                                          :name "start-refresh"
+                                          :attributes {:session-id sess-id}})
   (let [auth (get-auth! store-conn sess-id)
         app-id (-> auth :app :id)
         current-user (-> auth :user)
@@ -193,17 +197,25 @@
         drop-spam? (flags/drop-refresh-spam? app-id)
         computations (if drop-spam?
                        computations
-                       recompute-results)]
+                       recompute-results)
+        tracer-attrs {:num-recomputations num-recomputations
+                      :num-spam num-spam
+                      :num-computations num-computations
+                      :dropped-spam? drop-spam?}]
+    (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id event)
+                                            :name "finish-refresh-queries"
+                                            :attributes (assoc tracer-attrs
+                                                               :session-id sess-id)})
     (tracer/with-span! {:name "handle-refresh/send-event!"
-                        :attributes {:num-recomputations num-recomputations
-                                     :num-spam num-spam
-                                     :num-computations num-computations
-                                     :dropped-spam? drop-spam?}}
+                        :attributes tracer-attrs}
       (when (seq computations)
-        (rs/send-event! store-conn app-id sess-id {:op :refresh-ok
-                                                   :processed-tx-id processed-tx-id
-                                                   :attrs attrs
-                                                   :computations computations})))))
+        (rs/send-event! store-conn app-id sess-id (with-meta
+                                                    {:op :refresh-ok
+                                                     :processed-tx-id processed-tx-id
+                                                     :attrs attrs
+                                                     :computations computations}
+                                                    {:tx-id (:tx-id event)
+                                                     :session-id sess-id}))))))
 
 ;; -----
 ;; transact
@@ -566,17 +578,21 @@
                       (#(%))))
        (assoc metadata :skipped-size skipped-size)))))
 
-(defmulti consolidate
-  (fn [type batch]
-    (if (= 1 (count batch))
-      :default
-      type)))
+(defn resolve-consolidate [type batch]
+  (if (= 1 (count batch))
+    :default
+    type))
+
+(defmulti consolidate #'resolve-consolidate)
 
 (defmethod consolidate :default [_ batch]
   batch)
 
 (defmethod consolidate :refresh [_ batch]
-  [(-> (first batch)
+  (doseq [{:keys [item]} (drop-last batch)]
+    (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id item)
+                                            :name "skipped-refresh"}))
+  [(-> (last batch)
        (assoc :skipped-size (dec (count batch))))])
 
 (defmethod consolidate :refresh-presence [_ batch]
@@ -601,7 +617,7 @@
 (defn straight-jacket-process-receive-q-batch [store-conn batch metadata]
   (try
     (let [type (-> metadata :group-key first)]
-      (doseq [entry (consolidate type batch)]
+      (doseq [entry (#'consolidate type batch)]
         (process-receive-q-entry store-conn entry metadata)))
     (catch Throwable e
       (tracer/record-exception-span! e {:name "receive-worker/handle-receive-batch-straight-jacket"

--- a/server/src/instant/util/delay.clj
+++ b/server/src/instant/util/delay.clj
@@ -1,5 +1,5 @@
 (ns instant.util.delay
-  (:import [java.util.concurrent ScheduledThreadPoolExecutor TimeUnit]))
+  (:import [java.util.concurrent Callable ScheduledThreadPoolExecutor TimeUnit ScheduledFuture]))
 
 (defn cpu-count []
   (.availableProcessors (Runtime/getRuntime)))
@@ -8,11 +8,11 @@
                      :or {thread-count (+ 2 (cpu-count))}}]
   (ScheduledThreadPoolExecutor. thread-count))
 
-(defn delay-fn [thread-pool delay-ms f]
+(defn delay-fn [^ScheduledThreadPoolExecutor thread-pool ^Long delay-ms ^Callable f]
   (.schedule thread-pool f delay-ms TimeUnit/MILLISECONDS))
 
-(defn repeat-fn [thread-pool delay-ms f]
+(defn repeat-fn [^ScheduledThreadPoolExecutor thread-pool delay-ms f]
   (.scheduleAtFixedRate thread-pool f delay-ms delay-ms TimeUnit/MILLISECONDS))
 
-(defn shutdown-pool! [pool]
+(defn shutdown-pool! [^ScheduledThreadPoolExecutor pool]
   (.shutdown pool))

--- a/server/src/instant/util/delay.clj
+++ b/server/src/instant/util/delay.clj
@@ -1,5 +1,6 @@
 (ns instant.util.delay
-  (:import [java.util.concurrent Callable ScheduledThreadPoolExecutor TimeUnit ScheduledFuture]))
+  (:import
+   (java.util.concurrent Callable ScheduledThreadPoolExecutor TimeUnit)))
 
 (defn cpu-count []
   (.availableProcessors (Runtime/getRuntime)))

--- a/server/src/instant/util/e2e_tracer.clj
+++ b/server/src/instant/util/e2e_tracer.clj
@@ -1,0 +1,64 @@
+(ns instant.util.e2e-tracer
+  (:require [instant.util.tracer :as tracer])
+  (:import
+   (io.opentelemetry.api.trace SpanContext)
+   (io.opentelemetry.sdk.trace SdkSpan)
+   (java.lang.reflect Field)
+   (java.nio ByteBuffer)
+   (org.apache.commons.codec.binary Hex)))
+
+(def tx-id-magic-prefix ^byte (byte -95))
+
+(defn tx-id->trace-id
+  "Creates a stable trace id for a given tx-id so that we can attach
+   a series of spans executing on different machines to the same parent."
+  [^Long tx-id]
+  (-> (ByteBuffer/allocate 16) ;; 16 bytes for the traceid
+      (.put ^byte tx-id-magic-prefix)
+      (.putLong tx-id)
+      (.array)
+      (Hex/encodeHexString)))
+
+(defn tx-id->span-id
+  "Creates a stable span id for a given tx-id so that we can attach
+   a series of spans executing on different machines to the same parent."
+  [^Long tx-id]
+  (-> (ByteBuffer/allocate 8) ;; 16 bytes for the spanId
+      (.putLong tx-id)
+      (.array)
+      (Hex/encodeHexString)))
+
+(defn get-field
+  "Gets a private field from a class instance using reflection."
+  [^Class cls ^String field-name]
+  (doto (.getDeclaredField cls field-name)
+    (.setAccessible true)))
+
+(def context-field ^Field (get-field SdkSpan "context"))
+
+
+(defn make-invalidator-tracking-span [^Long tx-id attrs]
+  (let [span (binding [tracer/*span* nil] ;; make sure this is a top-level span
+               (tracer/new-span! {:name "e2e/invalidator/tracking-span"
+                                  :attributes (merge {:tx-id tx-id}
+                                                     attrs)}))
+        context (.getSpanContext ^SdkSpan span)
+        modified-context (SpanContext/create (tx-id->trace-id tx-id)
+                                             (tx-id->span-id tx-id)
+                                             (.getTraceFlags context)
+                                             (.getTraceState context))]
+    (.set ^Field context-field span modified-context)
+    span))
+
+(defn start-invalidator-tracking! [{:keys [^Long tx-id app-id]}]
+  (tracer/end-span! (make-invalidator-tracking-span tx-id {:app-id app-id})))
+
+;; XXX: Need to do something to prevent ourselves from being removed by refinery
+(defn invalidator-tracking-step! [{:keys [^Long tx-id name] :as span-opts}]
+  ;; Create a new span with a stable trace-id and span-id for the parent
+  (binding [tracer/*span* (make-invalidator-tracking-span tx-id nil)]
+    (tracer/record-info! (-> span-opts
+                             (update :name (fn [s] (format "e2e/invalidator/%s" name)))
+                             (update :attributes (fn [a]
+                                                   (merge a
+                                                          {:tx-id tx-id})))))))

--- a/server/src/instant/util/e2e_tracer.clj
+++ b/server/src/instant/util/e2e_tracer.clj
@@ -7,6 +7,7 @@
    (java.nio ByteBuffer)
    (org.apache.commons.codec.binary Hex)))
 
+;; Starts the trace-id with a1 so that it's easy to spot
 (def tx-id-magic-prefix ^byte (byte -95))
 
 (defn tx-id->trace-id
@@ -53,12 +54,11 @@
 (defn start-invalidator-tracking! [{:keys [^Long tx-id app-id]}]
   (tracer/end-span! (make-invalidator-tracking-span tx-id {:app-id app-id})))
 
-;; XXX: Need to do something to prevent ourselves from being removed by refinery
 (defn invalidator-tracking-step! [{:keys [^Long tx-id name] :as span-opts}]
   ;; Create a new span with a stable trace-id and span-id for the parent
   (binding [tracer/*span* (make-invalidator-tracking-span tx-id nil)]
     (tracer/record-info! (-> span-opts
-                             (update :name (fn [s] (format "e2e/invalidator/%s" name)))
+                             (update :name (fn [s] (format "e2e/invalidator/%s" s)))
                              (update :attributes (fn [a]
                                                    (merge a
                                                           {:tx-id tx-id})))))))

--- a/server/src/instant/util/e2e_tracer.clj
+++ b/server/src/instant/util/e2e_tracer.clj
@@ -59,7 +59,7 @@
                                                       :entropy tx-id})]
       (tracer/end-span! span))))
 
-(defn invalidator-tracking-step! [{:keys [^Long tx-id name] :as span-opts}]
+(defn invalidator-tracking-step! [{:keys [^Long tx-id] :as span-opts}]
   ;; Create a new span with a stable trace-id and span-id for the parent
   (when (flags/e2e-should-honeycomb-publish? tx-id)
     (binding [tracer/*span* (make-invalidator-tracking-span tx-id nil)]

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -1,20 +1,20 @@
 (ns instant.util.tracer
   "Span lib for integrating with Honeycomb"
+  (:gen-class)
   (:require
    [clojure.main :as main]
-   [instant.util.logging-exporter :as logging-exporter]
    [instant.config :as config]
+   [instant.util.logging-exporter :as logging-exporter]
    [steffan-westcott.clj-otel.api.attributes :as attr])
   (:import
-   (io.opentelemetry.sdk OpenTelemetrySdk)
-   (io.opentelemetry.api.common Attributes AttributeKey)
+   (io.opentelemetry.api.common AttributeKey Attributes)
    (io.opentelemetry.api.trace Span StatusCode)
    (io.opentelemetry.context Context)
    (io.opentelemetry.exporter.otlp.trace OtlpGrpcSpanExporter)
+   (io.opentelemetry.sdk OpenTelemetrySdk)
    (io.opentelemetry.sdk.resources Resource)
-   (io.opentelemetry.sdk.trace SdkTracerProvider SdkTracer)
-   (io.opentelemetry.sdk.trace.export BatchSpanProcessor SimpleSpanProcessor))
-  (:gen-class))
+   (io.opentelemetry.sdk.trace SdkTracer SdkTracerProvider)
+   (io.opentelemetry.sdk.trace.export BatchSpanProcessor SimpleSpanProcessor)))
 
 (def ^:dynamic *span* nil)
 


### PR DESCRIPTION
Right now we don't have a great way of seeing the full lifecycle of a transaction, from when the user calls `db.transact` to the point where the clients subscribed to that query re-render with new data. Our best metric right now is manually visiting the examples page and checking/unchecking tasks.

This PR introduces end-to-end tracing that will allow us to track from when `transact!` finishes to when we finish delivering the final websocket :refresh message for the transaction. It's not quite the full latency that the user sees, but it's close.

We use the transaction id to tie all of the spans to a single trace. It's one thing that we can track across multiple machines and know it will be the same on all machines. We generate our own parent trace-id and span-id from the tx-id and then create parent spans with that trace-id. That allows us to have spans from different machines all share the same parent.

It produces a trace diagram that looks like this:

<img width="1540" alt="image" src="https://github.com/user-attachments/assets/b2b15fcc-e00a-44df-90e3-c2292998a9b6" />

All of the spans are just single points because the parent spans have no way of knowing when the child spans complete.

We only log one out of every 10,000 transactions (configurable via instant-config) and we add an extra `:entropy` attr that will encourage refinery to forward our spans.
