### PR TITLE
[Emails] Send welcome email

### DIFF
--- a/client/www/_emails/html/welcome_feb_2025.html
+++ b/client/www/_emails/html/welcome_feb_2025.html
@@ -1,0 +1,5 @@
+<p>Hey there! Welcome to Instant! Full disclosure: this is an automated
+email, but if you respond, a real human (likely Joe or Stopa, the
+founders) will read it and get back to you.</p>
+<p>How’s your experience with Instant been so far? Any feedback to
+share?</p>

--- a/client/www/_emails/markdown/welcome_feb_2025.md
+++ b/client/www/_emails/markdown/welcome_feb_2025.md
@@ -1,0 +1,4 @@
+Hey there! Welcome to Instant! Full disclosure: this is an automated email, but
+if you respond, a real human (likely Joe or Stopa, the founders) will read it and get back to you.
+
+How's your experience with Instant been so far? Any feedback to share?

--- a/client/www/_emails/txt/welcome_feb_2025.txt
+++ b/client/www/_emails/txt/welcome_feb_2025.txt
@@ -1,0 +1,4 @@
+Hey there! Welcome to Instant! Full disclosure: this is an automated email, but
+if you respond, a real human (likely Joe or Stopa, the founders) will read it and get back to you.
+
+How's your experience with Instant been so far? Any feedback to share?

--- a/server/resources/migrations/49_add_user_flags.down.sql
+++ b/server/resources/migrations/49_add_user_flags.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE user_flags;

--- a/server/resources/migrations/49_add_user_flags.up.sql
+++ b/server/resources/migrations/49_add_user_flags.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE user_flags (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES instant_users(id) ON DELETE CASCADE,
+    flag_name TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    UNIQUE (user_id, flag_name)
+);

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -28,6 +28,7 @@
    [instant.runtime.routes :as runtime-routes]
    [instant.scripts.analytics :as analytics]
    [instant.scripts.daily-metrics :as daily-metrics]
+   [instant.scripts.welcome-email :as welcome-email]
    [instant.session-counter :as session-counter]
    [instant.storage.routes :as storage-routes]
    [instant.stripe :as stripe]
@@ -224,6 +225,9 @@
     (when (= (config/get-env) :prod)
       (log-init :daily-metrics
         (daily-metrics/start)))
+    (when (= (config/get-env) :prod)
+      (log-init :welcome-email
+        (welcome-email/start)))
     (log-init :web-server
       (start))
     (log-init :shutdown-hook

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -1,7 +1,9 @@
 ;; The flags are populated and kept up to date by instant.flag-impl
 ;; We separate the namespaces so that this namespace has no dependencies
 ;; and can be required from anywhere.
-(ns instant.flags)
+(ns instant.flags 
+  (:require
+    [clojure.walk :as w]))
 
 ;; Map of query to {:result {result-tree}
 ;;                  :tx-id int}
@@ -16,6 +18,7 @@
             :drop-refresh-spam {}
             :promo-emails {}
             :rate-limited-apps {}
+            :welcome-email-config {}
             :e2e-logging {}})
 
 (defn transform-query-result
@@ -85,14 +88,16 @@
                                         first)]
                       {:invalidator-every-n (try (/ 1 (get flag "invalidator-rate"))
                                                  (catch Exception _e
-                                                   10000))})]
+                                                   10000))})
+        welcome-email-config (-> result (get "welcome-email-config") first w/keywordize-keys)]
     {:emails emails
      :storage-enabled-whitelist storage-enabled-whitelist
      :use-patch-presence use-patch-presence
      :promo-code-emails promo-code-emails
      :drop-refresh-spam drop-refresh-spam
      :rate-limited-apps rate-limited-apps
-     :e2e-logging e2e-logging}))
+     :e2e-logging e2e-logging
+     :welcome-email-config welcome-email-config}))
 
 (def queries [{:query query :transform #'transform-query-result}])
 
@@ -111,6 +116,9 @@
 
 (defn promo-code-emails []
   (get (query-result) :promo-code-emails))
+
+(defn welcome-email-config []
+  (get (query-result) :welcome-email-config))
 
 (defn promo-code-email? [email]
   (contains? (promo-code-emails)

--- a/server/src/instant/postmark.clj
+++ b/server/src/instant/postmark.clj
@@ -26,18 +26,19 @@
      (-> e ex-data :body :ErrorCode)))
 ;; -------- 
 ;; API
-(defn send! [{:keys [from to cc bcc subject html
+(defn send! [{:keys [from to cc bcc subject html text
                      reply-to]
               :or {reply-to "hello@instantdb.com"}}]
-  (let [body {:From from
-              :To to
-              :Cc cc
-              :Bcc bcc
-              :ReplyTo reply-to
-              :Subject subject
-              :MessageStream "outbound"
-              :HTMLBody
-              html}]
+  (let [body (cond-> {:From from
+                      :To to
+                      :Cc cc
+                      :Bcc bcc
+                      :ReplyTo reply-to
+                      :Subject subject
+                      :MessageStream "outbound"
+                      :HTMLBody
+                      html}
+               text (assoc :TextBody text))]
     (if-not (config/postmark-send-enabled?)
       (tracer/with-span! {:name "postmark/send-disabled"
                           :attributes body}

--- a/server/src/instant/scripts/welcome_email.clj
+++ b/server/src/instant/scripts/welcome_email.clj
@@ -1,0 +1,90 @@
+(ns instant.scripts.welcome-email
+  "Send welcome emails to our users"
+  (:require
+   [instant.util.date :as date]
+   [instant.postmark :as postmark]
+   [chime.core :as chime-core]
+   [clojure.tools.logging :as log]
+   [instant.grab :as grab]
+   [instant.jdbc.aurora :as aurora]
+
+   [instant.jdbc.sql :as sql]
+   [instant.flags :as flags])
+  (:import
+   (java.time Period DayOfWeek)))
+
+(defn find-new-users
+  ([] (find-new-users (aurora/conn-pool :read)))
+  ([conn]
+   (sql/select
+    :welcome-email-users
+    conn
+    ["SELECT email
+     FROM instant_users
+     WHERE created_at BETWEEN (CURRENT_TIMESTAMP - INTERVAL '2 days')
+                          AND (CURRENT_TIMESTAMP - INTERVAL '1 day')"])))
+
+(def html-body
+  "<p>Hey there! Welcome to Instant! Full disclosure: this is an automated
+email, but if you respond, a real human (likely Joe or Stopa, the
+founders) will read it and get back to you!</p>
+<p>How’s your experience with Instant been so far? Any feedback to
+share?</p>")
+
+(def text-body
+  "Hey there! Welcome to Instant! Full disclosure: this is an automated email, but
+if you respond, a real human (likely Joe or Stopa, the founders) will read it and get back to you!
+
+How's your experience with Instant been so far? Any feedback to share?")
+
+(defn send-welcome-email! []
+  (let [{:keys [enabled? limit]} (flags/welcome-email-config)
+        date-str (-> (date/pst-now)
+                     date/numeric-date-str)]
+    (when enabled?
+      (grab/run-once!
+       (str "welcome-email-" date-str)
+       (fn []
+         (let [emails (map :email (find-new-users))
+               shuffled (cond->> (shuffle emails)
+                          limit (take limit))]
+           (run! (fn [to]
+                   (postmark/send! {:from "founders@pm.instantdb.com"
+                                    :to to
+                                    :reply-to "founders@instantdb.com"
+                                    :subject "Welcome to Instant!"
+                                    :html html-body
+                                    :text text-body})) shuffled)))))))
+
+(comment)
+
+(defn period []
+  (let [now (date/pst-now)
+        send-at-pst (-> (date/pst-now)
+                        (.withHour 8) ;; send at 8am
+                        (.withMinute 0))
+        periodic-seq (chime-core/periodic-seq
+                      send-at-pst
+                      (Period/ofDays 1))]
+    (->> periodic-seq
+         (filter (fn [x] (.isAfter x now)))
+         ;; Only run Monday through Friday
+         (filter (fn [x]
+                   (let [day-of-week (.getDayOfWeek x)]
+                     (not (contains? #{DayOfWeek/SATURDAY DayOfWeek/SUNDAY}
+                                     day-of-week))))))))
+
+(def schedule (atom nil))
+
+(defn start []
+  (log/info "Starting welcome email daemon")
+  (reset! schedule (chime-core/chime-at (period) send-welcome-email!)))
+
+(defn stop []
+  (when @schedule
+    (.close @schedule)
+    (reset! schedule nil)))
+
+(defn restart []
+  (stop)
+  (start))

--- a/server/src/instant/scripts/welcome_email.clj
+++ b/server/src/instant/scripts/welcome_email.clj
@@ -7,7 +7,6 @@
    [clojure.tools.logging :as log]
    [instant.grab :as grab]
    [instant.jdbc.aurora :as aurora]
-
    [instant.jdbc.sql :as sql]
    [instant.flags :as flags])
   (:import
@@ -56,12 +55,10 @@ How's your experience with Instant been so far? Any feedback to share?")
                                     :html html-body
                                     :text text-body})) shuffled)))))))
 
-(comment)
-
 (defn period []
   (let [now (date/pst-now)
         send-at-pst (-> (date/pst-now)
-                        (.withHour 8) ;; send at 8am
+                        (.withHour 8) ;; send at 8am pst
                         (.withMinute 0))
         periodic-seq (chime-core/periodic-seq
                       send-at-pst

--- a/server/src/instant/scripts/welcome_email.clj
+++ b/server/src/instant/scripts/welcome_email.clj
@@ -85,7 +85,7 @@ How's your experience with Instant been so far? Any feedback to share?")
                      (not (contains? #{DayOfWeek/SATURDAY DayOfWeek/SUNDAY}
                                      day-of-week))))))))
 
-(def schedule (atom nil))
+(defonce schedule (atom nil))
 
 (defn start []
   (log/info "Starting welcome email daemon")

--- a/server/src/instant/scripts/welcome_email.clj
+++ b/server/src/instant/scripts/welcome_email.clj
@@ -66,7 +66,8 @@ How's your experience with Instant been so far? Any feedback to share?")
                                     :reply-to "founders@instantdb.com"
                                     :subject "Welcome to Instant!"
                                     :html html-body
-                                    :text text-body})) shuffled)))))))
+                                    :text text-body}))
+                                    shuffled)))))))
 
 (defn period []
   (let [now (date/pst-now)


### PR DESCRIPTION
We sent a few emails to users yesterday to figure out the burst in signups and it was nice to get some feedback!

Figured we'd do well with sending some automated emails. We may want to tweak our strategy in the future but for now the idea is this:

Monday -> Friday we'll send out an email to users who signed up between 2 days ago and the previous day. This way we email people after they've tried us for at least 24 hours.

I also added a flag in our config app to turn this off and just the limit (right now set to 50) for the amount of emails we send
