### PR TITLE
[Storage] Paginate storage tab

### DIFF
--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -47,10 +47,9 @@
   ([bucket-name prefix]
    (loop [all-objects []
           continuation-token nil]
-     (let [with-pagination (fn [opts] (if continuation-token
-                                        (assoc opts :continuation-token continuation-token)
-                                        opts))
-           opts (with-pagination {:bucket-name bucket-name :prefix prefix})
+     (let [opts (cond-> {:bucket-name bucket-name :prefix prefix}
+                  continuation-token
+                  (assoc :continuation-token continuation-token))
            {:keys [object-summaries next-continuation-token truncated?]}
            (list-objects-v2 opts)]
        (if truncated?

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -52,7 +52,7 @@
                   (assoc :continuation-token continuation-token))
            {:keys [object-summaries next-continuation-token truncated?]}
            (list-objects-v2 opts)]
-       (if truncated?
+       (if (and truncated? (< (count all-objects) 50000))
          (recur (into all-objects object-summaries) next-continuation-token)
          (into all-objects object-summaries))))))
 

--- a/server/src/instant/util/storage.clj
+++ b/server/src/instant/util/storage.clj
@@ -11,7 +11,6 @@
   (:import
    (java.util UUID)))
 
-
 ;; scopes filename to app-id directory
 (defn ->object-key [app-id filename]
   (str app-id "/" filename))
@@ -32,7 +31,6 @@
   (def program (rule-model/get-program! rules "$files" "create"))
   (cel/eval-program! program {"auth" (cel/->cel-map {} {"id" "alex"})
                               "data" (cel/->cel-map {} {"path" "demo/image.png"})}))
-
 
 (defn assert-storage-permission! [action {:keys [app-id
                                                  filepath
@@ -58,7 +56,6 @@
                            "data" (cel/->cel-map {:type :data
                                                   :ctx ctx}
                                                  {"path" filepath})})))))
-
 
 (defn upload-image-to-s3 [app-id filename image-url]
   (let [object-key (->object-key app-id filename)]
@@ -111,8 +108,7 @@
         prefix (if (string/blank? subdirectory)
                  app-id
                  (str app-id "/" subdirectory))
-        objects-resp (s3-util/list-app-objects prefix)
-        objects (:object-summaries objects-resp)]
+        objects (s3-util/list-app-objects prefix)]
     (map format-object objects)))
 
 ;; Deletes a single file by name/path (e.g. "demo.png", "profiles/me.jpg")
@@ -132,7 +128,6 @@
   (let [keys (mapv (fn [filename] (->object-key app-id filename)) filenames)]
     (storage-beta/assert-storage-enabled! app-id)
     (s3-util/delete-objects keys)))
-
 
 (comment
   (def app-id #uuid "524bc106-1f0d-44a0-b222-923505264c47")


### PR DESCRIPTION
Right now the storage tab only fetches the first 1k files from s3 for an app. This caused some confusion when files weren't showing up [[Discord]](https://discord.com/channels/1031957483243188235/1329216151288414352)

This PR adds pagination logic for instances when there are >1k files in a path.