### PR TITLE
Faster hazelcast startup in tests

### DIFF
--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -53,7 +53,8 @@
 
         eph-hz          (delay
                           @(future ;; avoid pinning vthread
-                             (eph/init-hz store-conn
+                             (eph/init-hz :test
+                                          store-conn
                                           (let [id (+ 100000 (rand-int 900000))]
                                             {:instance-name (str "test-instance-" id)
                                              :cluster-name  (str "test-cluster-" id)}))))
@@ -79,8 +80,6 @@
                     eph/hz                  eph-hz
                     ws/send-json!           (fn [_app-id msg fake-ws-conn]
                                               (a/>!! fake-ws-conn msg))
-                    session/handle-receive-timeout-ms 10000
-
                     rq/instaql-query-reactive!
                     (fn [store-conn {:keys [session-id] :as base-ctx} instaql-query return-type]
                       (let [res (query-reactive store-conn base-ctx instaql-query return-type)]


### PR DESCRIPTION
I had a flaky test run because hazelcast was slow to start. I found this stackoverflow post explaining how to start Hazelcast in standalone mode: https://stackoverflow.com/a/65594539/361969

Now Hazelcast starts in ~50ms for tests instead of ~3 seconds.