### PR TITLE
[overview] overview dashboard

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -1051,3 +1051,9 @@ export function twel<T = {}>(
 export function cn(...inputs: clsx.ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function FullscreenLoading() {
+  return (
+    <div className="animate-slow-pulse flex w-full flex-1 flex-col bg-gray-300"></div>
+  );
+}

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -35,6 +35,7 @@ import {
   Content,
   Copyable,
   Dialog,
+  FullscreenLoading,
   Label,
   ScreenHeading,
   SectionHeading,
@@ -440,9 +441,9 @@ function Dashboard() {
         {screen === 'new' ? (
           <CreateApp onDone={onCreateApp} />
         ) : dashResponse.isLoading ? (
-          <Loading />
+          <FullscreenLoading />
         ) : dashResponse.error ? (
-          <ErrorMessage message={errMessage(dashResponse.error)} />
+          <FullscreenErrorMessage message={errMessage(dashResponse.error)} />
         ) : showAppOnboarding ? (
           <Onboarding
             onCreate={async (p) => {
@@ -1444,13 +1445,7 @@ function CreateApp({ onDone }: { onDone: (o: { name: string }) => void }) {
   );
 }
 
-function Loading() {
-  return (
-    <div className="animate-slow-pulse flex w-full flex-1 flex-col bg-gray-300"></div>
-  );
-}
-
-function ErrorMessage({ message }: { message: string }) {
+function FullscreenErrorMessage({ message }: { message: string }) {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 p-2">
       <div className="rounded bg-red-100 p-4 text-red-700">{message}</div>

--- a/client/www/pages/intern/overview.tsx
+++ b/client/www/pages/intern/overview.tsx
@@ -1,0 +1,219 @@
+import React, { use, useEffect, useState } from 'react';
+
+import { useAuthToken } from '@/lib/auth';
+import { jsonFetch } from '@/lib/fetch';
+import config from '@/lib/config';
+import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
+
+import { FullscreenLoading, LogoIcon } from '@/components/ui';
+import Head from 'next/head';
+import { format, parse, subDays } from 'date-fns';
+
+async function fetchDailyOverview(token: string) {
+  return jsonFetch(`${config.apiURI}/dash/overview/daily`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+  });
+}
+
+async function fetchMinuteOverview(token: string) {
+  return jsonFetch(`${config.apiURI}/dash/overview/minute`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+  });
+}
+
+function useCurrentDate({ refreshSeconds }: { refreshSeconds: number }) {
+  const [date, setDate] = useState(new Date());
+  const refreshMs = refreshSeconds * 1000;
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDate(new Date());
+    }, refreshMs);
+    return () => clearInterval(interval);
+  }, [refreshMs]);
+  return date;
+}
+
+function useDailyOverview(token: string) {
+  const sentAt = useCurrentDate({ refreshSeconds: 60 * 5 });
+  const [state, setState] = useState<any>({
+    isLoading: true,
+    error: undefined,
+    data: undefined,
+  });
+  useEffect(() => {
+    let cancel = false;
+    async function exec() {
+      try {
+        const data = await fetchDailyOverview(token);
+        if (cancel) return;
+        setState({ data, error: undefined, isLoading: false });
+      } catch (error) {
+        if (cancel) return;
+        setState({ data: undefined, error, isLoading: false });
+      }
+    }
+    exec();
+    return () => {
+      cancel = true;
+    };
+  }, [token, sentAt]);
+
+  return { ...state, sentAt };
+}
+
+function useMinuteOverview(token: string) {
+  const sentAt = useCurrentDate({ refreshSeconds: 30 });
+  const [state, setState] = useState<any>({
+    isLoading: true,
+    error: undefined,
+    data: undefined,
+  });
+  useEffect(() => {
+    let cancel = false;
+    async function exec() {
+      try {
+        const data = await fetchMinuteOverview(token);
+        if (cancel) return;
+        setState({ data, error: undefined, isLoading: false });
+      } catch (error) {
+        if (cancel) return;
+        setState({ data: undefined, error, isLoading: false });
+      }
+    }
+    exec();
+    return () => {
+      cancel = true;
+    };
+  }, [token, sentAt]);
+
+  return { ...state, sentAt };
+}
+
+function flattenedSessionReports(machineToReport: any) {
+  const merged: any = {};
+  for (const memberId in machineToReport) {
+    const memberReports = machineToReport[memberId];
+    for (const sessionId in memberReports) {
+      const session = memberReports[sessionId];
+      if (merged[sessionId]) {
+        merged[sessionId].count = merged[sessionId].count + session.count;
+      } else {
+        merged[sessionId] = { ...session };
+      }
+    }
+  }
+  const items = Object.values(merged);
+  return items;
+}
+
+export function Main() {
+  const token = useAuthToken();
+  const daily = useDailyOverview(token!);
+  const minute = useMinuteOverview(token!);
+  if (daily.isLoading || minute.isLoading) return <FullscreenLoading />;
+  if (daily.error || minute.error) {
+    return (
+      <div>
+        Error: <pre>{JSON.stringify(daily.error.body, null, 2)}</pre>
+      </div>
+    );
+  }
+  const rollingStats = daily.data['data-points']['rolling-monthly-stats'];
+  const latestRolling = rollingStats[rollingStats.length - 1];
+  const charts = daily.data['charts'];
+  const sessions = flattenedSessionReports(
+    minute.data['session-reports'],
+  ).toSorted((a: any, b: any) => a.count - b.count);
+  const totalSessions = sessions.reduce(
+    (acc: number, x: any) => acc + x.count,
+    0,
+  );
+  const dateAnalyzed = parse(daily.data.date, 'yyyy-MM-dd', new Date());
+  return (
+    <div className="flex flex-col font-mono min-h-0">
+      <div className="p-4 space-x-4 flex items-center border-b">
+        <LogoIcon size="normal" />
+        <h3 className="text-xl">
+          <span className="font-bold">instant</span> metrics
+        </h3>
+      </div>
+      <div className="flex min-h-0">
+        <div className="flex-1 p-4 space-y-2">
+          <div>
+            <h3 className="text-lg">{format(dateAnalyzed, 'MMMM d, yyyy')}</h3>
+            <div className="inline-flex items-baseline space-x-4">
+              <h1 className="leading-none" style={{ fontSize: 120 }}>
+                {latestRolling['distinct_apps']}
+              </h1>
+              <div className="font-bold leading-none">Monthly Active Apps</div>
+            </div>
+            <div className="flex space-y-4">
+              <div>
+                <img src={charts['rolling-monthly-active-apps']} />
+              </div>
+              <div>
+                <img src={charts['month-to-date-active-apps']} />
+              </div>
+            </div>
+          </div>
+          <div className="flex space-x-4">
+            <div>
+              <h3 className="font-bold" style={{ fontSize: 30 }}>
+                {latestRolling['distinct_users']}
+              </h3>
+              <div>Monthly Active Devs</div>
+            </div>
+          </div>
+        </div>
+        {/* I want this part to scroll */}
+        <div className="flex-1 p-4 space-y-2 flex flex-col min-h-0">
+          <h3 className="text-lg">{format(minute.sentAt, 'hh:mma')}</h3>
+          <div className="inline-flex items-baseline space-x-4">
+            <h1 className="leading-none" style={{ fontSize: 120 }}>
+              {totalSessions}
+            </h1>
+            <div className="font-bold leading-none">Active Connections</div>
+          </div>
+          <div className="mt-4 border overflow-y-scroll">
+            <table className="w-full">
+              <tbody>
+                {sessions.map((session: any, i) => (
+                  <tr key={session['app-title'] + i}>
+                    <td className="px-4 py-2">{session['app-title']}</td>
+                    <td className="px-4 py-2">
+                      {session['creator-email'] || '-'}
+                    </td>
+                    <td className="px-4 py-2 text-right">{session.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Page() {
+  const isHydrated = useIsHydrated();
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden md:flex-row">
+      <Head>
+        <title>Instant Overview</title>
+        <meta name="description" content="Welcome to Instant." />
+      </Head>
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {isHydrated ? <Main /> : null}
+      </div>
+    </div>
+  );
+}

--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -107,7 +107,7 @@
        (insert-new-activity)
        (let [stats (get-daily-actives date-minus-one-str)
              conn (aurora/conn-pool :read)
-             charts (->> (metrics/overview-metrics conn (.minusDays (LocalDate/now) 1))
+             charts (->> (metrics/overview-metrics conn)
                          :charts
                          (map (fn [[k chart]]
                                 {:name (format "%s.png" (name k))


### PR DESCRIPTION
This adds an Overview Dashboard for us. 

(See screenshots in Team Discord) 

Some things we show: 
1. Rolling Actives
2. Month-To-Date Actives vs Target
3. Number of active connections (refreshed every minute)
4. Connections grouped by app

One bugfix for Month to Date Actives

1. Previously, the "real data" line would expand to the end of the month. Now we only show real data until the day we are looking.

@dwwoelfel @nezaj @tonsky 