### PR TITLE
Always use fewer-vfutures

### DIFF
--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -223,4 +223,4 @@
   ;; valid
   @config-map)
 
-(defonce fewer-vfutures? (= 0 (rand-int 3)))
+(defonce fewer-vfutures? true)


### PR DESCRIPTION
Seeing better metrics with the fewer vfuture instances from https://github.com/instantdb/instant/pull/748

Leaving the flag for now in case something unexpected happens.