### PR TITLE
Use threads for cpu-heavy invalidator workers

### DIFF
--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -192,8 +192,7 @@
                                                     process-fn
                                                     worker-count]
                                              :or {worker-count 2}}]
-  (let [executor (ua/make-virtual-thread-executor)
-        semaphore (Semaphore. 0)
+  (let [semaphore (Semaphore. 0)
         grouped-queue (create {:group-fn group-fn
                                :on-add (fn []
                                          (.release semaphore))})


### PR DESCRIPTION
I noticed a lot of time is spent waiting in `handle-receive` for simple things like `:refresh-presence` or `:server-broadcast` and I have a hunch that it's because the invalidator is doing a lot of cpu-heavy work in the virtual threads. Then the virtual thread we create to call `handle-receive` gets blocked waiting for the cpu-heavy task to finish.

This PR makes the invalidator queue use a fixed set of workers, each inside a future. It seemed as fast as the virtual thread version in my testing, as long as the number of threads wasn't too high.