### PR TITLE
Fix handling of database connection strings

### DIFF
--- a/server/src/instant/aurora_config.clj
+++ b/server/src/instant/aurora_config.clj
@@ -21,10 +21,12 @@
                                    ^GetSecretValueRequest request)
 
                   (.secretString)
-                  (<-json true))]
-    (assert (:username creds) "missing username")
-    (assert (:password creds) "missing password")
-    creds))
+                  (<-json true))
+        {:keys [username password]} creds]
+    (assert username "missing username")
+    (assert password "missing password")
+    {:user username
+     :password password}))
 
 (defn rds-cluster-id->db-config [cluster-id]
   (let [rds-client (-> (RdsClient/builder)

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -5,7 +5,8 @@
             [instant.util.crypt :as crypt-util]
             [instant.util.aws :as aws-util]
             [instant.aurora-config :as aurora-config]
-            [lambdaisland.uri :as uri])
+            [lambdaisland.uri :as uri]
+            [lambdaisland.uri.normalize :as normalize])
   (:import
    (java.net InetAddress)))
 
@@ -108,7 +109,7 @@
                      (subs path 1)
                      path)
            :user user
-           :password password
+           :password (normalize/percent-decode password)
            :host host
            :port (when port
                    (Integer/parseInt port))})

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -107,7 +107,7 @@
            :dbname (if (string/starts-with? path "/")
                      (subs path 1)
                      path)
-           :username user
+           :user user
            :password password
            :host host
            :port (when port

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -107,10 +107,10 @@
         (tracer/with-span! {:name "aurora/get-connection"}
           (loop [attempt 1
                  failed-credentials nil]
-            (let [{:keys [username password] :as creds}
+            (let [{:keys [user password] :as creds}
                   (get-creds {:failed-credentials failed-credentials
                               :attempts 3})
-                  conn (try (next-jdbc/get-connection aurora-config username password)
+                  conn (try (next-jdbc/get-connection aurora-config user password)
                             (catch Exception e
                               (let [throwing? (>= attempt 3)]
                                 (tracer/record-info! {:name "aurora/get-conn-error"

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -162,7 +162,11 @@
                         (.setMaximumPoolSize pool-size))
         _ (if-let [secret-arn (:secret-arn aurora-config)]
             (.setDataSource hikari-config (datasource-with-secretsmanager secret-arn config))
-            (.setJdbcUrl hikari-config (connection/jdbc-url config)))
+            (doto hikari-config
+              (.setUsername (:user config))
+              (.setPassword (:password config))
+              (.setJdbcUrl (connection/jdbc-url (dissoc config
+                                                        :user :password)))))
 
         pool (HikariDataSource. hikari-config)]
     ;; Check that the pool is working

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -49,7 +49,7 @@
 ;; Connection
 
 (defn jdbc-username ^String [db-spec]
-  (or (:username db-spec)
+  (or (:user db-spec)
       (:user (uri/query-map (jdbc-url db-spec)))))
 
 (defn jdbc-password ^String [db-spec]
@@ -74,7 +74,7 @@
               (.set PGProperty/ASSUME_MIN_SERVER_VERSION props "9.4")
               (.set PGProperty/PREFER_QUERY_MODE props "simple"))
         conn (DriverManager/getConnection (jdbc-url (-> db-spec
-                                                        (dissoc :username :password)))
+                                                        (dissoc :user :password)))
                                           props)]
     (.unwrap conn PGConnection)))
 


### PR DESCRIPTION
Does two things:

1. Renames `username` to `user` so that it works properly with jdbc connection urls
2. Query-decodes password when we get it from the connection string. Then we set the password directly because `next-jdbc/jdbc-url` won't url-encode its params.