### PR TITLE
Catch PopState Event (goback) and Redirect to popNavStack

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -487,6 +487,20 @@ export function Explorer({
     }
   }, [namespaces === null]);
 
+  useEffect(() =>{
+    function handlePopState(e: PopStateEvent) {
+        if (selectedNamespace && currentNav && allItems && showBackButton) {
+            e.preventDefault();
+            popNavStack();
+        }
+    }
+    
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [selectedNamespace, currentNav, allItems, showBackButton]);
+
   useClickOutside(nsRef, () => {
     setIsNsOpen(false);
   });


### PR DESCRIPTION
Minor UX enhancement:

Catch PopState Event (goback) and Redirect to popNavStack so that if you are exploring in the explorer and traverse a path of links, you can go back by using the go back browser button or any shortcuts from the keyboard or trackpad/mouse.