### PR TITLE
Monitor transact steps perf

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -24,7 +24,7 @@
         software.amazon.awssdk/rds {:mvn/version "2.30.7"}
         software.amazon.awssdk/secretsmanager {:mvn/version "2.30.7"}
         juji/editscript {:mvn/version "0.6.4"}
-        io.github.tonsky/clojure-plus {:git/sha "c9555d72accf55d313b83387015d766b4960803b"}
+        io.github.tonsky/clojure-plus {:mvn/version "1.0.0"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
         incanter/incanter {:mvn/version "1.9.3"

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -93,13 +93,23 @@
       (throw exinfo))))
 
 (defn transact! [span-name conn tx-data]
-  (tracer/with-span! {:name span-name}
-    (try
-      (let [ret (d/transact! conn tx-data)]
-        (tracer/add-data! {:attributes {:changed-datoms-count (count (:tx-data ret))}})
-        ret)
-      (catch clojure.lang.ExceptionInfo e
-        (translate-datascript-exceptions e)))))
+  (let [t0 (System/nanoTime)]
+    (tracer/with-span! {:name span-name}
+      (let [t1 (System/nanoTime)]
+        (try
+          (locking conn      
+            (let [t2  (System/nanoTime)
+                  ret (d/transact! conn tx-data)
+                  t3  (System/nanoTime)]
+              (tracer/add-data! {:attributes {:changed-datoms-count (count (:tx-data ret))
+                                              :span-time-ms         (-> t1 (- t0) (/ 1000000) double)
+                                              :lock-time-ms         (-> t2 (- t1) (/ 1000000) double)
+                                              :tx-time-ms           (-> t3 (- t2) (/ 1000000) double)
+                                              :db-before-size       (count (:db-before ret))
+                                              :db-after-size        (count (:db-after ret))}})
+              ret))
+          (catch clojure.lang.ExceptionInfo e
+            (translate-datascript-exceptions e)))))))
 
 ;; -----
 ;; reports


### PR DESCRIPTION
transact! on store-conn takes suspiciously long time. One hypothesis is that it’s contention on lock. This metric will allow us to check it

![Screenshot 2025-01-31 at 17 03 29](https://github.com/user-attachments/assets/75cca786-365b-4955-aff2-8269d00c5cd9)
