### PR TITLE
Use the s3 aws jdk 2

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -21,8 +21,11 @@
         cider/cider-nrepl {:mvn/version "0.45.0"}
 
         amazonica/amazonica {:mvn/version "0.3.167"}
-        software.amazon.awssdk/rds {:mvn/version "2.30.7"}
-        software.amazon.awssdk/secretsmanager {:mvn/version "2.30.7"}
+        software.amazon.awssdk/rds {:mvn/version "2.30.11"}
+        software.amazon.awssdk/secretsmanager {:mvn/version "2.30.11"}
+        software.amazon.awssdk/s3 {:mvn/version "2.30.11"}
+        software.amazon.awssdk.crt/aws-crt {:mvn/version "0.33.11"}
+
         juji/editscript {:mvn/version "0.6.4"}
         io.github.tonsky/clojure-plus {:mvn/version "1.0.0"}
 

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -376,6 +376,7 @@
         data (storage-coordinator/upload-file! {:app-id app-id
                                                 :path path
                                                 :content-type content-type
+                                                :content-length (:content-length req)
                                                 :skip-perms-check? true}
                                                file)]
     (response/ok {:data data})))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -943,7 +943,8 @@
               {:app-id app-id
                :path path
                :file file
-               :content-type (:content-type file)
+               :content-type (:content-type req)
+               :content-length (:content-length req)
                :skip-perms-check? true}
                file)]
     (response/ok {:data data})))

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -2,7 +2,8 @@
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [instant.util.s3 :as s3-util]
-            [instant.flags :as flags]))
+            [instant.flags :as flags])
+  (:import [java.time Duration]))
 
 ;; Legacy S3 migration helpers
 ;; ------------------
@@ -68,14 +69,14 @@
   (-> object-metadata
       (select-keys [:content-disposition :content-type :content-length :etag])
       (assoc :size (:content-length object-metadata)
-             :last-modified (-> object-metadata :last-modified .getMillis)
+             :last-modified (-> object-metadata :last-modified .toEpochMilli)
              :path (object-key->path key))))
 
 (defn get-object-metadata
   ([app-id path] (get-object-metadata s3-util/default-bucket app-id path))
   ([bucket-name app-id path]
    (let [object-key (->object-key app-id path)]
-     (format-object (s3-util/get-object bucket-name object-key)))))
+     (format-object (s3-util/head-object bucket-name object-key)))))
 
 (defn delete-file! [app-id filename]
   (let [object-key (->object-key app-id filename)]
@@ -86,22 +87,22 @@
     (s3-util/delete-objects-paginated keys)))
 
 (defn create-legacy-signed-download-url! [app-id filename]
-  (let [expiration (+ (System/currentTimeMillis) (* 1000 60 60 24 7)) ;; 7 days
+  (let [duration (Duration/ofDays 7)
         object-key (->legacy-object-key app-id filename)]
     (str (s3-util/generate-presigned-url
           {:method :get
            :bucket-name s3-util/default-bucket
            :key object-key
-           :expiration expiration}))))
+           :duration duration}))))
 
 (defn create-signed-download-url! [app-id filename]
-  (let [expiration (+ (System/currentTimeMillis) (* 1000 60 60 24 7)) ;; 7 days
+  (let [duration (Duration/ofDays 7)
         object-key (->object-key app-id filename)]
     (str (s3-util/generate-presigned-url
           {:method :get
            :bucket-name s3-util/default-bucket
            :key object-key
-           :expiration expiration}))))
+           :duration duration}))))
 
 ;; S3 Usage Metrics
 ;; These functions calculate usage by talking to S3 directly. We can use these

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -8,9 +8,6 @@
                                             StaticCredentialsProvider)
    (software.amazon.awssdk.core.async AsyncRequestBody
                                       BlockingInputStreamAsyncRequestBody)
-   (software.amazon.awssdk.http.async SdkAsyncHttpClient)
-
-   (software.amazon.awssdk.http.nio.netty NettyNioAsyncHttpClient)
    (software.amazon.awssdk.services.s3 S3AsyncClient
                                        S3Client)
    (software.amazon.awssdk.services.s3.model Delete
@@ -34,10 +31,6 @@
 (def default-content-disposition "inline")
 
 (def ^S3Client default-s3-client (.build (S3Client/builder)))
-(def ^SdkAsyncHttpClient default-s3-async-http-client
-  (-> (NettyNioAsyncHttpClient/builder)
-      (.maxConcurrency (int 2048))
-      (.build)))
 (def ^S3AsyncClient default-s3-async-client (-> (S3AsyncClient/crtBuilder)
                                                 (.targetThroughputInGbps 20.0)
                                                 (.build)))


### PR DESCRIPTION
Replaces amazonica with the aws-jdk 2 for s3 operations. Uses the aws crt client for uploads, which is supposed to have high throughput: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html

A couple of incidental changes:

1. I pass the `content-type` from the `req` to `upload-stream-to-s3` in dash. This gave me better content type when I was uploading from the dashboard.

2. I pass along the `content-length` field from the `req`, which allows us to use an optimized upload path when we know the content-length ahead of time.