### PR TITLE
Hide  for non-enabled apps

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -452,11 +452,9 @@ export function Explorer({
   // data
   const { namespaces: _namespaces } = useSchemaQuery(db);
   // (TODO): When fully launching storage we can remove this check
-  const namespaces =
-    _namespaces &&
-    _namespaces.filter((ns) =>
-      isStorageEnabled ? true : ns.name !== '$files',
-    );
+  const namespaces = isStorageEnabled
+    ? _namespaces && _namespaces.filter((ns) => ns.name !== '$files')
+    : _namespaces;
   const { selectedNamespace } = useMemo(
     () => ({
       selectedNamespace: namespaces?.find(

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -1,7 +1,14 @@
 import { id, tx } from '@instantdb/core';
 import { InstantReactWebDatabase } from '@instantdb/react';
 import { isObject, debounce, last } from 'lodash';
-import { useCallback, useEffect, useMemo, useRef, useState, useContext } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useContext,
+} from 'react';
 import { jsonFetch } from '@/lib/fetch';
 import config from '@/lib/config';
 import produce from 'immer';

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -378,9 +378,11 @@ function SearchInput({
 export function Explorer({
   db,
   appId,
+  isStorageEnabled,
 }: {
   db: InstantReactWebDatabase<any>;
   appId: string;
+  isStorageEnabled: boolean;
 }) {
   // DEV
   _dev(db);
@@ -441,7 +443,13 @@ export function Explorer({
   }
 
   // data
-  const { namespaces } = useSchemaQuery(db);
+  const { namespaces: _namespaces } = useSchemaQuery(db);
+  // (TODO): When fully launching storage we can remove this check
+  const namespaces =
+    _namespaces &&
+    _namespaces.filter((ns) =>
+      isStorageEnabled ? true : ns.name !== '$files',
+    );
   const { selectedNamespace } = useMemo(
     () => ({
       selectedNamespace: namespaces?.find(

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -9,7 +9,7 @@ import { APIResponse, useAuthToken, useTokenFetch } from '@/lib/auth';
 import { Sandbox } from '@/components/dash/Sandbox';
 import { Explorer } from '@/components/dash/explorer/Explorer';
 import { init } from '@instantdb/react';
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useMemo } from 'react';
 import {
   Button,
   Checkbox,
@@ -51,6 +51,13 @@ export default function Devtool() {
         db: InstantReactClient;
       }
   >({ state: 'pending' });
+
+  const isStorageEnabled = useMemo(() => {
+    const storageEnabledAppIds =
+      dashResponse.data?.flags?.storage_enabled_apps ?? [];
+
+    return storageEnabledAppIds.includes(appId);
+  }, [appId, dashResponse.data?.flags?.storage_enabled_apps]);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
@@ -217,7 +224,11 @@ export default function Devtool() {
           />
           <div className="flex w-full flex-1 overflow-auto">
             {tab === 'explorer' ? (
-              <Explorer db={connection.db} appId={appId} />
+              <Explorer
+                db={connection.db}
+                appId={appId}
+                isStorageEnabled={isStorageEnabled}
+              />
             ) : tab === 'sandbox' ? (
               <div className="min-w-[960px] w-full">
                 <Sandbox app={app} />

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -484,7 +484,11 @@ function Dashboard() {
                 {tab === 'home' ? (
                   <Home />
                 ) : tab === 'explorer' ? (
-                  <ExplorerTab appId={appId} db={connection.db} />
+                  <ExplorerTab
+                    appId={appId}
+                    db={connection.db}
+                    isStorageEnabled={isStorageEnabled}
+                  />
                 ) : tab === 'repl' ? (
                   <QueryInspector
                     className="flex-1 w-full"
@@ -843,11 +847,24 @@ function Home() {
   );
 }
 
-function ExplorerTab({ db, appId }: { db: InstantReactClient; appId: string }) {
+function ExplorerTab({
+  db,
+  appId,
+  isStorageEnabled,
+}: {
+  db: InstantReactClient;
+  appId: string;
+  isStorageEnabled: boolean;
+}) {
   return (
     <div className="flex-1 overflow-hidden flex flex-col">
       <div className="flex flex-1 flex-col overflow-hidden">
-        <Explorer db={db} appId={appId} key={db._core._reactor.config.appId} />
+        <Explorer
+          db={db}
+          appId={appId}
+          isStorageEnabled={isStorageEnabled}
+          key={db._core._reactor.config.appId}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
dww pointed out that it's weird to see `$files` if you can't use them yet. We already pass an `isStorageEnabled` check to the frontend so figured for now we can just hide the namespace until we fully launch