### PR TITLE
Fix another flaky test

### DIFF
--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -705,15 +705,14 @@
                    :room-id rid})
 
         (let [msgs (read-msgs 2 socket)
-              join-room-ok (ucoll/seek (fn [msg] (= :join-room-ok (:op msg))) msgs)
-              room-id (:room-id join-room-ok)]
+              join-room-ok (ucoll/seek (fn [msg] (= :join-room-ok (:op msg))) msgs)]
 
           (is (= [:join-room-ok :refresh-presence]
                  (sort (map :op msgs))))
 
           (is join-room-ok)
 
-          (is (= room-id room-id))
+          (is (= rid (:room-id join-room-ok)))
           (is (eph/in-room? movies-app-id rid sess-id)))))))
 
 (deftest leave-room-works

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -698,11 +698,8 @@
       (blocking-send-msg :init-ok socket {:op :init
                                           :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
-            sess-id (:id socket)
-            {:keys [op room-id]} (blocking-send-msg :join-room-ok
-                                                    socket
-                                                    {:op :join-room
-                                                     :room-id rid})]
+            sess-id (:id socket)]
+
         (send-msg socket
                   {:op :join-room
                    :room-id rid})

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -706,14 +706,14 @@
 
         (let [msgs (read-msgs 2 socket)
               join-room-ok (ucoll/seek (fn [msg] (= :join-room-ok (:op msg))) msgs)
-              rid (:room-id join-room-ok)]
+              room-id (:room-id join-room-ok)]
 
-          (is (= #{:join-room-ok :refresh-presence}
-                 (set (map :op msgs))))
+          (is (= [:join-room-ok :refresh-presence]
+                 (sort (map :op msgs))))
 
           (is join-room-ok)
 
-          (is (= rid room-id))
+          (is (= room-id room-id))
           (is (eph/in-room? movies-app-id rid sess-id)))))))
 
 (deftest leave-room-works

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -711,6 +711,9 @@
               join-room-ok (ucoll/seek (fn [msg] (= :join-room-ok (:op msg))) msgs)
               rid (:room-id join-room-ok)]
 
+          (is (= #{:join-room-ok :refresh-presence}
+                 (set (map :op msgs))))
+
           (is join-room-ok)
 
           (is (= rid room-id))


### PR DESCRIPTION
Fixes the `join-room` test, where `refresh-presence` might get delivered before `join-room-ok`.

Example of a failing run here: https://github.com/instantdb/instant/actions/runs/13125160638/job/36619894359