### PR TITLE
Fix explorer namespaces becoming outdated

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -236,6 +236,14 @@ function isTabAvailable(tab: Tab, role?: Role) {
   return tab.minRole ? role && isMinRole(tab.minRole, role) : true;
 }
 
+function WatchNamespaces({ db }: { db: InstantReactWebDatabase<any> }) {
+  // (XXX)
+  // Hack to ensure that the namespaces in the Explorer tab are always
+  // kept up-to-date.
+  useSchemaQuery(db);
+  return null;
+}
+
 function Dashboard() {
   const token = useContext(TokenContext);
   const router = useRouter();
@@ -414,6 +422,14 @@ function Dashboard() {
           <title>Instant - {tabIndex.get(tab)?.title}</title>
           <meta name="description" content="Welcome to Instant." />
         </Head>
+
+        {showApp ? (
+          <WatchNamespaces
+            key={connection.db._core._reactor.config.appId}
+            db={connection.db}
+          />
+        ) : null}
+
         <StyledToastContainer />
         <PersonalAccessTokensScreen />
       </div>


### PR DESCRIPTION
This PR seeks to resolve #790 (see issue for reproduction steps). In brief, the namespaces list in the explorer dashboard tab does not update if new namespaces are added while another tab is loaded. To solve this I created a renderless component which ensures that the namespaces are always updated even if the explorer is not currently visible. I made use of the already existing `useSchemaQuery` to set the namespaces.

I'm sure there is a better way of doing this, this fix seems a bit hacky, but it's what I was able to come up with in a relatively short amount of time. One downside of this solution, if my understanding of the dashboard code is correct, is that while the components that already use `useSchemaQuery` are loaded (i.e. Explorer and Query Inspector) there will be duplicate `setNamespaces` calls due to `onAttrs` being registered twice.

Let me know if you have any questions, clarifications, or improvements.

## Before

![G1](https://github.com/user-attachments/assets/0e0ea95a-c62e-4bce-b22d-2853be1478cf)

## After

![G2](https://github.com/user-attachments/assets/e47c5103-4a2e-4e73-934e-f44a59be70a3)
