### PR TITLE
[essay] be more explicit about stop the world

### DIFF
--- a/client/www/_posts/pg_upgrade.md
+++ b/client/www/_posts/pg_upgrade.md
@@ -325,9 +325,9 @@ So, how could we follow these rules?
 
 The simplest way to switch writes would have been to stop the world:
 
-1. Turn off all writes.
-1. Wait for 16 to catch up
-1. Enable writes again — this time they all go to 16
+1. Use a feature flag turn off all writes.
+2. Wait a few seconds, and execute a query that makes sure 16 is caught up
+3. Use a feature flag to enable writes again — this time they all go to 16
 
 If we went with the ‘stop the world approach’, we’d have about the same kind of downtime as blue-green deployments: a minute or so.
 

--- a/client/www/_posts/pg_upgrade.md
+++ b/client/www/_posts/pg_upgrade.md
@@ -325,13 +325,11 @@ So, how could we follow these rules?
 
 The simplest way to switch writes would have been to stop the world:
 
-1. Use a feature flag turn off all writes.
-2. Wait a few seconds, and execute a query that makes sure 16 is caught up
-3. Use a feature flag to enable writes again — this time they all go to 16
+1. Turn off all writes.
+1. Wait for 16 to catch up
+1. Enable writes again — this time they all go to 16
 
-If we went with the ‘stop the world approach’, we’d have about the same kind of downtime as blue-green deployments: a minute or so.
-
-We were okay with a minute of downtime. But we had already spent a day setting up our manual method, could we do better?
+If we manually executed each step in ‘stop the world', we’d have about a minute of downtime. We could write a function which did these steps for us, and get to only a few seconds of downtime. But we had already spent a day setting up our manual method, could we do better?
 
 Since we were switching manually we had finer control over our connections. We realized that with just a little bit more work...we could have no downtime at all!
 


### PR DESCRIPTION
A user asked: wouldn't 'stop the world' also take a few seconds? 

I wrote a minute because I imagined the stop the world approach to be more manual. If we automated it, the function would get very close to what we already wrote for zero downtime. I updated the essay to mention this. 

@dwwoelfel @nezaj @tonsky 