### PR TITLE
[overview] rolling actives, month-to-date actives

### DIFF
--- a/server/src/instant/intern/metrics.clj
+++ b/server/src/instant/intern/metrics.clj
@@ -338,9 +338,9 @@
                                                             :analysis_date
                                                             :distinct_apps
                                                             "Month To Date Active Apps >= 1 tx")
-                                       (add-goal-line month-to-date-stats 
-                                                      :analysis_date 
-                                                      :distinct_apps 
+                                       (add-goal-line month-to-date-stats
+                                                      :analysis_date
+                                                      :distinct_apps
                                                       (* 1.2 (:distinct_apps prev-month-stats))))]
     {:charts {:rolling-monthly-active-apps rolling-monthly-active-apps
               :month-to-date-active-apps month-to-date-active-apps}}))

--- a/server/src/instant/intern/metrics.clj
+++ b/server/src/instant/intern/metrics.clj
@@ -125,9 +125,73 @@
 (comment
   (tool/with-prod-conn [conn]
     (rolling-actives conn
-                     {:start-date "2025-01-01"
-                      :end-date "2025-01-30"
+                     {:start-date (LocalDate/parse "2025-01-01")
+                      :end-date (LocalDate/parse "2025-01-30")
                       :window-days 30})))
+
+(defn month-start-actives
+  "Given the month in `month-date`: 
+   
+   For each `day` of the month: 
+     Calculates active users from `start-of-month` to the `day` (inclusive)"
+  [conn {:keys [month-date]}]
+  (let [start-of-month (.withDayOfMonth month-date 1)
+        end-of-month   (.withDayOfMonth month-date (.lengthOfMonth month-date))
+        query {:with [[:date_series
+                       {:select [[[:cast [:generate_series
+                                          [:date_trunc "day" [:cast start-of-month :date]]
+                                          [:date_trunc "day" [:cast end-of-month :date]]
+                                          [:interval "1 day"]]
+                                   :date]
+                                  :analysis_date]]}]
+                      [[:excluded_emails {:columns [:email]}]
+                       {:values (map (fn [x] [x]) (excluded-emails))}]
+                      [:rolling_metrics
+                       {:select [[:ds.analysis_date :analysis_date]
+                                 [[:count [:distinct :a.id]] :distinct_apps]
+                                 [[:count [:distinct :u.id]] :distinct_users]
+                                 [[:count :*] :total_transactions]]
+                        :from [[:date_series :ds]]
+                        :left-join [[:daily_app_transactions :dat]
+                                    [:and [:between :dat.date
+                                           [:date_trunc "month" :ds.analysis_date]
+                                           :ds.analysis_date]
+                                     :dat.is_active]
+                                    [:apps :a] [:= :dat.app_id :a.id]
+                                    [:instant_users :u] [:= :a.creator_id :u.id]]
+                        :where [:not-in :u.email {:select :email :from :excluded_emails}]
+                        :group-by [:ds.analysis_date]}]]
+               :select :*
+               :from :rolling_metrics
+               :order-by :analysis_date}]
+    (sql/select conn (hsql/format query))))
+
+(comment
+  (tool/with-prod-conn [conn]
+    (month-start-actives conn
+                         {:month-date (LocalDate/parse "2025-01-01")})))
+
+(defn calendar-monthly-actives-for-month
+  [conn {:keys [month-date]}]
+  (first  (sql/select conn
+                      ["SELECT
+                  DATE_TRUNC('month', dat.date) AS analysis_date,
+                  COUNT(DISTINCT u.id) AS distinct_users,
+                  COUNT(DISTINCT a.id) AS distinct_apps
+                FROM daily_app_transactions dat
+                JOIN apps a ON dat.app_id = a.id
+                JOIN instant_users u ON a.creator_id = u.id
+                WHERE dat.is_active AND u.email NOT IN (SELECT unnest(?::text[]))
+                      AND DATE_TRUNC('month', ?::date) = DATE_TRUNC('month', dat.date) 
+                GROUP BY 1"
+                       (with-meta (excluded-emails) {:pgtype "text[]"})
+                       month-date])))
+
+(comment
+  (tool/with-prod-conn [conn]
+    (calendar-monthly-actives-for-month
+     conn
+     {:month-date (LocalDate/parse "2025-01-01")})))
 
 (defn generate-bar-chart [metrics x-key y1-key title]
   (let [x-values (map x-key metrics)
@@ -227,6 +291,40 @@
 
     chart))
 
+(defn add-goal-line
+  "Given an existing line chart for (metrics, x-key, y-key), overlays a goal line computed 
+   as a linear interpolation from the first day’s value to a value growth-percent
+   higher on the final day."
+  [chart metrics x-key y-key end-goal]
+  (let [x-values (map x-key metrics)
+        y-values (map y-key metrics)
+        n (count x-values)
+        baseline (first y-values)
+        goal-values (map-indexed
+                     (fn [i _]
+                       (+ baseline (* (- end-goal baseline) (/ i (dec n)))))
+                     x-values)]
+    (charts/add-categories chart x-values goal-values :series-label "Goal")
+    chart))
+
+(comment
+  (def date (LocalDate/parse "2025-01-01"))
+  (def prev-month-date (.minusMonths date 1))
+  (def prev-month-stats (tool/with-prod-conn [conn]
+                          (calendar-monthly-actives-for-month
+                           conn
+                           {:month-date  prev-month-date})))
+
+  (def stats (tool/with-prod-conn [conn]
+               (month-start-actives conn {:month-date (LocalDate/parse "2025-01-01")})))
+
+  (save-chart-into-file! (->  (generate-line-chart stats :analysis_date :distinct_apps "test")
+                              (add-goal-line stats :analysis_date :distinct_apps (* 1.2
+                                                                                    (:distinct_apps prev-month-stats))))
+                         (str "resources/metrics/"  "test.png"))
+
+  (shell/sh "open" "resources/metrics/test.png"))
+
 (defn mom-growth [stats k]
   (let [[prev-m curr-m] (take-last 2 stats)
         [prev-v curr-v] (map k [prev-m curr-m])
@@ -238,18 +336,33 @@
 
 (defn overview-metrics [conn end-date]
   (let [start-date (.minusDays end-date 30)
-        monthly-stats (rolling-actives conn
-                                       {:start-date start-date
-                                        :end-date end-date
-                                        :window-days 30})
-        _ (ex/assert-valid! :stats monthly-stats (when (empty? monthly-stats)
-                                                   [{:message "No data found for stats"}]))
-        rolling-monthly-active-apps (generate-line-chart  monthly-stats
-                                                          :analysis_date :distinct_apps
-                                                          "Rolling Monthly Active Apps >= 1 tx")]
+        rolling-monthly-stats (rolling-actives conn
+                                               {:start-date start-date
+                                                :end-date end-date
+                                                :window-days 30})
+        prev-month-stats (calendar-monthly-actives-for-month conn
+                                                             {:month-date (.minusMonths end-date 1)})
 
-    {:data-points {:monthly-active-apps rolling-monthly-active-apps}
-     :charts {:rolling-monthly-active-apps rolling-monthly-active-apps}}))
+        month-start-stats (month-start-actives conn {:month-date end-date})
+
+        _ (ex/assert-valid! :stats rolling-monthly-stats (when (or (empty? rolling-monthly-stats)
+                                                                   (empty? month-start-stats)
+                                                                   (nil? prev-month-stats))
+                                                           [{:message "No data found for stats"}]))
+
+        rolling-monthly-active-apps (generate-line-chart  rolling-monthly-stats
+                                                          :analysis_date :distinct_apps
+                                                          "Rolling Monthly Active Apps >= 1 tx")
+
+        month-start-active-apps (->  (generate-line-chart month-start-stats
+                                                          :analysis_date
+                                                          :distinct_apps
+                                                          "Month Start Active Apps >= 1 tx")
+                                     (add-goal-line month-start-stats :analysis_date :distinct_apps (* 1.2 (:distinct_apps prev-month-stats))))]
+
+    {:data-points {:rolling-monthly-active-apps rolling-monthly-active-apps}
+     :charts {:rolling-monthly-active-apps rolling-monthly-active-apps
+              :month-start-active-apps month-start-active-apps}}))
 
 (comment
   (def overview-metrics (tool/with-prod-conn [conn]


### PR DESCRIPTION
Added two kinds of calculations for our dashboard: 

### 1. Rolling Actives

`rolling-actives` reports how our `Monthly Active` stats change day-by-day. Here's how the function works: 

1. We generate a series of `analysis_dates` between `start-date` and `end-date` (inclusive) 
2. For each`analysis_date`, we calculate actives going back `window-days`. 

So if `window-days` is 30 days, each `analysis_date` reports monthly stats for a 30 day window, where the end is that date. 

The goal for this is to get a sense of how our MAU number is changing over time. 

```sql
WITH date_series AS (
  SELECT
    CAST(
      GENERATE_SERIES(
        DATE_TRUNC('day', CAST('2025-01-01' AS DATE)),
        DATE_TRUNC('day', CAST('2025-01-30' AS DATE)),
        INTERVAL '1 day'
      ) AS DATE
    ) AS analysis_date
),
excluded_emails (email) AS (
  VALUES
    ('hello+ephemeralapps@instantdb.com'),
    ('testuser@instantdb.com'),
    -- ...
),
rolling_metrics AS (
  SELECT
    ds.analysis_date AS analysis_date,
    COUNT(DISTINCT a.id) AS distinct_apps,
    COUNT(DISTINCT u.id) AS distinct_users,
    COUNT(*) AS total_transactions
  FROM
    date_series AS ds
    LEFT JOIN daily_app_transactions AS dat ON dat.date BETWEEN (ds.analysis_date - INTERVAL '30 days')
    AND ds.analysis_date
    AND dat.is_active
    LEFT JOIN apps AS a ON dat.app_id = a.id
    LEFT JOIN instant_users AS u ON a.creator_id = u.id
  WHERE
    u.email NOT IN (
      SELECT
        email
      FROM
        excluded_emails
    )
  GROUP BY
    ds.analysis_date
)
SELECT
  *
FROM
  rolling_metrics
ORDER BY
  analysis_date ASC
```

## 2. Month-To-Date Actives

The second reports how we are trending towards our target `Monthly Active` Goal. The way do this: 

1. We calculate the target by multiplying last month's result with 20% 
2. We then calculate how MAPs are changing in the _current_ month
  a. i.e calculate 'active' devs from start of the month, to each _day_ in the current month

The SQL query for this looks like: 

```SQL
WITH date_series AS (
  SELECT
    CAST(
      GENERATE_SERIES(
        DATE_TRUNC('day', CAST('2025-01-01' AS DATE)),
        DATE_TRUNC('day', CAST('2025-01-31' AS DATE)),
        INTERVAL '1 day'
      ) AS DATE
    ) AS analysis_date
),
excluded_emails (email) AS (
  VALUES
    ('hello+ephemeralapps@instantdb.com'),
    ('testuser@instantdb.com')
    -- ...
),
rolling_metrics AS (
  SELECT
    ds.analysis_date AS analysis_date,
    COUNT(DISTINCT a.id) AS distinct_apps,
    COUNT(DISTINCT u.id) AS distinct_users,
    COUNT(*) AS total_transactions
  FROM
    date_series AS ds
    LEFT JOIN daily_app_transactions AS dat ON dat.date BETWEEN DATE_TRUNC('month', ds.analysis_date)
    AND ds.analysis_date
    AND dat.is_active
    LEFT JOIN apps AS a ON dat.app_id = a.id
    LEFT JOIN instant_users AS u ON a.creator_id = u.id
  WHERE
    u.email NOT IN (
      SELECT
        email
      FROM
        excluded_emails
    )
  GROUP BY
    ds.analysis_date
)
SELECT
  *
FROM
  rolling_metrics
ORDER BY
  analysis_date ASC;
```

## Notes

There's some opportunity to abstract most of our queries. For now I am copy-pastaing -- will look into generalizing later