### PR TITLE
[sm] fix react warning on fences

### DIFF
--- a/client/www/components/docs/Fence.jsx
+++ b/client/www/components/docs/Fence.jsx
@@ -34,9 +34,10 @@ export function Fence({ children, language, showCopy }) {
               <Fragment key={lineIndex}>
                 {line
                   .filter((token) => !token.empty)
-                  .map((token, tokenIndex) => (
-                    <span key={tokenIndex} {...getTokenProps({ token })} />
-                  ))}
+                  .map((token, tokenIndex) => {
+                    const { key, ...props } = getTokenProps({ token });
+                    return <span key={key || tokenIndex} {...props} />;
+                  })}
                 {'\n'}
               </Fragment>
             ))}

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -242,7 +242,7 @@ export function TextArea({
   disabled,
   title,
   cols,
-  rows
+  rows,
 }: {
   value: string;
   className?: string;
@@ -723,7 +723,15 @@ export function Copyable({
         'text-base': size === 'large',
       })}
     >
-      <div className="border-r bg-gray-50 px-3 py-1.5" style={{borderTopLeftRadius: "calc(0.25rem - 1px)", borderBottomLeftRadius: "calc(0.25rem - 1px)"}}>{label}</div>
+      <div
+        className="border-r bg-gray-50 px-3 py-1.5"
+        style={{
+          borderTopLeftRadius: 'calc(0.25rem - 1px)',
+          borderBottomLeftRadius: 'calc(0.25rem - 1px)',
+        }}
+      >
+        {label}
+      </div>
       <pre
         className="flex-1 truncate px-4 py-1.5"
         title={value}
@@ -960,9 +968,10 @@ export function Fence({
               <Fragment key={lineIndex}>
                 {line
                   .filter((token) => !token.empty)
-                  .map((token, tokenIndex) => (
-                    <span key={tokenIndex} {...getTokenProps({ token })} />
-                  ))}
+                  .map((token, tokenIndex) => {
+                    const { key, ...props } = getTokenProps({ token });
+                    return <span key={key || tokenIndex} {...props} />;
+                  })}
                 {'\n'}
               </Fragment>
             ))}


### PR DESCRIPTION
Noticed this error from react: 

<img width="663" alt="CleanShot 2025-01-15 at 16 55 48@2x" src="https://github.com/user-attachments/assets/4d9fddd5-185d-4a53-a79e-51ab1a8d7ea4" />

Made a quick update so we don't spread the key. 

@dwwoelfel @nezaj @tonsky 

