### PR TITLE
Fix for null query

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -560,7 +560,6 @@ export default class Reactor {
       const q = msg["original-event"]?.q;
       const hash = weakHash(q);
       this.notifyQueryError(weakHash(q), errorMessage);
-      console.log(q, hash, eventId, errorMessage);
       this.notifyQueryOnceError(q, hash, eventId, errorMessage);
       return;
     }

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -130,6 +130,11 @@
       (rs/send-event! store-conn (:id app) sess-id {:op :add-query-exists :q q
                                                     :client-event-id client-event-id})
 
+      (nil? q)
+      (ex/throw-validation-err! :add-query
+                                {:q q}
+                                [{:message "Query can not be null."}])
+
       :else
       (let [return-type (keyword (or return-type "join-rows"))
             {app-id :id} app

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -254,6 +254,14 @@
         (is (= 400
                (:status (blocking-send-msg :error socket {:op :add-query :q {:movie "Foo"}}))))))))
 
+(deftest add-nil-query-rejected
+  (with-session
+    (fn [_store-conn {:keys [socket]}]
+      (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
+      (testing "nil queries are rejected"
+        (is (= 400
+               (:status (blocking-send-msg :error socket {:op :add-query :q nil}))))))))
+
 (deftest add-query-works
   (with-session
     (fn [_store-conn {:keys [socket]}]


### PR DESCRIPTION
If we get a null query, we'll throw a noisy exception. This PR turns it into a normal error and notifies the client.

It seems like this can happen with `queryOnce`.