### PR TITLE
Downgrade postgres driver back down to 42.7.3

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -10,7 +10,7 @@
         org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/core.async {:mvn/version "1.6.673"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
-        org.postgresql/postgresql {:mvn/version "42.7.5"}
+        org.postgresql/postgresql {:mvn/version "42.7.3"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         ring/ring {:mvn/version "1.8.0"}
         ring/ring-codec {:mvn/version "1.2.0"}


### PR DESCRIPTION
We're seeing a lot of virtual thread pinning that lines up with when we upgraded the postgres driver in https://github.com/instantdb/instant/pull/742

I want to downgrade and see if they go away.

Stack trace looks like this:

```
 VirtualThread[#3897183]/runnable@ForkJoinPool-1-worker-43 reason:MONITOR
 java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:199)
 java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
 java.base/java.lang.VirtualThread.park(VirtualThread.java:596)
 java.base/java.lang.System$2.parkVirtualThread(System.java:2648)
 java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
 java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:369)
 java.base/sun.nio.ch.Poller.poll(Poller.java:178)
 java.base/sun.nio.ch.Poller.poll(Poller.java:137)
 java.base/sun.nio.ch.NioSocketImpl.park(NioSocketImpl.java:175)
 java.base/sun.nio.ch.NioSocketImpl.park(NioSocketImpl.java:201)
 java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:309)
 java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:346)
 java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:796)
 java.base/java.net.Socket$SocketInputStream.implRead(Socket.java:1108)
 java.base/java.net.Socket$SocketInputStream.read(Socket.java:1095)
 java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489)
 java.base/sun.security.ssl.SSLSocketInputRecord.readHeader(SSLSocketInputRecord.java:483)
 java.base/sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(SSLSocketInputRecord.java:70)
 java.base/sun.security.ssl.SSLSocketImpl.readApplicationRecord(SSLSocketImpl.java:1462)
 java.base/sun.security.ssl.SSLSocketImpl$AppInputStream.read(SSLSocketImpl.java:1068)
 org.postgresql.core.VisibleBufferedInputStream.readMore(VisibleBufferedInputStream.java:192)
 org.postgresql.core.VisibleBufferedInputStream.ensureBytes(VisibleBufferedInputStream.java:159)
 org.postgresql.core.VisibleBufferedInputStream.ensureBytes(VisibleBufferedInputStream.java:144)
 org.postgresql.core.VisibleBufferedInputStream.read(VisibleBufferedInputStream.java:76)
 org.postgresql.core.PGStream.receiveChar(PGStream.java:476)
 org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2174)
 org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:372)
 org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:517)
 org.postgresql.jdbc.PgStatement.execute(PgStatement.java:434)
 org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:194)
 org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:180)
 com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44)
 com.zaxxer.hikari.pool.HikariProxyPreparedStatement.execute(HikariProxyPreparedStatement.java)
 next.jdbc.result_set$stmt__GT_result_set.invokeStatic(result_set.clj:674)
 next.jdbc.result_set$stmt__GT_result_set.invoke(result_set.clj:669)
 next.jdbc.result_set$fn__12665.invokeStatic(result_set.clj:982)
 next.jdbc.result_set$fn__12665.invoke(result_set.clj:862)
 next.jdbc.protocols$fn__11890$G__11870__11899.invoke(protocols.clj:34)
 next.jdbc$execute_BANG_.invokeStatic(jdbc.clj:258)
 next.jdbc$execute_BANG_.invoke(jdbc.clj:242)
 next.jdbc.sql$query.invokeStatic(sql.clj:107)
 next.jdbc.sql$query.invoke(sql.clj:98)
 instant.jdbc.sql$select_arrays.invokeStatic(sql.clj:257)
 instant.jdbc.sql$select_arrays.invoke(sql.clj:257)
 instant.jdbc.sql$select_arrays.invokeStatic(sql.clj:257)
 instant.jdbc.sql$select_arrays.invoke(sql.clj:257)
 instant.db.datalog$send_query_nested.invokeStatic(datalog.clj:1853)
 instant.db.datalog$send_query_nested.invoke(datalog.clj:1834)
 instant.db.datalog$query_nested.invokeStatic(datalog.clj:1893)
 instant.db.datalog$query_nested.invoke(datalog.clj:1890)
 instant.db.datalog$query.invokeStatic(datalog.clj:1951)
 instant.db.datalog$query.invoke(datalog.clj:1913)
 instant.db.cel$prefetch_data_refs.invokeStatic(cel.clj:372)
 instant.db.cel$prefetch_data_refs.invoke(cel.clj:350)
 instant.db.permissioned_transaction$preload_refs.invokeStatic(permissioned_transaction.clj:526)
 instant.db.permissioned_transaction$preload_refs.invoke(permissioned_transaction.clj:518)
 instant.db.permissioned_transaction$transact_BANG_$fn__23390.invoke(permissioned_transaction.clj:661)
 next.jdbc.transaction$transact_STAR_.invokeStatic(transaction.clj:72)
 next.jdbc.transaction$transact_STAR_.invoke(transaction.clj:51)
 next.jdbc.transaction$fn__12781.invokeStatic(transaction.clj:135) <== monitors:1
 next.jdbc.transaction$fn__12781.invoke(transaction.clj:123)
 next.jdbc.protocols$fn__11945$G__11940__11954.invoke(protocols.clj:58)
 next.jdbc.transaction$fn__12787.invokeStatic(transaction.clj:148)
 next.jdbc.transaction$fn__12787.invoke(transaction.clj:123)
 next.jdbc.protocols$fn__11945$G__11940__11954.invoke(protocols.clj:58)
 next.jdbc$transact.invokeStatic(jdbc.clj:424)
 next.jdbc$transact.invoke(jdbc.clj:416)
 instant.db.permissioned_transaction$transact_BANG_.invokeStatic(permissioned_transaction.clj:612)
 instant.db.permissioned_transaction$transact_BANG_.invoke(permissioned_transaction.clj:589)
 instant.reactive.session$handle_transact_BANG_.invokeStatic(session.clj:234)
 instant.reactive.session$handle_transact_BANG_.invoke(session.clj:227)
 instant.reactive.session$handle_event.invokeStatic(session.clj:408)
 instant.reactive.session$handle_event.invoke(session.clj:398)
 instant.reactive.session$handle_receive$fn__36072$fn__36073.invoke(session.clj:509)
 instant.util.async$future_call$fn__21973.invoke(async.clj:102)
 clojure.lang.AFn.applyToHelper(AFn.java:152)
 clojure.lang.AFn.applyTo(AFn.java:144)
 clojure.core$apply.invokeStatic(core.clj:667)
 clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1990)
 clojure.core$with_bindings_STAR_.doInvoke(core.clj:1990)
 clojure.lang.RestFn.invoke(RestFn.java:428)
 clojure.lang.AFn.applyToHelper(AFn.java:156)
 clojure.lang.RestFn.applyTo(RestFn.java:135)
 clojure.core$apply.invokeStatic(core.clj:671)
 clojure.core$bound_fn_STAR_$fn__5837.doInvoke(core.clj:2020)
 clojure.lang.RestFn.invoke(RestFn.java:400)
 clojure.lang.AFn.call(AFn.java:18)
 java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
 ```