### PR TITLE
Add Storage sweeper

### DIFF
--- a/client/sandbox/admin-sdk-express/src/index.ts
+++ b/client/sandbox/admin-sdk-express/src/index.ts
@@ -218,14 +218,40 @@ async function testDeleteFileTransactFails() {
   }
 }
 
-// testUploadFile("circle_blue.jpg", "circle_blue.jpg", "image/jpeg");
+async function testDeleteAllowedInTx(
+  src: string,
+  dest: string,
+  contentType?: string,
+) {
+  const buffer = fs.readFileSync(path.join(__dirname, src));
+  const { data } = await db.storage.uploadFile(dest, buffer, {
+    contentType: contentType,
+  });
+  const fileId = data.id;
+  const q = {
+    $files: {
+      $: {
+        where: { id: fileId },
+      },
+    },
+  };
+  const before = await query(q);
+  console.log('Before', JSON.stringify(before, null, 2));
+
+  await transact(tx['$files'][fileId].delete());
+
+  const after = await query(q);
+  console.log('After', JSON.stringify(after, null, 2));
+}
+
+// testUploadFile('circle_blue.jpg', 'circle_blue.jpg', 'image/jpeg');
 // testUploadFile("circle_blue.jpg", "circle_blue2.jpg", "image/jpeg");
 // testQueryFiles()
 // testDeleteSingleFile("circle_blue.jpg");
 // testDeleteBulkFile(["circle_blue.jpg", "circle_blue2.jpg"]);
 // testUpdateFileFails()
 // testMergeFileFails()
-// testDeleteFileTransactFails()
+// testDeleteAllowedInTx('circle_blue.jpg', 'circle_blue.jpg', 'image/jpeg');
 
 /**
  * Legacy Storage API tests (deprecated Jan 2025)

--- a/server/resources/migrations/51_add_file_delete_trigger.down.sql
+++ b/server/resources/migrations/51_add_file_delete_trigger.down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER insert_files_to_sweep_trigger ON triples;
+DROP TRIGGER delete_files_to_sweep_trigger ON triples;
+
+DROP FUNCTION create_file_to_sweep();
+DROP FUNCTION delete_file_to_sweep();
+
+DROP TABLE app_files_to_sweep;

--- a/server/resources/migrations/51_add_file_delete_trigger.up.sql
+++ b/server/resources/migrations/51_add_file_delete_trigger.up.sql
@@ -1,0 +1,51 @@
+CREATE TABLE app_files_to_sweep (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    app_id uuid NOT NULL REFERENCES apps(id),
+    path text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT NOW(),
+    UNIQUE (app_id, path)
+);
+
+-- Whenever we delete file triples we want to ensure they are scheduled for
+-- deletion in S3.
+CREATE FUNCTION create_file_to_sweep()
+RETURNS trigger AS $$
+BEGIN
+    -- This should match the attr_id for $files.path
+    IF OLD.attr_id = '96653230-13ff-ffff-2a34-f04cffffffff' THEN
+        INSERT INTO app_files_to_sweep (app_id, path)
+        VALUES (
+            OLD.app_id,
+            OLD.value #>> '{}'  -- Extract from JSON
+        )
+        ON CONFLICT DO NOTHING;
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER insert_files_to_sweep_trigger
+    AFTER DELETE ON triples
+    FOR EACH ROW
+    EXECUTE FUNCTION create_file_to_sweep();
+
+-- When file triples are created, the path may be similar to one that was
+-- scheduled for deletion previously. We want to remove this from the sweep table
+-- since they are no longer candidates for deletion
+CREATE FUNCTION delete_file_to_sweep()
+RETURNS trigger AS $$
+BEGIN
+    -- This should match the attr_id for $files.path
+    IF NEW.attr_id = '96653230-13ff-ffff-2a34-f04cffffffff' THEN
+        DELETE FROM app_files_to_sweep 
+        WHERE app_id = NEW.app_id 
+        AND path = NEW.value #>> '{}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER delete_files_to_sweep_trigger
+    AFTER INSERT ON triples
+    FOR EACH ROW
+    EXECUTE FUNCTION delete_file_to_sweep();

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -10,6 +10,7 @@
    [instant.auth.oauth :as oauth]
    [instant.config :as config]
    [instant.dash.ephemeral-app :as ephemeral-app]
+   [instant.storage.sweeper :as storage-sweeper]
    [instant.dash.routes :as dash-routes]
    [instant.db.indexing-jobs :as indexing-jobs]
    [instant.flags :as flags]
@@ -220,6 +221,8 @@
       (session-counter/start))
     (with-log-init :indexing-jobs
       (indexing-jobs/start))
+    (with-log-init :storage-sweeper
+      (storage-sweeper/start))
     (when (= (config/get-env) :prod)
       (with-log-init :analytics
         (analytics/start)))

--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -136,18 +136,8 @@
      [op t]
      [{:message (format "update or merge is not allowed on $files in transact.")}])))
 
-(defn prevent-$files-deletes! [op tx-steps]
-  (doseq [t tx-steps
-          :let [[_op _eid etype] t]
-          :when (= etype "$files")]
-    (ex/throw-validation-err!
-     :tx-step
-     [op t]
-     [{:message (format "delete is not allowed on $files in transact.")}])))
-
 (defn prevent-$files-updates
-  "With the exception of linking/unlinking, we prevent most updates unless it's
-  gone through an explicitly allowed code path"
+  "Similar to $users, we don't allow updates to $files"
   [attrs grouped-tx-steps opts]
   (when (not (:allow-$files-update? opts))
     (doseq [batch grouped-tx-steps
@@ -155,9 +145,6 @@
       (case op
         (:add-triple :deep-merge-triple :retract-triple)
         (prevent-$files-add-retract! op attrs tx-steps)
-
-        :delete-entity
-        (prevent-$files-deletes! op tx-steps)
 
         nil))))
 

--- a/server/src/instant/model/app_file_to_sweep.clj
+++ b/server/src/instant/model/app_file_to_sweep.clj
@@ -1,0 +1,22 @@
+(ns instant.model.app-file-to-sweep
+  (:require
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [honey.sql :as hsql]))
+
+(defn get-all
+  ([] (get-all (aurora/conn-pool :read)))
+  ([conn]
+   (sql/select
+    conn (hsql/format
+          {:select [:*]
+           :from [:app_files_to_sweep]}))))
+
+(defn delete-by-ids!
+  ([params] (delete-by-ids! (aurora/conn-pool :write) params))
+  ([conn {:keys [ids]}]
+   (sql/execute-one!
+    conn
+    (hsql/format
+     {:delete-from :app_files_to_sweep
+      :where [:in :id ids]}))))

--- a/server/src/instant/storage/sweeper.clj
+++ b/server/src/instant/storage/sweeper.clj
@@ -1,0 +1,69 @@
+(ns instant.storage.sweeper
+  (:require
+   [chime.core :as chime-core]
+   [instant.flags :as flags]
+   [instant.model.app-file-to-sweep :as app-file-to-sweep]
+   [instant.storage.s3 :as instant-s3]
+   [instant.util.s3 :as s3-util]
+   [instant.util.tracer :as tracer]
+   [instant.util.date :as date]
+   [clojure.tools.logging :as log])
+  (:import
+   (java.lang AutoCloseable)
+   (java.time Period)))
+
+(defn handle-sweep! []
+  (tracer/with-span! {:name "storage/sweeper"}
+    (let [files (app-file-to-sweep/get-all)
+          migration? (-> (flags/storage-migration) :disableLegacy? not)
+          keys-to-delete (mapv #(instant-s3/->object-key (:app_id %) (:path %)) files)
+          legacy-keys-to-delete (delay
+                                  (map #(instant-s3/->legacy-object-key
+                                         (:app_id %)
+                                         (:path %))
+                                       files))
+          all-keys (cond-> keys-to-delete
+                     migration? (into @legacy-keys-to-delete))]
+      (when (seq all-keys)
+        (s3-util/delete-objects-paginated all-keys)
+        (app-file-to-sweep/delete-by-ids!
+         {:ids (mapv :id files)})))))
+
+(comment
+  (handle-sweep!))
+
+(defn period []
+  (let [now (date/pst-now)
+        run-at-pst (-> (date/pst-now)
+                       (.withHour 5)
+                       (.withMinute 0))
+        periodic-seq (chime-core/periodic-seq
+                      run-at-pst
+                      (Period/ofDays 1))]
+
+    (->> periodic-seq
+         (filter (fn [x] (.isAfter x now))))))
+
+(comment
+  (first (period)))
+
+(defonce schedule (atom nil))
+
+(defn start []
+  (log/info "Starting storage sweeper daemon")
+  (swap! schedule (fn [curr-schedule]
+                    (if curr-schedule
+                      curr-schedule
+                      (chime-core/chime-at
+                       (period)
+                       (fn [_time]
+                         (handle-sweep!)))))))
+
+(defn stop []
+  (when-let [curr-schedule @schedule]
+    (.close ^AutoCloseable curr-schedule)
+    (reset! schedule nil)))
+
+(defn restart []
+  (stop)
+  (start))


### PR DESCRIPTION
Adds sweeper logic for storage files. Introduces a table to record files to be swept which is populated by triggers.

* Whenever file triples are deleted we add to the sweep table no-ops if delete is already there)
* Whenever file triples are added we remove from the sweep table (no-ops if nothing there)
* We run the sweeper once a day to clean-up any missed files.

The upshot if this is now `$files` will be properly cleaned up on clearing an app and/or deleting an app. This will also enable proper behavior when using `:on-delete` with `$files` links.

h/t to dww for the idea!