### PR TITLE
[investor-updates] graphs -> investor updates

### DIFF
--- a/client/www/pages/intern/investor_updates.tsx
+++ b/client/www/pages/intern/investor_updates.tsx
@@ -6,7 +6,7 @@ import { jsonFetch } from '@/lib/fetch';
 import config from '@/lib/config';
 
 function fetchGraphData(token: string | undefined) {
-  return jsonFetch(`${config.apiURI}/dash/graphs`, {
+  return jsonFetch(`${config.apiURI}/dash/investor_updates`, {
     method: 'GET',
     headers: {
       authorization: `Bearer ${token}`,
@@ -39,7 +39,12 @@ function useGraphData(token: string | undefined) {
           isLoading: false,
           error: err.body
             ? err
-            : { body: { message: err.message || 'Uh oh, we goofed up' , hint: err.hint} },
+            : {
+                body: {
+                  message: err.message || 'Uh oh, we goofed up',
+                  hint: err.hint,
+                },
+              },
           data: undefined,
         });
       },
@@ -47,6 +52,10 @@ function useGraphData(token: string | undefined) {
   }, [token]);
 
   return state;
+}
+
+function round(num: number, precision = 2) { 
+  return Math.round(num * Math.pow(10, precision)) / Math.pow(10, precision);
 }
 
 function Page() {
@@ -61,19 +70,28 @@ function Page() {
   }
 
   if (error) {
-    return <div>Error: <pre>{JSON.stringify(error.body, null, 2)}</pre></div>;
+    return (
+      <div>
+        Error: <pre>{JSON.stringify(error.body, null, 2)}</pre>
+      </div>
+    );
   }
+
   return (
     <div>
       <Head>
-        <title>Instant Metrics</title>
+        <title>Instant Investor Update Metrics</title>
         <meta name="description" content="Welcome to Instant." />
       </Head>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4 justify-items-center">
-      <img src={data.metrics.charts['weekly-active-apps']} />
-      <img src={data.metrics.charts['monthly-active-apps']} />
-        <img src={data.metrics.charts['weekly-active-devs']} />
-        <img src={data.metrics.charts['monthly-active-devs']} />
+      <div className="p-4">
+        <div>Monthly Active Apps M/M Growth: {round(data.metrics['monthly-active-apps-mom'])}%</div>
+        <div>Monthly Active Devs M/M Growth: {round(data.metrics['monthly-active-devs-mom'])}%</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 justify-items-center">
+          <img src={data.metrics.charts['weekly-active-apps']} />
+          <img src={data.metrics.charts['monthly-active-apps']} />
+          <img src={data.metrics.charts['weekly-active-devs']} />
+          <img src={data.metrics.charts['monthly-active-devs']} />
+        </div>
       </div>
     </div>
   );

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -161,7 +161,7 @@
                                                       (indexing-jobs/stop)))]]
                                  (deref fut))))))
 
-(defmacro log-init [operation & body]
+(defmacro with-log-init [operation & body]
   `(do
      (tracer/record-info! {:name (format "init.start.%s" (name ~operation))})
      (tracer/with-span! {:name (format "init.finish.%s" (name ~operation))}
@@ -178,59 +178,59 @@
     (log/info "Init tracer")
     (tracer/init)
 
-    (log-init :uncaught-exception-handler
+    (with-log-init :uncaught-exception-handler
       (Thread/setDefaultUncaughtExceptionHandler
        (ua/logging-uncaught-exception-handler)))
 
-    (log-init :gauges
+    (with-log-init :gauges
       (gauges/start))
-    (log-init :nrepl
+    (with-log-init :nrepl
       (nrepl/start))
-    (log-init :oauth
+    (with-log-init :oauth
       (oauth/start))
-    (log-init :jwt
+    (with-log-init :jwt
       (jwt/start))
-    (log-init :aurora
+    (with-log-init :aurora
       (aurora/start))
-    (log-init :system-catalog
+    (with-log-init :system-catalog
       (ensure-attrs-on-system-catalog-app))
-    (log-init :reactive-store
+    (with-log-init :reactive-store
       (rs/start))
-    (log-init :ephemeral
+    (with-log-init :ephemeral
       (eph/start))
-    (log-init :stripe
+    (with-log-init :stripe
       (stripe/init))
-    (log-init :session
+    (with-log-init :session
       (session/start))
-    (log-init :invalidator
+    (with-log-init :invalidator
       (inv/start-global))
-    (log-init :wal
+    (with-log-init :wal
       (wal/init))
 
     (when-let [config-app-id (config/instant-config-app-id)]
-      (log-init :flags
+      (with-log-init :flags
         (flags-impl/init config-app-id
                          flags/queries
                          flags/query-results)))
 
-    (log-init :ephemeral-app
+    (with-log-init :ephemeral-app
       (ephemeral-app/start))
-    (log-init :session-counter
+    (with-log-init :session-counter
       (session-counter/start))
-    (log-init :indexing-jobs
+    (with-log-init :indexing-jobs
       (indexing-jobs/start))
     (when (= (config/get-env) :prod)
-      (log-init :analytics
+      (with-log-init :analytics
         (analytics/start)))
     (when (= (config/get-env) :prod)
-      (log-init :daily-metrics
+      (with-log-init :daily-metrics
         (daily-metrics/start)))
     (when (= (config/get-env) :prod)
-      (log-init :welcome-email
+      (with-log-init :welcome-email
         (welcome-email/start)))
-    (log-init :web-server
+    (with-log-init :web-server
       (start))
-    (log-init :shutdown-hook
+    (with-log-init :shutdown-hook
       (add-shutdown-hook))
     (log/info "Finished init")))
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -274,11 +274,11 @@
     (assert-admin-email! email)
     (response/ok {:users (dash-admin/get-top-users n-val)})))
 
-(defn admin-graphs-get [req]
+(defn admin-investor-updates-get [req]
   (let [{:keys [email]} (req->auth-user! req)
         _ (assert-admin-email! email)
         conn (aurora/conn-pool :read)
-        metrics (metrics/generate conn)
+        metrics (metrics/investor-update-metrics conn)
         metrics-with-b64-charts
         (update metrics :charts (partial medley/map-vals
                                          (fn [chart] (metrics/chart->base64-png chart
@@ -1199,7 +1199,7 @@
   (GET "/dash/top" [] admin-top-get)
   (GET "/dash/paid" [] admin-paid-get)
   (GET "/dash/storage" [] admin-storage-get)
-  (GET "/dash/graphs" [] admin-graphs-get)
+  (GET "/dash/investor_updates" [] admin-investor-updates-get)
 
   (GET "/dash" [] dash-get)
   (POST "/dash/apps" [] apps-post)

--- a/server/src/instant/intern/metrics.clj
+++ b/server/src/instant/intern/metrics.clj
@@ -183,7 +183,10 @@
         growth (* (/ (- curr-v prev-v) (* prev-v 1.0)) 100)]
     growth))
 
-(defn generate [conn]
+;; ---------------- 
+;; Investor Update Metrics 
+
+(defn investor-update-metrics [conn]
   (let [weekly-stats  (get-weekly-stats conn)
         monthly-stats (get-monthly-stats conn)
         _ (ex/assert-valid! :stats [weekly-stats monthly-stats] (when (or (empty? weekly-stats)
@@ -211,7 +214,7 @@
 ;; save-pngs
 (comment
   (def metrics (tool/with-prod-conn [conn]
-                 (generate conn)))
+                 (investor-update-metrics conn)))
 
   (doseq [[k chart] (:charts metrics)]
     (save-chart-into-file! chart (str "resources/metrics/" (name k) ".png")))


### PR DESCRIPTION
Small changes as I get back into our dashboard work. 

I thought we should have a standalone page for investor updates. This way it's always easy to see MoM growth at the end of the month, paste it into our email, etc. 

1. Changed the route to be called investor_updates
2. Added MoM growth metrics at the top

@dwwoelfel @nezaj @tonsky 

