### PR TITLE
Don't let init have child spans

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -163,7 +163,9 @@
   `(do
      (tracer/record-info! {:name (format "init.start.%s" (name ~operation))})
      (tracer/with-span! {:name (format "init.finish.%s" (name ~operation))}
-       ~@body)))
+       ;; Don't let ourselves be the parent of any child spans
+       (binding [tracer/*span* nil]
+         ~@body))))
 
 (defn -main [& _args]
   (binding [*print-namespace-maps* false]


### PR DESCRIPTION
Fixes an issue where we are sending too many spans to Honeycomb because all of the `invalidator/work` spans have the same parent.