### PR TITLE
[graphs] move graphs to a page

### DIFF
--- a/client/www/pages/intern/graphs.tsx
+++ b/client/www/pages/intern/graphs.tsx
@@ -1,0 +1,82 @@
+import Head from 'next/head';
+import React, { useEffect, useState } from 'react';
+import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
+import { useAuthToken } from '@/lib/auth';
+import { jsonFetch } from '@/lib/fetch';
+import config from '@/lib/config';
+
+function fetchGraphData(token: string | undefined) {
+  return jsonFetch(`${config.apiURI}/dash/graphs`, {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+  });
+}
+
+function useGraphData(token: string | undefined) {
+  const [state, setState] = useState<{
+    isLoading: boolean;
+    error: undefined | { body: { message: string } };
+    data: any | undefined;
+  }>({
+    isLoading: true,
+    error: undefined,
+    data: undefined,
+  });
+  useEffect(() => {
+    fetchGraphData(token).then(
+      (data) => {
+        setState({
+          isLoading: false,
+          error: undefined,
+          data,
+        });
+      },
+      (err) => {
+        setState({
+          isLoading: false,
+          error: err.body
+            ? err
+            : { body: { message: err.message || 'Uh oh, we goofed up' , hint: err.hint} },
+          data: undefined,
+        });
+      },
+    );
+  }, [token]);
+
+  return state;
+}
+
+function Page() {
+  const isHydrated = useIsHydrated();
+  const token = useAuthToken();
+  const { isLoading, error, data } = useGraphData(token);
+
+  if (!isHydrated) return null;
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: <pre>{JSON.stringify(error.body, null, 2)}</pre></div>;
+  }
+  return (
+    <div>
+      <Head>
+        <title>Instant Metrics</title>
+        <meta name="description" content="Welcome to Instant." />
+      </Head>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4 justify-items-center">
+      <img src={data.metrics.charts['weekly-active-apps']} />
+      <img src={data.metrics.charts['monthly-active-apps']} />
+        <img src={data.metrics.charts['weekly-active-devs']} />
+        <img src={data.metrics.charts['monthly-active-devs']} />
+      </div>
+    </div>
+  );
+}
+
+export default Page;

--- a/server/.clj-kondo/.gitignore
+++ b/server/.clj-kondo/.gitignore
@@ -3,4 +3,5 @@
 !config.edn
 !ci-config.edn
 !hooks/defsql.clj
+!hooks/with_prod_conn.clj
 !hooks

--- a/server/.clj-kondo/config.edn
+++ b/server/.clj-kondo/config.edn
@@ -3,7 +3,8 @@
            :unresolved-var {:exclude [ring.util.http-response/set-cookie
                                       amazonica.aws.s3]}}
  :ignore [:inline-def]
- :hooks {:analyze-call {instant.jdbc.sql/defsql hooks.defsql/defsql}}
+ :hooks {:analyze-call {instant.jdbc.sql/defsql hooks.defsql/defsql
+                        tool/with-prod-conn hooks.with-prod-conn/with-prod-conn}}
  :lint-as {instant.jdbc.sql/with-connection clojure.core/let
            instant.util.tracer/with-exceptions-silencer clojure.core/fn
            clojure.core.cache/defcache clojure.core/defrecord}}

--- a/server/.clj-kondo/hooks/with_prod_conn.clj
+++ b/server/.clj-kondo/hooks/with_prod_conn.clj
@@ -1,0 +1,16 @@
+(ns hooks.with-prod-conn
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-prod-conn
+  [{:keys [node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        conn-sym-node (first (:children binding-vec))
+        new-node
+        (api/list-node
+         (list*
+          (api/token-node 'clojure.core/let)
+          (api/vector-node
+           [conn-sym-node
+            (api/token-node :dummy-v)])
+          body))]
+    {:node new-node}))

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -20,3 +20,4 @@ server.iml
 .babashka-pod-*
 dev-resources/honeycomb-export*
 dev-resources/certs
+resources/metrics

--- a/server/src/instant/intern/metrics.clj
+++ b/server/src/instant/intern/metrics.clj
@@ -1,12 +1,13 @@
-(ns instant.scripts.metrics
+(ns instant.intern.metrics
   "Generate metrics for our monthly updates
-  Usage:
-    1. Run `make dev-with-prod` to connect to prod data
-    2. Run `generate!` at the bottom generate metrics
-    3. Run `open resources/metrics/*-usage.png` in the terminal from the /server directory to view the metrics
+  
+  Usage: 
+   Most of the time you can load: http://instantdb.com/intern/graphs
+  
+   You can also change up the queries locally and run the `save-pngs` comment below.
   
   We define active users as someone who:
-
+  
   * Has made at least 1 transaction in the time period.
   * Transaction happened at least one week after the users very first transaction
     (this is a heuristic to remove people who try us out once and then quit)
@@ -18,13 +19,17 @@
    [instant.jdbc.aurora :as aurora]
    [instant.flags :refer [get-emails]]
    [incanter.core :as i]
-   [incanter.charts :as charts])
+   [incanter.charts :as charts]
+   [instant.util.exception :as ex]
+   [clojure.java.shell :as shell])
   (:import [org.jfree.chart.renderer.category BarRenderer]
            [org.jfree.chart.labels StandardCategoryItemLabelGenerator]
            [org.jfree.chart.axis CategoryLabelPositions]
            [org.jfree.ui RectangleInsets]
-           [java.io File]
-           [java.awt Color]))
+           [java.io File ByteArrayOutputStream]
+           [java.awt Color]
+           [javax.imageio ImageIO]
+           [java.util Base64]))
 
 (defn excluded-emails []
   (let [{:keys [test team friend]} (get-emails)]
@@ -35,11 +40,6 @@
         parent-dir (.getParentFile file)]
     (when (and parent-dir (not (.exists parent-dir)))
       (.mkdirs parent-dir))))
-
-(def dir-path "resources/metrics")
-
-(defn output-file [filename]
-  (str dir-path "/" filename))
 
 (defn get-weekly-stats
   ([]
@@ -79,7 +79,7 @@
                 ORDER BY 1"
                 (with-meta (excluded-emails) {:pgtype "text[]"})])))
 
-(defn generate-bar-chart [metrics x-key y1-key title filename]
+(defn generate-bar-chart [metrics x-key y1-key title]
   (let [x-values (map x-key metrics)
         y-values (map y1-key metrics)
         chart (charts/bar-chart x-values y-values
@@ -126,10 +126,23 @@
     (.setShadowVisible renderer false)
     (.setBackgroundPaint chart (Color. 255 255 255))
 
-    (ensure-directory-exists filename)
-    (i/save chart filename)))
+    chart))
 
-(defn generate-line-chart [metrics x-key y1-key title filename]
+(defn save-chart-into-file! [chart filename]
+  (ensure-directory-exists filename)
+  (i/save chart filename))
+
+(defn chart->base64-png [chart width height]
+  (let [buf-img (.createBufferedImage chart width height)
+        baos (ByteArrayOutputStream.)
+        _ (ImageIO/write buf-img, "png", baos)
+        img-bytes (.toByteArray baos)
+        encoder (Base64/getEncoder)
+        b64 (.encodeToString encoder img-bytes)
+        s (str "data:image/png;base64, " b64)]
+    s))
+
+(defn generate-line-chart [metrics x-key y1-key title]
   (let [x-values (map x-key metrics)
         y-values (map y1-key metrics)
         chart (charts/line-chart x-values y-values
@@ -162,8 +175,7 @@
     (.setBackgroundPaint plot (Color. 255 255 255))
     (.setBackgroundPaint chart (Color. 255 255 255))
 
-    (ensure-directory-exists filename)
-    (i/save chart filename)))
+    chart))
 
 (defn mom-growth [stats k]
   (let [[prev-m curr-m] (take-last 2 stats)
@@ -171,28 +183,37 @@
         growth (* (/ (- curr-v prev-v) (* prev-v 1.0)) 100)]
     growth))
 
-(defn generate! []
-  (let [weekly-stats  (get-weekly-stats)
-        monthly-stats (get-monthly-stats)]
-    (generate-line-chart weekly-stats
-                         :date_start :distinct_users
-                         "Weekly Active Devs >= 1 tx"
-                         (output-file "wau-usage.png"))
-    (generate-bar-chart monthly-stats
-                        :date_start :distinct_users
-                        "Monthly Active Devs >= 1 tx"
-                        (output-file "mau-usage.png"))
-    (generate-line-chart weekly-stats
-                         :date_start :distinct_apps
-                         "Weekly Active Apps >= 1 tx"
-                         (output-file "wap-usage.png"))
-    (generate-bar-chart monthly-stats
-                        :date_start :distinct_apps
-                        "Monthly Active Apps >= 1 tx"
-                        (output-file "map-usage.png"))
-    {:images-dir dir-path
+(defn generate [conn]
+  (let [weekly-stats  (get-weekly-stats conn)
+        monthly-stats (get-monthly-stats conn)
+        _ (ex/assert-valid! :stats [weekly-stats monthly-stats] (when (or (empty? weekly-stats)
+                                                                          (empty? monthly-stats))
+                                                                  [{:message "No data found for stats"}]))
+        weekly-active-devs (generate-line-chart weekly-stats
+                                                :date_start :distinct_users
+                                                "Weekly Active Devs >= 1 tx")
+        monthly-active-devs (generate-bar-chart monthly-stats
+                                                :date_start :distinct_users
+                                                "Monthly Active Devs >= 1 tx")
+        weekly-active-apps (generate-line-chart weekly-stats
+                                                :date_start :distinct_apps
+                                                "Weekly Active Apps >= 1 tx")
+        monthly-active-apps (generate-bar-chart monthly-stats
+                                                :date_start :distinct_apps
+                                                "Monthly Active Apps >= 1 tx")]
+    {:charts {:weekly-active-devs weekly-active-devs
+              :monthly-active-devs monthly-active-devs
+              :weekly-active-apps weekly-active-apps
+              :monthly-active-apps monthly-active-apps}
      :monthly-active-apps-mom (mom-growth monthly-stats :distinct_apps)
      :monthly-active-devs-mom (mom-growth monthly-stats :distinct_users)}))
 
+;; save-pngs
 (comment
-  (generate!))
+  (def metrics (tool/with-prod-conn [conn]
+                 (generate conn)))
+
+  (doseq [[k chart] (:charts metrics)]
+    (save-chart-into-file! chart (str "resources/metrics/" (name k) ".png")))
+
+  (shell/sh "open" "resources/metrics"))

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -251,6 +251,3 @@
          start-pool# (requiring-resolve 'instant.jdbc.aurora/start-pool)]
      (with-open [~conn-name (start-pool# 1 (rds-cluster-id->db-config# cluster-id#))]
        ~@body)))
-
-
-


### PR DESCRIPTION
Previously, we needed to run a script to generate graphs. 

**Previous Steps** 

The previous steps used to be: 

```
    1. Run `make dev-with-prod` to connect to prod data
    2. Run `generate!` at the bottom generate metrics
    3. Run `open resources/metrics/*-usage.png` in the terminal from the /server directory to view the metrics
```

**New Steps**

Now, **you no longer need to run `make dev-with-prod`**

To get the latest version, you can always load instantdb.com/intern/graphs 

If you want to customize the graph, you run instant locally and run the `save-pngs` comment

@nezaj @dwwoelfel @tonsky 
