### PR TITLE
Use the zgc garbage collector

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -79,7 +79,8 @@
                               io.github.tonsky/clj-reload   {:mvn/version "0.7.1"}
                               eftest/eftest                 {:mvn/version "0.6.0"}
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.5.1"}}
-                 :jvm-opts ["-enableassertions"
+                 :jvm-opts ["-XX:+UseZGC"
+                            "-enableassertions"
                             ;; Allow clj-async-profiler to attach
                             "-Djdk.attach.allowAttachSelf"
                             ;; print stack traces instead of "Full report at ..."
@@ -103,7 +104,8 @@
            :test {:extra-paths ["test" "dev-resources"]
                   :extra-deps {eftest/eftest {:mvn/version "0.6.0"}}
                   :main-opts ["-m" "instant.test-core"]
-                  :jvm-opts ["-enableassertions"
+                  :jvm-opts ["-XX:+UseZGC"
+                             "-enableassertions"
                              "-Djdk.tracePinnedThreads=full"
                              ;; print stack traces instead of "Full report at ..."
                              "-Dclojure.main.report=stderr"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     network_mode: "host"
     stop_grace_period: 1m
     restart: on-failure
-    command: sh -c 'java $${JAVA_OPTS} -agentpath:/usr/local/YourKit-JavaProfiler-2024.9/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED -server -jar target/instant-standalone.jar'
+    command: sh -c 'java $${JAVA_OPTS} -XX:+UseZGC -agentpath:/usr/local/YourKit-JavaProfiler-2024.9/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED -server -jar target/instant-standalone.jar'


### PR DESCRIPTION
We're currently using g1c and see 30-50ms pauses every ~45 seconds.

<img width="998" alt="image" src="https://github.com/user-attachments/assets/e899d7ce-9d37-4b86-9b85-d71c46dadfe0" />

This switches us to zgc, which should reduce the number of stop-the-world pauses.

We'll be able to look at the `gc` events to see how many pauses we get.