### PR TITLE
Attach latency_ms to e2e events

### DIFF
--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -207,9 +207,12 @@
 
            results-with-on-deletes (enforce-on-deletes conn attrs app-id results)
            tx (transaction-model/create! conn {:app-id app-id})]
-       (e2e-tracer/start-invalidator-tracking! {:tx-id (:id tx)})
-       (e2e-tracer/invalidator-tracking-step! {:tx-id (:id tx)
-                                               :name "transact"})
+       (let [tx-created-at (.toInstant (:created_at tx))]
+         (e2e-tracer/start-invalidator-tracking! {:tx-id (:id tx)
+                                                  :tx-created-at tx-created-at})
+         (e2e-tracer/invalidator-tracking-step! {:tx-id (:id tx)
+                                                 :tx-created-at tx-created-at
+                                                 :name "transact"}))
        (assoc tx :results results-with-on-deletes)))))
 
 (defn transact!

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -218,6 +218,7 @@
           (when-let [tx-id (-> obj meta :tx-id)]
             (e2e-tracer/invalidator-tracking-step!
              {:tx-id tx-id
+              :tx-created-at (-> obj meta :tx-created-at)
               :name "send-json-delivered"
               :attributes {:session-id (-> obj meta :session-id)}}))
           (when (instance? Throwable ret)

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -216,10 +216,13 @@
             (.unlock send-lock)))
         (let [ret @p]
           (when-let [tx-id (-> obj meta :tx-id)]
-            (e2e-tracer/invalidator-tracking-step!
-             {:tx-id tx-id
-              :tx-created-at (-> obj meta :tx-created-at)
-              :name "send-json-delivered"
-              :attributes {:session-id (-> obj meta :session-id)}}))
+            (let [tx-created-at (-> obj meta :tx-created-at)]
+              (when-let [latency-ms (e2e-tracer/tx-latency-ms tx-created-at)]
+                (tracer/add-data! {:attributes {:tx-latency-ms latency-ms}}))
+              (e2e-tracer/invalidator-tracking-step!
+               {:tx-id tx-id
+                :tx-created-at tx-created-at
+                :name "send-json-delivered"
+                :attributes {:session-id (-> obj meta :session-id)}})))
           (when (instance? Throwable ret)
             (throw ret)))))))

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -349,7 +349,8 @@
 
       (try
         (let [sockets (invalidate! process-id store-conn wal-record)]
-          (tracer/add-data! {:attributes {:num-sockets (count sockets)}})
+          (tracer/add-data! {:attributes {:num-sockets (count sockets)
+                                          :tx-latency-ms (e2e-tracer/tx-latency-ms tx-created-at)}})
           (e2e-tracer/invalidator-tracking-step! {:tx-id tx-id
                                                   :tx-created-at tx-created-at
                                                   :name "send-refreshes"

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -202,7 +202,8 @@
         tracer-attrs {:num-recomputations num-recomputations
                       :num-spam num-spam
                       :num-computations num-computations
-                      :dropped-spam? drop-spam?}]
+                      :dropped-spam? drop-spam?
+                      :tx-latency-ms (e2e-tracer/tx-latency-ms (:tx-created-at event))}]
     (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id event)
                                             :tx-created-at (:tx-created-at event)
                                             :name "finish-refresh-queries"

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -170,6 +170,7 @@
 
 (defn- handle-refresh! [store-conn sess-id event debug-info]
   (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id event)
+                                          :tx-created-at (:tx-created-at event)
                                           :name "start-refresh"
                                           :attributes {:session-id sess-id}})
   (let [auth (get-auth! store-conn sess-id)
@@ -203,6 +204,7 @@
                       :num-computations num-computations
                       :dropped-spam? drop-spam?}]
     (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id event)
+                                            :tx-created-at (:tx-created-at event)
                                             :name "finish-refresh-queries"
                                             :attributes (assoc tracer-attrs
                                                                :session-id sess-id)})
@@ -215,6 +217,7 @@
                                                      :attrs attrs
                                                      :computations computations}
                                                     {:tx-id (:tx-id event)
+                                                     :tx-created-at (:tx-created-at event)
                                                      :session-id sess-id}))))))
 
 ;; -----
@@ -591,6 +594,7 @@
 (defmethod consolidate :refresh [_ batch]
   (doseq [{:keys [item]} (drop-last batch)]
     (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id item)
+                                            :tx-created-at (:tx-created-at item)
                                             :name "skipped-refresh"}))
   [(-> (last batch)
        (assoc :skipped-size (dec (count batch))))])

--- a/server/src/instant/util/e2e_tracer.clj
+++ b/server/src/instant/util/e2e_tracer.clj
@@ -60,6 +60,10 @@
                                                       :entropy tx-id})]
       (tracer/end-span! span))))
 
+(defn tx-latency-ms [^Instant tx-created-at]
+  (when tx-created-at
+    (.toMillis (Duration/between tx-created-at (Instant/now)))))
+
 (defn invalidator-tracking-step! [{:keys [^Long tx-id tx-created-at] :as span-opts}]
   ;; Create a new span with a stable trace-id and span-id for the parent
   (when (flags/e2e-should-honeycomb-publish? tx-id)
@@ -73,6 +77,5 @@
                                          ;; encourage honeycomb not
                                          ;; to skip this span
                                          :entropy tx-id}
-                                        (when tx-created-at
-                                          {:latency-ms (.toMillis (Duration/between tx-created-at
-                                                                                    (Instant/now)))})))))))))
+                                        (when-let [latency-ms (tx-latency-ms tx-created-at)]
+                                          {:tx-latency-ms latency-ms})))))))))

--- a/server/src/instant/util/e2e_tracer.clj
+++ b/server/src/instant/util/e2e_tracer.clj
@@ -6,6 +6,7 @@
    (io.opentelemetry.sdk.trace SdkSpan)
    (java.lang.reflect Field)
    (java.nio ByteBuffer)
+   (java.time Duration Instant)
    (org.apache.commons.codec.binary Hex)))
 
 ;; Starts the trace-id with a1 so that it's easy to spot
@@ -59,7 +60,7 @@
                                                       :entropy tx-id})]
       (tracer/end-span! span))))
 
-(defn invalidator-tracking-step! [{:keys [^Long tx-id] :as span-opts}]
+(defn invalidator-tracking-step! [{:keys [^Long tx-id tx-created-at] :as span-opts}]
   ;; Create a new span with a stable trace-id and span-id for the parent
   (when (flags/e2e-should-honeycomb-publish? tx-id)
     (binding [tracer/*span* (make-invalidator-tracking-span tx-id nil)]
@@ -71,4 +72,7 @@
                                         {:tx-id tx-id
                                          ;; encourage honeycomb not
                                          ;; to skip this span
-                                         :entropy tx-id}))))))))
+                                         :entropy tx-id}
+                                        (when tx-created-at
+                                          {:latency-ms (.toMillis (Duration/between tx-created-at
+                                                                                    (Instant/now)))})))))))))


### PR DESCRIPTION
Tracks the latency between when we created the transaction and when we execute a step in the invalidation pipeline.

This will let us create a metric we can use to track the experience of "click on checkbox in one window and watch it update in another window" and create alerts if it's too slow. 

It's not perfect, because we don't know when the trace is fully finished, but tracking it on send-refresh or json-delivered is pretty close.

I attempted to do this with Honeycomb's derived columns, but there doesn't appear to be any way to calculate the difference between a span's timestamp and the root timestamp.