### PR TITLE
[overview] machine summarizer

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -20,6 +20,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
    [instant.lib.ring.undertow :as undertow-adapter]
+   [instant.machine-summaries]
    [instant.nrepl :as nrepl]
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.invalidator :as inv]

--- a/server/src/instant/intern/metrics.clj
+++ b/server/src/instant/intern/metrics.clj
@@ -47,7 +47,7 @@
    (sql/select conn
                ["SELECT
                   TO_CHAR(DATE_TRUNC('week', dat.date), 'YYYY-MM-DD') AS date_start,
-                  COUNT(dat.count) AS total_transactions,
+                  SUM(dat.count) AS total_transactions,
                   COUNT(DISTINCT u.id) AS distinct_users,
                   COUNT(DISTINCT a.id) AS distinct_apps
                 FROM daily_app_transactions dat
@@ -66,7 +66,7 @@
    (sql/select conn
                ["SELECT
                   TO_CHAR(DATE_TRUNC('month', dat.date), 'YYYY-MM-DD') AS date_start,
-                  COUNT(dat.count) AS total_transactions,
+                  SUM(dat.count) AS total_transactions,
                   COUNT(DISTINCT u.id) AS distinct_users,
                   COUNT(DISTINCT a.id) AS distinct_apps
                 FROM daily_app_transactions dat

--- a/server/src/instant/machine_summaries.clj
+++ b/server/src/instant/machine_summaries.clj
@@ -22,7 +22,7 @@
 
 (defn get-all-session-reports [hz]
   (let [executor (.getExecutorService hz "session-report-executor")
-        futures  (.submitToAllMembers executor (hz/Task. session-report-task))]
+        futures  (.submitToAllMembers executor (hz/->Task #'session-report-task))]
     (into {} (for [[member fut] futures]
                [(str member) @fut]))))
 

--- a/server/src/instant/machine_summaries.clj
+++ b/server/src/instant/machine_summaries.clj
@@ -1,0 +1,30 @@
+(ns instant.machine-summaries
+  (:require
+   [instant.util.hazelcast :as hz]
+   [instant.reactive.ephemeral :as eph]
+   [instant.reactive.store :as rs]))
+
+(defn store->session-report [db]
+  (->> (rs/report-active-sessions db)
+       (filter :app-id)
+       (map (juxt :app-id :app-title :creator-email))
+       frequencies
+       (map (fn [[[app-id app-title creator-email] cnt]]
+              [app-id
+               {:app-title app-title
+                :creator-email creator-email
+                :count cnt}]))
+       (into {})))
+
+(defn session-report-task
+  []
+  (store->session-report @rs/store-conn))
+
+(defn get-all-session-reports [hz]
+  (let [executor (.getExecutorService hz "session-report-executor")
+        futures  (.submitToAllMembers executor (hz/Task. session-report-task))]
+    (into {} (for [[member fut] futures]
+               [(str member) @fut]))))
+
+(comment
+  (get-all-session-reports (eph/get-hz)))

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -125,7 +125,6 @@
                        :data {}}}
           (->JoinRoomMergeV1 session-id user-id)))
 
-
 (def ^ByteArraySerializer join-room-serializer
   (reify ByteArraySerializer
     ;; Must be unique within the project
@@ -234,3 +233,13 @@
    join-room-config
    set-presence-config
    room-key-config])
+
+;; --------------- 
+;; Executor Helpers 
+
+(deftype Task [fun]
+  java.io.Serializable
+
+  Callable
+  (call [_] (fun)))
+

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -210,6 +210,30 @@
   (make-serializer-config RoomBroadcastV1
                           room-broadcast-serializer))
 
+;; ---------------
+;; Executor Helpers
+
+;; Expects a var that takes no arguments
+(defrecord Task [^clojure.lang.Var v]
+  Callable
+  (call [_]
+    (v)))
+
+(def ^ByteArraySerializer task-serializer
+  (reify ByteArraySerializer
+    ;; Must be unique within the project
+    (getTypeId [_] 7)
+    (write ^bytes [_ {:keys [v]}]
+      (assert (var? v) "Expected Task to get a resolved var.")
+      (nippy/fast-freeze (str (symbol v))))
+    (read [_ ^bytes in]
+      (->Task (resolve (symbol (nippy/fast-thaw in)))))
+    (destroy [_])))
+
+(def task-config
+  (make-serializer-config Task
+                          task-serializer))
+
 ;; -----------------
 ;; Global serializer
 
@@ -232,14 +256,5 @@
    room-broadcast-config
    join-room-config
    set-presence-config
-   room-key-config])
-
-;; --------------- 
-;; Executor Helpers 
-
-(deftype Task [fun]
-  java.io.Serializable
-
-  Callable
-  (call [_] (fun)))
-
+   room-key-config
+   task-config])


### PR DESCRIPTION
For our `overview` field, I wanted to get a ~live view of how many connections we are supporting.  Ideally we'd have a table below that we can scroll through, to see all active apps. 

### Problem 

Since we have multiple machines, we can't just get this info in memory

### Solution

We use Hazelcast's [ExecutorService](https://docs.hazelcast.com/imdg/4.2/computing/executor-service), run a `summarize` function across all machines, and return the result together. 

@dwwoelfel @nezaj @tonsky 