### PR TITLE
Add memoization in db.rooms hooks

### DIFF
--- a/client/packages/react/src/InstantReactRoom.ts
+++ b/client/packages/react/src/InstantReactRoom.ts
@@ -288,15 +288,15 @@ export function useTypingIndicator<
     setActive(false);
   }, [setActive]);
 
-  const ret = useMemo(() => {
-    return {
-      active,
-      setActive,
-      inputProps: { onKeyDown, onBlur },
-    };
-  }, [active, setActive, onKeyDown, onBlur]);
+  const inputProps = useMemo(() => {
+    return { onKeyDown, onBlur };
+  }, [onKeyDown, onBlur]);
   
-  return ret;
+  return {
+    active,
+    setActive,
+    inputProps,
+  };
 }
 
 // --------------


### PR DESCRIPTION
We had a few instances where we would return functions that didn't have stable values. This would cause consumers to re-render unnecesarily. I looked over the our hooks and added `useCallback` and `useMemo` in places that could keep stable values.

@dwwoelfel @nezaj @tonsky 