### PR TITLE
[sm] use forward attr in cascade delete dialog

### DIFF
--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -422,7 +422,8 @@ function AddAttrForm({
               onChange={setIsCascade}
               label={
                 <span>
-                  <strong>Cascade delete</strong> When <strong>{reverseNamespace?.name}</strong> is deleted, all linked <strong>{namespace.name}</strong> will be deleted automatically
+                  <div><strong>Cascade Delete</strong></div>
+                   When <strong>{attrName}</strong> is deleted, all linked <strong>{namespace.name}</strong> will be deleted automatically
                 </span>
               }
             />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2487a803-19d1-4d95-a233-f366f239ed74)
- Using the `forward attr name` in the description text
- Changed up the layout a bit, so "Cascade Delete" is on it's own line. 

@dwwoelfel @nezaj @tonsky 