### PR TITLE
Test fewer vfutures in the receive queue

### DIFF
--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -222,3 +222,5 @@
   ;; instantiate the config-map so we can fail early if it's not
   ;; valid
   @config-map)
+
+(defonce fewer-vfutures? (= 0 (rand-int 3)))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -48,7 +48,10 @@
 (declare receive-q-stop-signal)
 (def handle-receive-timeout-ms 5000)
 
-(def num-receive-workers (* 100 (delay/cpu-count)))
+(def num-receive-workers (* (if config/fewer-vfutures?
+                              20
+                              100)
+                            (delay/cpu-count)))
 
 ;; ------
 ;; handlers

--- a/server/src/instant/util/async.clj
+++ b/server/src/instant/util/async.clj
@@ -126,6 +126,9 @@
       (.put parent-vfutures fut-id wrapped-fut))
     wrapped-fut))
 
+(defmacro tracked-future [& body]
+  `(future-call clojure.lang.Agent/soloExecutor nil (^{:once true} fn* [] ~@body)))
+
 (defmacro vfuture
   "Takes a body of expressions and yields a future object that will
   invoke the body in a **virtual thread**, and will cache the result and

--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -60,7 +60,8 @@
      "detailed_tx_steps"
      "process_id"
      "instance_id"
-     "query") true
+     "query"
+     "fewer_vfutures") true
     false))
 
 (defn format-attr-value

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -86,7 +86,8 @@
         {:keys [code-ns code-line code-file]} source
         default-attributes (cond-> {"host.name" @config/hostname
                                     "process-id" @config/process-id
-                                    "instance-id" @config/instance-id}
+                                    "instance-id" @config/instance-id
+                                    "fewer-vfutures" config/fewer-vfutures?}
                              thread (assoc "thread.name"
                                            (.getName thread)
                                            "thread.id"


### PR DESCRIPTION
We're seeing it take a long time to start a virtual future in prod, but starting a regular future is still fast.

I'd like to experiment with using fewer virtual futures as a quick bandaid. This will hopefully make ephemeral state a lot faster because it shouldn't have to hit a single vfuture.

On 1/3 of the instances, this will use `thread` for both the receive queue workers and for wrapping `handle-receive`.
