### PR TITLE
Remove vfuture-pmap

### DIFF
--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -45,6 +45,9 @@ const graph = i.graph(
     "test-emails": i.entity({
       email: i.string(),
     }),
+    "threading": i.entity({
+      "use-vfutures": i.boolean()
+    })
   },
   // You can define links here.
   // For example, if `posts` should have many `comments`.

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -201,7 +201,7 @@
         _ (reset! debug-info {:processed-tx-id processed-tx-id
                               :instaql-queries (map :instaql-query/query stale-queries)})
         recompute-results (->> stale-queries
-                               (ua/pmap-all (partial recompute-instaql-query! opts)))
+                               (ua/pmap (partial recompute-instaql-query! opts)))
         {computations true spam false} (group-by :result-changed? recompute-results)
         num-spam (count spam)
         num-computations (count computations)

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -150,7 +150,9 @@
                  :admin? admin?
                  :current-user user}
             {:keys [instaql-result]} (rq/instaql-query-reactive! store-conn ctx q return-type)]
-        (rs/send-event! store-conn app-id sess-id {:op :add-query-ok :q q :result instaql-result
+        (rs/send-event! store-conn app-id sess-id {:op :add-query-ok
+                                                   :q q
+                                                   :result instaql-result
                                                    :processed-tx-id processed-tx-id
                                                    :client-event-id client-event-id})))))
 
@@ -199,7 +201,7 @@
         _ (reset! debug-info {:processed-tx-id processed-tx-id
                               :instaql-queries (map :instaql-query/query stale-queries)})
         recompute-results (->> stale-queries
-                               (ua/vfuture-pmap (partial recompute-instaql-query! opts)))
+                               (ua/pmap-all (partial recompute-instaql-query! opts)))
         {computations true spam false} (group-by :result-changed? recompute-results)
         num-spam (count spam)
         num-computations (count computations)

--- a/server/src/instant/session_counter.clj
+++ b/server/src/instant/session_counter.clj
@@ -52,7 +52,7 @@
             (tracer/add-data! {:attributes
                                {:ws-count (count ws-channels)
                                 :report-count (count report)}})
-            (ua/vfuture-pmap
+            (ua/pmap-all
              (fn [ws-conn] (send-report! report ws-conn))
              ws-channels))
           (catch Throwable e

--- a/server/src/instant/session_counter.clj
+++ b/server/src/instant/session_counter.clj
@@ -52,7 +52,7 @@
             (tracer/add-data! {:attributes
                                {:ws-count (count ws-channels)
                                 :report-count (count report)}})
-            (ua/pmap-all
+            (ua/pmap
              (fn [ws-conn] (send-report! report ws-conn))
              ws-channels))
           (catch Throwable e

--- a/server/src/instant/util/async.clj
+++ b/server/src/instant/util/async.clj
@@ -1,9 +1,10 @@
 (ns instant.util.async
-  (:refer-clojure :exclude [future-call])
+  (:refer-clojure :exclude [future-call pmap])
   (:require
    [clojure.core.async :as a]
    [clojure.core.async.impl.buffers]
    [clojure.core.async.impl.protocols :as a-impl]
+   [instant.flags :as flags]
    [instant.gauges :as gauges]
    [instant.util.tracer :as tracer])
   (:import
@@ -138,7 +139,7 @@
   [& body]
   `(future-call default-virtual-thread-executor nil (^{:once true} fn* [] ~@body)))
 
-(defn vfuture-pmap
+(defn pmap
   "Like pmap, but uses vfutures to parallelize the work.
 
   Why would you want to use this instead of pmap?
@@ -150,13 +151,12 @@
   This executor is unbounded, so even if you have a recursive function, 
   you won't deadlock."
   [f coll]
-  (let [futs (mapv #(vfuture (f %)) coll)]
-    (mapv deref futs)))
-
-(defn pmap-all [f coll]
   (->> coll
-    (mapv #(future (f %))) ;; force whole seq
-    (mapv deref)))
+       ;; mapv to force entire seq
+       (mapv #(if (flags/use-vfutures?)
+                (vfuture (f %))
+                (tracked-future (f %))))
+       (mapv deref)))
 
 (defmacro vfut-bg
   "Futures only throw when de-referenced. vfut-bg writes a future with a

--- a/server/src/instant/util/async.clj
+++ b/server/src/instant/util/async.clj
@@ -153,6 +153,11 @@
   (let [futs (mapv #(vfuture (f %)) coll)]
     (mapv deref futs)))
 
+(defn pmap-all [f coll]
+  (->> coll
+    (mapv #(future (f %))) ;; force whole seq
+    (mapv deref)))
+
 (defmacro vfut-bg
   "Futures only throw when de-referenced. vfut-bg writes a future with a
   top-level try-catch, so you can run code asynchronously, without


### PR DESCRIPTION
For unknown reason, just spinning up vfuture takes significant time on prod. Local dev machine:

![Screenshot 2025-01-31 at 16 30 53](https://github.com/user-attachments/assets/47449f34-e805-406d-9ffa-5650bb6449a6)

Prod:

![Screenshot 2025-01-31 at 16 31 47](https://github.com/user-attachments/assets/44af0b40-9d1a-4624-bd4d-c693476ff2ba)

Times varies greatly, but it’s usually between 70 and 250 ms just to start a virtual thread!

Since spinning up real threads is faster (although more resource-intensive), we can try switching to agent thread pool & physical threads to try to improve latency