### PR TITLE
Log the span id in prod

### DIFF
--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -59,6 +59,7 @@
      "detailed_patterns"
      "detailed_tx_steps"
      "process_id"
+     "instance_id"
      "query") true
     false))
 
@@ -104,8 +105,9 @@
   (if (= :prod (config/get-env))
     (fn [^SpanData span]
       (let [attr-str (attr-str span)]
-        (format "[%s] %sms [%s] %s"
+        (format "[%s/%s] %sms [%s] %s"
                 (.getTraceId span)
+                (.getSpanId span)
                 (duration-ms span)
                 (.getName span)
                 (escape-newlines attr-str))))


### PR DESCRIPTION
This will make it easier to track down the log from the span attrs we add to the query (added in #725)