### PR TITLE
Enable clj-async-profiler in production

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -250,7 +250,7 @@ jobs:
       uses: "./.github/actions/elastic-beanstalk"
       with:
         working-directory: "server"
-        files: '["docker-compose.yml", ".ebextensions/resources.config"]'
+        files: '["docker-compose.yml", ".ebextensions/resources.config", ".ebextensions/sysctl.config"]'
         aws-region: "us-east-1"
         bucket: "elasticbeanstalk-us-east-1-597134865416"
         application-name: "instant-docker-prod"

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -186,9 +186,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    #if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
-    needs: [ detect_clj ]
+    #needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     # Publish to elastic beanstalk only if we pass the tests
     needs:
-      - clj-check
+      #- clj-check
       - publish-image
     permissions:
       id-token: write

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -186,9 +186,9 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
-    #if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
+    if: needs.detect_clj.outputs.did_change == 'True' && github.ref == 'refs/heads/main'
     # Start publish image if we have clj changes
-    #needs: [ detect_clj ]
+    needs: [ detect_clj ]
     permissions:
       id-token: write
       contents: read
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     # Publish to elastic beanstalk only if we pass the tests
     needs:
-      #- clj-check
+      - clj-check
       - publish-image
     permissions:
       id-token: write

--- a/server/.ebextensions/sysctl.config
+++ b/server/.ebextensions/sysctl.config
@@ -1,0 +1,14 @@
+files:
+  "/etc/sysctl.d/99-instant.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      kernel.perf_event_paranoid = 1
+      kernel.kptr_restrict = 0
+
+commands:
+  01_reload_sysctl:
+    command: |
+      sysctl -w kernel.perf_event_paranoid=1
+      sysctl -w kernel.kptr_restrict=0

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -81,8 +81,12 @@
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.5.1"}}
                  :jvm-opts ["-XX:+UseZGC"
                             "-enableassertions"
-                            ;; Allow clj-async-profiler to attach
-                            "-Djdk.attach.allowAttachSelf"
+
+                            ;; clj-async-profiler
+                            "-Djdk.attach.allowAttachSelf" ;; allow to attach
+                            "-XX:+UnlockDiagnosticVMOptions" ;; better profile accuracy
+                            "-XX:+DebugNonSafepoints" ;; better profile accuracy
+
                             ;; print stack traces instead of "Full report at ..."
                             "-Dclojure.main.report=stderr"
                             "-Dclojure.server.repl={:port 6006 :accept clojure.core.server/repl}"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -11,4 +11,6 @@ services:
     network_mode: "host"
     stop_grace_period: 1m
     restart: on-failure
-    command: sh -c 'java $${JAVA_OPTS} -agentpath:/usr/local/YourKit-JavaProfiler-2024.9/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED -server -jar target/instant-standalone.jar'
+    cap_add:
+      - CAP_PERFMON
+    command: sh -c 'java $${JAVA_OPTS} -agentpath:/usr/local/YourKit-JavaProfiler-2024.9/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -Djdk.attach.allowAttachSelf -server -jar target/instant-standalone.jar'

--- a/server/scripts/aws_tunnel.sh
+++ b/server/scripts/aws_tunnel.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# set -x
+# set -e
+
+remote_port=8193
+local_port=8193  # Default port
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --instance-id) instance_id="$2"; shift ;;
+    --local-port) local_port="$2"; shift ;;
+    --remote-port) remote_port="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+if [ -z "$instance_id" ]; then
+  instance_id=$(
+    aws ec2 describe-instances \
+      --filter "Name=tag:elasticbeanstalk:environment-name,Values=Instant-docker-prod-env-2" \
+      --query "Reservations[].Instances[?State.Name == 'running'].InstanceId[]" \
+      --output text
+  )
+fi
+
+echo "Setting up tunnel to $instance_id on port $local_port to remote port $remote_port"
+
+aws ssm start-session \
+    --document-name "AWS-StartPortForwardingSession" \
+    --target "$instance_id" \
+    --parameters "{\"portNumber\":[\"$remote_port\"],\"localPortNumber\":[\"$local_port\"]}" \
+    --region "us-east-1"
+
+echo "Tunnel closed"

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -11,7 +11,8 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [honey.sql :as hsql]
-   [portal.api :as p])
+   [portal.api :as p]
+   [clj-async-profiler.core :as prof])
   (:import
    (clojure.lang Compiler TaggedLiteral)
    (com.github.vertical_blank.sqlformatter SqlFormatter)
@@ -199,3 +200,8 @@
    it is evaluated. Dev only"
   [form]
   `(p-impl (p-pos) '~form ~form))
+
+(defmacro profile [options? & body]
+  `(prof/profile ~options? ~body))
+
+(def prof-serve-ui prof/serve-ui)


### PR DESCRIPTION
Adds what we need to enable clj-async-profiler in production (following the instructions at https://clojure-goes-fast.com/kb/profiling/clj-async-profiler/production/).

Tested in staging and all looks ok.