### PR TITLE
Remove type-where in paginated queries

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1158,15 +1158,11 @@
                              (reverse-direction direction)
                              direction)
 
-        type-where (when (not= order-col-type :created-at-timestamp)
-                     [[:= :checked_data_type [:cast [:inline (name order-col-type)] :checked_data_type]]])
-
         query (-> query
                   ;; Move `where` to join conds so that we get the null fields
                   (dissoc :where :from)
                   (assoc :from [prev-table])
-                  (assoc :left-join [:triples (concat (:where query)
-                                                      type-where)])
+                  (assoc :left-join [:triples (:where query)])
 
                   ;; Make sure we're getting each entity once
                   (dissoc :select)


### PR DESCRIPTION
This was causing postgres to use a nested loop with a join filter that caused it to filter many more rows than it needed to. I think the ave index allows it to be faster because the entity_id is in the index.

I was hoping the typed indexes would help with the sorting, but we may have to restructure the queries to get that benefit.

Did a back test (searching for queries that included "order") and didn't see any queries that got much worse, but many queries got much better.

<details>
<summary>Explains</summary>
With the type check:

```
CTE Scan on match_0_1  (cost=17.34..17.36 rows=1 width=200) (actual time=2587.296..2587.366 rows=100 loops=1)
  CTE match_0_0
    ->  Index Scan using vae_index on triples  (cost=0.56..8.59 rows=1 width=117) (actual time=0.045..4.422 rows=1221 loops=1)
          Index Cond: ((app_id = 'app-id'::uuid) AND (value = '"value"'::jsonb) AND (attr_id = 'attr-id'::uuid))
  CTE match_0_1
    ->  Limit  (cost=8.74..8.75 rows=1 width=229) (actual time=2587.295..2587.343 rows=100 loops=1)
          ->  Unique  (cost=8.74..8.75 rows=1 width=229) (actual time=2587.294..2587.333 rows=100 loops=1)
                ->  Sort  (cost=8.74..8.74 rows=1 width=229) (actual time=2587.293..2587.310 rows=100 loops=1)
                      Sort Key: (triples_extract_date_value(triples_1.value)) DESC NULLS LAST, (COALESCE(match_0_0.match_0_0_entity_id)) DESC
                      Sort Method: quicksort  Memory: 316kB
                      ->  Nested Loop Left Join  (cost=0.42..8.73 rows=1 width=229) (actual time=1.457..2586.216 rows=1221 loops=1)
                            Join Filter: (triples_1.entity_id = match_0_0.match_0_0_entity_id)
                            Rows Removed by Join Filter: 3925515
                            ->  CTE Scan on match_0_0  (cost=0.00..0.02 rows=1 width=88) (actual time=0.046..5.627 rows=1221 loops=1)
                            ->  Index Scan using triples_date_type_idx on triples triples_1  (cost=0.42..8.44 rows=1 width=102) (actual time=0.007..1.802 rows=3216 loops=1221)
                                  Index Cond: ((app_id = 'app-id'::uuid) AND (attr_id = 'attr-id'::uuid))
Planning Time: 0.352 ms
Execution Time: 2587.570 ms
```

Without the type check
```
CTE Scan on match_0_1  (cost=17.48..17.50 rows=1 width=200) (actual time=14.082..14.153 rows=100 loops=1)
  CTE match_0_0
    ->  Index Scan using vae_index on triples  (cost=0.56..8.59 rows=1 width=117) (actual time=0.046..3.113 rows=1221 loops=1)
          Index Cond: ((app_id = 'app-id'::uuid) AND (value = '"value"'::jsonb) AND (attr_id = 'attr-id'::uuid))
  CTE match_0_1
    ->  Limit  (cost=8.88..8.90 rows=1 width=229) (actual time=14.081..14.127 rows=100 loops=1)
          ->  Unique  (cost=8.88..8.90 rows=1 width=229) (actual time=14.080..14.117 rows=100 loops=1)
                ->  Sort  (cost=8.88..8.89 rows=1 width=229) (actual time=14.080..14.093 rows=100 loops=1)
                      Sort Key: (triples_extract_date_value(triples_1.value)) DESC NULLS LAST, (COALESCE(match_0_0.match_0_0_entity_id)) DESC
                      Sort Method: quicksort  Memory: 316kB
                      ->  Nested Loop Left Join  (cost=0.56..8.88 rows=1 width=229) (actual time=0.099..13.578 rows=1221 loops=1)
                            ->  CTE Scan on match_0_0  (cost=0.00..0.02 rows=1 width=88) (actual time=0.047..3.618 rows=1221 loops=1)
                            ->  Index Scan using triples_pkey on triples triples_1  (cost=0.56..8.59 rows=1 width=102) (actual time=0.005..0.005 rows=1 loops=1221)
                                  Index Cond: ((app_id = 'app-id'::uuid) AND (entity_id = match_0_0.match_0_0_entity_id) AND (attr_id = 'attr-id'::uuid))
                                  Filter: ave
Planning Time: 0.371 ms
Execution Time: 14.252 ms
```
</details>


<details>

<summary>Improvement numbers</summary>

(the nils are invalid queries):

```
(nil
 nil
 nil
 nil
 nil
 nil
 nil
 -107.09424899999999
 -81.26295900000002
 -73.91483299999993
 -73.26479200000006
 -69.66150000000005
 -65.02833399999997
 -65.02820799999995
 -60.98241700000001
 -36.373165999999856
 -31.399291000000005
 -30.316624999999988
 -30.218500000000006
 -26.700376000000006
 -21.62104099999999
 -21.563582999999994
 -20.744083000000003
 -19.333541999999966
 -15.878874999999994
 -12.281207999999992
 -11.722250000000003
 -9.146208000000001
 -8.554376000000019
 -8.365583999999998
 -8.306874999999991
 -7.095250000000021
 -6.959082999999964
 -6.935292000000004
 -6.65029100000001
 -6.630083000000013
 -6.46237499999998
 -6.440166000000005
 -6.423249999999996
 -6.15666699999997
 -6.145415999999997
 -6.0138749999999845
 -5.969374999999999
 -5.895541000000009
 -5.802791999999982
 -5.408417
 -4.9872919999999965
 -4.909500000000008
 -4.796917000000008
 -4.751083999999992
 -4.589958999999993
 -4.576875000000001
 -4.557457999999997
 -4.546375000000012
 -4.534290999999996
 -4.524832999999987
 -4.518876000000006
 -4.2762500000000045
 -4.138290999999995
 -3.9410000000000025
 -3.8882079999999917
 -3.7371669999999995
 -3.595124999999996
 -3.534000000000006
 -3.518416000000002
 -3.4398750000000007
 -3.342124999999996
 -3.3182910000000163
 -3.2842509999999834
 -3.175332999999995
 -3.1198759999999766
 -3.0987930000000006
 -2.857959000000008
 -2.8342079999999896
 -2.810959000000011
 -2.7851249999999936
 -2.7754580000000146
 -2.7702910000000003
 -2.7261669999999754
 -2.7228739999999902
 -2.68745899999999
 -2.6007919999999842
 -2.48195800000002
 -2.414541999999983
 -2.3323330000000055
 -2.2887489999999957
 -2.287041000000002
 -2.0435830000000124
 -1.9109589999999912
 -1.8900820000000067
 -1.8021659999999997
 -1.8013329999999996
 -1.781209000000004
 -1.6757920000000013
 -1.643166999999977
 -1.6355839999999944
 -1.5939170000000047
 -1.5531249999999943
 -1.5271670000000057
 -1.5188330000000008
 -1.407123999999996
 -1.40625
 -1.3909579999999835
 -1.347126000000003
 -1.344208999999978
 -1.340916000000007
 -1.332459
 -1.325458000000026
 -1.274583000000007
 -1.230084000000005
 -1.190958999999964
 -1.1705010000000016
 -1.0972920000000101
 -1.087541999999985
 -1.0790420000000012
 -0.9134169999999955
 -0.9036250000000337
 -0.891791000000012
 -0.8055420000000026
 -0.7978750000000048
 -0.7609589999999997
 -0.7479590000000087
 -0.7100829999999974
 -0.6686660000000018
 -0.6470840000000067
 -0.6451239999999814
 -0.643540999999999
 -0.6312909999999192
 -0.6304579999999902
 -0.6061250000000058
 -0.6048329999999851
 -0.5739590000000021
 -0.558084000000008
 -0.5552079999999933
 -0.5537510000000339
 -0.5490410000000026
 -0.5263740000000041
 -0.5174159999999972
 -0.4962499999999892
 -0.49370799999999804
 -0.48537600000000225
 -0.47416699999999423
 -0.46741699999999753
 -0.466542000000004
 -0.4634590000000003
 -0.43849999999997635
 -0.4029999999999916
 -0.3838749999999891
 -0.3719169999999963
 -0.370459000000011
 -0.35420899999999733
 -0.3441669999999988
 -0.3402499999999975
 -0.31620900000000063
 -0.3137919999999923
 -0.30758300000002237
 -0.3052080000000075
 -0.29299999999999216
 -0.29095799999998917
 -0.284000000000006
 -0.25654200000001026
 -0.23979099999999676
 -0.23866599999999494
 -0.23700099999999225
 -0.23187500000000227
 -0.21858199999999783
 -0.21058399999999722
 -0.20600000000000307
 -0.20545799999999304
 -0.18962599999998986
 -0.1835009999999926
 -0.1810000000000116
 -0.17883300000001157
 -0.1781660000000045
 -0.1713759999999951
 -0.15337399999999946
 -0.14562500000000966
 -0.12670800000000781
 -0.11820899999999313
 -0.11149999999999238
 -0.0952920000000006
 -0.09062500000000284
 -0.04845799999999656
 -0.01870800000000372
 -1.6600000000721593E-4
 0.015500000000002956
 0.03720800000000679
 0.05133299999999963
 0.0848749999999967
 0.11437599999999293
 0.11704299999999535
 0.13899899999999832
 0.1465830000000068
 0.14958400000000438
 0.15620899999998983
 0.15979199999999594
 0.1615419999999972
 0.16350099999999657
 0.18429100000000176
 0.19454100000000096
 0.20462499999999295
 0.20949999999999136
 0.2653760000000034
 0.2685419999999965
 0.269874999999999
 0.31116699999999753
 0.3319580000000002
 0.33279299999999523
 0.3485419999999948
 0.3753330000000119
 0.4034989999999823
 0.41166699999999423
 0.41508299999998144
 0.41654200000000685
 0.4433340000000072
 0.4446669999999955
 0.45700000000000784
 0.4572909999999979
 0.48220799999999997
 0.484209000000007
 0.5349590000000006
 0.6461670000000055
 0.6688749999999999
 0.669708
 0.6777079999999955
 0.6777500000000032
 0.6805000000000092
 0.6838329999999928
 0.7126670000000104
 0.7166239999999959
 0.7187080000000066
 0.7249170000000049
 0.731749999999991
 0.7533340000000237
 0.7727909999999838
 0.7747079999999755
 0.8119170000000082
 0.813834
 0.840834000000001
 0.8730010000000021
 0.886415999999997
 0.906833000000006
 0.9109579999999937
 0.9598749999999967
 0.979582999999991
 1.002291999999997
 1.017417000000009
 1.0190829999999949
 1.0530009999999947
 1.0653739999999914
 1.0757090000000176
 1.1024579999999986
 1.1998330000000124
 1.2289580000000058
 1.267957999999993
 1.2858760000000018
 1.2913750000000022
 1.3093339999999927
 1.3935829999999925
 1.4001249999999885
 1.4036250000000052
 1.4174579999999963
 1.4423749999999984
 1.4540839999999946
 1.4926250000000039
 1.5038339999999835
 1.5091670000000192
 1.543582999999984
 1.579999999999984
 1.610416999999984
 1.615000000000009
 1.621959000000004
 1.6261250000000018
 1.6623749999999973
 1.6722489999999937
 1.7829580000000078
 1.9341670000000022
 1.998583999999994
 2.044249999999991
 2.1067919999999845
 2.206374999999994
 2.20979100000001
 2.227499999999992
 2.278165999999999
 2.295458999999994
 2.4641249999999957
 2.4662909999999556
 2.544040999999993
 2.6752089999999953
 2.7172079999999994
 2.976957999999996
 2.986624999999975
 3.021000000000001
 3.1138329999999996
 3.1335009999999954
 3.1340409999999963
 3.1893329999999764
 3.2109990000000153
 3.2155010000000175
 3.2510000000000048
 3.290083999999979
 3.46879100000001
 3.4690829999999835
 3.4782920000000104
 3.493167000000085
 3.5419580000000224
 3.6316659999999956
 3.729208
 3.7389579999999967
 3.879167999999993
 3.932040999999998
 4.1100840000000005
 4.140791000000007
 4.147625000000005
 4.235584000000017
 4.271124999999984
 4.3141259999999875
 4.314249000000018
 4.396082999999976
 4.427458999999999
 4.557541000000015
 4.587625000000003
 4.590249999999969
 4.642250000000018
 4.6779169999999795
 4.688000000000002
 4.786875000000009
 4.801208000000003
 4.989750000000001
 5.1036670000000015
 5.227334000000013
 5.230249000000072
 5.532666000000006
 5.5685840000000155
 5.978207999999995
 6.138333000000003
 6.157124999999951
 6.398750000000007
 6.596583999999993
 6.800748999999996
 7.266999999999996
 8.100291999999968
 8.40662500000002
 8.768500000000017
 9.019791999999995
 12.228125000000006
 13.876916999999992
 14.536459000000036
 14.776916999999997
 16.299166999999983
 16.358375000000024
 24.123459000000025
 33.06345800000001
 56.01804200000004
 64.23120800000004
 72.68145800000002
 73.60204199999998
 76.29637500000001
 97.39412400000003
 121.280125
 142.227083
 499.23079099999995
 570.654375
 573.4751660000002
 1306.032292
 2413.397376
 2967.057542
 4590.415166
 4594.470499
 4609.036833
 4665.208875
 4684.515041000001
 4699.215416
 4702.789624999999
 4712.3769999999995
 4759.6431250000005
 4761.439084
 4826.1558749999995
 4939.1599160000005
 5043.189125
 6713.717000000001
 7258.377501000001
 7909.399708)

</details>
