### PR TITLE
Fix schema push

### DIFF
--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -218,10 +218,13 @@
                :when (= :add-attr op)
                :let [fwd-name (attr-model/fwd-ident-name attr)
                      rev-name (attr-model/rev-ident-name attr)
+                     current-rev-name (get current-links-mapping-rev fwd-name)
                      message
                      (cond
                        ;; link-backwards-conflict?
-                       (= rev-name (get current-links-mapping-rev fwd-name))
+                       (and (not (and (nil? rev-name)
+                                      (nil? current-rev-name)))
+                            (= rev-name current-rev-name))
                        (backwards-link-message fwd-name)
 
                        ;; link-fwd-exists?


### PR DESCRIPTION
Makes sure that we don't treat changing the reverse link from nil -> nil as duplicating the reverse link.

Fixes a bug users are having doing schema push.