### PR TITLE
[pricing] most popular -> for teams

### DIFF
--- a/client/www/pages/pricing/index.tsx
+++ b/client/www/pages/pricing/index.tsx
@@ -120,11 +120,11 @@ function Plan({ plan }: { plan: any }) {
           <h5 className="font-mono text-black text-2xl font-medium tracking-tight mr-2">
             {name}
           </h5>
-          {isFeatured && (
+          {/* {isFeatured && (
             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-md font-medium bg-orange-200/20 text-orange-600">
               Most popular
             </span>
-          )}
+          )} */}
         </div>
         <div className="text-black opacity-70">{description}</div>
         <span className="text-black inline-flex gap-1 items-baseline my-4">

--- a/client/www/pages/pricing/index.tsx
+++ b/client/www/pages/pricing/index.tsx
@@ -120,11 +120,11 @@ function Plan({ plan }: { plan: any }) {
           <h5 className="font-mono text-black text-2xl font-medium tracking-tight mr-2">
             {name}
           </h5>
-          {/* {isFeatured && (
+          {isFeatured && (
             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-md font-medium bg-orange-200/20 text-orange-600">
-              Most popular
+              For teams
             </span>
-          )} */}
+          )}
         </div>
         <div className="text-black opacity-70">{description}</div>
         <span className="text-black inline-flex gap-1 items-baseline my-4">


### PR DESCRIPTION
A user mentioned that "Most Popular" didn't make sense, as obviously the Free tier was the most popular. 

Updated it to say "For teams"

<img width="1063" alt="CleanShot 2025-01-29 at 17 04 03@2x" src="https://github.com/user-attachments/assets/38f10a7f-82ec-4a12-a4af-24a68f064471" />


@nezaj @dwwoelfel @tonsky 