### PR TITLE
Ignore the prettier changes in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Enforced prettier formatting: https://github.com/instantdb/instant/pull/810
+de921d5ae4821cada6af1f5d11068f8f5d63e27d


### PR DESCRIPTION
Ignores the formatting changes in git blame:

https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view