### PR TITLE
More logging

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -186,9 +186,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    #if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
-    needs: [ detect_clj ]
+    #needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     # Publish to elastic beanstalk only if we pass the tests
     needs:
-      - clj-check
+      #- clj-check
       - publish-image
     permissions:
       id-token: write

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -186,9 +186,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    #if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
-    #needs: [ detect_clj ]
+    needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     # Publish to elastic beanstalk only if we pass the tests
     needs:
-      #- clj-check
+      - clj-check
       - publish-image
     permissions:
       id-token: write

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -3,6 +3,7 @@
             [clojure.tools.logging :as log]
             [instant.config-edn :as config-edn]
             [instant.util.crypt :as crypt-util]
+            [instant.util.aws :as aws-util]
             [lambdaisland.uri :as uri])
   (:import
    (java.net InetAddress)
@@ -26,11 +27,21 @@
     (= "true" (System/getenv "TEST"))       :test
     :else                                   :dev))
 
+(defonce instance-id
+  (delay
+    (when (= :prod (get-env))
+      (aws-util/get-instance-id))))
+
 (defonce process-id
   (delay
-    (str (name (get-env))
-         "_"
-         (string/replace (UUID/randomUUID) #"-" "_"))))
+    (string/replace
+     (string/join "_"
+                  [(name (get-env))
+                   (if (= :prod (get-env))
+                     @instance-id
+                     (crypt-util/random-hex 8))
+                   (crypt-util/random-hex 8)])
+     #"-" "_")))
 
 (def config-map
   (delay (do

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -6,8 +6,7 @@
             [instant.util.aws :as aws-util]
             [lambdaisland.uri :as uri])
   (:import
-   (java.net InetAddress)
-   (java.util UUID)))
+   (java.net InetAddress)))
 
 (defonce hostname
   (delay

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -162,7 +162,7 @@
 (defmacro log-init [operation & body]
   `(do
      (tracer/record-info! {:name (format "init.start.%s" (name ~operation))})
-     (tracer/with-span! {:name (format "init.%s" (name ~operation))}
+     (tracer/with-span! {:name (format "init.finish.%s" (name ~operation))}
        ~@body)))
 
 (defn -main [& _args]

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -215,7 +215,7 @@
 (defn annotate-query-with-debug-info [query]
   (if-let [{:keys [span-id trace-id]} (tracer/current-span-ids)]
     (update query 0 (fn [s]
-                      (format "-- trace-id=%s\n-- span-id=%s\n%s" trace-id span-id s)))
+                      (format "-- trace-id=%s, span-id=%s\n%s" trace-id span-id s)))
     query))
 
 (defmacro defsql [name query-fn rw opts]
@@ -240,7 +240,7 @@
 
                     query# (annotate-query-with-debug-info ~'query)]
                 (try
-                  (with-open [ps# (next-jdbc/prepare c# ~'query opts#)
+                  (with-open [ps# (next-jdbc/prepare c# query# opts#)
                               _cleanup# (register-in-progress create-connection?# ~rw c# ps#)]
                     (~query-fn ps# nil opts#))
                   (finally

--- a/server/src/instant/util/aws.clj
+++ b/server/src/instant/util/aws.clj
@@ -4,20 +4,23 @@
 
 (def environment-tag-name "elasticbeanstalk:environment-name")
 
+(defn get-instance-id []
+  (let [token (-> (clj-http/put
+
+                   "http://169.254.169.254/latest/api/token"
+                   {:headers {"X-aws-ec2-metadata-token-ttl-seconds" "21600"}})
+                  :body)]
+    (-> (clj-http.client/get
+         "http://169.254.169.254/latest/meta-data/instance-id"
+         {:headers {"X-aws-ec2-metadata-token" token}})
+        :body)))
+
 (defn get-tag
   "Gets instance id from the metadata API
    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
    Then fetches the instance info from the aws api to get the tags."
   [tag-name]
-  (let [token (-> (clj-http/put
-
-                   "http://169.254.169.254/latest/api/token"
-                   {:headers {"X-aws-ec2-metadata-token-ttl-seconds" "21600"}})
-                  :body)
-        instance-id (-> (clj-http.client/get
-                         "http://169.254.169.254/latest/meta-data/instance-id"
-                         {:headers {"X-aws-ec2-metadata-token" token}})
-                        :body)]
+  (let [instance-id (get-instance-id)]
     (->> (ec2/describe-instances {:instance-ids [instance-id]})
          :reservations
          first

--- a/server/src/instant/util/crypt.clj
+++ b/server/src/instant/util/crypt.clj
@@ -15,6 +15,7 @@
                                   HybridDecryptWrapper$WrappedHybridDecrypt
                                   HybridEncryptWrapper$WrappedHybridEncrypt)
    (com.google.crypto.tink.integration.awskms AwsKmsClient)
+   (com.google.crypto.tink.subtle Random)
    (org.apache.commons.codec.binary Hex)))
 
 (defn uuid->sha256
@@ -57,6 +58,12 @@
 
 (defn hex-string->bytes [^String s]
   (Hex/decodeHex s))
+
+(defn random-bytes [^Long size]
+  (Random/randBytes size))
+
+(defn random-hex [^Long size]
+  (bytes->hex-string (Random/randBytes size)))
 
 (defonce default-aead (atom nil))
 

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -85,7 +85,8 @@
   (let [thread (Thread/currentThread)
         {:keys [code-ns code-line code-file]} source
         default-attributes (cond-> {"host.name" @config/hostname
-                                    "process-id" @config/process-id}
+                                    "process-id" @config/process-id
+                                    "instance-id" @config/instance-id}
                              thread (assoc "thread.name"
                                            (.getName thread)
                                            "thread.id"
@@ -224,3 +225,12 @@
       dataset-name
       trace-id
       span-id))))
+
+(defn current-span-ids []
+  (when-let [^Span span *span*]
+    {:span-id (-> span
+                  (.getSpanContext)
+                  (.getSpanId))
+     :trace-id (-> span
+                   (.getSpanContext)
+                   (.getTraceId))}))


### PR DESCRIPTION
A few changes to make it easier to track down problems in the database:

1. The instance_id is logged on every span
2. The process_id in prod includes the instance_id. This makes it easy to get back to the instance from the replication slot name and the application name
3. Adds a log before and after each startup step in instant.core. When we have issues during startup, this makes it a lot easier to track down which step is causing the issue.
4. Annotate every sql query with its span_id and trace_id by prepending it with a comment. It looks like this:
<img width="1682" alt="image" src="https://github.com/user-attachments/assets/ac87bc41-8884-45b9-8b23-6c21b8e35d4b" />
