### PR TITLE
Add support for read-only connections

### DIFF
--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -86,7 +86,7 @@
         inference? (-> req :body :inference? boolean)
         {:keys [app-id] :as perms} (get-perms! req)
         attrs (attr-model/get-by-app-id app-id)
-        ctx (merge {:db {:conn-pool (aurora/conn-pool)}
+        ctx (merge {:db {:conn-pool (aurora/conn-pool :read)}
                     :app-id app-id
                     :attrs attrs
                     :datalog-query-fn d/query
@@ -113,7 +113,7 @@
         rules-override (-> req :body :rules-override ->json <-json)
         query (ex/get-param! req [:body :query] #(when (map? %) %))
         attrs (attr-model/get-by-app-id app-id)
-        ctx (merge {:db {:conn-pool (aurora/conn-pool)}
+        ctx (merge {:db {:conn-pool (aurora/conn-pool :read)}
                     :app-id app-id
                     :attrs attrs
                     :datalog-query-fn d/query
@@ -146,7 +146,7 @@
                                  [:body :throw-on-missing-attrs?] boolean)
         {:keys [app-id] :as perms} (get-perms! req)
         attrs (attr-model/get-by-app-id app-id)
-        ctx (merge {:db {:conn-pool (aurora/conn-pool)}
+        ctx (merge {:db {:conn-pool (aurora/conn-pool :write)}
                     :app-id app-id
                     :attrs attrs
                     :datalog-query-fn d/query
@@ -176,7 +176,7 @@
         rules (if rules-override
                 {:app_id app-id :code rules-override}
                 (rule-model/get-by-app-id {:app-id app-id}))
-        ctx (merge {:db {:conn-pool (aurora/conn-pool)}
+        ctx (merge {:db {:conn-pool (aurora/conn-pool :write)}
                     :app-id app-id
                     :attrs attrs
                     :datalog-query-fn d/query

--- a/server/src/instant/dash/admin.clj
+++ b/server/src/instant/dash/admin.clj
@@ -18,7 +18,7 @@
 
 (defn get-recent
   ([]
-   (get-recent (aurora/conn-pool)))
+   (get-recent (aurora/conn-pool :read)))
   ([conn]
    (sql/select conn
                ["SELECT
@@ -53,9 +53,9 @@
 (defn get-top-users
   "Fetches the users with their transactions in the last `n` days."
   ([]
-   (get-top-users (aurora/conn-pool) 7))
+   (get-top-users (aurora/conn-pool :read) 7))
    ([n]
-   (get-top-users (aurora/conn-pool) n))
+   (get-top-users (aurora/conn-pool :read) n))
   ([conn n]
    (let [interval (str n " days")]  ;; Create the interval string dynamically
      (sql/select conn
@@ -73,7 +73,7 @@
                   (with-meta (excluded-emails) {:pgtype "text[]"})]))))
 
 (defn get-paid
-  ([] (get-paid (aurora/conn-pool)))
+  ([] (get-paid (aurora/conn-pool :read)))
   ([conn]
    (let [subscriptions (stripe/subscriptions)]
      (sql/select conn

--- a/server/src/instant/data/bootstrap.clj
+++ b/server/src/instant/data/bootstrap.clj
@@ -110,9 +110,9 @@
 
 (defn add-zeneca-to-app!
   "Bootstraps an app with zeneca data."
-  ([app-id] (add-zeneca-to-app! (aurora/conn-pool) false app-id))
+  ([app-id] (add-zeneca-to-app! (aurora/conn-pool :write) false app-id))
   ([checked-data? app-id]
-   (add-zeneca-to-app! (aurora/conn-pool) checked-data? app-id))
+   (add-zeneca-to-app! (aurora/conn-pool :write) checked-data? app-id))
   ([conn checked-data? app-id]
    ;; Note: This is ugly code, but it works.
    ;; Maybe we clean it up later, but we don't really need to right now.
@@ -220,7 +220,7 @@
   ;; Maybe we clean it up later, but we don't really need to right now.
   ;; One idea for a cleanup, is to create an "exported app" file.
   ;; We can then write a function that works on this kind of file schema.
-  (attr-model/delete-by-app-id! (aurora/conn-pool) app-id)
+  (attr-model/delete-by-app-id! (aurora/conn-pool :write) app-id)
   (let [json-triples
         (<-json (slurp (io/resource "sample_triples/movie.json")))
         id-triples
@@ -299,12 +299,12 @@
 
     (uspec/conform-throwing ::tx/tx-steps tx-steps)
 
-    (tx/transact! (aurora/conn-pool)
+    (tx/transact! (aurora/conn-pool :write)
                   (attr-model/get-by-app-id app-id)
                   app-id
                   tx-steps)
 
     (count (triple-model/fetch
-            (aurora/conn-pool)
+            (aurora/conn-pool :read)
             app-id))))
 

--- a/server/src/instant/data/resolvers.clj
+++ b/server/src/instant/data/resolvers.clj
@@ -116,7 +116,7 @@
   ([] (make-movies-resolver movies-app-id))
   ([app-id]
    (make-resolver
-    {:conn-pool (aurora/conn-pool)}
+    {:conn-pool (aurora/conn-pool :read)}
     app-id
     [["movie" "title"]
      ["person" "name"]])))
@@ -125,7 +125,7 @@
   ([] (make-zeneca-resolver zeneca-app-id))
   ([app-id]
    (make-resolver
-    {:conn-pool (aurora/conn-pool)}
+    {:conn-pool (aurora/conn-pool :read)}
     app-id
     [["users" "fullName"]
      ["books" "title"]
@@ -182,6 +182,6 @@
   (walk-friendly
    r
    (d/query
-    {:db {:conn-pool (aurora/conn-pool)}
+    {:db {:conn-pool (aurora/conn-pool :read)}
      :app-id movies-app-id}
     [[:ea (->uuid r "eid-tina-turner")]])))

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -119,7 +119,7 @@
                :delay-ms 5
                :timeout-ms 5000}))
 (comment
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id
             :datalog-query-fn d/query
             :attrs (attr-model/get-by-app-id zeneca-app-id)})
@@ -439,7 +439,7 @@
 
 (comment
   (def attrs (attr-model/get-by-app-id zeneca-app-id))
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id
             :datalog-query-fn d/query
             :attrs attrs})

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -40,7 +40,7 @@
             [instant.jdbc.sql :as sql]
             [instant.util.json :refer [->json]]
             [instant.util.string :refer [safe-name]])
-  (:import (com.zaxxer.hikari HikariDataSource)
+  (:import (javax.sql DataSource)
            (java.util UUID)))
 
 ;; ---
@@ -1970,7 +1970,7 @@
                     ;; other threads will add additional items to our batch.
                     ;; Be careful not to do additional blocking code while we
                     ;; have the connection checked out.
-                    (sql/with-connection [conn ^HikariDataSource (:conn-pool db)]
+                    (sql/with-connection [conn ^DataSource (:conn-pool db)]
                       (let [items (take-batch! datalog-loader (:conn-pool db) max-items)]
                         (try
                           (if (= 1 (count items))

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -100,7 +100,7 @@
 
 (defn get-by-id
   ([job-id]
-   (get-by-id (aurora/conn-pool) job-id))
+   (get-by-id (aurora/conn-pool :read) job-id))
   ([conn job-id]
    (sql/select-one ::get-by-id
                    conn (hsql/format {:select :*
@@ -178,7 +178,7 @@
 
 (defn get-by-id-for-client
   ([app-id job-id]
-   (get-by-id-for-client (aurora/conn-pool) app-id job-id))
+   (get-by-id-for-client (aurora/conn-pool :read) app-id job-id))
   ([conn app-id job-id]
    (let [q (get-for-client-q app-id [:= :id job-id])
          res (sql/select-one ::get-by-id-for-client conn (hsql/format q))]
@@ -186,7 +186,7 @@
 
 (defn get-by-group-id-for-client
   ([app-id group-id]
-   (get-by-group-id-for-client (aurora/conn-pool) app-id group-id))
+   (get-by-group-id-for-client (aurora/conn-pool :read) app-id group-id))
   ([conn app-id group-id]
    (let [q (get-for-client-q app-id [:= :group-id group-id])
          jobs (sql/select ::get-by-group-id-for-client conn (hsql/format q))]
@@ -194,7 +194,7 @@
 
 (defn invalid-triples
   ([limit job-id]
-   (invalid-triples (aurora/conn-pool) limit job-id))
+   (invalid-triples (aurora/conn-pool :read) limit job-id))
   ([conn limit job-id]
    (sql/select ::invalid-triples
                conn (hsql/format {:select [:t.* [[:jsonb_typeof :value] :json-type]]
@@ -210,7 +210,7 @@
 
 (defn create-job!
   ([params]
-   (create-job! (aurora/conn-pool) params))
+   (create-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id
@@ -238,7 +238,7 @@
 
 (defn create-check-data-type-job!
   ([params]
-   (create-check-data-type-job! (aurora/conn-pool) params))
+   (create-check-data-type-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id
@@ -254,7 +254,7 @@
 
 (defn create-remove-data-type-job!
   ([params]
-   (create-remove-data-type-job! (aurora/conn-pool) params))
+   (create-remove-data-type-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id]}]
@@ -267,7 +267,7 @@
 
 (defn create-index-job!
   ([params]
-   (create-index-job! (aurora/conn-pool) params))
+   (create-index-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id]}]
@@ -280,7 +280,7 @@
 
 (defn create-remove-index-job!
   ([params]
-   (create-remove-index-job! (aurora/conn-pool) params))
+   (create-remove-index-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id]}]
@@ -293,7 +293,7 @@
 
 (defn create-unique-job!
   ([params]
-   (create-unique-job! (aurora/conn-pool) params))
+   (create-unique-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id]}]
@@ -306,7 +306,7 @@
 
 (defn create-remove-unique-job!
   ([params]
-   (create-remove-unique-job! (aurora/conn-pool) params))
+   (create-remove-unique-job! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  group-id
                  attr-id]}]
@@ -336,7 +336,7 @@
 
 (defn grab-job!
   ([job-id]
-   (grab-job! (aurora/conn-pool) job-id))
+   (grab-job! (aurora/conn-pool :write) job-id))
   ([conn job-id]
    (sql/execute-one! ::grab-job!
                      conn (hsql/format
@@ -356,7 +356,7 @@
 
 (defn update-work-estimate!
   ([job next-stage]
-   (update-work-estimate! (aurora/conn-pool) next-stage job))
+   (update-work-estimate! (aurora/conn-pool :write) next-stage job))
   ([conn next-stage job]
    (let [estimate (-> (sql/select-one
                        ::get-work-estimate!
@@ -376,7 +376,7 @@
 
 (defn add-work-completed!
   ([completed-count job]
-   (add-work-completed! (aurora/conn-pool) completed-count job))
+   (add-work-completed! (aurora/conn-pool :write) completed-count job))
   ([conn completed-count job]
    (sql/execute-one! ::add-work-completed!
                      conn (hsql/format {:update :indexing-jobs
@@ -388,7 +388,7 @@
                                                completed-count]}}))))
 
 (defn release-job!
-  ([job] (release-job! (aurora/conn-pool) job))
+  ([job] (release-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "release-job" job)
      (sql/execute-one! ::release-job!
@@ -399,7 +399,7 @@
 
 (defn mark-job-completed!
   ([job]
-   (mark-job-completed! (aurora/conn-pool) job))
+   (mark-job-completed! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "mark-job-completed" job)
      (sql/execute-one! ::mark-job-completed!
@@ -411,7 +411,7 @@
 
 (defn set-next-stage!
   ([stage job]
-   (set-next-stage! (aurora/conn-pool) stage job))
+   (set-next-stage! (aurora/conn-pool :write) stage job))
   ([conn stage job]
    (tracer/with-span! (update (job-span-attrs "set-next-stage" job)
                               :attributes assoc :next-stage stage)
@@ -423,7 +423,7 @@
 
 (defn mark-error!
   ([props job]
-   (mark-error! (aurora/conn-pool) props job))
+   (mark-error! (aurora/conn-pool :write) props job))
   ([conn props job]
    (tracer/with-span! (merge (job-span-attrs "mark-error" job)
                              props)
@@ -436,7 +436,7 @@
 
 (defn mark-error-from-ex-info!
   ([^clojure.lang.ExceptionInfo e job]
-   (mark-error-from-ex-info! (aurora/conn-pool) e job))
+   (mark-error-from-ex-info! (aurora/conn-pool :write) e job))
   ([conn ^clojure.lang.ExceptionInfo e job]
    (let [error-data (ex-data e)
          validation-error (some-> error-data
@@ -474,7 +474,7 @@
 
 (defn check-next-batch!
   ([job]
-   (check-next-batch! (aurora/conn-pool) job))
+   (check-next-batch! (aurora/conn-pool :write) job))
   ([conn {:keys [app_id attr_id job_type checked_data_type]}]
    (assert (= "check-data-type" job_type))
    (assert checked_data_type)
@@ -498,7 +498,7 @@
 
 (defn check-batch-and-update-job!
   ([job]
-   (check-batch-and-update-job! (aurora/conn-pool) job))
+   (check-batch-and-update-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "check-batch" job)
      (let [update-count (check-next-batch! conn job)]
@@ -509,7 +509,7 @@
 
 (defn has-invalid-row?
   ([job]
-   (has-invalid-row? (aurora/conn-pool) job))
+   (has-invalid-row? (aurora/conn-pool :read) job))
   ([conn {:keys [app_id attr_id checked_data_type]}]
    (->> (hsql/format
          {:select [[[:exists {:select :*
@@ -547,7 +547,7 @@
 
 (defn update-attr-for-check-start!
   ([job]
-   (update-attr-for-check-start! (aurora/conn-pool) job))
+   (update-attr-for-check-start! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -558,7 +558,7 @@
 
 (defn update-attr-for-check-done!
   ([job]
-   (update-attr-for-check-done! (aurora/conn-pool) job))
+   (update-attr-for-check-done! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -570,7 +570,7 @@
 
 (defn rollback-attr-for-check!
   ([job]
-   (rollback-attr-for-check! (aurora/conn-pool) job))
+   (rollback-attr-for-check! (aurora/conn-pool :write) job))
   ([conn job]
    (update-attr! conn {:app-id (:app_id job)
                        :attr-id (:attr_id job)
@@ -581,7 +581,7 @@
 
 (defn validate-check!
   ([next-stage job]
-   (validate-check! (aurora/conn-pool) next-stage job))
+   (validate-check! (aurora/conn-pool :write) next-stage job))
   ([conn next-stage job]
    (if (has-invalid-row? conn job)
      (do
@@ -591,7 +591,7 @@
 
 (defn run-next-check-step
   ([job]
-   (run-next-check-step (aurora/conn-pool) job))
+   (run-next-check-step (aurora/conn-pool :write) job))
   ([conn job]
    (case (:job_stage job)
      ;; make sure this will work
@@ -608,7 +608,7 @@
 
 (defn update-attr-for-remove-data-type-start!
   ([job]
-   (update-attr-for-remove-data-type-start! (aurora/conn-pool) job))
+   (update-attr-for-remove-data-type-start! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -619,7 +619,7 @@
 
 (defn update-attr-for-remove-data-type-done!
   ([job]
-   (update-attr-for-remove-data-type-done! (aurora/conn-pool) job))
+   (update-attr-for-remove-data-type-done! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -631,7 +631,7 @@
 
 (defn remove-data-type-next-batch!
   ([job]
-   (remove-data-type-next-batch! (aurora/conn-pool) job))
+   (remove-data-type-next-batch! (aurora/conn-pool :write) job))
   ([conn {:keys [app_id attr_id job_type checked_data_type]}]
    (assert (= "remove-data-type" job_type))
    (assert (nil? checked_data_type))
@@ -652,7 +652,7 @@
 
 (defn remove-data-type-batch-and-update-job!
   ([job]
-   (check-batch-and-update-job! (aurora/conn-pool) job))
+   (check-batch-and-update-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "remove-data-type-batch" job)
      (let [update-count (remove-data-type-next-batch! conn job)]
@@ -664,7 +664,7 @@
 
 (defn run-next-remove-data-type-step
   ([job]
-   (run-next-remove-data-type-step (aurora/conn-pool) job))
+   (run-next-remove-data-type-step (aurora/conn-pool :write) job))
   ([conn job]
    (case (:job_stage job)
      "update-attr-start" (update-attr-for-remove-data-type-start! conn job)
@@ -674,7 +674,7 @@
 
 (defn update-attr-for-index-start!
   ([job]
-   (update-attr-for-index-start! (aurora/conn-pool) job))
+   (update-attr-for-index-start! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -685,7 +685,7 @@
 
 (defn update-attr-for-index-done!
   ([job]
-   (update-attr-for-index-done! (aurora/conn-pool) job))
+   (update-attr-for-index-done! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -697,7 +697,7 @@
 
 (defn index-next-batch!
   ([job]
-   (index-next-batch! (aurora/conn-pool) job))
+   (index-next-batch! (aurora/conn-pool :write) job))
   ([conn {:keys [app_id attr_id job_type]}]
    (assert (= "index" job_type))
    (let [q {:update :triples
@@ -732,7 +732,7 @@
 
 (defn index-batch-and-update-job!
   ([job]
-   (index-batch-and-update-job! (aurora/conn-pool) job))
+   (index-batch-and-update-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "index" job)
      (try
@@ -747,7 +747,7 @@
 
 (defn run-next-index-step
   ([job]
-   (run-next-index-step (aurora/conn-pool) job))
+   (run-next-index-step (aurora/conn-pool :write) job))
   ([conn job]
    (case (:job_stage job)
      "update-attr-start" (update-attr-for-index-start! conn job)
@@ -757,7 +757,7 @@
 
 (defn update-attr-for-remove-index-start!
   ([job]
-   (update-attr-for-remove-index-start! (aurora/conn-pool) job))
+   (update-attr-for-remove-index-start! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -768,7 +768,7 @@
 
 (defn update-attr-for-remove-index-done!
   ([job]
-   (update-attr-for-remove-index-done! (aurora/conn-pool) job))
+   (update-attr-for-remove-index-done! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -780,7 +780,7 @@
 
 (defn remove-index-next-batch!
   ([job]
-   (remove-index-next-batch! (aurora/conn-pool) job))
+   (remove-index-next-batch! (aurora/conn-pool :write) job))
   ([conn {:keys [app_id attr_id job_type]}]
    (assert (= "remove-index" job_type))
    (let [q {:update :triples
@@ -800,7 +800,7 @@
 
 (defn remove-index-batch-and-update-job!
   ([job]
-   (remove-index-batch-and-update-job! (aurora/conn-pool) job))
+   (remove-index-batch-and-update-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "remove-index" job)
      (let [update-count (remove-index-next-batch! conn job)]
@@ -811,7 +811,7 @@
 
 (defn run-next-remove-index-step
   ([job]
-   (run-next-index-step (aurora/conn-pool) job))
+   (run-next-index-step (aurora/conn-pool :write) job))
   ([conn job]
    (assert (= "remove-index" (:job_type job)))
    (case (:job_stage job)
@@ -822,7 +822,7 @@
 
 (defn update-attr-for-unique-start!
   ([job]
-   (update-attr-for-unique-start! (aurora/conn-pool) job))
+   (update-attr-for-unique-start! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -833,7 +833,7 @@
 
 (defn update-attr-for-unique-done!
   ([job]
-   (update-attr-for-unique-done! (aurora/conn-pool) job))
+   (update-attr-for-unique-done! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -845,7 +845,7 @@
 
 (defn unique-next-batch!
   ([job]
-   (unique-next-batch! (aurora/conn-pool) job))
+   (unique-next-batch! (aurora/conn-pool :write) job))
   ([conn {:keys [app_id attr_id job_type]}]
    (assert (= "unique" job_type))
    (let [q {:update :triples
@@ -881,7 +881,7 @@
 
 (defn unique-batch-and-update-job!
   ([job]
-   (unique-batch-and-update-job! (aurora/conn-pool) job))
+   (unique-batch-and-update-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "unique" job)
      (try
@@ -896,7 +896,7 @@
 
 (defn run-next-unique-step
   ([job]
-   (run-next-unique-step (aurora/conn-pool) job))
+   (run-next-unique-step (aurora/conn-pool :write) job))
   ([conn job]
    (case (:job_stage job)
      "update-attr-start" (update-attr-for-unique-start! conn job)
@@ -906,7 +906,7 @@
 
 (defn update-attr-for-remove-unique-start!
   ([job]
-   (update-attr-for-remove-unique-start! (aurora/conn-pool) job))
+   (update-attr-for-remove-unique-start! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -917,7 +917,7 @@
 
 (defn update-attr-for-remove-unique-done!
   ([job]
-   (update-attr-for-remove-unique-done! (aurora/conn-pool) job))
+   (update-attr-for-remove-unique-done! (aurora/conn-pool :write) job))
   ([conn job]
    (if (update-attr! conn {:app-id (:app_id job)
                            :attr-id (:attr_id job)
@@ -929,7 +929,7 @@
 
 (defn remove-unique-next-batch!
   ([job]
-   (remove-unique-next-batch! (aurora/conn-pool) job))
+   (remove-unique-next-batch! (aurora/conn-pool :write) job))
   ([conn {:keys [app_id attr_id job_type]}]
    (assert (= "remove-unique" job_type))
    (let [q {:update :triples
@@ -949,7 +949,7 @@
 
 (defn remove-unique-batch-and-update-job!
   ([job]
-   (remove-unique-batch-and-update-job! (aurora/conn-pool) job))
+   (remove-unique-batch-and-update-job! (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "remove-unique" job)
      (let [update-count (remove-unique-next-batch! conn job)]
@@ -960,7 +960,7 @@
 
 (defn run-next-remove-unique-step
   ([job]
-   (run-next-unique-step (aurora/conn-pool) job))
+   (run-next-unique-step (aurora/conn-pool :write) job))
   ([conn job]
    (assert (= "remove-unique" (:job_type job)))
    (case (:job_stage job)
@@ -971,7 +971,7 @@
 
 (defn run-next-step
   ([job]
-   (run-next-step (aurora/conn-pool) job))
+   (run-next-step (aurora/conn-pool :write) job))
   ([conn job]
    (tracer/with-span! (job-span-attrs "run-next-step" job)
      (assert (= "processing" (:job_status job)) (:job_status job))
@@ -993,7 +993,7 @@
 
 (defn process-job
   ([chan job]
-   (process-job (aurora/conn-pool) chan job))
+   (process-job (aurora/conn-pool :write) chan job))
   ([conn chan job]
    (let [updated-job (run-next-step conn job)]
      (if (not= "processing" (:job_status updated-job))
@@ -1018,7 +1018,7 @@
                                         :escaping? false
                                         :attributes {:job-id job-id}})
       (sql/execute-one! ::handle-process-error
-                        (aurora/conn-pool)
+                        (aurora/conn-pool :write)
                         (hsql/format {:update :indexing-jobs
                                       :where (job-update-wheres
                                               [:= :id job-id])
@@ -1033,7 +1033,7 @@
       (recur))))
 
 (defn grab-forgotten-jobs!
-  ([] (grab-forgotten-jobs! (aurora/conn-pool)))
+  ([] (grab-forgotten-jobs! (aurora/conn-pool :write)))
   ([conn]
    (tracer/with-span! {:name "indexing-jobs/grab-forgotten-jobs!"}
      (let [jobs (sql/select ::grab-forgotten-jobs!
@@ -1048,7 +1048,7 @@
        jobs))))
 
 (defn warn-stuck-jobs!
-  ([] (warn-stuck-jobs! (aurora/conn-pool)))
+  ([] (warn-stuck-jobs! (aurora/conn-pool :read)))
   ([conn]
    (tracer/with-span! {:name "indexing-jobs/grab-forgotten-jobs!"}
      (let [q {:select :id
@@ -1126,7 +1126,7 @@
     (println (format "Updating attr %s.%s"
                      (attr-model/fwd-etype attr)
                      (attr-model/fwd-label attr)))
-    (update-attr! (aurora/conn-pool)
+    (update-attr! (aurora/conn-pool :write)
                   {:app-id system-catalog/system-catalog-app-id
                    :attr-id (:id attr)
                    :set {:checked-data-type [:cast
@@ -1150,7 +1150,7 @@
                                   :checked-data-type
                                   [:cast checked-data-type :checked_data_type]]
                                  [:= :checked-data-type nil]]]}]}
-            res (sql/do-execute! (aurora/conn-pool) (hsql/format q))]
+            res (sql/do-execute! (aurora/conn-pool :write) (hsql/format q))]
         (when (<= batch-size (:next.jdbc/update-count (first res)))
           (recur))))))
 

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1800,7 +1800,7 @@
 (comment
   (def r (resolvers/make-zeneca-resolver))
   (def attrs (attr-model/get-by-app-id zeneca-app-id))
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id
             :datalog-query-fn #'d/query
             :attrs attrs})
@@ -1818,7 +1818,7 @@
 
   (def attrs (attr-model/get-by-app-id rec-app-id))
 
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id rec-app-id
             :attrs attrs})
 
@@ -1831,7 +1831,7 @@
 (comment
   (def r (resolvers/make-zeneca-resolver))
   (def attrs (attr-model/get-by-app-id zeneca-app-id))
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id
             :attrs attrs})
   (resolvers/walk-friendly
@@ -1843,7 +1843,7 @@
 (comment
   (def app-id #uuid "6a0e56c8-f847-4890-8ae9-06bba6249d34")
   (query
-   {:db {:conn-pool (aurora/conn-pool)}
+   {:db {:conn-pool (aurora/conn-pool :read)}
     :app-id app-id
     :attrs (attr-model/get-by-app-id app-id)}
    {:tables {:rows {}, :$ {:where {:id "b2f7658d-c5b5-4486-b298-e811098009b9"}}}}))

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -601,9 +601,9 @@
 
 (defn get-by-app-id
   ([app-id]
-   (cache/lookup-or-miss attr-cache app-id (partial get-by-app-id* (aurora/conn-pool))))
+   (cache/lookup-or-miss attr-cache app-id (partial get-by-app-id* (aurora/conn-pool :read))))
   ([conn app-id]
-   (if (= conn (aurora/conn-pool))
+   (if (= conn (aurora/conn-pool :read))
      (get-by-app-id app-id)
      ;; Don't cache if we're using a custom connection
      (get-by-app-id* conn app-id))))
@@ -636,22 +636,22 @@
 ;; play
 
 (comment
-  (delete-by-app-id! (aurora/conn-pool) empty-app-id)
+  (delete-by-app-id! (aurora/conn-pool :write) empty-app-id)
   (insert-multi!
-   (aurora/conn-pool)
+   (aurora/conn-pool :write)
    empty-app-id
    [(gen/generate (s/gen ::attr))])
   (map (partial s/valid? ::attr)
-       (get-by-app-id (aurora/conn-pool) empty-app-id))
-  (def a (first (get-by-app-id (aurora/conn-pool) empty-app-id)))
+       (get-by-app-id (aurora/conn-pool :read) empty-app-id))
+  (def a (first (get-by-app-id (aurora/conn-pool :read) empty-app-id)))
   (update-multi!
-   (aurora/conn-pool)
+   (aurora/conn-pool :write)
    empty-app-id
    [{:id (:id a)
      :forward-identity
      [(-> a :forward-identity first) "new_etype" "new_label"]
      :index? true}])
   (delete-multi!
-   (aurora/conn-pool)
+   (aurora/conn-pool :write)
    empty-app-id
    [(:id a)]))

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -445,7 +445,7 @@
 
 (comment
   (def attrs (attr-model/get-by-app-id zeneca-app-id))
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id
             :datalog-query-fn #'d/query
             :attrs attrs})

--- a/server/src/instant/db/model/transaction.clj
+++ b/server/src/instant/db/model/transaction.clj
@@ -4,7 +4,7 @@
    [instant.jdbc.aurora :as aurora]))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id]}]
    (sql/execute-one! ::create!
                      conn

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -614,10 +614,10 @@
            (concat [:and [:= :app-id app-id]] stmts)})))))
 
 (comment
-  (attr-model/delete-by-app-id! (aurora/conn-pool) empty-app-id)
+  (attr-model/delete-by-app-id! (aurora/conn-pool :write) empty-app-id)
   (def name-attr-id #uuid "3c0c37e2-49f7-4912-8808-02ca553cb36d")
   (attr-model/insert-multi!
-   (aurora/conn-pool)
+   (aurora/conn-pool :write)
    empty-app-id
    [{:id name-attr-id
      :forward-identity [#uuid "963c3f22-4389-4f5a-beea-87644409e458"
@@ -627,12 +627,12 @@
      :index? false
      :unique? false}])
   (def t [#uuid "83ae4cbf-8b19-42f6-bb8f-3eac7bd6da29" name-attr-id "Stopa"])
-  (insert-multi! (aurora/conn-pool)
+  (insert-multi! (aurora/conn-pool :write)
                  (attr-model/get-by-app-id empty-app-id)
                  empty-app-id
                  [t])
-  (fetch (aurora/conn-pool) empty-app-id)
-  (delete-multi! (aurora/conn-pool) empty-app-id [t]))
+  (fetch (aurora/conn-pool :read) empty-app-id)
+  (delete-multi! (aurora/conn-pool :write) empty-app-id [t]))
 
 ;; Migration for inferred types
 ;; ----------------------------

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -711,7 +711,7 @@
     (def tx-steps [[:add-triple goal-eid goal-id-attr goal-eid]
                    [:add-triple goal-eid goal-creator-id-attr joe-eid]
                    [:add-triple goal-eid goal-title-attr "Get a job"]]))
-  (transact! {:db {:conn-pool (aurora/conn-pool)}
+  (transact! {:db {:conn-pool (aurora/conn-pool :write)}
               :app-id colors-app-id
               :attrs app-attrs
               :current-user {:id joe-eid}
@@ -719,7 +719,7 @@
               :datalog-query-fn d/query} tx-steps)
 
   ;; OG transact
-  (tx/transact! (aurora/conn-pool)
+  (tx/transact! (aurora/conn-pool :write)
                 (attr-model/get-by-app-id colors-app-id)
                 colors-app-id
                 tx-steps))

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -67,7 +67,7 @@
                                   (uri/assoc-query* {:currentSchema schema})
                                   str)]
         (try
-          (sql/execute! (aurora/conn-pool) [(format "create schema \"%s\"" schema)])
+          (sql/execute! (aurora/conn-pool :write) [(format "create schema \"%s\"" schema)])
           (app-model/set-connection-string!
            {:app-id id
             :connection-string connection-string})
@@ -86,7 +86,7 @@
                  app
                  r)))
           (finally
-            (sql/execute! (aurora/conn-pool) [(format "drop schema \"%s\" cascade" schema)])))))))
+            (sql/execute! (aurora/conn-pool :write) [(format "drop schema \"%s\" cascade" schema)])))))))
 
 (defn with-pro-app [owner f]
   (let [app-id (UUID/randomUUID)

--- a/server/src/instant/flags_impl.clj
+++ b/server/src/instant/flags_impl.clj
@@ -56,7 +56,7 @@
           attrs (attr-model/get-by-app-id config-app-id)
           ctx {:app-id (:id app)
                :attrs attrs
-               :db {:conn-pool (aurora/conn-pool)}}
+               :db {:conn-pool (aurora/conn-pool :read)}}
           query->transform (zipmap (map :query queries)
                                    (map :transform queries))
           ws-conn {:websocket-stub (fn [msg] (handle-msg query-results-atom
@@ -106,7 +106,7 @@
           machine-attr-id (resolve-attr-id
                            attrs
                            :app-users-to-triples-migration/processId)]
-      (tx/transact! (aurora/conn-pool)
+      (tx/transact! (aurora/conn-pool :write)
                     attrs
                     config-app-id
                     [[:add-triple eid id-attr-id eid]
@@ -122,7 +122,7 @@
                            attrs
                            :app-users-to-triples-migration/processId)
           ctx {:attrs attrs
-               :db {:conn-pool (aurora/conn-pool)}
+               :db {:conn-pool (aurora/conn-pool :read)}
                :app-id config-app-id}
           eids (-> (datalog/query ctx [[:ea '?e]
                                        [:ea '?e #{machine-attr-id} #{@config/process-id}]
@@ -130,7 +130,7 @@
                    :symbol-values
                    (get '?e))]
       (when (seq eids)
-        (tx/transact! (aurora/conn-pool)
+        (tx/transact! (aurora/conn-pool :write)
                       attrs
                       config-app-id
                       (map (fn [eid]

--- a/server/src/instant/grab.clj
+++ b/server/src/instant/grab.clj
@@ -20,7 +20,7 @@
                        DO NOTHING RETURNING id" k]))))
 
 (defn run-once! [k f]
-  (if (try-grab! (aurora/conn-pool) k)
+  (if (try-grab! (aurora/conn-pool :write) k)
     (f)
     :no-op))
 

--- a/server/src/instant/health.clj
+++ b/server/src/instant/health.clj
@@ -13,7 +13,7 @@
 
 (defn mark-wal-unhealthy []
   (sql/execute!
-   (aurora/conn-pool)
+   (aurora/conn-pool :write)
    (hsql/format
     {:insert-into :config
      :values [{:k "wal-errors"
@@ -23,7 +23,7 @@
 
 (defn mark-wal-healthy []
   (sql/execute!
-   (aurora/conn-pool)
+   (aurora/conn-pool :write)
    (hsql/format
     {:update :config
      :set {:v [:- [:cast :v :jsonb] [:cast @config/process-id :text]]}
@@ -48,7 +48,7 @@
                                                              :escpaing? false}))))))
 
 (defn health-get [_req]
-  (let [wal-errors (sql/select-one (aurora/conn-pool) ["select v from config where k = 'wal-errors'"])]
+  (let [wal-errors (sql/select-one (aurora/conn-pool :read) ["select v from config where k = 'wal-errors'"])]
     (if (some-> wal-errors :v seq)
       (response/internal-server-error {:wal :error})
       (response/ok {:wal :ok}))))

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -4,8 +4,7 @@
    [instant.jdbc.sql :as sql]
    [instant.util.tracer :as tracer])
   (:import
-   (com.zaxxer.hikari HikariDataSource)
-   (javax.sql DataSource)))
+   (com.zaxxer.hikari HikariDataSource)))
 
 ;; Stores a single memoized value for the read-only
 ;; connection.

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -9,10 +9,10 @@
 
 ;; Stores a single memoized value for the read-only
 ;; connection.
-(defonce read-only-memoize (atom nil))
+(def read-only-memoize (atom nil))
 
 (defn read-only-wrapper [^HikariDataSource pool]
-  (proxy [DataSource] []
+  (proxy [HikariDataSource] []
     (getConnection
       ([]
        (let [conn (.getConnection pool)]
@@ -27,7 +27,9 @@
     (unwrap [iface]
       (.unwrap pool iface))
     (isWrapperFor [iface]
-      (.isWrapperFor pool iface))))
+      (.isWrapperFor pool iface))
+    (getHikariPoolMXBean []
+      (.getHikariPoolMXBean pool))))
 
 (defn memoized-read-only-wrapper [^HikariDataSource pool]
   (if-let [wrapper (when-let [[memo-pool wrapper] @read-only-memoize]

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -2,11 +2,50 @@
   (:require
    [instant.config :as config]
    [instant.jdbc.sql :as sql]
-   [instant.util.tracer :as tracer]))
+   [instant.util.tracer :as tracer])
+  (:import
+   (com.zaxxer.hikari HikariDataSource)
+   (javax.sql DataSource)))
+
+;; Stores a single memoized value for the read-only
+;; connection.
+(defonce read-only-memoize (atom nil))
+
+(defn read-only-wrapper [^HikariDataSource pool]
+  (proxy [DataSource] []
+    (getConnection
+      ([]
+       (let [conn (.getConnection pool)]
+         (.setReadOnly conn true)
+         (.setAutoCommit conn false)
+         conn))
+      ([user pass]
+       (let [conn (.getConnection pool user pass)]
+         (.setReadOnly conn true)
+         (.setAutoCommit conn false)
+         conn)))
+    (unwrap [iface]
+      (.unwrap pool iface))
+    (isWrapperFor [iface]
+      (.isWrapperFor pool iface))))
+
+(defn memoized-read-only-wrapper [^HikariDataSource pool]
+  (if-let [wrapper (when-let [[memo-pool wrapper] @read-only-memoize]
+                     (when (= memo-pool pool)
+                       wrapper))]
+    wrapper
+    (let [wrapper (read-only-wrapper pool)]
+      (reset! read-only-memoize [pool wrapper])
+      wrapper)))
 
 (declare -conn-pool)
-(defn conn-pool []
-  -conn-pool)
+(defn conn-pool
+  "Takes a single argument that should be either :read for a read-only connection
+   or :write for a read-write connection."
+  [rw]
+  (if (= rw :read)
+    (memoized-read-only-wrapper -conn-pool)
+    -conn-pool))
 
 (defn start []
   (let [conn-pool-size (config/get-connection-pool-size)]
@@ -19,7 +58,7 @@
                             :targetServerType "primary")))))
 
 (defn stop []
-  (.close -conn-pool))
+  (.close ^HikariDataSource -conn-pool))
 
 (defn restart []
   (stop)

--- a/server/src/instant/jdbc/failover.clj
+++ b/server/src/instant/jdbc/failover.clj
@@ -35,7 +35,10 @@
     ;; Make the connections wait. For a future improvement, we could have the
     ;; caller tell us if they wanted a read-only connection and then we wouldn't
     ;; have to pause reads until after we waited for writes to complete
-    (alter-var-root #'aurora/conn-pool (fn [_] (fn [] @next-pool-promise)))
+    (alter-var-root #'aurora/conn-pool (fn [_] (fn [rw]
+                                                 (if (= :read rw)
+                                                   (aurora/memoized-read-only-wrapper prev-pool)
+                                                   @next-pool-promise))))
     ;; Give transactions half the receive-timeout to complete
     (println "Waiting for 2.5 seconds for transactions to complete")
     (Thread/sleep 2500)

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -17,6 +17,7 @@
    (com.zaxxer.hikari HikariDataSource)
    (java.sql Array Connection PreparedStatement ResultSet ResultSetMetaData)
    (java.time Instant LocalDate LocalDateTime)
+   (javax.sql DataSource)
    (org.postgresql.util PGobject PSQLException)))
 
 (defn ->pg-text-array
@@ -119,7 +120,7 @@
    the pool (e.g. datalog/query batching).
    Binds *conn-pool-span-stats* at call time to be consistent with calling e.g.
    `select` with the conn-pool directly."
-  [[conn-name ^HikariDataSource conn-pool] & body]
+  [[conn-name ^DataSource conn-pool] & body]
   `(binding [*conn-pool-span-stats* (span-attrs-from-conn-pool ~conn-pool)]
      (io/tag-io
        (with-open [~conn-name (.getConnection ~conn-pool)]

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -37,7 +37,7 @@
        res#)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id title creator-id admin-token]}]
 
    (next-jdbc/with-transaction [tx-conn conn]
@@ -59,21 +59,21 @@
 
 (defn get-by-id
   ([{:keys [id]}]
-   (cache/lookup-or-miss app-cache id (partial get-by-id* (aurora/conn-pool))))
+   (cache/lookup-or-miss app-cache id (partial get-by-id* (aurora/conn-pool :read))))
   ([conn {:keys [id] :as params}]
-   (if (= conn (aurora/conn-pool))
+   (if (= conn (aurora/conn-pool :read))
      (get-by-id params)
      ;; Don't cache if we're using a custom connection
      (get-by-id* conn id))))
 
 (defn get-by-id!
   ([params]
-   (get-by-id! (aurora/conn-pool) params))
+   (get-by-id! (aurora/conn-pool :read) params))
   ([conn params]
    (ex/assert-record! (get-by-id conn params) :app {:args [params]})))
 
 (defn list-by-creator-id
-  ([user-id] (list-by-creator-id (aurora/conn-pool) user-id))
+  ([user-id] (list-by-creator-id (aurora/conn-pool :read) user-id))
   ([conn user-id]
    (sql/select ::list-by-creator-id
                conn
@@ -87,7 +87,7 @@
   (list-by-creator-id user-id))
 
 (defn get-by-id-and-creator
-  ([params] (get-by-id-and-creator (aurora/conn-pool) params))
+  ([params] (get-by-id-and-creator (aurora/conn-pool :read) params))
   ([conn {:keys [user-id app-id]}]
    (sql/select-one ::get-by-id-and-creator
                    conn
@@ -107,7 +107,7 @@
   (get-by-id-and-creator {:user-id user-id :app-id app-id}))
 
 (defn get-app-ids-created-before
-  ([params] (get-app-ids-created-before (aurora/conn-pool) params))
+  ([params] (get-app-ids-created-before (aurora/conn-pool :read) params))
   ([conn {:keys [creator-id created-before]}]
    (map :id (sql/select
              ::get-app-ids-created-before
@@ -121,7 +121,7 @@
               creator-id created-before]))))
 
 (defn get-with-creator-by-ids
-  ([params] (get-with-creator-by-ids (aurora/conn-pool) params))
+  ([params] (get-with-creator-by-ids (aurora/conn-pool :read) params))
   ([conn app-ids]
    (sql/select ::get-with-creator-by-ids
                conn ["SELECT a.*, u.email AS creator_email
@@ -138,7 +138,7 @@
                             "59aafa92-a900-4b3d-aaf1-45032ee8d415"]))
 
 (defn get-all-for-user
-  ([params] (get-all-for-user (aurora/conn-pool) params))
+  ([params] (get-all-for-user (aurora/conn-pool :read) params))
   ([conn {:keys [user-id]}]
    (sql/select ::get-all-for-user
                conn ["WITH s AS (
@@ -248,7 +248,7 @@
                      user-id user-id user-id user-id])))
 
 (defn get-dash-auth-data
-  ([params] (get-dash-auth-data (aurora/conn-pool) params))
+  ([params] (get-dash-auth-data (aurora/conn-pool :read) params))
   ([conn {:keys [app-id]}]
    (query-op
     conn
@@ -302,21 +302,21 @@
                 "authorized_redirect_origins" redirect-origins}})))))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (with-cache-invalidation id
      (sql/execute-one! ::delete-by-id!
                        conn ["DELETE FROM apps WHERE id = ?::uuid" id]))))
 
 (defn rename-by-id!
-  ([params] (rename-by-id! (aurora/conn-pool) params))
+  ([params] (rename-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id title]}]
    (with-cache-invalidation id
      (sql/execute-one! ::rename-by-id!
                        conn ["UPDATE apps SET title = ? WHERE id = ?::uuid " title id]))))
 
 (defn change-creator!
-  ([params] (change-creator! (aurora/conn-pool) params))
+  ([params] (change-creator! (aurora/conn-pool :write) params))
   ([conn {:keys [id new-creator-id]}]
    (instant-user-model/with-cache-invalidation id
      (with-cache-invalidation id
@@ -328,7 +328,7 @@
 
 (defn clear-by-id!
   "Deletes attrs, rules, and triples for the specified app_id"
-  ([params] (clear-by-id! (aurora/conn-pool) params))
+  ([params] (clear-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (next-jdbc/with-transaction [tx-conn conn]
      (attr-model/delete-by-app-id! tx-conn id)
@@ -339,7 +339,7 @@
   (clear-by-id! {:id "9a6d8f38-991d-4264-9801-4a05d8b1eab1"}))
 
 (defn delete-by-ids!
-  ([params] (delete-by-ids! (aurora/conn-pool) params))
+  ([params] (delete-by-ids! (aurora/conn-pool :write) params))
   ([conn {:keys [creator-id ids]}]
    (with-cache-invalidation ids
      (sql/execute-one! ::delete-by-ids!
@@ -371,7 +371,7 @@
 
   Multiplying the app_id data size by the overhead factor gives an estimate of
   real usage"
-  ([params] (app-usage (aurora/conn-pool) params))
+  ([params] (app-usage (aurora/conn-pool :read) params))
   ([conn {:keys [app-id]}]
    (sql/select-one
     ::app-usage
@@ -390,7 +390,7 @@
       (String. "UTF-8")))
 
 (defn set-connection-string!
-  ([params] (set-connection-string! (aurora/conn-pool) params))
+  ([params] (set-connection-string! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id connection-string]}]
    (with-cache-invalidation app-id
      (sql/execute-one! ::set-connection-string!
@@ -401,4 +401,4 @@
                         app-id]))))
 
 (comment
-  (app-usage (aurora/conn-pool) {:app-id "5cb86bd5-5dfb-4489-a455-78bb86cd3da3"}))
+  (app-usage (aurora/conn-pool :read) {:app-id "5cb86bd5-5dfb-4489-a455-78bb86cd3da3"}))

--- a/server/src/instant/model/app_admin_token.clj
+++ b/server/src/instant/model/app_admin_token.clj
@@ -5,7 +5,7 @@
             [instant.util.exception :as ex]))
 
 (defn fetch
-  ([params] (fetch (aurora/conn-pool) params))
+  ([params] (fetch (aurora/conn-pool :read) params))
   ([conn {:keys [token app-id]}]
    (sql/select-one conn
                    ["SELECT * FROM app_admin_tokens WHERE token = ?::uuid AND app_id = ?::uuid"
@@ -15,21 +15,21 @@
   (ex/assert-record! (fetch params) :app-admin-token {:args [params]}))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [token app-id]}]
    (sql/execute-one! conn
                      ["INSERT INTO app_admin_tokens (token, app_id) VALUES (?::uuid, ?::uuid)"
                       token app-id])))
 
 (defn delete-by-app-id!
-  ([params] (delete-by-app-id! (aurora/conn-pool) params))
+  ([params] (delete-by-app-id! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id]}]
    (sql/execute-one! conn
                      ["DELETE FROM app_admin_tokens WHERE app_id = ?::uuid"
                       app-id])))
 
 (defn recreate!
-  ([params] (recreate! (aurora/conn-pool) params))
+  ([params] (recreate! (aurora/conn-pool :write) params))
   ([conn {:keys [token app-id]}]
    (next-jdbc/with-transaction [tx-conn conn]
      (delete-by-app-id! tx-conn {:app-id app-id})

--- a/server/src/instant/model/app_authorized_redirect_origin.clj
+++ b/server/src/instant/model/app_authorized_redirect_origin.clj
@@ -12,7 +12,7 @@
    (java.util UUID)))
 
 (defn add!
-  ([params] (add! (aurora/conn-pool) params))
+  ([params] (add! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id service params]}]
    (let [id (UUID/randomUUID)]
      (sql/execute-one!
@@ -23,7 +23,7 @@
        id app-id service (with-meta params {:pgtype "text[]"})]))))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id]}]
    (sql/execute-one!
     conn
@@ -36,7 +36,7 @@
     (ex/assert-record! record :app-authorized-redirect-origin {:args args})))
 
 (defn get-all-for-app
-  ([params] (get-all-for-app (aurora/conn-pool) params))
+  ([params] (get-all-for-app (aurora/conn-pool :read) params))
   ([conn {:keys [app-id]}]
    (sql/select
     conn

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -6,7 +6,7 @@
   (:import (java.util UUID)))
 
 (defn get-by-email
-  ([params] (get-by-email (aurora/conn-pool) params))
+  ([params] (get-by-email (aurora/conn-pool :read) params))
   ([conn {:keys [email]}]
    (sql/select-one conn
                    ["SELECT *
@@ -15,7 +15,7 @@
                     email])))
 
 (defn put!
-  ([params] (put! (aurora/conn-pool) params))
+  ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [email name user-id postmark-id]}]
    (sql/execute-one!
     conn

--- a/server/src/instant/model/app_email_template.clj
+++ b/server/src/instant/model/app_email_template.clj
@@ -6,7 +6,7 @@
    (java.util UUID)))
 
 (defn put!
-  ([params] (put! (aurora/conn-pool) params))
+  ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id sender-id email-type subject name body]}]
    (sql/execute-one!
     conn
@@ -25,7 +25,7 @@
      (UUID/randomUUID) app-id sender-id email-type subject name body])))
 
 (defn get-by-app-id-and-email-type
-  ([params] (get-by-app-id-and-email-type (aurora/conn-pool) params))
+  ([params] (get-by-app-id-and-email-type (aurora/conn-pool :read) params))
   ([conn {:keys [app-id email-type]}]
    (sql/select-one conn
                    ["SELECT
@@ -45,6 +45,6 @@
                     app-id email-type])))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id]}]
    (sql/execute-one! conn ["DELETE FROM app_email_templates WHERE id = ?::uuid AND app_id = ?::uuid" id app-id])))

--- a/server/src/instant/model/app_member_invites.clj
+++ b/server/src/instant/model/app_member_invites.clj
@@ -7,7 +7,7 @@
    (java.util UUID)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id inviter-id email role]}]
    (sql/execute-one!
     conn
@@ -20,7 +20,7 @@
      (UUID/randomUUID) app-id inviter-id email role role])))
 
 (defn get-by-id
-  ([params] (get-by-id (aurora/conn-pool) params))
+  ([params] (get-by-id (aurora/conn-pool :read) params))
   ([conn {:keys [id]}]
    (sql/select-one conn
                    ["SELECT * 
@@ -29,7 +29,7 @@
                     id])))
 
 (defn get-by-id!
-  ([params] (get-by-id! (aurora/conn-pool) params))
+  ([params] (get-by-id! (aurora/conn-pool :read) params))
   ([conn params]
    (ex/assert-record!
     (get-by-id conn params)
@@ -37,7 +37,7 @@
     {:args [params]})))
 
 (defn get-pending-for-invitee
-  ([params] (get-pending-for-invitee (aurora/conn-pool) params))
+  ([params] (get-pending-for-invitee (aurora/conn-pool :read) params))
   ([conn {:keys [email]}]
    (sql/select conn
                ["SELECT
@@ -55,7 +55,7 @@
                 email])))
 
 (defn accept-by-id!
-  ([params] (accept-by-id! (aurora/conn-pool) params))
+  ([params] (accept-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id] :as params}]
    (ex/assert-record!
     (sql/execute-one! conn
@@ -69,7 +69,7 @@
     {:args [params]})))
 
 (defn reject-by-id
-  ([params] (reject-by-id (aurora/conn-pool) params))
+  ([params] (reject-by-id (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (sql/execute-one! conn
                      ["UPDATE app_member_invites
@@ -79,7 +79,7 @@
                       id])))
 
 (defn reject-by-email-and-role
-  ([params] (reject-by-email-and-role (aurora/conn-pool) params))
+  ([params] (reject-by-email-and-role (aurora/conn-pool :write) params))
   ([conn {:keys [inviter-id app-id invitee-email role]}]
    (sql/execute! conn
                  ["UPDATE app_member_invites
@@ -92,7 +92,7 @@
                   inviter-id app-id invitee-email role])))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (sql/execute-one! conn
                      ["DELETE FROM app_member_invites WHERE id = ?::uuid" id])))

--- a/server/src/instant/model/app_members.clj
+++ b/server/src/instant/model/app_members.clj
@@ -6,7 +6,7 @@
    (java.util UUID)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id user-id role]}]
    (sql/execute-one!
     conn
@@ -17,21 +17,21 @@
      (UUID/randomUUID) app-id user-id role])))
 
 (defn get-all-for-app
-  ([params] (get-all-for-app (aurora/conn-pool) params))
+  ([params] (get-all-for-app (aurora/conn-pool :read) params))
   ([conn {:keys [app-id]}]
    (sql/select conn
                ["SELECT * FROM app_members WHERE app_id = ?"
                 app-id])))
 
 (defn get-by-app-and-user
-  ([params] (get-by-app-and-user (aurora/conn-pool) params))
+  ([params] (get-by-app-and-user (aurora/conn-pool :read) params))
   ([conn {:keys [app-id user-id]}]
    (sql/select-one conn
                    ["SELECT * FROM app_members WHERE app_id = ?::uuid AND user_id = ?::uuid"
                     app-id user-id])))
 
 (defn update-role
-  ([params] (update-role (aurora/conn-pool) params))
+  ([params] (update-role (aurora/conn-pool :write) params))
   ([conn {:keys [role id]}]
    (sql/execute-one! conn
                      ["UPDATE app_members
@@ -41,7 +41,7 @@
                       id])))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (sql/execute-one! conn
                      ["DELETE FROM app_members WHERE id = ?::uuid"

--- a/server/src/instant/model/app_oauth_client.clj
+++ b/server/src/instant/model/app_oauth_client.clj
@@ -13,7 +13,7 @@
 (def etype "$oauthClients")
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id
                  provider-id
                  client-name
@@ -61,7 +61,7 @@
         (get-entity id))))))
 
 (defn get-by-id
-  ([params] (get-by-id (aurora/conn-pool) params))
+  ([params] (get-by-id (aurora/conn-pool :read) params))
   ([conn {:keys [app-id id]}]
    (query-op conn
              {:app-id app-id
@@ -70,7 +70,7 @@
                (get-entity id)))))
 
 (defn get-by-client-name
-  ([params] (get-by-client-name (aurora/conn-pool) params))
+  ([params] (get-by-client-name (aurora/conn-pool :read) params))
   ([conn {:keys [app-id client-name]}]
    (query-op conn
              {:app-id app-id
@@ -82,7 +82,7 @@
   (ex/assert-record! (get-by-client-name params) :app-oauth-client {:args [params]}))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id]}]
    (update-op conn
               {:app-id app-id

--- a/server/src/instant/model/app_oauth_code.clj
+++ b/server/src/instant/model/app_oauth_code.clj
@@ -11,7 +11,7 @@
 (def etype "$oauthCodes")
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [code
                  user-id
                  app-id
@@ -86,7 +86,7 @@
 
 (defn consume!
   "Gets and deletes the oauth-code so that it can be used only once."
-  ([params] (consume! (aurora/conn-pool) params))
+  ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [code app-id verifier] :as params}]
    (let [oauth-code
          (update-op

--- a/server/src/instant/model/app_oauth_redirect.clj
+++ b/server/src/instant/model/app_oauth_redirect.clj
@@ -14,7 +14,7 @@
       (crypt-util/bytes->hex-string)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id state cookie redirect-url oauth-client-id
                  code-challenge-method code-challenge]}]
    (update-op
@@ -34,7 +34,7 @@
 
 (defn consume!
   "Gets and deletes the oauth-redirect so that it can be used only once."
-  ([params] (consume! (aurora/conn-pool) params))
+  ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [state app-id]}]
    (update-op
     conn

--- a/server/src/instant/model/app_oauth_service_provider.clj
+++ b/server/src/instant/model/app_oauth_service_provider.clj
@@ -10,7 +10,7 @@
 (def etype "$oauthProviders")
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id provider-name]}]
    (update-op
     conn
@@ -23,7 +23,7 @@
         (get-entity entity-id))))))
 
 (defn get-by-provider-name
-  ([params] (get-by-provider-name (aurora/conn-pool) params))
+  ([params] (get-by-provider-name (aurora/conn-pool :read) params))
   ([conn {:keys [app-id provider-name]}]
    (query-op conn
              {:app-id app-id

--- a/server/src/instant/model/app_user.clj
+++ b/server/src/instant/model/app_user.clj
@@ -12,7 +12,7 @@
 (def etype "$users")
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id email]}]
    (update-op
     conn
@@ -24,7 +24,7 @@
       (get-entity id)))))
 
 (defn get-by-id
-  ([params] (get-by-id (aurora/conn-pool) params))
+  ([params] (get-by-id (aurora/conn-pool :read) params))
   ([conn {:keys [app-id id]}]
    (query-op conn
              {:app-id app-id
@@ -33,7 +33,7 @@
                (get-entity id)))))
 
 (defn get-by-refresh-token
-  ([params] (get-by-refresh-token (aurora/conn-pool) params))
+  ([params] (get-by-refresh-token (aurora/conn-pool :read) params))
   ([conn {:keys [app-id refresh-token]}]
    (query-op
     conn
@@ -46,7 +46,7 @@
   (ex/assert-record! (get-by-refresh-token params) :app-user {:args [params]}))
 
 (defn get-by-email
-  ([params] (get-by-email (aurora/conn-pool) params))
+  ([params] (get-by-email (aurora/conn-pool :read) params))
   ([conn {:keys [app-id email]}]
    (query-op conn
              {:app-id app-id
@@ -58,7 +58,7 @@
   (ex/assert-record! (get-by-email params) :app-user {:args [params]}))
 
 (defn update-email!
-  ([params] (update-email! (aurora/conn-pool) params))
+  ([params] (update-email! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id email]}]
    (update-op
     conn
@@ -69,7 +69,7 @@
       (get-entity id)))))
 
 (defn delete-by-email!
-  ([params] (delete-by-email! (aurora/conn-pool) params))
+  ([params] (delete-by-email! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id email]}]
    (update-op
     conn
@@ -79,7 +79,7 @@
       (delete-entity! [(resolve-id :email) email])))))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id id]}]
    (update-op
     conn
@@ -90,7 +90,7 @@
 
 
 (defn get-by-email-or-oauth-link-qualified
-  ([params] (get-by-email-or-oauth-link-qualified (aurora/conn-pool) params))
+  ([params] (get-by-email-or-oauth-link-qualified (aurora/conn-pool :read) params))
   ([conn {:keys [app-id email sub provider-id]}]
    (query-op
     conn

--- a/server/src/instant/model/app_user_magic_code.clj
+++ b/server/src/instant/model/app_user_magic_code.clj
@@ -19,7 +19,7 @@
   (rand-num-str 6))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id id code user-id]}]
    (update-op
     conn
@@ -40,7 +40,7 @@
    (> (.between ChronoUnit/HOURS (.toInstant created-at) now) 24)))
 
 (defn consume!
-  ([params] (consume! (aurora/conn-pool) params))
+  ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [email code app-id] :as params}]
    (update-op
     conn

--- a/server/src/instant/model/app_user_oauth_link.clj
+++ b/server/src/instant/model/app_user_oauth_link.clj
@@ -5,7 +5,7 @@
 (def etype "$oauthUserLinks")
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id sub provider-id user-id]}]
    (update-op
     conn

--- a/server/src/instant/model/app_user_refresh_token.clj
+++ b/server/src/instant/model/app_user_refresh_token.clj
@@ -16,7 +16,7 @@
       crypt-util/bytes->hex-string))
 
 (defn get-by-id
-  ([params] (get-by-id (aurora/conn-pool) params))
+  ([params] (get-by-id (aurora/conn-pool :read) params))
   ([conn {:keys [app-id id]}]
    (query-op conn
              {:app-id app-id
@@ -30,7 +30,7 @@
                    (assoc res :id id)))))))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id user-id]}]
    (update-op
     conn
@@ -47,7 +47,7 @@
                :id id))))))
 
 (defn delete-by-user-id!
-  ([params] (delete-by-user-id! (aurora/conn-pool) params))
+  ([params] (delete-by-user-id! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id user-id]}]
    (update-op
     conn
@@ -61,7 +61,7 @@
                            ents))))))))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id id]}]
    (update-op
     conn

--- a/server/src/instant/model/instant_cli_login.clj
+++ b/server/src/instant/model/instant_cli_login.clj
@@ -8,7 +8,7 @@
    (java.time.temporal ChronoUnit)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [ticket secret]}]
    (sql/execute-one!
     conn
@@ -20,7 +20,7 @@
      ticket (crypt-util/uuid->sha256 secret)])))
 
 (defn claim!
-  ([params] (claim! (aurora/conn-pool) params))
+  ([params] (claim! (aurora/conn-pool :write) params))
   ([conn {:keys [ticket user-id]}]
    (sql/execute-one!
     conn
@@ -42,7 +42,7 @@
   (and used? (not user-id)))
 
 (defn use!
-  ([params] (use! (aurora/conn-pool) params))
+  ([params] (use! (aurora/conn-pool :write) params))
   ([conn {:keys [secret]}]
    (let [{user-id :user_id id :id :as login}
          (sql/select-one conn
@@ -82,7 +82,7 @@
      claimed)))
 
 (defn void!
-  ([params] (void! (aurora/conn-pool) params))
+  ([params] (void! (aurora/conn-pool :write) params))
   ([conn {:keys [ticket]}]
    (sql/execute-one!
     conn

--- a/server/src/instant/model/instant_oauth_code.clj
+++ b/server/src/instant/model/instant_oauth_code.clj
@@ -8,7 +8,7 @@
    (java.time.temporal ChronoUnit)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [code user-id redirect-path]}]
    (sql/execute-one! conn
                      ["INSERT INTO instant_oauth_codes (lookup_key, user_id, redirect_path)
@@ -22,7 +22,7 @@
 
 (defn consume!
   "Gets and deletes the oauth-code so that it can be used only once."
-  ([params] (consume! (aurora/conn-pool) params))
+  ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [code] :as params}]
    (let [record  (sql/execute-one! conn
                                    ["DELETE FROM instant_oauth_codes where lookup_key = ?::bytea"

--- a/server/src/instant/model/instant_oauth_redirect.clj
+++ b/server/src/instant/model/instant_oauth_redirect.clj
@@ -7,7 +7,7 @@
    (java.time.temporal ChronoUnit)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [state cookie service redirect-path redirect-to-dev ticket]}]
    (sql/execute-one!
     conn
@@ -17,7 +17,7 @@
 
 (defn consume!
   "Gets and deletes the oauth-redirect so that it can be used only once."
-  ([params] (consume! (aurora/conn-pool) params))
+  ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [state]}]
    (sql/execute-one! conn
                      ["DELETE FROM instant_oauth_redirects where lookup_key = ?::bytea"

--- a/server/src/instant/model/instant_personal_access_token.clj
+++ b/server/src/instant/model/instant_personal_access_token.clj
@@ -6,7 +6,7 @@
    (java.util UUID)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id user-id name]}]
    (sql/execute-one! conn
                      ["INSERT INTO instant_personal_access_tokens (id, user_id, name)
@@ -14,7 +14,7 @@
                       id user-id name])))
 
 (defn list-by-user-id!
-  ([params] (list-by-user-id! (aurora/conn-pool) params))
+  ([params] (list-by-user-id! (aurora/conn-pool :read) params))
   ([conn {:keys [user-id]}]
    (sql/select conn
                ["select *
@@ -23,7 +23,7 @@
                 user-id])))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id user-id]}]
    (sql/execute-one! conn
                      ["DELETE FROM instant_personal_access_tokens

--- a/server/src/instant/model/instant_profile.clj
+++ b/server/src/instant/model/instant_profile.clj
@@ -6,7 +6,7 @@
    [instant.model.instant-user :as instant-user-model]))
 
 (defn put!
-  ([params] (put! (aurora/conn-pool) params))
+  ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [user-id meta]}]
    (sql/execute-one!
     conn
@@ -15,7 +15,7 @@
      user-id (->json meta)])))
 
 (defn get-by-user-id
-  ([params] (get-by-user-id (aurora/conn-pool) params))
+  ([params] (get-by-user-id (aurora/conn-pool :read) params))
   ([conn {:keys [user-id]}]
    (sql/select-one conn
                    ["SELECT 
@@ -24,7 +24,7 @@
                      WHERE ip.id = ?::uuid" user-id])))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (sql/execute-one! conn ["DELETE FROM instant_profiles WHERE id = ?::uuid" id])))
 

--- a/server/src/instant/model/instant_stripe_customer.clj
+++ b/server/src/instant/model/instant_stripe_customer.clj
@@ -5,7 +5,7 @@
   (:import (com.stripe.model Customer)))
 
 (defn- create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [user]}]
    (let [{:keys [id email]} user
          opts {"metadata" {"instant_user_id" id}}
@@ -21,7 +21,7 @@
 
 (defn- get-by-instant-user-id
   "Get a stripe customer information by instant user id."
-  ([params] (get-by-instant-user-id (aurora/conn-pool) params))
+  ([params] (get-by-instant-user-id (aurora/conn-pool :read) params))
   ([conn {:keys [user-id]}]
    (sql/select-one conn
                    ["SELECT * FROM instant_stripe_customers WHERE user_id = ?::uuid"
@@ -29,7 +29,7 @@
 
 (defn get-or-create!
   "Get or create a stripe customer from an instant user."
-  ([params] (get-or-create! (aurora/conn-pool) params))
+  ([params] (get-or-create! (aurora/conn-pool :write) params))
   ([conn {:keys [user]}]
    (or (get-by-instant-user-id conn {:user-id (:id user)})
        (create! conn {:user user}))))

--- a/server/src/instant/model/instant_subscription.clj
+++ b/server/src/instant/model/instant_subscription.clj
@@ -4,7 +4,7 @@
    [instant.jdbc.sql :as sql]))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [user-id app-id subscription-type-id
                  stripe-customer-id stripe-subscription-id stripe-event-id]}]
    (sql/execute-one! conn
@@ -17,14 +17,14 @@
                       stripe-customer-id stripe-subscription-id stripe-event-id])))
 
 (defn get-by-event-id
-  ([params] (get-by-event-id (aurora/conn-pool) params))
+  ([params] (get-by-event-id (aurora/conn-pool :read) params))
   ([conn {:keys [event-id]}]
    (sql/select-one conn
                    ["SELECT * FROM instant_subscriptions WHERE stripe_event_id = ?"
                     event-id])))
 
 (defn get-by-app-id
-  ([params] (get-by-app-id (aurora/conn-pool) params))
+  ([params] (get-by-app-id (aurora/conn-pool :read) params))
   ([conn {:keys [app-id]}]
    (sql/select-one conn
                    ["SELECT s.app_id, s.stripe_subscription_id, t.name

--- a/server/src/instant/model/instant_user.clj
+++ b/server/src/instant/model/instant_user.clj
@@ -29,7 +29,7 @@
        res#)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id email google-sub]}]
    (sql/execute-one! ::create!
                      conn
@@ -37,7 +37,7 @@
                       id email google-sub])))
 
 (defn update-email!
-  ([params] (update-email! (aurora/conn-pool) params))
+  ([params] (update-email! (aurora/conn-pool :write) params))
   ([conn {:keys [id email]}]
    (with-cache-invalidation id
      (sql/execute-one! ::update-email!
@@ -46,7 +46,7 @@
                         email id]))))
 
 (defn update-google-sub!
-  ([params] (update-google-sub! (aurora/conn-pool) params))
+  ([params] (update-google-sub! (aurora/conn-pool :write) params))
   ([conn {:keys [id google-sub]}]
    (with-cache-invalidation id
      (sql/execute-one! ::update-google-sub!
@@ -55,7 +55,7 @@
                         google-sub id]))))
 
 (defn get-by-id
-  ([params] (get-by-id (aurora/conn-pool) params))
+  ([params] (get-by-id (aurora/conn-pool :read) params))
   ([conn {:keys [id]}]
    (sql/select-one ::get-by-id
                    conn
@@ -77,13 +77,13 @@
 
 (defn get-by-app-id
   ([{:keys [app-id]}]
-   (cache/lookup-or-miss user-by-app-cache app-id (partial get-by-app-id* (aurora/conn-pool))))
+   (cache/lookup-or-miss user-by-app-cache app-id (partial get-by-app-id* (aurora/conn-pool :read))))
   ([conn {:keys [app-id]}]
    ;; Don't cache if we're using a custom connection
    (get-by-app-id* conn app-id)))
 
 (defn get-by-refresh-token
-  ([params] (get-by-refresh-token (aurora/conn-pool) params))
+  ([params] (get-by-refresh-token (aurora/conn-pool :read) params))
   ([conn {:keys [refresh-token]}]
    (sql/select-one
     ::get-by-refresh-token
@@ -98,7 +98,7 @@
   (ex/assert-record! (get-by-refresh-token params) :instant-user {:args [params]}))
 
 (defn get-by-personal-access-token
-  ([params] (get-by-personal-access-token (aurora/conn-pool) params))
+  ([params] (get-by-personal-access-token (aurora/conn-pool :read) params))
   ([conn {:keys [personal-access-token]}]
    (sql/select-one
     ::get-by-personal-access-token
@@ -114,7 +114,7 @@
   (ex/assert-record! (get-by-personal-access-token params) :instant-user {:args [params]}))
 
 (defn get-by-email
-  ([params] (get-by-email (aurora/conn-pool) params))
+  ([params] (get-by-email (aurora/conn-pool :read) params))
   ([conn {:keys [email]}]
    (sql/select-one ::get-by-email
                    conn
@@ -122,7 +122,7 @@
                     email])))
 
 (defn get-by-email-or-google-sub
-  ([params] (get-by-email-or-google-sub (aurora/conn-pool) params))
+  ([params] (get-by-email-or-google-sub (aurora/conn-pool :read) params))
   ([conn {:keys [email google-sub]}]
    (sql/select ::get-by-email-or-google-sub
                conn
@@ -130,7 +130,7 @@
                 email google-sub])))
 
 (defn delete-by-email!
-  ([params] (delete-by-email! (aurora/conn-pool) params))
+  ([params] (delete-by-email! (aurora/conn-pool :write) params))
   ([conn {:keys [email]}]
    (let [res (sql/execute-one! ::delete-by-email!
                                conn

--- a/server/src/instant/model/instant_user_magic_code.clj
+++ b/server/src/instant/model/instant_user_magic_code.clj
@@ -14,7 +14,7 @@
   (rand-num-str 6))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id code user-id]}]
    (sql/execute-one! conn
                      ["INSERT INTO instant_user_magic_codes (id, code, user_id) VALUES (?::uuid, ?, ?::uuid)"
@@ -26,7 +26,7 @@
    (> (.between ChronoUnit/HOURS (.toInstant created-at) now) 24)))
 
 (defn consume!
-  ([params] (consume! (aurora/conn-pool) params))
+  ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [email code] :as params}]
    (let [m (sql/execute-one! conn
                              ["DELETE FROM instant_user_magic_codes

--- a/server/src/instant/model/instant_user_refresh_token.clj
+++ b/server/src/instant/model/instant_user_refresh_token.clj
@@ -6,14 +6,14 @@
    (java.util UUID)))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id user-id]}]
    (sql/execute-one! conn
                      ["INSERT INTO instant_user_refresh_tokens (id, user_id) VALUES (?::uuid, ?::uuid)"
                       id user-id])))
 
 (defn delete-by-id!
-  ([params] (delete-by-id! (aurora/conn-pool) params))
+  ([params] (delete-by-id! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
    (sql/execute-one! conn
                      ["DELETE FROM instant_user_refresh_tokens WHERE id = ?::uuid"

--- a/server/src/instant/model/outreach.clj
+++ b/server/src/instant/model/outreach.clj
@@ -5,18 +5,18 @@
    [instant.model.instant-user :as instant-user-model]))
 
 (defn create!
-  ([params] (create! (aurora/conn-pool) params))
+  ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [user-id]}]
    (sql/execute-one! conn
                     ["INSERT INTO instant_user_outreaches (user_id) VALUES (?::uuid)"
                      user-id])))
 (defn get-by-user-id
-  ([params] (get-by-user-id (aurora/conn-pool) params))
+  ([params] (get-by-user-id (aurora/conn-pool :read) params))
   ([conn {:keys [user-id]}]
    (sql/select-one conn ["SELECT * FROM instant_user_outreaches WHERE user_id = ?" user-id])))
 
 (defn delete-by-user-id!
-  ([params] (delete-by-user-id! (aurora/conn-pool) params))
+  ([params] (delete-by-user-id! (aurora/conn-pool :write) params))
   ([conn {:keys [user-id]}]
    (sql/execute-one! conn
                     ["DELETE FROM instant_user_outreaches WHERE user_id = ?::uuid"

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -25,7 +25,7 @@
        res#)))
 
 (defn put!
-  ([params] (put! (aurora/conn-pool) params))
+  ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id code]}]
    (with-cache-invalidation app-id
      (sql/execute-one!
@@ -36,7 +36,7 @@
        app-id (->json code)]))))
 
 (defn merge!
-  ([params] (merge! (aurora/conn-pool) params))
+  ([params] (merge! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id code]}]
    (with-cache-invalidation app-id
      (sql/execute-one!
@@ -54,13 +54,13 @@
 
 (defn get-by-app-id
   ([{:keys [app-id]}]
-   (cache/lookup-or-miss rule-cache app-id (partial get-by-app-id* (aurora/conn-pool))))
+   (cache/lookup-or-miss rule-cache app-id (partial get-by-app-id* (aurora/conn-pool :read))))
   ([conn {:keys [app-id]}]
    ;; Don't cache if we're using a custom connection
    (get-by-app-id* conn app-id)))
 
 (defn delete-by-app-id!
-  ([params] (delete-by-app-id! (aurora/conn-pool) params))
+  ([params] (delete-by-app-id! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id]}]
    (with-cache-invalidation app-id
      (sql/do-execute!

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -411,7 +411,7 @@
 
 (defn apply-plan! [app-id {:keys [steps] :as _plan}]
   (let [ctx {:admin? true
-             :db {:conn-pool (aurora/conn-pool)}
+             :db {:conn-pool (aurora/conn-pool :write)}
              :app-id app-id
              :attrs (attr-model/get-by-app-id app-id)
              :datalog-query-fn d/query

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -423,7 +423,7 @@
 (defn start-byop-worker [store-conn wal-chan]
   (tracer/record-info! {:name "invalidation-worker/start-byop"})
   (let [app-id config/instant-on-instant-app-id
-        {:keys [table-info]} (pg-introspect/introspect (aurora/conn-pool)
+        {:keys [table-info]} (pg-introspect/introspect (aurora/conn-pool :read)
                                                        "public")]
     (loop []
       (let [wal-record (a/<!! wal-chan)]
@@ -509,7 +509,7 @@
   (let [shutdown-future (future (wal/shutdown! wal-opts))]
     (loop []
       (when-not (realized? shutdown-future)
-        (wal/kick-wal (aurora/conn-pool))
+        (wal/kick-wal (aurora/conn-pool :write))
         (Thread/sleep 100)
         (recur))))
   (a/close! (:to wal-opts))

--- a/server/src/instant/reactive/query.clj
+++ b/server/src/instant/reactive/query.clj
@@ -22,7 +22,7 @@
   (rs/swap-datalog-cache! store-conn app-id d/query ctx datalog-query))
 
 (comment
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id})
   (def instaql-query '[[:ea ?e ?a "joe"]])
   (time
@@ -121,7 +121,7 @@
         (throw e)))))
 
 (comment
-  (def ctx {:db {:conn-pool (aurora/conn-pool)}
+  (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :attrs (attr-model/get-by-app-id zeneca-app-id)
             :app-id zeneca-app-id
             :current-user nil

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -77,7 +77,7 @@
 (defn get-attrs [app]
   (if-let [connection-string (-> app :connection_string)]
     ;; TODO(byop): Separate connection for byop app
-    (pg-introspect/introspect (aurora/conn-pool) (or (->> connection-string
+    (pg-introspect/introspect (aurora/conn-pool :read) (or (->> connection-string
                                                           (app-model/decrypt-connection-string (:id app))
                                                           uri/query-map
                                                           :currentSchema)
@@ -132,7 +132,7 @@
             processed-tx-id (rs/get-processed-tx-id @store-conn app-id)
             {:keys [table-info]} (get-attrs app)
             attrs (attr-model/get-by-app-id app-id)
-            ctx {:db {:conn-pool (aurora/conn-pool)}
+            ctx {:db {:conn-pool (aurora/conn-pool :read)}
                  :datalog-loader (rs/upsert-datalog-loader! store-conn sess-id d/make-loader)
                  :session-id sess-id
                  :app-id app-id
@@ -154,7 +154,7 @@
 (defn- recompute-instaql-query!
   [{:keys [store-conn current-user app-id sess-id attrs table-info admin?]}
    {:keys [instaql-query/query instaql-query/return-type]}]
-  (let [ctx {:db {:conn-pool (aurora/conn-pool)}
+  (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
              :session-id sess-id
              :app-id app-id
              :attrs attrs
@@ -232,7 +232,7 @@
         _ (tx/validate! coerced)
         {tx-id :id}
         (permissioned-tx/transact!
-         {:db {:conn-pool (aurora/conn-pool)}
+         {:db {:conn-pool (aurora/conn-pool :write)}
           :rules (rule-model/get-by-app-id {:app-id app-id})
           :app-id app-id
           :current-user (:user auth)

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -112,7 +112,7 @@
         app-id (ex/get-param! req [:body :app-id] uuid-util/coerce)
         app (app-model/get-by-id! {:id app-id})
         {user-id :id :as u} (or (app-user-model/get-by-email {:app-id app-id :email email})
-                                (next-jdbc/with-transaction [conn (aurora/conn-pool)]
+                                (next-jdbc/with-transaction [conn (aurora/conn-pool :write)]
                                   (let [app (app-user-model/create! conn {:id (random-uuid)
                                                                           :app-id app-id
                                                                           :email email})]

--- a/server/src/instant/scratch/export.clj
+++ b/server/src/instant/scratch/export.clj
@@ -76,13 +76,13 @@
         _ (println "Exported")
 
         _ (println (format "Fetch user by email = %s" local-user-email))
-        {user-id :id} (instant-user-model/get-by-email (aurora/conn-pool)
+        {user-id :id} (instant-user-model/get-by-email (aurora/conn-pool :write)
                                                        {:email local-user-email})
         _ (assert user-id (format "User with email %s not found" local-user-email))
         _ (println (format "Fetched user id = %s" user-id))
 
         _ (println (format  "Importing app_id = %s to user-email = %s" prod-app-id local-user-email))
-        _ (import-app (aurora/conn-pool) user-id exported-data)
+        _ (import-app (aurora/conn-pool :write) user-id exported-data)
         _ (println "Done!")]))
 
 (comment

--- a/server/src/instant/scripts/analytics.clj
+++ b/server/src/instant/scripts/analytics.clj
@@ -14,32 +14,32 @@
 (defn get-num-users
   "Total number of users, -2 for stopa, joe, and testuser"
   []
-  (:count (sql/select-one (aurora/conn-pool) ["SELECT COUNT(*) - 3 as count FROM instant_users"])))
+  (:count (sql/select-one (aurora/conn-pool :read) ["SELECT COUNT(*) - 3 as count FROM instant_users"])))
 
 (defn get-num-users-yday
   "Number of users who signed up yesterday"
   []
-  (:count (sql/select-one (aurora/conn-pool) ["SELECT COUNT(*) as count
+  (:count (sql/select-one (aurora/conn-pool :read) ["SELECT COUNT(*) as count
                                             FROM instant_users
                                             WHERE created_at::date >= (current_date - 1)"])))
 
 (defn get-num-apps []
   (:count (sql/select-one
-           (aurora/conn-pool)
+           (aurora/conn-pool :read)
            ["select count(*)
               from apps a join instant_users u on a.creator_id = u.id
               where u.email not in ('joe@instantdb.com', 'stopa@instantdb.com', 'testuser@instantdb.com')"])))
 
 (defn get-num-apps-yday []
   (:count (sql/select-one
-           (aurora/conn-pool)
+           (aurora/conn-pool :read)
            ["select count(*) from apps a join instant_users u on a.creator_id = u.id
               where u.email not in ('joe@instantdb.com', 'stopa@instantdb.com', 'testuser@instantdb.com')
               and a.created_at::date >= current_date - 1;"])))
 
 (defn get-email-app-creators-yday []
   (sql/select
-   (aurora/conn-pool)
+   (aurora/conn-pool :read)
    ["SELECT distinct(u.email) from apps a join instant_users u on a.creator_id = u.id
       where a.created_at::date >= current_date - 1;"]))
 
@@ -49,7 +49,7 @@
 
 (defn top-recent-users []
   (sql/select
-   (aurora/conn-pool)
+   (aurora/conn-pool :read)
    ["WITH app_counts AS (
      SELECT app_id, COUNT(*) as app_count
        FROM triples t
@@ -67,7 +67,7 @@
 
 (defn get-num-triples []
   (:count
-   (sql/select-one (aurora/conn-pool)
+   (sql/select-one (aurora/conn-pool :read)
                    ["WITH filtered_users AS (
                        SELECT id FROM instant_users
                        WHERE email NOT IN ('joe@instantdb.com', 'stopa@instantdb.com', 'testuser@instantdb.com')

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -21,7 +21,7 @@
 (defn get-daily-actives
   "Returns the number of active devs and apps for a day"
   ([date-str]
-   (get-daily-actives (aurora/conn-pool) date-str))
+   (get-daily-actives (aurora/conn-pool :read) date-str))
   ([conn date-str]
    (sql/select-one conn
                    ["SELECT
@@ -52,7 +52,7 @@
 (defn insert-new-activity
   "Insert new transactions into the daily_app_transactions table.
   This is intended to run daily to speed up monthly metrics generation."
-  ([] (insert-new-activity (aurora/conn-pool)))
+  ([] (insert-new-activity (aurora/conn-pool :write)))
   ([conn]
    (binding [sql/*query-timeout-seconds* 180]
      (sql/do-execute! conn

--- a/server/src/instant/scripts/metrics.clj
+++ b/server/src/instant/scripts/metrics.clj
@@ -43,7 +43,7 @@
 
 (defn get-weekly-stats
   ([]
-   (get-weekly-stats (aurora/conn-pool)))
+   (get-weekly-stats (aurora/conn-pool :read)))
   ([conn]
    (sql/select conn
                ["SELECT
@@ -62,7 +62,7 @@
 
 (defn get-monthly-stats
   ([]
-   (get-monthly-stats (aurora/conn-pool)))
+   (get-monthly-stats (aurora/conn-pool :read)))
   ([conn]
    (sql/select conn
                ["SELECT

--- a/server/src/instant/system_catalog_migration.clj
+++ b/server/src/instant/system_catalog_migration.clj
@@ -20,10 +20,10 @@
    (ensure-attrs-on-system-catalog-app system-catalog/system-catalog-app-id))
   ([app-id]
    (tracer/with-span! {:name "system-catalog/ensure-attrs-on-system-catalog-app"}
-     (let [existing-attrs (attr-model/get-by-app-id (aurora/conn-pool) app-id)
+     (let [existing-attrs (attr-model/get-by-app-id (aurora/conn-pool :read) app-id)
            new-attrs (missing-attrs existing-attrs)
            ids (when (seq new-attrs)
-                 (attr-model/insert-multi! (aurora/conn-pool)
+                 (attr-model/insert-multi! (aurora/conn-pool :write)
                                            app-id
                                            new-attrs
                                            {:allow-reserved-names? true
@@ -38,7 +38,7 @@
                             new-attrs)]
        (when (seq json-ids)
          (sql/execute!
-          (aurora/conn-pool)
+          (aurora/conn-pool :write)
           (hsql/format {:update :attrs
                         :where [:in :id json-ids]
                         :set {:inferred-types [:cast
@@ -47,7 +47,7 @@
                                                [:bit :32]]}})))
        (when (seq string-ids)
          (sql/execute!
-          (aurora/conn-pool)
+          (aurora/conn-pool :write)
           (hsql/format {:update :attrs
                         :where [:in :id string-ids]
                         :set {:inferred-types [:cast

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -23,7 +23,7 @@
      (instaql-nodes->object-tree
       {:attrs attrs}
       (iq/permissioned-query
-       {:db {:conn-pool (aurora/conn-pool)}
+       {:db {:conn-pool (aurora/conn-pool :read)}
         :app-id app-id
         :attrs attrs
         :datalog-query-fn d/query

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -714,7 +714,7 @@
 (deftest lookups-in-links-dont-override-attrs
   (with-empty-app
     (fn [{app-id :id admin-token :admin-token}]
-      (attr-model/insert-multi! (aurora/conn-pool)
+      (attr-model/insert-multi! (aurora/conn-pool :write)
                                 app-id
                                 [{:id (random-uuid)
                                   :forward-identity [(random-uuid) "posts" "id"]

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -24,7 +24,7 @@
   (let [res (resolvers/walk-friendly
              @r
              (d/query
-              {:db {:conn-pool (aurora/conn-pool)}
+              {:db {:conn-pool (aurora/conn-pool :read)}
                :app-id movies-app-id
                :datalog-loader (d/make-loader)}
               q))]
@@ -123,7 +123,7 @@
         clojure.lang.ExceptionInfo
         #"Invalid input"
         (d/query
-         {:db {:conn-pool (aurora/conn-pool)}
+         {:db {:conn-pool (aurora/conn-pool :read)}
           :app-id movies-app-id}
          [bad-pat])))))
   (testing "throws on unjoinable patterns"
@@ -132,7 +132,7 @@
       java.lang.AssertionError
       #"Pattern is not joinable"
       (d/query
-       {:db {:conn-pool (aurora/conn-pool)}
+       {:db {:conn-pool (aurora/conn-pool :read)}
         :app-id movies-app-id}
        '[[:ea ?a ?b ?c]
          [:ea ?d ?e ?f]])))))
@@ -142,7 +142,7 @@
     (testing "query pads with _"
       (is (= #{"Tina Turner" "1939-11-26T00:00:00Z"}
              (->> (d/query
-                   {:db {:conn-pool (aurora/conn-pool)}
+                   {:db {:conn-pool (aurora/conn-pool :read)}
                     :app-id  movies-app-id}
                    [[:ea tina-turner-eid]])
                   :join-rows
@@ -150,7 +150,7 @@
                   set))))
     (testing "ref values come back as uuids"
       (let [vs (->> (d/query
-                     {:db {:conn-pool (aurora/conn-pool)}
+                     {:db {:conn-pool (aurora/conn-pool :read)}
                       :app-id movies-app-id}
                      [[:eav '?e '?a tina-turner-eid]])
                     :join-rows
@@ -160,7 +160,7 @@
 
 (deftest batching-queries
   (let [app-id movies-app-id
-        ctx {:db {:conn-pool (aurora/conn-pool)}
+        ctx {:db {:conn-pool (aurora/conn-pool :read)}
              :app-id app-id}
         movie-title-aid (resolvers/->uuid @r :movie/title)
         movie-director-aid (resolvers/->uuid @r :movie/director)
@@ -186,7 +186,7 @@
                  1708623782646]]}
              (resolvers/walk-friendly
               @r
-              (:join-rows (d/send-query-single ctx (aurora/conn-pool) app-id named-ps-1)))))
+              (:join-rows (d/send-query-single ctx (aurora/conn-pool :read) app-id named-ps-1)))))
       (is (= #{[["eid-john-mctiernan" :person/name "John McTiernan" 1708623782646]
                 ["eid-die-hard" :movie/director "eid-john-mctiernan" 1708623782646]
                 ["eid-die-hard" :movie/title "Die Hard" 1708623782646]]
@@ -195,7 +195,7 @@
                 ["eid-predator" :movie/title "Predator" 1708623782646]]}
              (resolvers/walk-friendly
               @r
-              (:join-rows (d/send-query-single ctx (aurora/conn-pool) app-id named-ps-2))))))
+              (:join-rows (d/send-query-single ctx (aurora/conn-pool :read) app-id named-ps-2))))))
     (testing "send-query-batched"
       (is (= [#{[["eid-predator" :movie/title "Predator" 1708623782646]
                  ["eid-predator" :movie/director "eid-john-mctiernan" 1708623782646]
@@ -211,7 +211,7 @@
                  ["eid-predator" :movie/title "Predator" 1708623782646]]}]
              (resolvers/walk-friendly
               @r
-              (map :join-rows (d/send-query-batch ctx (aurora/conn-pool) [[app-id named-ps-1]
+              (map :join-rows (d/send-query-batch ctx (aurora/conn-pool :read) [[app-id named-ps-1]
                                                                           [app-id named-ps-2]]))))))))
 
 (def ^:dynamic *count-atom* nil)
@@ -393,7 +393,7 @@
               name-aid (resolvers/->uuid r :users/fullName)]
           (is (= #{"Alex"}
                  (->> (d/query
-                       {:db {:conn-pool (aurora/conn-pool)}
+                       {:db {:conn-pool (aurora/conn-pool :read)}
                         :app-id (:id app)}
                        [[:ea [handle-aid "alex"] name-aid '?name]])
                       :join-rows

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -50,14 +50,14 @@
                                      order-job
                                      created-at-job]))
                           1000)
-              title-triples (triple-model/fetch (aurora/conn-pool)
+              title-triples (triple-model/fetch (aurora/conn-pool :read)
                                                 (:id app)
                                                 [[:= :attr-id (resolvers/->uuid r :books/title)]])
-              order-triples (triple-model/fetch (aurora/conn-pool)
+              order-triples (triple-model/fetch (aurora/conn-pool :read)
                                                 (:id app)
                                                 [[:= :attr-id (resolvers/->uuid r :bookshelves/order)]])
 
-              created-at-triples (triple-model/fetch (aurora/conn-pool)
+              created-at-triples (triple-model/fetch (aurora/conn-pool :read)
                                                      (:id app)
                                                      [[:= :attr-id (resolvers/->uuid r :users/createdAt)]])]
           (is (pos? (count title-triples)))
@@ -105,7 +105,7 @@
                                       (= "errored" (:job_status (jobs/get-by-id id))))
                                     [handle-job]))
                           1000)
-              handle-triples (triple-model/fetch (aurora/conn-pool)
+              handle-triples (triple-model/fetch (aurora/conn-pool :read)
                                                  (:id app)
                                                  [[:= :attr-id (resolvers/->uuid r :users/handle)]])]
           (is (pos? (count handle-triples)))
@@ -138,7 +138,7 @@
                                       (= "completed" (:job_status (jobs/get-by-id id))))
                                     [title-job]))
                           1000)
-              title-triples (triple-model/fetch (aurora/conn-pool)
+              title-triples (triple-model/fetch (aurora/conn-pool :read)
                                                 (:id app)
                                                 [[:= :attr-id (resolvers/->uuid r :books/title)]])]
           (testing "setup worked"
@@ -160,7 +160,7 @@
                                         (= "completed" (:job_status (jobs/get-by-id id))))
                                       [remove-type-job]))
                             1000)
-                title-triples (triple-model/fetch (aurora/conn-pool)
+                title-triples (triple-model/fetch (aurora/conn-pool :read)
                                                   (:id app)
                                                   [[:= :attr-id (resolvers/->uuid r :books/title)]])]
             (is (pos? (count title-triples)))
@@ -186,7 +186,7 @@
                                       (= "completed" (:job_status (jobs/get-by-id id))))
                                     [title-job]))
                           1000)
-              title-triples (triple-model/fetch (aurora/conn-pool)
+              title-triples (triple-model/fetch (aurora/conn-pool :read)
                                                 (:id app)
                                                 [[:= :attr-id (resolvers/->uuid r :books/title)]])]
           (testing "index"
@@ -212,7 +212,7 @@
                                           (= "completed" (:job_status (jobs/get-by-id id))))
                                         [remove-index-job]))
                               1000)
-                  title-triples (triple-model/fetch (aurora/conn-pool)
+                  title-triples (triple-model/fetch (aurora/conn-pool :read)
                                                     (:id app)
                                                     [[:= :attr-id (resolvers/->uuid r :books/title)]])]
               (is (pos? (count title-triples)))
@@ -233,7 +233,7 @@
       (fn [app]
         (let [attr-id (random-uuid)
 
-              _ (tx/transact! (aurora/conn-pool)
+              _ (tx/transact! (aurora/conn-pool :write)
                               (attr-model/get-by-app-id (:id app))
                               (:id app)
                               [[:add-attr {:id attr-id
@@ -243,7 +243,7 @@
                                            :value-type :blob
                                            :cardinality :one}]])
               _ (dotimes [x 10]
-                  (tx/transact! (aurora/conn-pool)
+                  (tx/transact! (aurora/conn-pool :write)
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)
                                 (for [i (range 1002)]
@@ -258,7 +258,7 @@
                                       (= "completed" (:job_status (jobs/get-by-id id))))
                                     [job]))
                           1000)
-              triples (triple-model/fetch (aurora/conn-pool)
+              triples (triple-model/fetch (aurora/conn-pool :read)
                                           (:id app)
                                           [[:= :attr-id attr-id]])]
           (testing "unique"
@@ -282,7 +282,7 @@
                                           (= "completed" (:job_status (jobs/get-by-id id))))
                                         [remove-unique-job]))
                               1000)
-                  triples (triple-model/fetch (aurora/conn-pool)
+                  triples (triple-model/fetch (aurora/conn-pool :read)
                                               (:id app)
                                               [[:= :attr-id attr-id]])]
               (is (pos? (count triples)))
@@ -301,7 +301,7 @@
       (fn [app]
         (let [attr-id (random-uuid)
 
-              _ (tx/transact! (aurora/conn-pool)
+              _ (tx/transact! (aurora/conn-pool :write)
                               (attr-model/get-by-app-id (:id app))
                               (:id app)
                               [[:add-attr {:id attr-id
@@ -311,12 +311,12 @@
                                            :value-type :blob
                                            :cardinality :one}]])
               _ (dotimes [x 5]
-                  (tx/transact! (aurora/conn-pool)
+                  (tx/transact! (aurora/conn-pool :write)
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)
                                 (for [i (range 1002)]
                                   [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
-              _ (tx/transact! (aurora/conn-pool)
+              _ (tx/transact! (aurora/conn-pool :write)
                               (attr-model/get-by-app-id (:id app))
                               (:id app)
                               [[:add-triple (random-uuid) attr-id "a"]
@@ -331,7 +331,7 @@
                                       (= "errored" (:job_status (jobs/get-by-id id))))
                                     [job]))
                           1000)
-              triples (triple-model/fetch (aurora/conn-pool)
+              triples (triple-model/fetch (aurora/conn-pool :read)
                                           (:id app)
                                           [[:= :attr-id attr-id]])
               job-for-client (jobs/get-by-id-for-client (:app_id job) (:id job))]
@@ -359,7 +359,7 @@
       (fn [app]
         (let [attr-id (random-uuid)
 
-              _ (tx/transact! (aurora/conn-pool)
+              _ (tx/transact! (aurora/conn-pool :write)
                               (attr-model/get-by-app-id (:id app))
                               (:id app)
                               [[:add-attr {:id attr-id
@@ -369,13 +369,13 @@
                                            :value-type :blob
                                            :cardinality :one}]])
               _ (dotimes [x 5]
-                  (tx/transact! (aurora/conn-pool)
+                  (tx/transact! (aurora/conn-pool :write)
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)
                                 (for [i (range 1002)]
                                   [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
               bad-id (random-uuid)
-              _ (tx/transact! (aurora/conn-pool)
+              _ (tx/transact! (aurora/conn-pool :write)
                               (attr-model/get-by-app-id (:id app))
                               (:id app)
                               [[:add-triple bad-id attr-id (apply str (repeatedly 1024 random-uuid))]])
@@ -394,7 +394,7 @@
                                     [unique-job
                                      index-job]))
                           1000)
-              triples (triple-model/fetch (aurora/conn-pool)
+              triples (triple-model/fetch (aurora/conn-pool :read)
                                           (:id app)
                                           [[:= :attr-id attr-id]])
               unique-job-for-client (jobs/get-by-id-for-client (:id app) (:id unique-job))

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -41,7 +41,7 @@
                                                         tx-steps))}
                                 {:test "permissioned-tx/transact!"
                                  :tx-fn (fn [app-id tx-steps]
-                                          (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
+                                          (let [ctx {:db {:conn-pool (aurora/conn-pool :write)}
                                                      :app-id app-id
                                                      :attrs (attr-model/get-by-app-id app-id)
                                                      :datalog-query-fn d/query
@@ -985,7 +985,7 @@
 (deftest write-perms-merged
   (with-zeneca-app
     (fn [{app-id :id :as _app} r]
-      (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
+      (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :write)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
@@ -1017,7 +1017,7 @@
                               [" with lookup ref" (fn [r] [(resolvers/->uuid r :users/email) "stopa@instantdb.com"])]]]
     (with-zeneca-app
       (fn [{app-id :id :as _app} r]
-        (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
+        (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :write)}
                                :app-id app-id
                                :attrs (attr-model/get-by-app-id app-id)
                                :datalog-query-fn d/query
@@ -1413,7 +1413,7 @@
                                      :view  "size(data.ref('org.id')) == 1"
                                      :delete  "size(data.ref('org.id')) == 1"}}}})
               rules (rule-model/get-by-app-id {:app-id app-id})
-              ctx {:db {:conn-pool (aurora/conn-pool :read)}
+              ctx {:db {:conn-pool (aurora/conn-pool :write)}
                    :app-id app-id
                    :attrs attrs
                    :datalog-query-fn d/query
@@ -2185,7 +2185,7 @@
             book-creator-attr-id (random-uuid)
             book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :write)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
@@ -2222,7 +2222,7 @@
             book-isbn-attr-id (random-uuid)
             book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :write)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
@@ -2278,7 +2278,7 @@
     (fn [{app-id :id}]
       (let [r (resolvers/make-movies-resolver app-id)
             id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :write)}
                              :app-id app-id
                              :admin? true
                              :attrs (attr-model/get-by-app-id app-id)
@@ -2322,7 +2322,7 @@
             book-title-attr-id (random-uuid)
             book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :write)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -28,24 +28,24 @@
   ([app-id where-clause]
    (set (map :triple
              (triple-model/fetch
-              (aurora/conn-pool)
+              (aurora/conn-pool :read)
               app-id
               where-clause)))))
 
 (deftest attrs-create-delete
   (doseq [{:keys [test tx-fn]} [{:test "tx/transact!"
                                  :tx-fn (fn [app-id tx-steps]
-                                          (tx/transact! (aurora/conn-pool)
+                                          (tx/transact! (aurora/conn-pool :write)
                                                         (attr-model/get-by-app-id app-id)
                                                         app-id
                                                         tx-steps))}
                                 {:test "permissioned-tx/transact!"
                                  :tx-fn (fn [app-id tx-steps]
-                                          (let [ctx {:db {:conn-pool (aurora/conn-pool)}
+                                          (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
                                                      :app-id app-id
                                                      :attrs (attr-model/get-by-app-id app-id)
                                                      :datalog-query-fn d/query
-                                                     :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                                                     :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                                                      :current-user nil}]
                                             (permissioned-tx/transact! ctx tx-steps)))}]]
     (testing test
@@ -83,7 +83,7 @@
                           set))))
             (testing "triples are created"
               (is (= #{"Stopa" "Blue"}
-                     (->> (triple-model/fetch (aurora/conn-pool) app-id)
+                     (->> (triple-model/fetch (aurora/conn-pool :read) app-id)
                           (map :triple)
                           (map last)
                           set))))
@@ -100,7 +100,7 @@
                             set))))
               (testing "associated triples are deleted"
                 (is (= #{"Stopa"}
-                       (->> (triple-model/fetch (aurora/conn-pool) app-id)
+                       (->> (triple-model/fetch (aurora/conn-pool :read) app-id)
                             (map :triple)
                             (map last)
                             set)))))))))))
@@ -116,7 +116,7 @@
             name-fwd-ident #uuid "e33d8ba7-a6fb-41bb-92a8-17582dec616d"
             tag-one-eid #uuid "da5e3210-c002-4743-ad9e-27206e048926"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -145,7 +145,7 @@
                       set))))
         (testing "changing forward-identity works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:update-attr
@@ -159,7 +159,7 @@
                       set))))
         (testing "changing reverse-identity works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:update-attr
@@ -173,16 +173,16 @@
                       set))))
         (testing "indexes are what we expect"
           (is  (= [#{:eav :vae}]
-                  (->> (triple-model/fetch (aurora/conn-pool) app-id
+                  (->> (triple-model/fetch (aurora/conn-pool :read) app-id
                                            [[:= :attr-id tag-attr-id]])
                        (map :index))))
           (is  (= [#{:ea}]
-                  (->> (triple-model/fetch (aurora/conn-pool) app-id
+                  (->> (triple-model/fetch (aurora/conn-pool :read) app-id
                                            [[:= :attr-id name-attr-id]])
                        (map :index)))))
         (testing "changing a column that affects an index works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:update-attr
@@ -201,16 +201,16 @@
                   tag-attr-id
                   (attr-model/get-by-app-id app-id))))
           (is (= [#{:eav :vae :ea}]
-                 (->> (triple-model/fetch (aurora/conn-pool) app-id
+                 (->> (triple-model/fetch (aurora/conn-pool :read) app-id
                                           [[:= :attr-id tag-attr-id]])
                       (map :index))))
           (is (= [#{:ea}]
-                 (->> (triple-model/fetch (aurora/conn-pool) app-id
+                 (->> (triple-model/fetch (aurora/conn-pool :read) app-id
                                           [[:= :attr-id name-attr-id]])
                       (map :index)))))
         (testing "changing multiple columns at once works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:update-attr
@@ -229,11 +229,11 @@
                   name-attr-id
                   (attr-model/get-by-app-id app-id))))
           (is (= [#{:eav :vae :ea}]
-                 (->> (triple-model/fetch (aurora/conn-pool) app-id
+                 (->> (triple-model/fetch (aurora/conn-pool :read) app-id
                                           [[:= :attr-id tag-attr-id]])
                       (map :index))))
           (is (= [#{:av :ea}]
-                 (->> (triple-model/fetch (aurora/conn-pool) app-id
+                 (->> (triple-model/fetch (aurora/conn-pool :read) app-id
                                           [[:= :attr-id name-attr-id]])
                       (map :index)))))))))
 
@@ -244,7 +244,7 @@
             name-fwd-ident #uuid "8935944f-1371-4600-b66b-153feeb19124"
             stopa-eid #uuid "476c9d7f-14db-4ee3-8639-0fe2a135f438"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -276,12 +276,12 @@
                    :md5 "d9beab677fefb1bb874e6894f92ff8ef",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id name-attr-id]]))))
         (testing "implicit retract works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid name-attr-id "Joe"]])
@@ -293,7 +293,7 @@
                  :md5 "55f6507b8e39426e7d559db45ab1fdd0",
                  :index #{:ea}}]
                (triple-model/fetch
-                (aurora/conn-pool)
+                (aurora/conn-pool :read)
                 app-id
                 [[:= :attr-id name-attr-id]]))))))))
 
@@ -304,7 +304,7 @@
             zip-fwd-ident #uuid "0d5e1430-1f97-4fa3-ab8d-486c3ddcc4fe"
             stopa-eid #uuid "72aa9c7b-a288-4579-b308-d314219a1e1f"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -337,12 +337,12 @@
                    :md5 "70ce574f8884b16169e3e5a8e691c028",
                    :index #{:ave :ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id zip-attr-id]]))))
         (testing "implicit retract still works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid zip-attr-id "11207"]])
@@ -353,7 +353,7 @@
                    :md5 "ed5e18951da7c0bb257840c7c98706cb"
                    :index #{:ave :ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id zip-attr-id]]))))))))
 
@@ -365,7 +365,7 @@
             stopa-eid #uuid "23c6400b-72a5-4147-8a06-79cdcda0b0d1"
             joe-eid #uuid "9f64613b-286a-44f8-a228-3c3e6a4fa4ce"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -397,13 +397,13 @@
                    :md5 "66c461730d99ab77911770a07fcce6bf"
                    :index #{:ave :ea :av}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id email-attr-id]]))))
 
         (testing "implicit retract still works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid email-attr-id "test2@instantdb.com"]])
@@ -412,7 +412,7 @@
                    :md5 "3f073721c34987c8f438e1bad08f48cc"
                    :index #{:ave :ea :av}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id email-attr-id]]))))
         (testing "unicity throws"
@@ -420,7 +420,7 @@
            (= ::ex/record-not-unique
               (::ex/type (instant-ex-data
                           (tx/transact!
-                           (aurora/conn-pool)
+                           (aurora/conn-pool :write)
                            (attr-model/get-by-app-id app-id)
                            app-id
                            [[:add-triple joe-eid email-attr-id "test2@instantdb.com"]]))))))))))
@@ -435,7 +435,7 @@
             tag-one-eid #uuid "0651748f-cf27-49a6-b895-7baa00ebf805"
             tag-two-eid #uuid "374b9692-fdf5-4682-b2c3-3ce87f267784"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -468,12 +468,12 @@
                    :md5 "d0a560693570bacd7b02574480981f33"
                    :index #{:eav :vae}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id tag-attr-id]]))))
         (testing "cardinality many works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid tag-attr-id tag-two-eid]])
@@ -486,7 +486,7 @@
                     :md5 "797a59d372e168dd573b6e42080a4d1e"
                     :index #{:eav :vae}}}
                  (set (triple-model/fetch
-                       (aurora/conn-pool)
+                       (aurora/conn-pool :read)
                        app-id
                        [[:= :attr-id tag-attr-id]])))))
         (testing "invalid uuids are rejected"
@@ -494,7 +494,7 @@
            (= :invalid-text-representation
               (->  (instant-ex-data
                     (tx/transact!
-                     (aurora/conn-pool)
+                     (aurora/conn-pool :write)
                      (attr-model/get-by-app-id app-id)
                      app-id
                      [[:add-triple stopa-eid tag-attr-id "Foo"]]))
@@ -504,7 +504,7 @@
            (= "Check Violation: ref_values_are_uuid"
               (-> (instant-ex-data
                    (tx/transact!
-                    (aurora/conn-pool)
+                    (aurora/conn-pool :write)
                     (attr-model/get-by-app-id app-id)
                     app-id
                     [[:add-triple stopa-eid tag-attr-id {:foo "bar"}]]))
@@ -524,7 +524,7 @@
             stopa-eid #uuid "75297d98-bc86-484d-94cd-170f4f607a22"
             joe-eid #uuid "2d9d4ed7-6b72-46e1-8564-af033861a5b1"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -556,12 +556,12 @@
                    :md5 "cf4a51ae88088110a27c1742ad1dedae"
                    :index #{:eav :vae :ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id owner-attr-id]]))))
         (testing "implicit retract works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple post-eid owner-attr-id joe-eid]])
@@ -569,7 +569,7 @@
                    :md5 "460869771b15d18ffcbeda1f64b80d97"
                    :index #{:eav :vae :ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id owner-attr-id]]))))))))
 
@@ -584,7 +584,7 @@
             stopa-eid #uuid "75297d98-bc86-484d-94cd-170f4f607a22"
             joe-eid #uuid "2d9d4ed7-6b72-46e1-8564-af033861a5b1"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -616,12 +616,12 @@
                    :md5 "c0071c9a4cc18dc66115d788b76c12b5"
                    :index #{:eav :vae :ea :av}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id config-attr-id]]))))
         (testing "implicit retract works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid config-attr-id second-config-eid]])
@@ -629,7 +629,7 @@
                    :md5 "6635175fed8c0da3dd51bdeda050eee4"
                    :index #{:eav :vae :ea :av}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id config-attr-id]]))))
 
@@ -637,7 +637,7 @@
          (= ::ex/record-not-unique
             (::ex/type (instant-ex-data
                         (tx/transact!
-                         (aurora/conn-pool)
+                         (aurora/conn-pool :write)
                          (attr-model/get-by-app-id app-id)
                          app-id
                          [[:add-triple joe-eid config-attr-id second-config-eid]])))))))))
@@ -646,7 +646,7 @@
   (with-zeneca-app
     (fn [{app-id :id} r]
       (let [attrs (attr-model/get-by-app-id app-id)
-            ctx {:db {:conn-pool (aurora/conn-pool)}
+            ctx {:db {:conn-pool (aurora/conn-pool :read)}
                  :app-id app-id
                  :attrs attrs
                  :datalog-query-fn d/query}
@@ -664,7 +664,7 @@
                     "alex@instantdb.com"]}
                  (fetch-triples app-id [[:= :attr-id email-attr-id]
                                         [:= :entity-id alex-eid]])))
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple [handle-attr-id "alex"] email-attr-id "a@example.com"]])
@@ -674,7 +674,7 @@
                  (fetch-triples app-id [[:= :attr-id email-attr-id]
                                         [:= :entity-id alex-eid]]))))
         (testing "upserts if necessary"
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple [handle-attr-id "nobody"] email-attr-id "nobody@example.com"]])
@@ -684,7 +684,7 @@
                   (iq/query ctx {:users {:$ {:where {:handle "nobody"}}}})))))
 
         (testing "setting ids works"
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple [handle-attr-id "id-test"] email-attr-id "id-test@example.com"]
@@ -698,7 +698,7 @@
             (is (uuid? (get user "id")))))
 
         (testing "retractions work"
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:retract-triple [handle-attr-id "alex"] email-attr-id "a@example.com"]])
@@ -708,7 +708,7 @@
 
         (testing "delete entity works"
           (is (seq (fetch-triples app-id [[:= :entity-id stopa-eid]])))
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:delete-entity [handle-attr-id "stopa"]]])
@@ -731,7 +731,7 @@
                                   (get % "isbn13"))))
 
             ;; check retract
-            (tx/transact! (aurora/conn-pool)
+            (tx/transact! (aurora/conn-pool :write)
                           (attr-model/get-by-app-id app-id)
                           app-id
                           [[:retract-triple eid-nonfiction bookshelf-attr-id [isbn-attr-eid feynman-isbn]]])
@@ -746,7 +746,7 @@
                           (get % "books"))))
 
             ;; check adding back
-            (tx/transact! (aurora/conn-pool)
+            (tx/transact! (aurora/conn-pool :write)
                           (attr-model/get-by-app-id app-id)
                           app-id
                           [[:add-triple eid-nonfiction bookshelf-attr-id [isbn-attr-eid feynman-isbn]]])
@@ -764,7 +764,7 @@
                                   (get % "isbn13"))))))
 
         (testing "value lookup refs are ignored for regular attributes"
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple alex-eid email-attr-id [email-attr-id "test"]]])
@@ -782,7 +782,7 @@
             stopa-eid #uuid "38f7038b-19e4-4c5e-9a3f-4ca9949014bc"
             joe-eid #uuid "efdaf919-9384-4afc-9629-6aef505ff589"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -800,7 +800,7 @@
                  (fetch-triples app-id [[:= :attr-id color-attr-id]]))))
         (testing "retract works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:retract-triple stopa-eid color-attr-id "Blue"]])
@@ -819,7 +819,7 @@
             joe-eid #uuid "6ea7045a-0d1b-4d30-bd91-dacaf6655206"
             billy-eid #uuid "29d5eaa4-8eee-4a30-bb3a-1aa6ee4ce3f9"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr {:id likes-attr-id
@@ -838,7 +838,7 @@
 
         (testing "double-inserting on ea works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid fav-nickname-attr-id "Stoopa"]
@@ -849,7 +849,7 @@
                  (fetch-triples app-id [[:= :attr-id fav-nickname-attr-id]]))))
         (testing "double-inserting on eav works"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple stopa-eid likes-attr-id billy-eid]
@@ -873,7 +873,7 @@
             joe-eid #uuid "6ea7045a-0d1b-4d30-bd91-dacaf6655206"
             billy-eid #uuid "29d5eaa4-8eee-4a30-bb3a-1aa6ee4ce3f9"]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr {:id likes-attr-id
@@ -892,7 +892,7 @@
 
         ;; add and verify some data
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-triple stopa-eid fav-nickname-attr-id "Stopa"]
@@ -910,7 +910,7 @@
 
         ;; delete entity removes both object triples and references
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:delete-entity billy-eid]])
@@ -929,7 +929,7 @@
             ex-board (UUID/randomUUID)
             ex-node (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr {:id board-id-attr-id
@@ -958,7 +958,7 @@
                  [ex-node node-id-attr-id (str ex-node)]
                  [ex-board board-nodes-attr-id ex-node]}
                (fetch-triples app-id)))
-        (tx/transact! (aurora/conn-pool)
+        (tx/transact! (aurora/conn-pool :write)
                       (attr-model/get-by-app-id app-id)
                       app-id
                       [[:delete-entity ex-node "nodes"]])
@@ -985,15 +985,15 @@
 (deftest write-perms-merged
   (with-zeneca-app
     (fn [{app-id :id :as _app} r]
-      (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+      (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})]
         (testing "updates are sequentially merged"
           (rule-model/put!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            {:app-id app-id :code {:users {:allow {:update "newData.handle.foo == '1' && newData.handle.bar == '2' && newData.handle.baz == '3'"}}}})
           (permissioned-tx/transact!
            (make-ctx)
@@ -1017,16 +1017,16 @@
                               [" with lookup ref" (fn [r] [(resolvers/->uuid r :users/email) "stopa@instantdb.com"])]]]
     (with-zeneca-app
       (fn [{app-id :id :as _app} r]
-        (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+        (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                                :app-id app-id
                                :attrs (attr-model/get-by-app-id app-id)
                                :datalog-query-fn d/query
-                               :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                               :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                                :current-user nil})
               lookup (get-lookup r)]
           (testing (str "no perms accepts" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {}})
             (permissioned-tx/transact!
              (make-ctx)
@@ -1041,7 +1041,7 @@
                       set))))
           (testing (str "false blocks updates" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:update "false"}}}})
             (is
              (perm-err?
@@ -1050,7 +1050,7 @@
                [[:add-triple lookup (resolvers/->uuid r :users/handle) "stopa3"]]))))
           (testing (str "right value successfully updates" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:update "newData.handle == 'stopado'"}}}})
             (permissioned-tx/transact!
              (make-ctx)
@@ -1065,7 +1065,7 @@
                       set))))
           (testing (str "wrong value blocks update" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:update "newData.handle == 'stopado'"}}}})
             (is
              (perm-err?
@@ -1074,7 +1074,7 @@
                [[:add-triple lookup (resolvers/->uuid r :users/handle) "stopa"]]))))
           (testing (str "bind works" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:update "newData.handle == handle"}
                                             :bind ["handle" "'strooper'"]}}})
             (permissioned-tx/transact!
@@ -1091,7 +1091,7 @@
 
           (testing (str "ref works" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:bookshelves {:allow {:update "handle in data.ref('users.handle')"}
                                                   :bind ["handle" "'alex'"]}}})
             (permissioned-tx/transact!
@@ -1107,7 +1107,7 @@
                       set))))
           (testing (str "invalid ref blocks" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:bookshelves {:allow {:update "handle in data.ref('users.handle')"}
                                                   :bind ["handle" "'alex'"]}}})
             (is
@@ -1118,7 +1118,7 @@
 
           (testing (str "correct auth works" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:bookshelves {:allow {:update "handle in data.ref('users.handle')"}
                                                   :bind ["handle" "auth.handle"]}}})
             (permissioned-tx/transact!
@@ -1136,7 +1136,7 @@
 
           (testing (str "incorrect auth fails" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:bookshelves {:allow {:update "handle in data.ref('users.handle')"}
                                                   :bind ["handle" "auth.handle"]}}})
             (is
@@ -1147,7 +1147,7 @@
                [[:add-triple (resolvers/->uuid r "eid-short-stories") (resolvers/->uuid r :bookshelves/name) "Longer Stories"]]))))
           (testing (str "admin can do anything" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:update "false"}}}})
             (permissioned-tx/transact!
              (assoc (make-ctx) :admin? true)
@@ -1163,7 +1163,7 @@
 
           (testing (str "create can block" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:create "false"}}}})
             (let [boop-id (UUID/randomUUID)]
               (is
@@ -1175,7 +1175,7 @@
 
           (testing (str "ref in create allows" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:bookshelves {:allow {:create "handle in data.ref('users.handle')"}
                                                   :bind ["handle" "auth.handle"]}}})
             (let [alex-id (resolvers/->uuid r "eid-alex")
@@ -1196,7 +1196,7 @@
                         set)))))
           (testing (str "ref in create blocks" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:bookshelves {:allow {:create "handle in data.ref('users.handle')"}
                                                   :bind ["handle" "auth.handle"]}}})
             (let [joe-id (resolvers/->uuid r "eid-joe-averbukh")
@@ -1212,7 +1212,7 @@
 
           (testing (str "delete can block" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:users {:allow {:delete "false"}}}})
             (is
              (perm-err?
@@ -1227,7 +1227,7 @@
                [[:delete-entity (random-uuid)]]))))
           (testing (str "attr can block" title)
             (rule-model/put!
-             (aurora/conn-pool)
+             (aurora/conn-pool :write)
              {:app-id app-id :code {:attrs {:allow {:create "false"}}}})
             (is
              (perm-err?
@@ -1294,7 +1294,7 @@
             (let [common-id (random-uuid)
                   delete-id (random-uuid)]
               (rule-model/put!
-               (aurora/conn-pool)
+               (aurora/conn-pool :write)
                {:app-id app-id :code {:users {:allow {:delete "false"
                                                       :view "false"
                                                       :update "false"
@@ -1319,7 +1319,7 @@
                                            [[:add-triple delete-id (resolvers/->uuid r :users/id) delete-id]])
                 (is (= delete-id
                        (-> (triple-model/fetch
-                            (aurora/conn-pool)
+                            (aurora/conn-pool :read)
                             app-id
                             [[:= :entity-id delete-id]])
                            first
@@ -1349,7 +1349,7 @@
 
             acme-org-eid (random-uuid)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1405,7 +1405,7 @@
           [:add-triple acme-org-eid org-name-aid "ACME"]])
         (let [attrs (attr-model/get-by-app-id app-id)
               _ (rule-model/put!
-                 (aurora/conn-pool)
+                 (aurora/conn-pool :write)
                  {:app-id app-id
                   :code {:profiles {:allow
                                     {:create "size(data.ref('org.id')) == 1"
@@ -1413,7 +1413,7 @@
                                      :view  "size(data.ref('org.id')) == 1"
                                      :delete  "size(data.ref('org.id')) == 1"}}}})
               rules (rule-model/get-by-app-id {:app-id app-id})
-              ctx {:db {:conn-pool (aurora/conn-pool)}
+              ctx {:db {:conn-pool (aurora/conn-pool :read)}
                    :app-id app-id
                    :attrs attrs
                    :datalog-query-fn d/query
@@ -1429,7 +1429,7 @@
                 [:add-triple [p-handle-aid "alyssa"] p-id-aid [p-handle-aid "alyssa"]]
                 [:add-triple instant-org-eid org-members-aid [p-handle-aid "alyssa"]]])
               (is (= #{"stopa" "alyssa"}
-                     (->>  (triple-model/fetch (aurora/conn-pool)
+                     (->>  (triple-model/fetch (aurora/conn-pool :read)
                                                app-id
                                                [[:= :attr-id p-handle-aid]])
                            (map (comp last :triple))
@@ -1444,7 +1444,7 @@
                ctx
                [[:delete-entity [p-handle-aid "alyssa"] "profiles"]])
               (is (= #{"stopa"}
-                     (->>  (triple-model/fetch (aurora/conn-pool)
+                     (->>  (triple-model/fetch (aurora/conn-pool :read)
                                                app-id
                                                [[:= :attr-id p-handle-aid]])
                            (map (comp last :triple))
@@ -1455,7 +1455,7 @@
                [[:add-triple [p-handle-aid "stopa"] p-fullname-aid "Stopachka"]])
               (is
                (=  "Stopachka"
-                   (->  (triple-model/fetch (aurora/conn-pool)
+                   (->  (triple-model/fetch (aurora/conn-pool :read)
                                             app-id
                                             [[:= :attr-id p-fullname-aid]
                                              [:= :entity-id stopa-eid]])
@@ -1472,7 +1472,7 @@
                 [:add-triple instant-org-eid org-members-aid [p-handle-aid "stopa"]]])
               (is
                (=  "Stopanado"
-                   (->  (triple-model/fetch (aurora/conn-pool)
+                   (->  (triple-model/fetch (aurora/conn-pool :read)
                                             app-id
                                             [[:= :attr-id p-fullname-aid]
                                              [:= :entity-id stopa-eid]])
@@ -1484,15 +1484,15 @@
 (deftest rejects-bad-lookups
   (with-zeneca-app
     (fn [{app-id :id :as _app} r]
-      (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+      (let [make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})
             lookup [(resolvers/->uuid r :users/email) "stopa@instantdb.com"]]
         (rule-model/put!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          {:app-id app-id :code {}})
         (testing "Can't use a lookup attr from one namespace with attrs from another"
           (is (validation-err?
@@ -1550,7 +1550,7 @@
             email-fwd-ident (UUID/randomUUID)]
         (testing "add-attr twice triggers unicity constraints"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-attr
@@ -1565,7 +1565,7 @@
                  (::ex/type
                   (instant-ex-data
                    (tx/transact!
-                    (aurora/conn-pool)
+                    (aurora/conn-pool :write)
                     (attr-model/get-by-app-id app-id)
                     app-id
                     [[:add-attr
@@ -1580,7 +1580,7 @@
           (is (= ::ex/record-foreign-key-invalid
                  (->  (instant-ex-data
                        (tx/transact!
-                        (aurora/conn-pool)
+                        (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple stopa-eid (UUID/randomUUID) "Stopa"]]))
@@ -1591,7 +1591,7 @@
     (fn [{app-id :id}]
       (let [email-attr-id (random-uuid)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1603,7 +1603,7 @@
             :index? true
             :checked-data-type :string}]])
         (testing "allows good data"
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple (random-uuid) email-attr-id "test@example.com"]])
@@ -1611,7 +1611,7 @@
                  (map (fn [{:keys [triple]}]
                         (nth triple 2))
                       (triple-model/fetch
-                       (aurora/conn-pool)
+                       (aurora/conn-pool :read)
                        app-id
                        [[:= :attr-id email-attr-id]])))))
         ;; If this failed it might be because we added new columns to the triples
@@ -1631,7 +1631,7 @@
                                                       :attr-id (str email-attr-id)
                                                       :entity-id (str eid)}}]}}
                    (instant-ex-data
-                    (tx/transact! (aurora/conn-pool)
+                    (tx/transact! (aurora/conn-pool :write)
                                   (attr-model/get-by-app-id app-id)
                                   app-id
                                   [[:add-triple eid email-attr-id 10]]))))))))))
@@ -1642,7 +1642,7 @@
       (let [email-attr-id (random-uuid)
             unique-attr-id (random-uuid)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1680,7 +1680,7 @@
                                                       :entity-id (str eid)
                                                       :value-too-large? true}}]}}
                    (instant-ex-data
-                    (tx/transact! (aurora/conn-pool)
+                    (tx/transact! (aurora/conn-pool :write)
                                   (attr-model/get-by-app-id app-id)
                                   app-id
                                   [[:add-triple eid email-attr-id (apply str (repeat 1000000 "a"))]]))))))
@@ -1700,7 +1700,7 @@
                                                       :entity-id (str eid)
                                                       :value-too-large? true}}]}}
                    (instant-ex-data
-                    (tx/transact! (aurora/conn-pool)
+                    (tx/transact! (aurora/conn-pool :write)
                                   (attr-model/get-by-app-id app-id)
                                   app-id
                                   [[:add-triple eid unique-attr-id (apply str (repeat 1000000 "a"))]]))))))))))
@@ -1712,7 +1712,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1732,7 +1732,7 @@
                    :md5 "ff768df223517b2d23d6e99d23148dd0",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1743,7 +1743,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1763,7 +1763,7 @@
                    :md5 "e262b690a6c13d36e7972baa39215438",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1774,7 +1774,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1794,7 +1794,7 @@
                    :md5 "f5239c9772076e520bcbef45c51aae76",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1805,7 +1805,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1825,7 +1825,7 @@
                    :md5 "b64d96a034f7bf16cc5658f10c8236b4",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1836,7 +1836,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1855,7 +1855,7 @@
                    :md5 "e262b690a6c13d36e7972baa39215438",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1866,7 +1866,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1886,7 +1886,7 @@
                    :md5 "aed14e1ea3b55bd8fe81df9f3d51802d",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1897,7 +1897,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1917,7 +1917,7 @@
                    :md5 "84fa8808f6849fe863794bf2206f288c",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1928,7 +1928,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1949,7 +1949,7 @@
                    :md5 "2d013ac4023532c1bd0f1c1a23d246b9",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1960,7 +1960,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -1980,7 +1980,7 @@
                    :md5 "f8fa6a9a7cd0824d718876d059931ba7",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -1994,7 +1994,7 @@
           (is
            (string/includes?
             (::ex/message (instant-ex-data (tx/transact!
-                                            (aurora/conn-pool)
+                                            (aurora/conn-pool :write)
                                             (attr-model/get-by-app-id app-id)
                                             app-id
                                             [[:add-attr
@@ -2015,7 +2015,7 @@
             info-fwd-ident (UUID/randomUUID)
             target-eid (UUID/randomUUID)]
         (tx/transact!
-         (aurora/conn-pool)
+         (aurora/conn-pool :write)
          (attr-model/get-by-app-id app-id)
          app-id
          [[:add-attr
@@ -2035,7 +2035,7 @@
                    :md5 "757d204b68e8e1c419288694ab908f55",
                    :index #{:ea}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :attr-id info-attr-id]]))))))))
 
@@ -2047,7 +2047,7 @@
              (let [attr-id (random-uuid)
                    target-eid (random-uuid)]
                (try (tx/transact!
-                     (aurora/conn-pool)
+                     (aurora/conn-pool :write)
                      (attr-model/get-by-app-id app-id)
                      app-id
                      [[:add-attr
@@ -2080,7 +2080,7 @@
     (with-empty-app
       (fn [{app-id :id}]
         (let [attr-id (random-uuid)]
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-attr
@@ -2096,7 +2096,7 @@
                  (->> (attr-model/get-by-app-id app-id)
                       (attr-model/seek-by-id attr-id)
                       :inferred-types)))
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-triple (random-uuid) attr-id false]])
@@ -2111,7 +2111,7 @@
       (fn [{app-id :id}]
         (let [attr-id (random-uuid)
               eid (random-uuid)]
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:add-attr
@@ -2127,7 +2127,7 @@
                  (->> (attr-model/get-by-app-id app-id)
                       (attr-model/seek-by-id attr-id)
                       :inferred-types)))
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:deep-merge-triple eid attr-id {:patch :values}]])
@@ -2141,7 +2141,7 @@
   (with-empty-app
     (fn [{app-id :id}]
       (validation-err?
-       (tx/transact! (aurora/conn-pool)
+       (tx/transact! (aurora/conn-pool :write)
                      (attr-model/get-by-app-id app-id)
                      app-id
                      [[:add-attr {:id (random-uuid)
@@ -2156,11 +2156,11 @@
     (fn [{app-id :id}]
       (let [r (resolvers/make-movies-resolver app-id)
             id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})]
         (validation-err?
          (permissioned-tx/transact! (make-ctx)
@@ -2185,11 +2185,11 @@
             book-creator-attr-id (random-uuid)
             book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})
             tx-steps [[:add-attr {:id book-id-attr-id
                                   :forward-identity [(random-uuid) "books" "id"]
@@ -2206,7 +2206,7 @@
                                   :index? false}]
                       [:add-triple book-id book-id-attr-id book-id]
                       [:add-triple book-id book-creator-attr-id user-id]]]
-        (app-user-model/create! (aurora/conn-pool) {:app-id app-id
+        (app-user-model/create! (aurora/conn-pool :write) {:app-id app-id
                                                     :id user-id
                                                     :email "test@example.com"})
         (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
@@ -2222,14 +2222,14 @@
             book-isbn-attr-id (random-uuid)
             book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})
             _ (tx/transact!
-               (aurora/conn-pool)
+               (aurora/conn-pool :write)
                (attr-model/get-by-app-id app-id)
                app-id
                [[:add-attr {:id book-id-attr-id
@@ -2253,7 +2253,7 @@
                             :index? false}]
                 [:add-triple book-id book-id-attr-id book-id]
                 [:add-triple book-id book-isbn-attr-id "1234"]])
-            _ (app-user-model/create! (aurora/conn-pool) {:app-id app-id
+            _ (app-user-model/create! (aurora/conn-pool :write) {:app-id app-id
                                                           :id user-id
                                                           :email "test@example.com"})
             tx-steps [[:add-triple
@@ -2278,12 +2278,12 @@
     (fn [{app-id :id}]
       (let [r (resolvers/make-movies-resolver app-id)
             id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :admin? true
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})]
 
         (permissioned-tx/transact! (make-ctx)
@@ -2322,17 +2322,17 @@
             book-title-attr-id (random-uuid)
             book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})
-            user (app-user-model/create! (aurora/conn-pool) {:app-id app-id
+            user (app-user-model/create! (aurora/conn-pool :write) {:app-id app-id
                                                              :id user-id
                                                              :email "test@example.com"})
             _ (tx/transact!
-               (aurora/conn-pool)
+               (aurora/conn-pool :write)
                (attr-model/get-by-app-id app-id)
                app-id
                [[:add-attr {:id book-id-attr-id
@@ -2363,7 +2363,7 @@
                 [:add-triple book-id book-id-attr-id book-id]
                 [:add-triple book-id book-isbn-attr-id "1234"]
                 [:add-triple book-id book-creator-attr-id user-id]])]
-        (rule-model/put! (aurora/conn-pool)
+        (rule-model/put! (aurora/conn-pool :write)
                          {:app-id app-id
                           :code {:books {:allow {:update "'1234' in auth.ref('$user.books.isbn')"}}}})
 
@@ -2384,7 +2384,7 @@
                    :md5 "a17f4110df08cd978152ff459b1aefde",
                    :index #{:ea :av}}]
                  (triple-model/fetch
-                  (aurora/conn-pool)
+                  (aurora/conn-pool :read)
                   app-id
                   [[:= :entity-id book-id]
                    [:= :attr-id book-title-attr-id]]))))))))
@@ -2399,14 +2399,14 @@
             book-id (random-uuid)
             other-book-id (random-uuid)
             user-id (random-uuid)
-            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool)}
+            make-ctx (fn [] {:db {:conn-pool (aurora/conn-pool :read)}
                              :app-id app-id
                              :attrs (attr-model/get-by-app-id app-id)
                              :datalog-query-fn d/query
-                             :rules (rule-model/get-by-app-id (aurora/conn-pool) {:app-id app-id})
+                             :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})
             insert-res (attr-model/insert-multi!
-                        (aurora/conn-pool)
+                        (aurora/conn-pool :write)
                         app-id
                         [{:id user-id-attr-id
                           :forward-identity [(random-uuid) "users" "id"]
@@ -2432,7 +2432,7 @@
                         {:allow-on-deletes? true})
 
             tx-res (tx/transact!
-                    (aurora/conn-pool)
+                    (aurora/conn-pool :write)
                     (attr-model/get-by-app-id app-id)
                     app-id
                     [[:add-triple book-id book-id-attr-id book-id]
@@ -2453,12 +2453,12 @@
                     :index #{:ea :av}}}
                  (set (map #(dissoc % :md5)
                            (triple-model/fetch
-                            (aurora/conn-pool)
+                            (aurora/conn-pool :read)
                             app-id
                             [[:= :attr-id book-id-attr-id]]))))))
 
         (testing "deleting the user deletes the book"
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:delete-entity user-id "users"]])
@@ -2470,13 +2470,13 @@
                    :index #{:ea :av}}]
                  (map #(dissoc % :md5)
                       (triple-model/fetch
-                       (aurora/conn-pool)
+                       (aurora/conn-pool :read)
                        app-id
                        [[:= :attr-id book-id-attr-id]])))))
 
         (testing "deleting the book doesn't delete the user"
           (tx/transact!
-           (aurora/conn-pool)
+           (aurora/conn-pool :write)
            (attr-model/get-by-app-id app-id)
            app-id
            [[:add-triple user-id user-id-attr-id user-id]
@@ -2490,11 +2490,11 @@
                    :index #{:ea :av :ave}}]
                  (map #(dissoc % :md5)
                       (triple-model/fetch
-                       (aurora/conn-pool)
+                       (aurora/conn-pool :read)
                        app-id
                        [[:= :attr-id user-id-attr-id]]))))
 
-          (tx/transact! (aurora/conn-pool)
+          (tx/transact! (aurora/conn-pool :write)
                         (attr-model/get-by-app-id app-id)
                         app-id
                         [[:delete-entity book-id "books"]])
@@ -2505,7 +2505,7 @@
                    :index #{:ea :av :ave}}]
                  (map #(dissoc % :md5)
                       (triple-model/fetch
-                       (aurora/conn-pool)
+                       (aurora/conn-pool :read)
                        app-id
                        [[:= :attr-id user-id-attr-id]])))))))))
 

--- a/server/test/instant/reactive/invalidator_test.clj
+++ b/server/test/instant/reactive/invalidator_test.clj
@@ -408,7 +408,7 @@
           (let [process (inv/start machine-id)
                 uid (random-uuid)]
             (try
-              (tx/transact! (aurora/conn-pool)
+              (tx/transact! (aurora/conn-pool :write)
                             (attr-model/get-by-app-id (:id app))
                             (:id app)
                             [[:add-triple uid (resolvers/->uuid r :users/id) uid]

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -574,7 +574,7 @@
                         pretty-subs)))
 
             ;; do mutation
-            (tx/transact! (aurora/conn-pool)
+            (tx/transact! (aurora/conn-pool :write)
                           (attr-model/get-by-app-id app-id)
                           app-id
                           [[:retract-triple

--- a/server/test/instant/util/uuid_test.clj
+++ b/server/test/instant/util/uuid_test.clj
@@ -10,7 +10,7 @@
   (let [ids (repeatedly 10000 #(random-uuid))]
     (is (= (sort uuid-util/pg-compare ids)
            (map :id
-                (sql/select (aurora/conn-pool)
+                (sql/select (aurora/conn-pool :read)
                             (hsql/format {:select :id
 
                                           :from [[[:unnest [:array
@@ -19,7 +19,7 @@
                                           :order-by [[:id :asc]]})))))
     (is (= (reverse (sort uuid-util/pg-compare ids))
            (map :id
-                (sql/select (aurora/conn-pool)
+                (sql/select (aurora/conn-pool :read)
                             (hsql/format {:select :id
 
                                           :from [[[:unnest [:array


### PR DESCRIPTION
Updates `aurora/conn-pool` to take a param indicating whether you want to use the connection for `:read` or `:write`. If you request a `:read` and try to do a write on it, then you'll get an error like `cannot execute INSERT in a read-only transaction`.

We use this to allow reads while we're in the process of failing over to an upgraded database.

In the future, we could potentially use this to direct reads to a secondary.