### PR TITLE
[primary-key] add dap primary key

### DIFF
--- a/server/resources/migrations/48_add_dap_primary_key.down.sql
+++ b/server/resources/migrations/48_add_dap_primary_key.down.sql
@@ -1,0 +1,1 @@
+alter table daily_app_transactions drop column id;

--- a/server/resources/migrations/48_add_dap_primary_key.up.sql
+++ b/server/resources/migrations/48_add_dap_primary_key.up.sql
@@ -1,0 +1,1 @@
+alter table daily_app_transactions add column id uuid primary key default gen_random_uuid();


### PR DESCRIPTION
I am testing aurora blue-green deployments again, to remind us of what the weird error was with replication slots. 

Right now I am getting the error: 

> Invalid configuration
> Creation of blue/green deployment failed due to incompatible parameter settings. See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/blue-green-deployments-creating.html#blue-green-deployments-creating-preparing-postgres to help resolve the issues, then delete and recreate the blue/green deployment.

The only bullet we don't hit right now is: 

> Make sure that all tables in the DB cluster have a primary key. PostgreSQL logical replication doesn't allow UPDATE or DELETE operations on tables that don't have a primary key.

I know we had written: 

```sql
ALTER TABLE daily_app_transactions
REPLICA IDENTITY USING INDEX daily_app_transactions_date_app_id_is_active_key;
```

But perhaps this is not good enough for aurora b/g deployments. I thought no harm in creating a primary key to see if that fixes it. 

@nezaj @dwwoelfel @tonsky  