### PR TITLE
Fix wal connection

### DIFF
--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -73,7 +73,9 @@
               (.set PGProperty/REPLICATION props "database")
               (.set PGProperty/ASSUME_MIN_SERVER_VERSION props "9.4")
               (.set PGProperty/PREFER_QUERY_MODE props "simple"))
-        conn (DriverManager/getConnection (jdbc-url db-spec) props)]
+        conn (DriverManager/getConnection (jdbc-url (-> db-spec
+                                                        (dissoc :username :password)))
+                                          props)]
     (.unwrap conn PGConnection)))
 
 (comment

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -63,7 +63,9 @@
    (e.g REPLICATION, ASSUME_MIN_SERVER_VERSION, PREFER_QUERY_MODE)"
   ^PGConnection [db-spec]
   (let [db-spec (if-let [secret-arn (:secret-arn db-spec)]
-                  (merge db-spec (aurora-config/secret-arn->db-creds secret-arn))
+                  (-> db-spec
+                      (dissoc db-spec :secret-arn)
+                      (merge (aurora-config/secret-arn->db-creds secret-arn)))
                   db-spec)
         props (Properties.)
         _ (do (.set PGProperty/USER props (jdbc-username db-spec))


### PR DESCRIPTION
Fixes bug creating the wal connection introduced in https://github.com/instantdb/instant/pull/772

The password wasn't getting url-encoded in the jdbc-url, which was causing the connection to fail. We don't need the password in the url since we set it in the properties, so we can just dissoc it from the spec before passing to `jdbc-url`.