### PR TITLE
cleanup http logs

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -4,7 +4,7 @@
    [tool]
    [clojure.java.io :as io]
    [clojure.tools.logging :as log]
-   [compojure.core :refer [defroutes GET POST routes]]
+   [compojure.core :refer [defroutes GET POST routes wrap-routes]]
    [instant.admin.routes :as admin-routes]
    [instant.auth.jwt :as jwt]
    [instant.auth.oauth :as oauth]
@@ -90,6 +90,7 @@
                storage-routes/routes
                generic-webhook-routes
                health/routes)
+       (wrap-routes http-util/tracer-record-route)
        http-util/tracer-record-attrs
        wrap-keyword-params
        wrap-params

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -73,36 +73,28 @@
   (POST "/hooks/honeycomb/exceptions" [] honeycomb-api/webhook))
 
 (defn handler []
-  (routes
-   (-> stripe-webhook-routes
+  (-> (routes home-routes
+              dash-routes/routes
+              runtime-routes/routes
+              admin-routes/routes
+              superadmin-routes/routes
+              storage-routes/routes
+              generic-webhook-routes
+              stripe-webhook-routes
+              health/routes)
+      (wrap-routes http-util/tracer-record-route)
+      http-util/tracer-record-attrs
+      wrap-keyword-params
+      wrap-params
+      wrap-multipart-params
+      (wrap-json-body {:keywords? true})
 
-       http-util/wrap-errors
+      http-util/wrap-errors
 
-       wrap-json-response
-       (wrap-cors :access-control-allow-origin [#".*"]
-                  :access-control-allow-methods [:get :put :post :delete])
-       http-util/tracer-wrap-span)
-   (-> (routes home-routes
-               dash-routes/routes
-               runtime-routes/routes
-               admin-routes/routes
-               superadmin-routes/routes
-               storage-routes/routes
-               generic-webhook-routes
-               health/routes)
-       (wrap-routes http-util/tracer-record-route)
-       http-util/tracer-record-attrs
-       wrap-keyword-params
-       wrap-params
-       wrap-multipart-params
-       (wrap-json-body {:keywords? true})
-
-       http-util/wrap-errors
-
-       wrap-json-response
-       (wrap-cors :access-control-allow-origin [#".*"]
-                  :access-control-allow-methods [:get :put :post :delete])
-       http-util/tracer-wrap-span)))
+      wrap-json-response
+      (wrap-cors :access-control-allow-origin [#".*"]
+                 :access-control-allow-methods [:get :put :post :delete])
+      http-util/tracer-wrap-span))
 
 (defn start []
   (tracer/record-info! {:name "server/start" :attributes {:port (config/get-server-port)}})

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -33,7 +33,9 @@
     (let [{:keys [uri request-method headers query-params]} request
           app-id (or (get headers "app-id")
                      (get query-params "app-id")
-                     (get query-params "app_id"))
+                     (get query-params "app_id")
+                     (get query-params :app-id)
+                     (get query-params :app_id))
           cli-version (get headers "instant-cli-version")
           core-version (get headers "instant-core-version")
           admin-version (get headers "instant-admin-version")

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -30,7 +30,7 @@
 
 (defn tracer-record-attrs [handler]
   (fn [request]
-    (let [{:keys [uri request-method headers body query-params]} request
+    (let [{:keys [uri request-method headers query-params]} request
           app-id (or (get headers "app-id")
                      (get query-params "app-id")
                      (get query-params "app_id"))


### PR DESCRIPTION
Cleans up the http logs a bit:

1. Wraps the stripe route middleware in `compojure.core/wrap-routes` so that it doesn't get applied to all routes (we were logging some things twice)
2. Adds a `:route` field to the span that has the actual route (e.g. `/apps/:app_id` instead of `/apps/a349ea6b-8e4d-4fb8-a563-a7130f015137`)
3. Log app_id from the route params
4. Don't log preflight requests
5. Don't log the body