### PR TITLE
Add record middleware to nrepl

### DIFF
--- a/server/src/instant/nrepl.clj
+++ b/server/src/instant/nrepl.clj
@@ -1,22 +1,46 @@
 (ns instant.nrepl
   (:require
-   [cider.nrepl]
    [cider.nrepl.middleware :refer [cider-middleware]]
-   [nrepl.server :as nrepl-server :refer [start-server]]
-   [instant.config :as config] 
    [clojure.java.io :as io]
-   [instant.util.tracer :as tracer]))
+   [instant.config :as config]
+   [instant.util.tracer :as tracer]
+   [nrepl.middleware :refer [set-descriptor!]]
+   [nrepl.middleware.interruptible-eval :refer [interruptible-eval]]
+   [nrepl.server :as nrepl-server :refer [start-server]]))
+
+(defn record-nrepl-msg [msg]
+  (tracer/record-info! {:name (str "nrepl/" (name (:op msg)))
+                        :attributes (assoc (select-keys msg [:op
+                                                             :id
+                                                             :msg
+                                                             :file
+                                                             :code
+                                                             :column
+                                                             :line])
+                                           :session-id (-> msg :session meta :id))}))
+
+(defn wrap-record [handler]
+  (fn [msg]
+    (record-nrepl-msg msg)
+    (handler msg)))
+
+(set-descriptor! #'wrap-record {:requires #{}
+                                :expects #{#'interruptible-eval}})
+
+(def nrepl-middleware
+  (let [refactor-middleware (try
+                              (require 'refactor-nrepl.middleware)
+                              (resolve 'refactor-nrepl.middleware/wrap-refactor)
+                              (catch Exception _e nil))
+        record-middleware (when (= :prod (config/get-env))
+                            #'wrap-record)]
+    (cond-> cider-middleware
+      refactor-middleware (conj refactor-middleware)
+      record-middleware (conj record-middleware))))
 
 (def nrepl-handler
   "We build our own custom nrepl handler, mimicking CIDER's."
-  (apply
-   nrepl-server/default-handler
-   (if-let [wrap-refactor (try
-                            (require 'refactor-nrepl.middleware)
-                            (resolve 'refactor-nrepl.middleware/wrap-refactor)
-                            (catch Exception _e nil))]
-     (conj cider-middleware wrap-refactor)
-     cider-middleware)))
+  (apply nrepl-server/default-handler nrepl-middleware))
 
 (defn start []
   (let [port (config/get-nrepl-port)


### PR DESCRIPTION
Adds middleware to our nrepl to log activity so that we have an audit trail. 

Only turned on in production. Logs to honeycomb and to stdout.