### PR TITLE
Faster store operations

### DIFF
--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -769,7 +769,7 @@
                                        [[:ea (-> q :users :$ :where :id)]]
                                        {:topics dummy-coarse-topics})))
 
-      (println "add-datalog-query")
+      (println "add-instaql-query")
       (time
        (doseq [sid session-ids
                q instaql-queries]
@@ -818,7 +818,7 @@
                                        [[:ea (-> q :users :$ :where :id)]]
                                        {:topics dummy-coarse-topics})))
 
-      (println "add-datalog-query")
+      (println "add-instaql-query")
       (time
        (doseq [sid session-ids
                q instaql-queries]

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -209,7 +209,7 @@
 
 (defn remove-subscriptions-tx-data
   "Should be used in a db.fn/call. Returns transactions.
-   Retracts the instaql-query and subscriptions for the session and instaql query."
+   Retracts the instaql-query and subscriptions for the query."
   [db session-id instaql-query]
   (if-let [query-eid (d/entid db [:instaql-query/session-id+query [session-id instaql-query]])]
     (conj (map (fn [datom]


### PR DESCRIPTION
I noticed a lot of time spent doing datalog store operations when looking at the profiler in production.

This improves some of the store operations by replacing `d/find` with `d/datoms` in a few places.

We also store a ref to the `instaql-query` in the `:subscription` entity instead of storing the instaql query itself. That lets us skip an expensive check in `add-instaql-query!` where we have to look up subscription by session-id and query. Now we can just look them up by the instaql-query entity id, since it already has the session-id in it.