### PR TITLE
Split rs/store-conn by app

### DIFF
--- a/server/src/instant/flags_impl.clj
+++ b/server/src/instant/flags_impl.clj
@@ -74,11 +74,11 @@
                     result (instaql-nodes->object-tree ctx data)]]
         (swap-result! query-results-atom query transform result 0))
 
-      (session/on-open store/store-conn socket)
-      (store/set-auth! store/store-conn
-                       socket-id
-                       {:app app
-                        :admin? true})
+      (session/on-open store/store socket)
+      (store/assoc-session! store/store
+                            socket-id
+                            :app app
+                            :admin? true)
       (doseq [{:keys [query]} queries]
         (session/on-message {:id socket-id
                              :receive-q receive-q
@@ -86,7 +86,7 @@
                                             :q query
                                             :return-type "tree"})}))
       (fn []
-        (session/on-close store/store-conn socket)
+        (session/on-close store/store socket)
         nil))))
 
 (defn resolve-attr-id [attrs namespaced-attr]

--- a/server/src/instant/machine_summaries.clj
+++ b/server/src/instant/machine_summaries.clj
@@ -14,8 +14,8 @@
      :count cnt
      :origins origins}))
 
-(defn store->session-report [db]
-  (->> (rs/report-active-sessions db)
+(defn store->session-report [store]
+  (->> (rs/report-active-sessions store)
        (filter :app-id)
        (group-by :app-id)
        (map (fn [[app-id app-sessions]]
@@ -24,7 +24,7 @@
 
 (defn session-report-task
   []
-  (store->session-report @rs/store-conn))
+  (store->session-report rs/store))
 
 (defn get-all-session-reports [hz]
   (let [executor (.getExecutorService hz "session-report-executor")
@@ -37,7 +37,7 @@
 
 (defn num-sessions-task
   []
-  (rs/num-sessions @rs/store-conn))
+  (rs/num-sessions @rs/store))
 
 (defn get-all-num-sessions [hz]
   (let [executor (.getExecutorService hz "session-nums-executor")

--- a/server/src/instant/machine_summaries.clj
+++ b/server/src/instant/machine_summaries.clj
@@ -37,7 +37,7 @@
 
 (defn num-sessions-task
   []
-  (rs/num-sessions @rs/store))
+  (rs/num-sessions rs/store))
 
 (defn get-all-num-sessions [hz]
   (let [executor (.getExecutorService hz "session-nums-executor")

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -155,7 +155,7 @@
   [_process-id store-conn {:keys [app-id tx-id] :as wal-record}]
   (let [topics (topics-for-changes wal-record)
         [db session-ids] (rs/mark-stale-topics! store-conn app-id tx-id topics)
-        sockets (keep (partial rs/get-socket db) session-ids)]
+        sockets (keep #(:session/socket (rs/session db %)) session-ids)]
     sockets))
 
 (defn- topics-for-byop-triple-insert [table-info change]
@@ -219,7 +219,7 @@
   [table-info app-id store-conn {:keys [tx-id] :as record}]
   (let [topics (topics-for-byop-changes table-info record)
         [db session-ids] (rs/mark-stale-topics! store-conn app-id tx-id topics)
-        sockets (keep (partial rs/get-socket db) session-ids)]
+        sockets (keep #(:session/socket (rs/session db %)) session-ids)]
     sockets))
 
 ;; ------

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -152,10 +152,10 @@
   "Given a collection of changes, stales all relevant queries and returns
   sockets to be refreshed."
   ;; process-id used for tests
-  [_process-id store-conn {:keys [app-id tx-id] :as wal-record}]
-  (let [topics (topics-for-changes wal-record)
-        [db session-ids] (rs/mark-stale-topics! store-conn app-id tx-id topics)
-        sockets (keep #(:session/socket (rs/session db %)) session-ids)]
+  [_process-id store {:keys [app-id tx-id] :as wal-record}]
+  (let [topics      (topics-for-changes wal-record)
+        session-ids (rs/mark-stale-topics! store app-id tx-id topics)
+        sockets     (keep #(:session/socket (rs/session store %)) session-ids)]
     sockets))
 
 (defn- topics-for-byop-triple-insert [table-info change]
@@ -216,10 +216,10 @@
 (defn- invalidate-byop!
   "Given a collection of changes, stales all relevant queries and returns
   sockets to be refreshed."
-  [table-info app-id store-conn {:keys [tx-id] :as record}]
-  (let [topics (topics-for-byop-changes table-info record)
-        [db session-ids] (rs/mark-stale-topics! store-conn app-id tx-id topics)
-        sockets (keep #(:session/socket (rs/session db %)) session-ids)]
+  [table-info app-id store {:keys [tx-id] :as record}]
+  (let [topics      (topics-for-byop-changes table-info record)
+        session-ids (rs/mark-stale-topics! store app-id tx-id topics)
+        sockets     (keep #(:session/socket (rs/session store %)) session-ids)]
     sockets))
 
 ;; ------
@@ -342,7 +342,7 @@
   (when tx-created-at
     (.between ChronoUnit/MILLIS tx-created-at (Instant/now))))
 
-(defn process-wal-record [process-id store-conn record-count wal-record]
+(defn process-wal-record [process-id store record-count wal-record]
   (let [{:keys [app-id tx-id tx-created-at tx-bytes]} wal-record]
     (tracer/with-span! {:name "invalidator/work"
                         :attributes {:app-id app-id
@@ -352,7 +352,7 @@
                                      :tx-bytes tx-bytes}}
 
       (try
-        (let [sockets (invalidate! process-id store-conn wal-record)]
+        (let [sockets (invalidate! process-id store wal-record)]
           (tracer/add-data! {:attributes {:num-sockets (count sockets)
                                           :tx-latency-ms (e2e-tracer/tx-latency-ms tx-created-at)}})
           (e2e-tracer/invalidator-tracking-step! {:tx-id tx-id
@@ -367,7 +367,7 @@
                                                  :tx-created-at tx-created-at}))))
         (catch Throwable t
           (def -wal-record wal-record)
-          (def -store-value @store-conn)
+          (def -store-value store)
           (tracer/add-exception! t {:escaping? false}))))))
 
 (defn invalidator-q-metrics [{:keys [grouped-queue get-worker-count]}]
@@ -380,7 +380,7 @@
    {:path "instant.reactive.invalidator.q.worker-count"
     :value (get-worker-count)}])
 
-(defn start-worker [process-id store-conn wal-chan]
+(defn start-worker [process-id store wal-chan]
   (tracer/record-info! {:name "invalidation-worker/start"})
   (let [queue-with-workers
         (grouped-queue/start-grouped-queue-with-cpu-workers
@@ -388,7 +388,7 @@
           :reserve-fn (fn [_ q] (grouped-queue/inflight-queue-reserve 100 q))
           :process-fn (fn [_key wal-records]
                         (process-wal-record process-id
-                                            store-conn
+                                            store
                                             (count wal-records)
                                             (combine-wal-records wal-records)))
           :worker-count 8})
@@ -406,10 +406,10 @@
             (do (grouped-queue/put! grouped-queue wal-record)
                 (recur))))))))
 
-(defn handle-byop-record [table-info app-id store-conn wal-record]
+(defn handle-byop-record [table-info app-id store wal-record]
   (when-let [record (transform-byop-wal-record wal-record)]
     (try
-      (let [sockets (invalidate-byop! table-info app-id store-conn record)]
+      (let [sockets (invalidate-byop! table-info app-id store record)]
         (tracer/add-data! {:attributes {:num-sockets (count sockets)}})
         (tracer/with-span! {:name "invalidator/send-refreshes"}
           (doseq [{:keys [id]} sockets]
@@ -417,10 +417,10 @@
                                                :session-id id}))))
       (catch Throwable t
         (def -wal-record wal-record)
-        (def -store-value @store-conn)
+        (def -store-value store)
         (tracer/add-exception! t {:escaping? false})))))
 
-(defn start-byop-worker [store-conn wal-chan]
+(defn start-byop-worker [store wal-chan]
   (tracer/record-info! {:name "invalidation-worker/start-byop"})
   (let [app-id config/instant-on-instant-app-id
         {:keys [table-info]} (pg-introspect/introspect (aurora/conn-pool :read)
@@ -433,11 +433,11 @@
             (try
               (handle-byop-record app-id
                                   table-info
-                                  store-conn
+                                  store
                                   wal-record)
               (catch Throwable t
                 (def -wal-record wal-record)
-                (def -store-value @store-conn)
+                (def -store-value store)
                 (tracer/add-exception! t {:escaping? false})))
             (recur)))))))
 
@@ -494,11 +494,11 @@
 
      @(:started-promise wal-opts)
 
-     (start-worker process-id rs/store-conn worker-chan)
+     (start-worker process-id rs/store worker-chan)
 
      (when byop-chan
        (ua/fut-bg
-        (start-byop-worker rs/store-conn byop-chan)))
+        (start-byop-worker rs/store byop-chan)))
 
      wal-opts)))
 

--- a/server/src/instant/reactive/query.clj
+++ b/server/src/instant/reactive/query.clj
@@ -18,15 +18,15 @@
 (defn- datalog-query-cached!
   "Returns the result of a datalog query. Leverages atom and
   delay to ensure queries are only run once in the face of concurrent requests."
-  [store-conn {:keys [app-id] :as ctx} datalog-query]
-  (rs/swap-datalog-cache! store-conn app-id d/query ctx datalog-query))
+  [store {:keys [app-id] :as ctx} datalog-query]
+  (rs/swap-datalog-cache! store app-id d/query ctx datalog-query))
 
 (comment
   (def ctx {:db {:conn-pool (aurora/conn-pool :read)}
             :app-id zeneca-app-id})
   (def instaql-query '[[:ea ?e ?a "joe"]])
   (time
-   (datalog-query-cached! rs/store-conn ctx instaql-query)))
+   (datalog-query-cached! rs/store ctx instaql-query)))
 
 (defn- datalog-query-reactive!
   "When a datalog query is in-flight we may miss an update. To mitigate this
@@ -35,13 +35,13 @@
   it as stale.
 
   Once the query completes we refine the subscription with the resolved topics"
-  [store-conn ctx datalog-query]
+  [store ctx datalog-query]
   (tracer/with-span! {:name "datalog-query-reactive!"
                       :attributes {:query (pr-str datalog-query)}}
     (let [coarse-topics (d/pats->coarse-topics datalog-query)
-          _ (rs/record-datalog-query-start! store-conn ctx datalog-query coarse-topics)
-          datalog-result (datalog-query-cached! store-conn ctx datalog-query)]
-      (rs/record-datalog-query-finish! store-conn ctx datalog-query datalog-result)
+          _ (rs/record-datalog-query-start! store ctx datalog-query coarse-topics)
+          datalog-result (datalog-query-cached! store ctx datalog-query)]
+      (rs/record-datalog-query-finish! store ctx datalog-query datalog-result)
       datalog-result)))
 
 (defn collect-triples [instaql-result]
@@ -91,33 +91,33 @@
 (defn instaql-query-reactive!
   "Returns the result of an instaql query while producing book-keeping side
   effects in the store. To be used with session"
-  [store-conn {:keys [session-id app-id attrs] :as base-ctx} instaql-query return-type]
+  [store {:keys [session-id app-id attrs] :as base-ctx} instaql-query return-type]
   (tracer/with-span! {:name "instaql-query-reactive!"
                       :attributes {:session-id session-id
                                    :app-id app-id
                                    :instaql-query instaql-query}}
     (try
-      (let [v (rs/bump-instaql-version! store-conn session-id instaql-query return-type)
+      (let [v (rs/bump-instaql-version! store app-id session-id instaql-query return-type)
             ctx (-> base-ctx
                     (assoc :v v
-                           :datalog-query-fn (partial datalog-query-reactive! store-conn)
+                           :datalog-query-fn (partial datalog-query-reactive! store)
                            :instaql-query instaql-query)
                     ((fn [ctx]
                        (-> ctx
-                           (assoc :record-datalog-query-start! (partial rs/record-datalog-query-start! store-conn ctx)
-                                  :record-datalog-query-finish! (partial rs/record-datalog-query-finish! store-conn ctx))))))
+                           (assoc :record-datalog-query-start! (partial rs/record-datalog-query-start! store ctx)
+                                  :record-datalog-query-finish! (partial rs/record-datalog-query-finish! store ctx))))))
 
             instaql-result (iq/permissioned-query ctx instaql-query)
             result-hash (hash {:instaql-result instaql-result
                                :attrs (attr-model/unwrap attrs)})
-            {:keys [result-changed?]} (rs/add-instaql-query! store-conn ctx result-hash)]
+            {:keys [result-changed?]} (rs/add-instaql-query! store ctx result-hash)]
         {:instaql-result (case return-type
                            :join-rows (collect-instaql-results-for-client instaql-result)
                            :tree (instaql-nodes->object-tree ctx instaql-result)
                            (collect-instaql-results-for-client instaql-result))
          :result-changed? result-changed?})
       (catch Throwable e
-        (rs/remove-query! store-conn session-id app-id instaql-query)
+        (rs/remove-query! store app-id session-id instaql-query)
         (throw e)))))
 
 (comment
@@ -127,4 +127,4 @@
             :current-user nil
             :session-id "moop"})
   (def instaql-query {"users" {}})
-  (instaql-query-reactive! rs/store-conn ctx instaql-query "join-rows"))
+  (instaql-query-reactive! rs/store ctx instaql-query "join-rows"))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -8,6 +8,7 @@
    commands."
   (:require
    [clojure.main :refer [root-cause]]
+   [datascript.core :as ds]
    [instant.config :as config]
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
@@ -87,46 +88,50 @@
                                                            "public"))
     {:attrs (attr-model/get-by-app-id (:id app))}))
 
-(defn- handle-init! [store-conn sess-id
-                     {:keys [refresh-token client-event-id versions __admin-token] :as event}]
-  (let [prev-auth (rs/get-auth @store-conn sess-id)
-        _ (when prev-auth
-            (ex/throw-validation-err! :init event [{:message "`init` has already run for this session."}]))
-        app-id (ex/get-param! event [:app-id] uuid-util/coerce)
-        app (app-model/get-by-id! {:id app-id})
+(defn- handle-init! [store sess-id event]
+  (let [{:keys [refresh-token client-event-id versions]
+         admin-token :__admin-token} event
+        prev-auth   (:session/auth (rs/session store sess-id))
+        _           (when prev-auth
+                      (ex/throw-validation-err! :init event [{:message "`init` has already run for this session."}]))
+        app-id      (ex/get-param! event [:app-id] uuid-util/coerce)
+        app         (app-model/get-by-id! {:id app-id})
         {:keys [attrs]} (get-attrs app)
-        user (when refresh-token
-               (app-user-model/get-by-refresh-token!
-                {:app-id app-id :refresh-token refresh-token}))
-        creator (instant-user-model/get-by-app-id {:app-id app-id})
-        admin? (and __admin-token
-                    (boolean
-                     (app-admin-token-model/fetch! {:app-id app-id
-                                                    :token __admin-token})))
-        auth {:app app :user user :admin? admin?}]
+        user        (when refresh-token
+                      (app-user-model/get-by-refresh-token!
+                       {:app-id app-id :refresh-token refresh-token}))
+        creator     (instant-user-model/get-by-app-id {:app-id app-id})
+        admin?      (and admin-token
+                         (boolean
+                          (app-admin-token-model/fetch! {:app-id app-id
+                                                         :token admin-token})))
+        auth        {:app    app
+                     :user   user
+                     :admin? admin?}]
     (tracer/add-data! {:attributes (auth-and-creator-attrs auth creator versions)})
-    (rs/set-session-props! store-conn sess-id {:auth auth
-                                               :creator creator
-                                               :versions versions})
-    (rs/send-event! store-conn app-id sess-id {:op :init-ok
-                                               :session-id sess-id
-                                               :client-event-id client-event-id
-                                               :auth auth
-                                               :attrs attrs})))
+    (apply rs/assoc-session! store sess-id
+           :session/auth auth
+           :session/creator creator
+           (when versions [:session/versions versions]))
+    (rs/send-event! store app-id sess-id {:op              :init-ok
+                                          :session-id      sess-id
+                                          :client-event-id client-event-id
+                                          :auth            auth
+                                          :attrs           attrs})))
 
-(defn- get-auth! [store-conn sess-id]
-  (let [auth (rs/get-auth @store-conn sess-id)]
+(defn- get-auth! [store sess-id]
+  (let [{:session/keys [auth]} (rs/sesison store sess-id)]
     (when-not (:app auth)
       (ex/throw-validation-err! :init {:sess-id sess-id} [{:message "`init` has not run for this session."}]))
     auth))
 
-(defn- handle-add-query! [store-conn sess-id {:keys [q client-event-id return-type] :as _event}]
-  (let [instaql-queries (rs/get-session-instaql-queries @store-conn sess-id)
-        {:keys [app user admin?]} (get-auth! store-conn sess-id)]
+(defn- handle-add-query! [store sess-id {:keys [q client-event-id return-type] :as _event}]
+  (let [instaql-queries (rs/get-session-instaql-queries @store sess-id)
+        {:keys [app user admin?]} (get-auth! store sess-id)]
 
     (cond
       (contains? instaql-queries q)
-      (rs/send-event! store-conn (:id app) sess-id {:op :add-query-exists :q q
+      (rs/send-event! store (:id app) sess-id {:op :add-query-exists :q q
                                                     :client-event-id client-event-id})
 
       (nil? q)
@@ -137,32 +142,32 @@
       :else
       (let [return-type (keyword (or return-type "join-rows"))
             {app-id :id} app
-            processed-tx-id (rs/get-processed-tx-id @store-conn app-id)
+            processed-tx-id (rs/get-processed-tx-id store app-id)
             {:keys [table-info]} (get-attrs app)
             attrs (attr-model/get-by-app-id app-id)
             ctx {:db {:conn-pool (aurora/conn-pool :read)}
-                 :datalog-loader (rs/upsert-datalog-loader! store-conn sess-id d/make-loader)
+                 :datalog-loader (rs/upsert-datalog-loader! store sess-id d/make-loader)
                  :session-id sess-id
                  :app-id app-id
                  :attrs attrs
                  :table-info table-info
                  :admin? admin?
                  :current-user user}
-            {:keys [instaql-result]} (rq/instaql-query-reactive! store-conn ctx q return-type)]
-        (rs/send-event! store-conn app-id sess-id {:op :add-query-ok
+            {:keys [instaql-result]} (rq/instaql-query-reactive! store ctx q return-type)]
+        (rs/send-event! store app-id sess-id {:op :add-query-ok
                                                    :q q
                                                    :result instaql-result
                                                    :processed-tx-id processed-tx-id
                                                    :client-event-id client-event-id})))))
 
-(defn- handle-remove-query! [store-conn sess-id {:keys [q client-event-id] :as _event}]
-  (let [{:keys [app]} (get-auth! store-conn sess-id)]
-    (rs/remove-query! store-conn sess-id (:id app) q)
-    (rs/send-event! store-conn (:id app) sess-id {:op :remove-query-ok :q q
+(defn- handle-remove-query! [store sess-id {:keys [q client-event-id] :as _event}]
+  (let [{:keys [app]} (get-auth! store sess-id)]
+    (rs/remove-query! store (:id app) sess-id q)
+    (rs/send-event! store (:id app) sess-id {:op :remove-query-ok :q q
                                                   :client-event-id client-event-id})))
 
 (defn- recompute-instaql-query!
-  [{:keys [store-conn current-user app-id sess-id attrs table-info admin?]}
+  [{:keys [store current-user app-id sess-id attrs table-info admin?]}
    {:keys [instaql-query/query instaql-query/return-type]}]
   (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
              :session-id sess-id
@@ -173,30 +178,30 @@
              :current-user current-user
              :admin? admin?}
         {:keys [instaql-result result-changed?]}
-        (rq/instaql-query-reactive! store-conn ctx query return-type)]
+        (rq/instaql-query-reactive! store ctx query return-type)]
     {:instaql-query query
      :instaql-result instaql-result
      :result-changed? result-changed?}))
 
-(defn- handle-refresh! [store-conn sess-id event debug-info]
+(defn- handle-refresh! [store sess-id event debug-info]
   (e2e-tracer/invalidator-tracking-step! {:tx-id (:tx-id event)
                                           :tx-created-at (:tx-created-at event)
                                           :name "start-refresh"
                                           :attributes {:session-id sess-id}})
-  (let [auth (get-auth! store-conn sess-id)
+  (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
         current-user (-> auth :user)
         admin? (-> auth :admin?)
         {:keys [attrs table-info]} (get-attrs (:app auth))
-        stale-queries (rs/get-stale-instaql-queries @store-conn sess-id)
-        opts {:store-conn store-conn
+        stale-queries (rs/get-stale-instaql-queries store app-id sess-id)
+        opts {:store store
               :app-id app-id
               :current-user current-user
               :sess-id sess-id
               :attrs attrs
               :table-info table-info
               :admin? admin?}
-        processed-tx-id (rs/get-processed-tx-id @store-conn app-id)
+        processed-tx-id (rs/get-processed-tx-id store app-id)
         _ (reset! debug-info {:processed-tx-id processed-tx-id
                               :instaql-queries (map :instaql-query/query stale-queries)})
         recompute-results (->> stale-queries
@@ -222,7 +227,7 @@
     (tracer/with-span! {:name "handle-refresh/send-event!"
                         :attributes tracer-attrs}
       (when (seq computations)
-        (rs/send-event! store-conn app-id sess-id (with-meta
+        (rs/send-event! store app-id sess-id (with-meta
                                                     {:op :refresh-ok
                                                      :processed-tx-id processed-tx-id
                                                      :attrs attrs
@@ -235,8 +240,8 @@
 ;; transact
 
 (defn handle-transact!
-  [store-conn sess-id {:keys [tx-steps client-event-id] :as _event}]
-  (let [auth (get-auth! store-conn sess-id)
+  [store sess-id {:keys [tx-steps client-event-id] :as _event}]
+  (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
         coerced (tx/coerce! tx-steps)
         _ (tx/validate! coerced)
@@ -250,7 +255,7 @@
           :datalog-query-fn d/query
           :attrs (attr-model/get-by-app-id app-id)}
          coerced)]
-    (rs/send-event! store-conn app-id sess-id
+    (rs/send-event! store app-id sess-id
                     {:op :transact-ok
                      :tx-id tx-id
                      :client-event-id client-event-id})))
@@ -258,14 +263,14 @@
 ;; -----
 ;; error
 
-(defn handle-error! [store-conn sess-id {:keys [status
+(defn handle-error! [store sess-id {:keys [status
                                                 app-id
                                                 client-event-id
                                                 original-event
                                                 type
                                                 message
                                                 hint]}]
-  (rs/send-event! store-conn
+  (rs/send-event! store
                   app-id
                   sess-id
                   {:op :error
@@ -280,15 +285,13 @@
 ;; worker
 
 (defn event-attributes
-  [store-conn
+  [store
    session-id
    {:keys [op
            client-event-id
            total-delay-ms
            ws-ping-latency-ms] :as _event}]
-  (let [auth (rs/get-auth @store-conn session-id)
-        creator (rs/get-creator @store-conn session-id)
-        versions (rs/get-versions @store-conn session-id)]
+  (let [{:session/keys [auth creator versions]} (rs/session store session-id)]
     (merge
      {:op op
       :client-event-id client-event-id
@@ -297,20 +300,20 @@
       :ws-ping-latency-ms ws-ping-latency-ms}
      (auth-and-creator-attrs auth creator versions))))
 
-(defn- handle-join-room! [store-conn sess-id {:keys [client-event-id room-id] :as _event}]
-  (let [auth (get-auth! store-conn sess-id)
+(defn- handle-join-room! [store sess-id {:keys [client-event-id room-id] :as _event}]
+  (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
         current-user (-> auth :user)]
     (eph/join-room! app-id sess-id current-user room-id)
-    (rs/send-event! store-conn app-id sess-id {:op :join-room-ok
+    (rs/send-event! store app-id sess-id {:op :join-room-ok
                                                :room-id room-id
                                                :client-event-id client-event-id})))
 
-(defn- handle-leave-room! [store-conn sess-id {:keys [client-event-id room-id] :as _event}]
-  (let [auth (get-auth! store-conn sess-id)
+(defn- handle-leave-room! [store sess-id {:keys [client-event-id room-id] :as _event}]
+  (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)]
     (eph/leave-room! app-id sess-id room-id)
-    (rs/send-event! store-conn app-id sess-id {:op :leave-room-ok
+    (rs/send-event! store app-id sess-id {:op :leave-room-ok
                                                :room-id room-id
                                                :client-event-id client-event-id})))
 
@@ -322,19 +325,20 @@
      [{:message "You have not entered this room yet."}])))
 
 (defn- handle-set-presence!
-  [store-conn sess-id {:keys [client-event-id room-id data] :as _event}]
-  (let [auth (get-auth! store-conn sess-id)
+  [store sess-id {:keys [client-event-id room-id data] :as _event}]
+  (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
         _ (assert-in-room! app-id room-id sess-id)]
     (eph/set-presence! app-id sess-id room-id data)
-    (rs/send-event! store-conn app-id sess-id {:op :set-presence-ok
+    (rs/send-event! store app-id sess-id {:op :set-presence-ok
                                                :room-id room-id
                                                :client-event-id client-event-id})))
 
 (def patch-presence-min-version (semver/parse "v0.17.5"))
 
-(defn- handle-refresh-presence! [store-conn sess-id {:keys [app-id room-id data edits]}]
-  (let [version (-> (rs/get-versions @store-conn sess-id)
+(defn- handle-refresh-presence! [store sess-id {:keys [app-id room-id data edits]}]
+  (let [version (-> (rs/session store sess-id)
+                    :session/versions
                     (get core-version-key))]
     (cond
       (and edits (empty? edits))
@@ -345,21 +349,21 @@
            (when-let [parsed-version (some-> version (semver/parse))]
              (pos? (semver/compare-semver parsed-version
                                           patch-presence-min-version))))
-      (rs/send-event! store-conn app-id sess-id
+      (rs/send-event! store app-id sess-id
                       {:op      :patch-presence
                        :room-id room-id
                        :edits   edits})
 
       :else
-      (rs/send-event! store-conn app-id sess-id
+      (rs/send-event! store app-id sess-id
                       {:op      :refresh-presence
                        :room-id room-id
                        :data    data}))))
 
 (defn- handle-client-broadcast!
   "Broadcasts a client message to other sessions in the room"
-  [store-conn sess-id {:keys [client-event-id room-id topic data] :as _event}]
-  (let [auth (get-auth! store-conn sess-id)
+  [store sess-id {:keys [client-event-id room-id topic data] :as _event}]
+  (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
         _ (assert-in-room! app-id room-id sess-id)
         current-user (-> auth :user)
@@ -372,7 +376,7 @@
                          :data data}}]
 
     (doseq [notify-sess-id local-ids
-            :let [q (:receive-q (rs/get-socket @store-conn notify-sess-id))]
+            :let [q (-> (rs/session store notify-sess-id) :session/socket :receive-q)]
             :when (and q (not= sess-id notify-sess-id))]
       (receive-queue/enqueue->receive-q q
                                         (assoc base-msg
@@ -382,37 +386,37 @@
     (when (seq remote-ids)
       (eph/broadcast app-id remote-ids base-msg))
 
-    (rs/send-event! store-conn app-id sess-id (assoc base-msg
+    (rs/send-event! store app-id sess-id (assoc base-msg
                                                      :op :client-broadcast-ok
                                                      :client-event-id client-event-id))))
 
-(defn- handle-server-broadcast! [store-conn sess-id {:keys [app-id room-id topic data]}]
+(defn- handle-server-broadcast! [store sess-id {:keys [app-id room-id topic data]}]
   (when (eph/in-room? app-id room-id sess-id)
-    (rs/send-event! store-conn app-id sess-id {:op :server-broadcast
+    (rs/send-event! store app-id sess-id {:op :server-broadcast
                                                :room-id room-id
                                                :topic topic
                                                :data data})))
 
-(defn handle-event [store-conn session event debug-info]
+(defn handle-event [store session event debug-info]
   (let [{:keys [op]} event
         {:keys [session/socket]} session
         {:keys [id]} socket]
-    (tracer/add-data! {:attributes (event-attributes store-conn id event)})
+    (tracer/add-data! {:attributes (event-attributes store id event)})
     (case op
-      :init (handle-init! store-conn id event)
-      :add-query (handle-add-query! store-conn id event)
-      :remove-query (handle-remove-query! store-conn id event)
-      :refresh (handle-refresh! store-conn id event debug-info)
-      :transact (handle-transact! store-conn id event)
-      :error (handle-error! store-conn id event)
+      :init         (handle-init! id event)
+      :add-query    (handle-add-query! store id event)
+      :remove-query (handle-remove-query! store id event)
+      :refresh      (handle-refresh! store id event debug-info)
+      :transact     (handle-transact! store id event)
+      :error        (handle-error! store id event)
       ;; -----
       ;; EPH events
-      :join-room (handle-join-room! store-conn id event)
-      :leave-room (handle-leave-room! store-conn id event)
-      :set-presence (handle-set-presence! store-conn id event)
-      :refresh-presence (handle-refresh-presence! store-conn id event)
-      :client-broadcast (handle-client-broadcast! store-conn id event)
-      :server-broadcast (handle-server-broadcast! store-conn id event))))
+      :join-room        (handle-join-room! store id event)
+      :leave-room       (handle-leave-room! store id event)
+      :set-presence     (handle-set-presence! store id event)
+      :refresh-presence (handle-refresh-presence! store id event)
+      :client-broadcast (handle-client-broadcast! store id event)
+      :server-broadcast (handle-server-broadcast! store id event))))
 
 ;; --------------
 ;; Receive Workers
@@ -487,29 +491,29 @@
                                                      " Please ping us (Joe and Stopa) on Discord and let us know!")
                                        :session-id sess-id})))
 
-(defn handle-receive-attrs [store-conn session event metadata]
+(defn handle-receive-attrs [store session event metadata]
   (let [{:keys [session/socket]} session
         sess-id (:session/id session)
-        event-attrs (event-attributes store-conn sess-id event)]
+        event-attrs (event-attributes store sess-id event)]
     (assoc (merge metadata event-attrs)
            :socket-origin (rs/socket-origin socket)
            :socket-ip (rs/socket-ip socket)
            :session-id sess-id)))
 
-(defn handle-receive [store-conn session event metadata]
+(defn handle-receive [store session event metadata]
   (tracer/with-exceptions-silencer [silence-exceptions]
     (tracer/with-span! {:name "receive-worker/handle-receive"
-                        :attributes (handle-receive-attrs store-conn session event metadata)}
+                        :attributes (handle-receive-attrs store session event metadata)}
       (let [pending-handlers (:pending-handlers (:session/socket session))
             in-progress-stmts (sql/make-statement-tracker)
             debug-info (atom nil)
             event-fut (binding [sql/*in-progress-stmts* in-progress-stmts]
                         (if config/fewer-vfutures?
-                          (ua/tracked-future (handle-event store-conn
+                          (ua/tracked-future (handle-event store
                                                            session
                                                            event
                                                            debug-info))
-                          (ua/vfuture (handle-event store-conn
+                          (ua/vfuture (handle-event store
                                                     session
                                                     event
                                                     debug-info))))
@@ -542,7 +546,8 @@
             (let [original-event event
                   instant-ex (ex/find-instant-exception e)
                   root-err (root-cause e)
-                  app-id (some-> (rs/get-auth @store-conn (:session/id session))
+                  app-id (some-> (rs/session store (:session/id session))
+                                 :session/auth
                                  :app
                                  :id)]
               (cond
@@ -559,11 +564,11 @@
           (finally
             (swap! pending-handlers disj pending-handler)))))))
 
-(defn process-receive-q-entry [store-conn entry metadata]
-  (let [{:keys [put-at item skipped-size]} entry
+(defn process-receive-q-entry [store entry metadata]
+  (let [{:keys [put-at item app-id skipped-size]} entry
         {:keys [session-id] :as event} item
-        now (Instant/now)
-        session (rs/get-session @store-conn session-id)]
+        now        (Instant/now)
+        session    (rs/get-session store session-id)]
     (cond
       (not session)
       (tracer/record-info! {:name "receive-worker/session-not-found"
@@ -572,8 +577,7 @@
 
       :else
       (handle-receive
-       store-conn
-
+       store
        (into {} session)
        (assoc event
               :total-delay-ms
@@ -622,11 +626,11 @@
                           entry)]
         (recur last-entry' (next batch) acc)))))
 
-(defn straight-jacket-process-receive-q-batch [store-conn batch metadata]
+(defn straight-jacket-process-receive-q-batch [store batch metadata]
   (try
     (let [type (-> metadata :group-key first)]
       (doseq [entry (consolidate type batch)]
-        (process-receive-q-entry store-conn entry metadata)))
+        (process-receive-q-entry store entry metadata)))
     (catch Throwable e
       (tracer/record-exception-span! e {:name "receive-worker/handle-receive-batch-straight-jacket"
                                         :attributes (assoc metadata
@@ -640,8 +644,8 @@
 
     (grouped-queue/inflight-queue-reserve 1 inflight-q)))
 
-(defn process-fn [store-conn group-key batch]
-  (straight-jacket-process-receive-q-batch store-conn
+(defn process-fn [store group-key batch]
+  (straight-jacket-process-receive-q-batch store
                                            batch
                                            {:batch-size (count batch)
                                             :group-key group-key}))
@@ -649,10 +653,10 @@
 ;; -----------------
 ;; Websocket Interop
 
-(defn on-open [store-conn {:keys [id] :as socket}]
+(defn on-open [store {sess-id :id :as socket}]
   (tracer/with-span! {:name "socket/on-open"
-                      :attributes {:session-id (:id socket)}}
-    (rs/add-socket! store-conn id socket)))
+                      :attributes {:session-id sess-id}}
+    (rs/assoc-session! store sess-id :session/socket socket)))
 
 (defn on-message [{:keys [id receive-q data]}]
   (receive-queue/enqueue->receive-q receive-q (-> (<-json data true)
@@ -666,7 +670,7 @@
                                           :attributes {:session-id id}
                                           :escaping? false})))
 
-(defn on-close [store-conn {:keys [id pending-handlers]}]
+(defn on-close [store {:keys [id pending-handlers]}]
   (tracer/with-span! {:name "socket/on-close"
                       :attributes {:session-id id}}
     (doseq [{:keys [op
@@ -681,29 +685,30 @@
         (sql/cancel-in-progress in-progress-stmts)
         (future-cancel future)))
 
-    (let [app-id (-> (rs/get-auth @store-conn id)
+    (let [app-id (-> (rs/session store id)
+                     :session/auth
                      :app
                      :id)]
-      (rs/remove-session! store-conn id)
+      (rs/remove-session! store id)
       (eph/leave-by-session-id! app-id id))))
 
 (defn undertow-config
-  [store-conn receive-q {:keys [id]}]
+  [store receive-q {:keys [id]}]
   (let [pending-handlers (atom #{})
         atomic-ping-latency-nanos (AtomicLong. 0)]
     {:undertow/websocket
      {:set-ping-latency-nanos (fn [^Long v]
                                 (.set atomic-ping-latency-nanos v))
-      :on-open (fn [{ws-conn :channel http-req :exchange :as _req}]
+      :on-open (fn [req]
                  (let [socket {:id id
-                               :http-req http-req
-                               :ws-conn ws-conn
+                               :http-req (:exchange req)
+                               :ws-conn (:channel req)
                                :receive-q receive-q
                                :pending-handlers pending-handlers
                                :get-ping-latency-ms (fn []
                                                       (double (/ (.get atomic-ping-latency-nanos)
                                                                  1000000.0)))}]
-                   (on-open store-conn socket)))
+                   (on-open store socket)))
       :on-message (fn [{:keys [data]}]
                     (on-message {:id id
                                  :data data
@@ -712,7 +717,7 @@
                   (on-error {:id id
                              :error error}))
       :on-close (fn [_]
-                  (on-close store-conn
+                  (on-close store
                             {:id id
                              :pending-handlers pending-handlers}))}}))
 
@@ -752,7 +757,7 @@
   (receive-queue/start {:max-workers num-receive-workers
                         :group-fn #'group-fn
                         :reserve-fn #'receive-worker-reserve-fn
-                        :process-fn (partial process-fn rs/store-conn)}))
+                        :process-fn (partial process-fn rs/store)}))
 
 (defn stop []
   (receive-queue/stop))

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -83,8 +83,11 @@
    :datalog-query/delayed-call {} ;; delay with datalog result (from query.clj)
    :datalog-query/topics {:db/type :db.type/list-of-topics}})
 
+(defn make-app-conn [_app-id]
+  (d/create-conn schema))
+
 (defn app-conn [store app-id]
-  (Map/.get (:conns store) app-id))
+  (Map/.computeIfAbsent (:conns store) app-id make-app-conn))
 
 ;; -----
 ;; misc
@@ -161,7 +164,7 @@
     (d/entity db [:session/id sess-id])))
 
 (defn assoc-session! [store sess-id & kvs]
-  (let [conn   @(:sessions store)
+  (let [conn   (:sessions store)
         entity (apply assoc {:session/id sess-id} kvs)]
     (transact! "store/assoc-session!" conn [entity])))
 
@@ -178,11 +181,10 @@
 
 (defn get-stale-instaql-queries [store app-id sess-id]
   (let [db @(app-conn store app-id)]
-    (->> (d/datoms db :avet :instaql-query/session-id sess-id)
-         (keep (fn [{:keys [e]}]
-                 (let [ent (d/entity db e)]
-                   (when (:instaql-query/stale? ent)
-                     ent)))))))
+    (for [datom (d/datoms db :avet :instaql-query/session-id sess-id)
+          :let [ent (d/entity db (:e datom))]
+          :when (:instaql-query/stale? ent)]
+      ent)))
 
 (defn bump-instaql-version-tx-data
   "Should be used in a db.fn/call. Returns transactions.
@@ -241,11 +243,11 @@
 ;; --------------
 ;; adding queries
 
-(defn clean-stale-subscriptions-tx-data
+(defn- clean-stale-subscriptions-tx-data
   "Should be used in a db.fn/call. Returns transactions.
    Retracts subscriptions for an older version of an instaql query."
   [db instaql-query-lookup-ref version]
-  (if-let [query-eid (d/entid db instaql-query-lookup-ref)]
+  (if-some [query-eid (d/entid db instaql-query-lookup-ref)]
     (keep (fn [datom]
             (let [sub-version (:v (d/find-datom db :eavt (:e datom) :subscription/v))]
               (when (or (not sub-version)
@@ -254,77 +256,74 @@
           (d/datoms db :avet :subscription/instaql-query query-eid))
     []))
 
-(defn set-instaql-query-result-tx-data
+(defn- set-instaql-query-result-tx-data
   "Should be used in a db.fn/call. Returns transactions.
    Sets the hash for the query result."
   [db lookup-ref result-hash]
-  (if-let [e (d/entid db lookup-ref)]
+  (if-some [e (d/entid db lookup-ref)]
     [[:db/add e :instaql-query/hash result-hash]]
     []))
 
-(defn add-instaql-query! [conn {:keys [session-id instaql-query v] :as _ctx} result-hash]
-  (let [lookup-ref [:instaql-query/session-id+query [session-id instaql-query]]
-        {:keys [db-before db-after] :as res}
-        (transact! "store/add-instaql-query!"
-                   conn
-                   [[:db.fn/call clean-stale-subscriptions-tx-data lookup-ref v]
-                    [:db.fn/call clean-stale-datalog-tx-data]
-                    [:db.fn/call set-instaql-query-result-tx-data lookup-ref result-hash]])
-
-        hash-before (:instaql-query/hash (d/entity db-before lookup-ref))
-        hash-after (:instaql-query/hash (d/entity db-after lookup-ref))
+(defn add-instaql-query! [store {:keys [app-id session-id instaql-query v] :as _ctx} result-hash]
+  (let [conn            (app-conn store app-id)
+        lookup-ref      [:instaql-query/session-id+query [session-id instaql-query]]
+        report          (transact! "store/add-instaql-query!"
+                                   conn
+                                   [[:db.fn/call clean-stale-subscriptions-tx-data lookup-ref v]
+                                    [:db.fn/call clean-stale-datalog-tx-data]
+                                    [:db.fn/call set-instaql-query-result-tx-data lookup-ref result-hash]])
+        hash-before     (:instaql-query/hash (d/entity (:db-before report) lookup-ref))
+        hash-after      (:instaql-query/hash (d/entity (:db-after report) lookup-ref))
         result-changed? (or (not= hash-before hash-after)
                             (and (nil? hash-before)
                                  (nil? hash-after)))]
-    (assoc res :result-changed? result-changed?)))
+    (assoc report :result-changed? result-changed?)))
 
 ;; ------
 ;; session
 
-(defn get-session [db sess-id]
-  (d/entity db [:session/id sess-id]))
+(defn session-instaql-queries [store app-id sess-id]
+  (let [db @(app-conn store app-id)]
+    (set
+     (for [datom (d/datoms db :avet :instaql-query/session-id sess-id)
+           :let  [ent (d/entity db (:e datom))]]
+       (:instaql-query/query ent)))))
 
-(defn get-session-instaql-queries [db sess-id]
-  (->> (d/q '{:find [?q]
-              :in [$ ?session-id]
-              :where [[?e :instaql-query/session-id ?session-id]
-                      [?e :instaql-query/query ?q]]}
-            db
-            sess-id)
-       (map first)
-       set))
-
-(defn remove-session-queries-tx-data
+(defn- remove-session-queries-tx-data
   "Should be used in a db.fn/call. Returns transactions.
    Retracts queries for the session."
-  [db session-id]
-  (map (fn [{:keys [e]}] [:db/retractEntity e])
-       (d/datoms db :avet :instaql-query/session-id session-id)))
+  [db sess-id]
+  (for [datom (d/datoms db :avet :instaql-query/session-id sess-id)]
+    [:db/retractEntity (:e datom)]))
 
-(defn remove-session-subscriptions-tx-data
+(defn- remove-session-subscriptions-tx-data
   "Should be used in a db.fn/call. Returns transactions.
    Retracts subscriptions for the session."
-  [db session-id]
-  (map (fn [{:keys [e]}] [:db/retractEntity e])
-       (d/datoms db :avet :subscription/session-id session-id)))
+  [db sess-id]
+  (for [datom (d/datoms db :avet :subscription/session-id sess-id)]
+    [:db/retractEntity (:e datom)]))
 
-(defn remove-session! [conn sess-id]
-  (transact! "store/remove-session!"
-             conn
-             [[:db.fn/retractEntity [:session/id sess-id]]
-              [:db.fn/call remove-session-queries-tx-data sess-id]
-
-              ;; remove subscriptions for session
-              [:db.fn/call remove-session-subscriptions-tx-data sess-id]
-
-              ;; remove datalog-queries that are no longer in use
-              [:db.fn/call clean-stale-datalog-tx-data]]))
+(defn remove-session! [store app-id sess-id]
+  ;; sync so new sessions are not added while we clean up this one
+  (locking (:sessions store)
+    (let [{:keys [db-after]} (transact! "store/remove-session!"
+                                        (:sessions store)
+                                        [[:db.fn/retractEntity [:session/id sess-id]]])]
+      (when app-id
+        (if (ucoll/seek #(= app-id (-> % :v :app :id))
+                        (d/datoms db-after :aevt :session/auth))
+          (transact! "store/remove-session-data!"
+                     (app-conn store app-id)
+                     [[:db.fn/call remove-session-queries-tx-data sess-id]
+                      [:db.fn/call remove-session-subscriptions-tx-data sess-id]
+                      [:db.fn/call clean-stale-datalog-tx-data]])
+          (Map/.remove (:conns store) app-id))))))
 
 
 ;; ------
 ;; datalog cache
 
-(defn swap-datalog-cache! [conn app-id datalog-query-fn ctx datalog-query]
+(defn swap-datalog-cache! [store app-id datalog-query-fn ctx datalog-query]
   (let [lookup-ref [:datalog-query/app-id+query [app-id datalog-query]]
         watcher-id (Object.)
         this-result-delay (atom {;; Promise holds the result of the query
@@ -335,16 +334,15 @@
                                  :watchers #{watcher-id}
                                  :cancel-signal (promise)
                                  :aborted? false})
+        conn (app-conn store app-id)
         {:keys [db-after]}
         (transact! "store/swap-datalog-cache!"
                    conn
                    [[:db.fn/call
                      (fn [db]
-                       (if-let [existing (d/entity db lookup-ref)]
+                       (if-some [existing (d/entity db lookup-ref)]
                          (if (not (:datalog-query/delayed-call existing))
-                           [[:db/add
-                             (:db/id existing)
-                             :datalog-query/delayed-call this-result-delay]]
+                           [[:db/add (:db/id existing) :datalog-query/delayed-call this-result-delay]]
                            (let [{:keys [watchers]}
                                  (swap! (:datalog-query/delayed-call existing)
                                         (fn [state]
@@ -352,9 +350,7 @@
                                             state
                                             (update state :watchers conj watcher-id))))]
                              (when-not (contains? watchers watcher-id)
-                               [[:db/add
-                                 (:db/id existing)
-                                 :datalog-query/delayed-call this-result-delay]])))
+                               [[:db/add (:db/id existing) :datalog-query/delayed-call this-result-delay]])))
                          [{:datalog-query/app-id app-id
                            :datalog-query/query datalog-query
                            :datalog-query/delayed-call this-result-delay}]))]])
@@ -429,74 +425,73 @@
       (finally
         (swap! result-delay update :watchers disj watcher-id)))))
 
+
 ;; --------------
 ;; datalog loader
 
-(defn upsert-datalog-loader! [conn sess-id make-loader-fn]
-  (if-let [loader (:session/datalog-loader (d/entity @conn [:session/id sess-id]))]
-    loader
-    (let [{:keys [db-after]}
-          (transact! "store/upsert-datalog-loader!"
-                     conn
-                     [[:db.fn/call
-                       (fn [db]
-                         (when-not (first (d/datoms db
-                                                    :eavt
-                                                    [:session/id sess-id]
-                                                    :session/datalog-loader))
-                           [[:db/add
-                             [:session/id sess-id]
-                             :session/datalog-loader
-                             (make-loader-fn)]]))]])]
-      (:session/datalog-loader (d/entity db-after [:session/id sess-id])))))
+(defn- upsert-datalog-loader-tx-data [db sess-id make-loader-fn]
+  (when-not (d/find-datom db :eavt [:session/id sess-id] :session/datalog-loader)
+    [[:db/add [:session/id sess-id] :session/datalog-loader (make-loader-fn)]]))
+
+(defn upsert-datalog-loader! [store sess-id make-loader-fn]
+  (let [conn (:sessions store)]
+    (if-some [loader (:session/datalog-loader (d/entity @conn [:session/id sess-id]))]
+      loader
+      (let [{:keys [db-after]}
+            (transact! "store/upsert-datalog-loader!"
+                       conn
+                       [[:db.fn/call upsert-datalog-loader-tx-data sess-id make-loader-fn]])]
+        (:session/datalog-loader (d/entity db-after [:session/id sess-id]))))))
+
 
 ;; ------
 ;; subscriptions
 
-(defn record-datalog-query-start! [conn ctx datalog-query coarse-topics]
-  (let [lookup-ref [:datalog-query/app-id+query [(:app-id ctx) datalog-query]]
-        query-lookup-ref [:instaql-query/session-id+query [(:session-id ctx)
-                                                           (:instaql-query ctx)]]]
+(defn record-datalog-query-start! [store ctx datalog-query coarse-topics]
+  (let [{:keys [app-id session-id instaql-query v]} ctx
+        conn (app-conn store app-id)]
     (transact! "store/record-datalog-query-start!"
                conn
                [[:db.fn/call
                  (fn [db]
-                   (let [existing-datalog-query (d/entity db lookup-ref)
-                         datalog-query-eid (or (:db/id existing-datalog-query)
-                                               -1)
-                         datalog-query-txes
-                         (if existing-datalog-query
-                           (when-not (:datalog-query/topics existing-datalog-query)
-                             [[:db/add datalog-query-eid :datalog-query/topics coarse-topics]])
-                           [{:db/id datalog-query-eid
-                             :datalog-query/app-id (:app-id ctx)
-                             :datalog-query/query datalog-query
-                             :datalog-query/topics coarse-topics}])
-                         subscription-txes
-                         (when-let [query-eid (d/entid db query-lookup-ref)]
-                           [{:subscription/app-id (:app-id ctx)
-                             :subscription/session-id (:session-id ctx)
-                             :subscription/v (:v ctx)
-                             :subscription/instaql-query query-eid
-                             :subscription/datalog-query datalog-query-eid}])]
-                     (into datalog-query-txes subscription-txes)))]])))
+                   (let [lookup-ref             [:datalog-query/app-id+query [app-id datalog-query]]
+                         existing-datalog-query (d/entity db lookup-ref)
+                         datalog-query-eid      (or (:db/id existing-datalog-query) -1)]
+                     (concat
+                      (if existing-datalog-query
+                        (when-not (:datalog-query/topics existing-datalog-query)
+                          [{:db/id                datalog-query-eid
+                            :datalog-query/topics coarse-topics}])
+                        [{:db/id                datalog-query-eid
+                          :datalog-query/app-id app-id
+                          :datalog-query/query  datalog-query
+                          :datalog-query/topics coarse-topics}])
+                      (when-some [query-eid (d/entid db [:instaql-query/session-id+query [session-id instaql-query]])]
+                        [{:subscription/app-id        app-id
+                          :subscription/session-id    session-id
+                          :subscription/v             v
+                          :subscription/instaql-query query-eid
+                          :subscription/datalog-query datalog-query-eid}]))))]])))
 
-(defn record-datalog-query-finish! [conn
+(defn record-datalog-query-finish! [store
                                     ctx
                                     datalog-query
                                     {:keys [topics] :as _result}]
 
-  (let [lookup-ref [:datalog-query/app-id+query [(:app-id ctx) datalog-query]]]
+  (let [{:keys [app-id]} ctx
+        conn       (app-conn store app-id)
+        lookup-ref [:datalog-query/app-id+query [app-id datalog-query]]]
     (transact!
      "store/record-datalog-query-finish!"
      conn
      [[:db.fn/call
        (fn [db]
-         (if-let [existing (d/entity db lookup-ref)]
+         (if-some [existing (d/entity db lookup-ref)]
            [[:db/add (:db/id existing) :datalog-query/topics topics]]
-           [{:datalog-query/app-id (:app-id ctx)
+           [{:datalog-query/app-id app-id
              :datalog-query/query datalog-query
              :datalog-query/topics topics}]))]])))
+
 
 ;; ------
 ;; invalidation
@@ -526,8 +521,11 @@
                                  "$")))]
     (re-matches (re-pattern regex-pattern) text)))
 
-(def like-match? (partial make-like-match? false))
-(def ilike-match? (partial make-like-match? true))
+(def like-match?
+  (partial make-like-match? false))
+
+(def ilike-match?
+  (partial make-like-match? true))
 
 (defn- match-topic-part? [iv-part dq-part]
   (cond
@@ -574,37 +572,30 @@
       dq-topics))
    iv-topics))
 
-(defn mark-instaql-queries-stale-tx-data
+(defn- mark-instaql-queries-stale-tx-data
   "Should be used in a db.fn/call. Returns transactions.
    Marks instaql-queries that have subscriptions that reference the datalog
    query stale."
   [db datalog-query-eids]
-  (persistent!
-   (reduce
-    (fn [txes datalog-query-eid]
-      (reduce
-       (fn [txes sub-datom]
-         (if-let [instaql-query-eid (:v (d/find-datom db
-                                                      :aevt
-                                                      :subscription/instaql-query
-                                                      (:e sub-datom)))]
-           (conj! txes [:db/add instaql-query-eid :instaql-query/stale? true])
-           txes))
-       txes
-       (d/datoms db :avet :subscription/datalog-query datalog-query-eid)))
-    (transient [])
-    datalog-query-eids)))
+  (for [datalog-query-eid datalog-query-eids
+        sub-datom         (d/datoms db :avet :subscription/datalog-query datalog-query-eid)
+        :let [sub-eid             (:e sub-datom)
+              instaql-query-datom (d/find-datom db :eavt sub-eid :subscription/instaql-query)
+              instaql-query-eid   (:v instaql-query-datom)]
+        :when instaql-query-eid]
+    [:db/add instaql-query-eid :instaql-query/stale? true]))
 
-(defn set-tx-id
+(defn- set-tx-id
   "Should be used in a db.fn/call. Returns transactions.
    Sets the processed-tx-id to the max of the given value and current value."
   [db app-id tx-id]
-  (if-let [current (:tx-meta/processed-tx-id (d/entity db [:tx-meta/app-id app-id]))]
-    [[:db/add [:tx-meta/app-id app-id] :tx-meta/processed-tx-id (max current tx-id)]]
+  (if-some [current (:tx-meta/processed-tx-id (d/entity db [:tx-meta/app-id app-id]))]
+    [{:tx-meta/app-id app-id
+      :tx-meta/processed-tx-id (max current tx-id)}]
     [{:tx-meta/app-id app-id
       :tx-meta/processed-tx-id tx-id}]))
 
-(defn mark-datalog-queries-stale!
+(defn- mark-datalog-queries-stale!
   "Stale-ing a datalog query has the following side-effects:
    1. Removes the datalog query from the datalog-cache
    2. Marks associated instaql entries as stale
@@ -613,68 +604,38 @@
   (transact!
    "store/mark-datalog-queries-stale!"
    conn
-   (list* [:db.fn/call set-tx-id app-id tx-id]
+   (concat
+    [[:db.fn/call set-tx-id app-id tx-id]
+     [:db.fn/call mark-instaql-queries-stale-tx-data datalog-query-eids]]
+    (for [e datalog-query-eids]
+      [:db.fn/retractEntity e]))))
 
-          [:db.fn/call mark-instaql-queries-stale-tx-data datalog-query-eids]
-
-          (mapv (fn [e] [:db.fn/retractEntity e]) datalog-query-eids))))
-
-(defn get-datalog-queries-for-topics [db app-id iv-topics]
-  (->> (d/datoms db :avet :datalog-query/app-id app-id)
-       (keep (fn [datom]
-               (when-let [dq-topics (:datalog-query/topics (d/entity db (:e datom)))]
-                 (when (matching-topic-intersection? iv-topics dq-topics)
-                   (:e datom)))))))
+(defn- get-datalog-queries-for-topics [db app-id iv-topics]
+  (for [datom (d/datoms db :avet :datalog-query/app-id app-id)
+        :let [dq-topics (:datalog-query/topics (d/entity db (:e datom)))]
+        :when dq-topics
+        :when (matching-topic-intersection? iv-topics dq-topics)]
+    (:e datom)))
 
 (defn mark-stale-topics!
   "Given topics, invalidates all relevant datalog qs and associated instaql queries.
 
   Returns affected session-ids"
-  [conn app-id tx-id topics]
-  (let [datalog-query-eids (get-datalog-queries-for-topics @conn app-id topics)
+  [store app-id tx-id topics]
+  (let [conn               (app-conn store app-id)
+        datalog-query-eids (get-datalog-queries-for-topics @conn app-id topics)
 
-        {:keys [db-before db-after]}
-        (mark-datalog-queries-stale! conn
-                                     app-id
-                                     tx-id
-                                     datalog-query-eids)
+        report
+        (mark-datalog-queries-stale! conn app-id tx-id datalog-query-eids)
 
-        session-ids (d/q '{:find [?session-id]
-                           :in [$ [?datalog-query ...]]
-                           :where [[?e :subscription/datalog-query ?datalog-query]
-                                   [?e :subscription/session-id ?session-id]]}
-                         db-before
+        session-ids (d/q '[:find [?session-id ...]
+                           :in   $ [?datalog-query ...]
+                           :where
+                           [?e :subscription/datalog-query ?datalog-query]
+                           [?e :subscription/session-id ?session-id]]
+                         (:db-before report)
                          datalog-query-eids)]
-    [db-after (map first session-ids)]))
-
-;; ------------
-;; Test Helpers
-
-(defn get-datalog-cache-for-app [db app-id]
-  (->> (d/q '{:find [?query ?result]
-              :in [$ ?app-id]
-              :where [[?e :datalog-query/app-id ?app-id]
-                      [?e :datalog-query/query ?query]
-                      [?e :datalog-query/delayed-call ?result]]}
-            db
-            app-id)
-       (into {})))
-
-(defn- format-subscription [ent]
-  {:app-id (:subscription/app-id ent)
-   :datalog-query (:datalog-query/query (:subscription/datalog-query ent))
-   :instaql-query (:instaql-query/query (:subscription/instaql-query ent))
-   :session-id (:subscription/session-id ent)
-   :v (:subscription/v ent)})
-
-(defn get-subscriptions-for-app-id [db app-id]
-  (let [res (d/q '{:find [?e]
-                   :in [$ ?app-id]
-                   :where [[?e :subscription/app-id ?app-id]]}
-                 db
-                 app-id)]
-    (->> res
-         (map (comp format-subscription (partial d/entity db) first)))))
+    session-ids))
 
 ;; -----------------
 ;; Websocket Helpers
@@ -690,9 +651,9 @@
 
 (defn try-send-event!
   "Does a best-effort send. If it fails, we record and swallow the exception"
-  [conn app-id sess-id event]
+  [store app-id sess-id event]
   (try
-    (send-event! conn app-id sess-id event)
+    (send-event! store app-id sess-id event)
     (catch Exception e
       (tracer/with-span! {:name "rs/try-send-event-swallowed-err"}
         (tracer/record-exception-span!
@@ -751,12 +712,12 @@
       (tool/def-locals)
       (println "add sockets")
       (time (doseq [sid session-ids]
-              (add-socket! test-store sid {})))
+              (assoc-session! test-store sid :session/socket {})))
       (println "register instaql-queries")
       (time
        (doseq [sid session-ids
                q instaql-queries]
-         (bump-instaql-version! test-store sid q :join-rows)))
+         (bump-instaql-version! test-store app-id sid q :join-rows)))
 
       (println "record-datalog-query-start")
       (time
@@ -799,13 +760,13 @@
       (println "get-stale")
       (time
        (doseq [sid session-ids]
-         (get-stale-instaql-queries @test-store sid)))
+         (get-stale-instaql-queries @test-store app-id sid)))
 
       (println "register instaql-queries")
       (time
        (doseq [sid session-ids
                q instaql-queries]
-         (bump-instaql-version! test-store sid q :join-rows)))
+         (bump-instaql-version! test-store app-id sid q :join-rows)))
 
       (println "record-datalog-query-start")
       (time

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -40,7 +40,7 @@
 ;; ws
 
 (defn session-get [_req]
-  (session/undertow-config rs/store-conn
+  (session/undertow-config rs/store
                            receive-queue/receive-q
                            {:id (squuid)}))
 

--- a/server/src/instant/session_counter.clj
+++ b/server/src/instant/session_counter.clj
@@ -23,8 +23,8 @@
 
 (def api-key "7deea103-7ef8-43f4-aae6-519f51ef33ed")
 
-(defn store->report [db]
-  (->> (rs/report-active-sessions db)
+(defn store->report [store]
+  (->> (rs/report-active-sessions store)
        (filter :app-id)
        (map (juxt :app-id :app-title :creator-email))
        frequencies
@@ -48,7 +48,7 @@
     (when (seq ws-channels)
       (tracer/with-span! {:name "session-counter/run-report"}
         (try
-          (let [report (store->report @rs/store-conn)]
+          (let [report (store->report rs/store)]
             (tracer/add-data! {:attributes
                                {:ws-count (count ws-channels)
                                 :report-count (count report)}})
@@ -82,7 +82,7 @@
                       (log/infof "[session-counters] new-message: %s" msg)
                       (if (= token api-key)
                         (do (add-websocket-listener! ws-id channel)
-                            (send-report! (store->report @rs/store-conn) channel))
+                            (send-report! (store->report rs/store) channel))
                         (ws/send-json! nil {:op :error
                                             :message "Invalid token"}
                                        channel))))

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -131,7 +131,7 @@
                          {:op :init :app-id non-existent-app-id})))))
       (testing "existing app"
         (let [{op :op event-auth :auth} (blocking-send-msg :init-ok socket {:op :init :app-id zeneca-app-id})
-              store-auth (rs/get-auth @store-conn id)]
+              store-auth (-> (rs/session store-conn id) :session/auth)]
           (is (= :init-ok op))
           (is (= ["Zeneca-ex" nil] (pretty-auth event-auth)))
           (is (= ["Zeneca-ex" nil] (pretty-auth store-auth)))))
@@ -463,7 +463,7 @@
                               :q (:kw-q query-1987)})
 
           ;; No stale queries at first
-          (is (empty? (rs/get-stale-instaql-queries @store-conn sess-id)))
+          (is (empty? (rs/get-stale-instaql-queries@store-conn app-id sess-id)))
 
           (rs/mark-stale-topics! store-conn
                                  app-id
@@ -474,7 +474,7 @@
 
             ;; Now we have a stale query
           (is (= [(:kw-q query-1987)]
-                 (map :instaql-query/query (rs/get-stale-instaql-queries @store-conn sess-id))))
+                 (map :instaql-query/query (rs/get-stale-instaql-queries store-conn app-id sess-id))))
 
             ;; We also removed datalog queries from cache
           (is (= '#{}
@@ -484,7 +484,7 @@
                       set)))
 
             ;; we also recorded the tx-id that was processed
-          (is (= 5 (rs/get-processed-tx-id @store-conn app-id))))))))
+          (is (= 5 (rs/get-processed-tx-id store-conn app-id))))))))
 
 (deftest refresh-populates-cache
   (with-movies-app
@@ -512,7 +512,7 @@
                                                    :op :refresh})
 
             ;; After refresh there should be no more stale queries
-            (is (empty? (rs/get-stale-instaql-queries @store-conn sess-id)))
+            (is (empty? (rs/get-stale-instaql-queries store-conn app-id sess-id)))
 
             ;; Datalog cache now has more things
             (is (= '#{{:children
@@ -548,7 +548,7 @@
 
             ;; No stale queries at first
             ;; datalog-cache, subs, instaql look good
-            (is (empty? (rs/get-stale-instaql-queries @store-conn sess-id)))
+            (is (empty? (rs/get-stale-instaql-queries store-conn app-id sess-id)))
             (is (= '#{{:children
                        {:pattern-groups
                         [{:patterns [[:vae ?movie-0 :movie/director "eid-john-mctiernan"]],
@@ -608,7 +608,7 @@
                                                    :op :refresh})
 
             ;; data is cleaned
-            (is (empty? (rs/get-stale-instaql-queries @store-conn sess-id)))
+            (is (empty? (rs/get-stale-instaql-queries store-conn app-id sess-id)))
             (is (= '#{{:children
                        {:pattern-groups
                         [{:patterns [[:vae ?movie-0 :movie/director "eid-john-mctiernan"]],

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -38,26 +38,28 @@
 (def ^:private non-existent-app-id
   #uuid "39b33777-3324-42dd-8f47-ce41d246c5a6")
 
-(def ^:dynamic *store-conn* nil)
-(def ^:dynamic *instaql-query-results* nil)
+(def ^:dynamic *store*
+  nil)
+
+(def ^:dynamic *instaql-query-results*
+  nil)
 
 (defn- with-session [f]
-  (let [store-conn (rs/init-store)
+  (let [store (rs/init)
 
         {receive-q :grouped-queue}
         (grouped-queue/start-grouped-queue-with-workers
          {:max-workers 1
           :group-fn session/group-fn
           :reserve-fn session/receive-worker-reserve-fn
-          :process-fn (partial session/process-fn store-conn)})
-
+          :process-fn (partial session/process-fn store)})
 
         realized-eph?   (atom false)
         eph-hz          (delay
                           (reset! realized-eph? true)
                           @(future ;; avoid pinning vthread
                              (eph/init-hz :test
-                                          store-conn
+                                          store
                                           (let [id (+ 100000 (rand-int 900000))]
                                             {:instance-name (str "test-instance-" id)
                                              :cluster-name  (str "test-cluster-" id)}))))
@@ -73,10 +75,10 @@
                          :ping-job         (future)
                          :pending-handlers (atom #{})}
         query-reactive  rq/instaql-query-reactive!]
-    (session/on-open store-conn socket)
-    (session/on-open store-conn socket-2)
+    (session/on-open store socket)
+    (session/on-open store socket-2)
 
-    (binding [*store-conn*            store-conn
+    (binding [*store*                 store
               *instaql-query-results* (atom {})]
       (with-redefs [receive-queue/receive-q receive-q
                     eph/room-maps           eph-room-maps
@@ -84,16 +86,15 @@
                     ws/send-json!           (fn [_app-id msg fake-ws-conn]
                                               (a/put! fake-ws-conn msg))
                     rq/instaql-query-reactive!
-                    (fn [store-conn {:keys [session-id] :as base-ctx} instaql-query return-type]
-                      (let [res (query-reactive store-conn base-ctx instaql-query return-type)]
+                    (fn [store {:keys [session-id] :as base-ctx} instaql-query return-type]
+                      (let [res (query-reactive store base-ctx instaql-query return-type)]
                         (swap! *instaql-query-results* assoc-in [session-id instaql-query] res)
                         res))]
         (try
-          (f store-conn {:socket   socket
-                         :socket-2 socket-2})
-
-          (session/on-close store-conn socket)
-          (session/on-close store-conn socket-2)
+          (f store {:socket   socket
+                    :socket-2 socket-2})
+          (session/on-close store socket)
+          (session/on-close store socket-2)
           (finally
             (when @realized-eph?
               (HazelcastInstance/.shutdown (:hz @eph-hz)))))))))
@@ -108,7 +109,7 @@
   (set (repeatedly n #(read-msg socket))))
 
 (defn- send-msg [{:keys [ws-conn id] :as socket} msg]
-  (session/handle-receive *store-conn* (rs/get-session @*store-conn* id) msg {}))
+  (session/handle-receive *store* (rs/session *store* id) msg {}))
 
 (defn- blocking-send-msg [expected-op socket msg]
   (send-msg socket msg)
@@ -121,7 +122,7 @@
 
 (deftest anon-auth
   (with-session
-    (fn [store-conn {:keys [socket]
+    (fn [store {:keys [socket]
                      {:keys [id]} :socket}]
       (testing "non-existent app"
         (is (= 400
@@ -131,7 +132,7 @@
                          {:op :init :app-id non-existent-app-id})))))
       (testing "existing app"
         (let [{op :op event-auth :auth} (blocking-send-msg :init-ok socket {:op :init :app-id zeneca-app-id})
-              store-auth (-> (rs/session store-conn id) :session/auth)]
+              store-auth (-> (rs/session store id) :session/auth)]
           (is (= :init-ok op))
           (is (= ["Zeneca-ex" nil] (pretty-auth event-auth)))
           (is (= ["Zeneca-ex" nil] (pretty-auth store-auth)))))
@@ -231,7 +232,7 @@
       (update-in [:data :datalog-result] drop-join-rows-created-at)
       (update :child-nodes (partial map remove-created-at))))
 
-(defn- pretty-query [_db session-id q]
+(defn- pretty-query [session-id q]
   (let [res (->> *instaql-query-results*
                  deref
                  (#(get-in % [session-id q]))
@@ -241,7 +242,7 @@
 
 (deftest add-query-requires-auth
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (is (= 400
              (:status (blocking-send-msg
                        :error
@@ -249,7 +250,7 @@
 
 (deftest add-malformed-query-rejected
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (testing "malformed query are rejected"
         (is (= 400
@@ -257,7 +258,7 @@
 
 (deftest add-nil-query-rejected
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (testing "nil queries are rejected"
         (is (= 400
@@ -265,7 +266,7 @@
 
 (deftest add-query-works
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
 
       (testing "add query: movies in 1987"
@@ -278,9 +279,31 @@
           (is (= (:client-resp query-1987)
                  (resolvers/walk-friendly @r (map remove-created-at result)))))))))
 
+(defn- get-datalog-cache-for-app [store app-id]
+  (let [db  @(rs/app-conn store app-id)]
+    (->> (ds/q '{:find [?query ?result]
+                 :in [$ ?app-id]
+                 :where [[?e :datalog-query/app-id ?app-id]
+                         [?e :datalog-query/query ?query]
+                         [?e :datalog-query/delayed-call ?result]]}
+               db
+               app-id)
+         (into {}))))
+
+(defn- get-subscriptions-for-app-id [store app-id]
+  (let [db  @(rs/app-conn store app-id)]
+    (for [datom (ds/datoms db :aevt :subscription/app-id)
+          :when (= app-id (:v datom))
+          :let  [ent (ds/entity db (:e datom))]]
+      {:app-id        (:subscription/app-id ent)
+       :datalog-query (:datalog-query/query (:subscription/datalog-query ent))
+       :instaql-query (:instaql-query/query (:subscription/instaql-query ent))
+       :session-id    (:subscription/session-id ent)
+       :v             (:subscription/v ent)})))
+
 (deftest add-query-sets-store
   (with-session
-    (fn [store-conn {:keys [socket]
+    (fn [store {:keys [socket]
                      {:keys [id]} :socket}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (blocking-send-msg :add-query-ok
@@ -315,7 +338,7 @@
                                                                     :movie/trivia
                                                                     :movie/title}]]}],
                        :join-sym ?movie-0}}]}}}
-               (->> (#'rs/get-datalog-cache-for-app @store-conn movies-app-id)
+               (->> (get-datalog-cache-for-app store movies-app-id)
                     (resolvers/walk-friendly @r)
                     keys
                     set))))
@@ -345,19 +368,19 @@
                                                                      :movie/trivia
                                                                      :movie/title}]]}],
                         :join-sym ?movie-0}}]}}}}
-               (->> (#'rs/get-subscriptions-for-app-id @store-conn movies-app-id)
+               (->> (get-subscriptions-for-app-id store movies-app-id)
                     (resolvers/walk-friendly @r)
                     pretty-subs))))
 
       (testing "instaql-queries are set"
         (is (= (:client-resp query-1987)
-               (pretty-query @store-conn id (:kw-q query-1987))))
+               (pretty-query id (:kw-q query-1987))))
         (is (= (:client-resp query-robocop)
-               (pretty-query @store-conn id (:kw-q query-robocop))))))))
+               (pretty-query id (:kw-q query-robocop))))))))
 
 (deftest add-duplicate-query-returns-query-exists
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (blocking-send-msg :add-query-ok socket {:op :add-query :q (:kw-q query-robocop)})
       (is (= {:op :add-query-exists,
@@ -367,7 +390,7 @@
 
 (deftest remove-query-works
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (blocking-send-msg :add-query-ok
                          socket
@@ -382,7 +405,7 @@
 
 (deftest remove-query-updates-store
   (with-session
-    (fn [store-conn {:keys [socket]}]
+    (fn [store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
 
       (blocking-send-msg :add-query-ok
@@ -415,7 +438,7 @@
                                                                     :movie/trivia
                                                                     :movie/title}]]}],
                        :join-sym ?movie-0}}]}}}
-               (->> (#'rs/get-datalog-cache-for-app @store-conn movies-app-id)
+               (->> (get-datalog-cache-for-app store movies-app-id)
                     (resolvers/walk-friendly @r)
                     keys
                     set))))
@@ -433,7 +456,7 @@
                                                                      :movie/trivia
                                                                      :movie/title}]]}],
                         :join-sym ?movie-0}}]}}}}
-               (some->> (#'rs/get-subscriptions-for-app-id @store-conn movies-app-id)
+               (some->> (get-subscriptions-for-app-id store movies-app-id)
                         seq
                         (resolvers/walk-friendly @r)
                         pretty-subs))))
@@ -447,25 +470,25 @@
                                  :q (:kw-q query-robocop)})))
 
       (testing "all subs are gone"
-        (is (empty? (#'rs/get-subscriptions-for-app-id @store-conn movies-app-id))))
+        (is (empty? (get-subscriptions-for-app-id store movies-app-id))))
 
       (testing "datalog-cache is cleaned"
-        (is (empty? (#'rs/get-datalog-cache-for-app @store-conn movies-app-id)))))))
+        (is (empty? (get-datalog-cache-for-app store movies-app-id)))))))
 
 (deftest mark-stale-topics-works
   (with-movies-app
     (fn [{app-id :id :as _app} r]
       (with-session
-        (fn [store-conn {{sess-id :id :as socket} :socket}]
+        (fn [store {{sess-id :id :as socket} :socket}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
           (blocking-send-msg :add-query-ok socket
                              {:op :add-query
                               :q (:kw-q query-1987)})
 
           ;; No stale queries at first
-          (is (empty? (rs/get-stale-instaql-queries@store-conn app-id sess-id)))
+          (is (empty? (rs/get-stale-instaql-queries store app-id sess-id)))
 
-          (rs/mark-stale-topics! store-conn
+          (rs/mark-stale-topics! store
                                  app-id
                                  5
                                  [(d/pat->coarse-topic
@@ -474,29 +497,29 @@
 
             ;; Now we have a stale query
           (is (= [(:kw-q query-1987)]
-                 (map :instaql-query/query (rs/get-stale-instaql-queries store-conn app-id sess-id))))
+                 (map :instaql-query/query (rs/get-stale-instaql-queries store app-id sess-id))))
 
             ;; We also removed datalog queries from cache
           (is (= '#{}
-                 (->> (#'rs/get-datalog-cache-for-app @store-conn app-id)
+                 (->> (get-datalog-cache-for-app store app-id)
                       (resolvers/walk-friendly r)
                       keys
                       set)))
 
             ;; we also recorded the tx-id that was processed
-          (is (= 5 (rs/get-processed-tx-id store-conn app-id))))))))
+          (is (= 5 (rs/get-processed-tx-id store app-id))))))))
 
 (deftest refresh-populates-cache
   (with-movies-app
     (fn [{app-id :id :as _app} r]
       (with-session
-        (fn [store-conn {{sess-id :id :as socket} :socket}]
+        (fn [store {{sess-id :id :as socket} :socket}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
           (blocking-send-msg :add-query-ok
                              socket
                              {:op :add-query
                               :q (:kw-q query-1987)})
-          (rs/mark-stale-topics! store-conn
+          (rs/mark-stale-topics! store
                                  app-id
                                  0
                                  [(d/pat->coarse-topic
@@ -505,14 +528,13 @@
 
           (testing "send refresh"
             ;; clear the query hash so that the refresh will trigger a send
-            (ds/transact! store-conn [[:db/retract
-                                       [:instaql-query/session-id+query [sess-id (:kw-q query-1987)]]
-                                       :instaql-query/hash]])
+            (ds/transact! (rs/app-conn store app-id)
+                          [[:db/retract [:instaql-query/session-id+query [sess-id (:kw-q query-1987)]] :instaql-query/hash]])
             (blocking-send-msg :refresh-ok socket {:session-id (:id socket)
                                                    :op :refresh})
 
             ;; After refresh there should be no more stale queries
-            (is (empty? (rs/get-stale-instaql-queries store-conn app-id sess-id)))
+            (is (empty? (rs/get-stale-instaql-queries store app-id sess-id)))
 
             ;; Datalog cache now has more things
             (is (= '#{{:children
@@ -527,7 +549,7 @@
                                                                         :movie/trivia
                                                                         :movie/title}]]}],
                            :join-sym ?movie-0}}]}}}
-                   (->> (#'rs/get-datalog-cache-for-app @store-conn app-id)
+                   (->> (get-datalog-cache-for-app store app-id)
                         (resolvers/walk-friendly r)
                         keys
                         set)))))))))
@@ -536,7 +558,7 @@
   (with-movies-app
     (fn [{app-id :id :as _app} r]
       (with-session
-        (fn [store-conn {{sess-id :id :as socket} :socket}]
+        (fn [store {{sess-id :id :as socket} :socket}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
           (let [john-uuid (resolvers/->uuid r "eid-john-mctiernan")
                 ted-uuid (resolvers/->uuid r "eid-ted-kotcheff")
@@ -548,7 +570,7 @@
 
             ;; No stale queries at first
             ;; datalog-cache, subs, instaql look good
-            (is (empty? (rs/get-stale-instaql-queries store-conn app-id sess-id)))
+            (is (empty? (rs/get-stale-instaql-queries store app-id sess-id)))
             (is (= '#{{:children
                        {:pattern-groups
                         [{:patterns [[:vae ?movie-0 :movie/director "eid-john-mctiernan"]],
@@ -561,7 +583,7 @@
                                                                         :movie/trivia
                                                                         :movie/title}]]}],
                            :join-sym ?movie-0}}]}}}
-                   (->> (#'rs/get-datalog-cache-for-app @store-conn app-id)
+                   (->> (get-datalog-cache-for-app store app-id)
                         (resolvers/walk-friendly r)
                         keys
                         set)))
@@ -579,7 +601,7 @@
                                                                          :movie/trivia
                                                                          :movie/title}]]}],
                             :join-sym ?movie-0}}]}}}}
-                   (->> (#'rs/get-subscriptions-for-app-id @store-conn app-id)
+                   (->> (get-subscriptions-for-app-id store app-id)
                         (resolvers/walk-friendly r)
                         pretty-subs)))
 
@@ -597,7 +619,7 @@
                             ted-uuid]])
 
             ;; mark topic as stale
-            (rs/mark-stale-topics! store-conn
+            (rs/mark-stale-topics! store
                                    app-id
                                    0
                                    [(d/pat->coarse-topic
@@ -608,7 +630,7 @@
                                                    :op :refresh})
 
             ;; data is cleaned
-            (is (empty? (rs/get-stale-instaql-queries store-conn app-id sess-id)))
+            (is (empty? (rs/get-stale-instaql-queries store app-id sess-id)))
             (is (= '#{{:children
                        {:pattern-groups
                         [{:patterns [[:vae ?movie-0 :movie/director "eid-john-mctiernan"]],
@@ -621,7 +643,7 @@
                                                                         :movie/trivia
                                                                         :movie/title}]]}],
                            :join-sym ?movie-0}}]}}}
-                   (->> (#'rs/get-datalog-cache-for-app @store-conn app-id)
+                   (->> (get-datalog-cache-for-app store app-id)
                         (resolvers/walk-friendly r)
                         keys
                         set)))
@@ -639,13 +661,13 @@
                                                                          :movie/trivia
                                                                          :movie/title}]]}],
                             :join-sym ?movie-0}}]}}}}
-                   (->> (#'rs/get-subscriptions-for-app-id @store-conn app-id)
+                   (->> (get-subscriptions-for-app-id store app-id)
                         (resolvers/walk-friendly r)
                         pretty-subs)))))))))
 
 (deftest transact-requires-auth
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (is (= 400
              (:status (blocking-send-msg
                        :error
@@ -655,7 +677,7 @@
   (with-empty-app
     (fn [{app-id :id}]
       (with-session
-        (fn [_store-conn {:keys [socket]}]
+        (fn [_store {:keys [socket]}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
           (is (= 400
                  (:status (blocking-send-msg
@@ -667,7 +689,7 @@
   (with-movies-app
     (fn [{app-id :id :as _app} r]
       (with-session
-        (fn [_store-conn {:keys [socket]}]
+        (fn [_store {:keys [socket]}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
           (let [robocop-eid (resolvers/->uuid r "eid-robocop")
                 name-attr-id (resolvers/->uuid r :movie/title)]
@@ -694,7 +716,7 @@
 
 (deftest join-room-works
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init
                                           :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
@@ -717,7 +739,7 @@
 
 (deftest leave-room-works
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (send-msg socket {:op :init
                         :app-id movies-app-id})
       (is (= :init-ok (:op (read-msg socket))))
@@ -744,7 +766,7 @@
 
 (deftest patch-presence-works
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (let [rid     (str (UUID/randomUUID))
             sess-id (:id socket)
             d1      {:a "a" :b "b" :c "c" :d "d" :e "e"}
@@ -796,7 +818,7 @@
 
 (deftest set-presence-two-sessions
   (with-session
-    (fn [_store-conn {socket-1 :socket
+    (fn [_store {socket-1 :socket
                       socket-2 :socket-2}]
       (let [rid       (str (UUID/randomUUID))
             sess-id-1 (:id socket-1)
@@ -880,7 +902,7 @@
 
 (deftest set-presence-fails-when-not-in-room
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
             d1 {:hello "world"}
@@ -890,7 +912,7 @@
 
 (deftest broadcast-works
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (let [rid (str (UUID/randomUUID))
             sess-id (:id socket)
             t1 "foo"
@@ -922,7 +944,7 @@
 
 (deftest broadcast-fails-when-not-in-room
   (with-session
-    (fn [_store-conn {:keys [socket]}]
+    (fn [_store {:keys [socket]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
             t1 "foo"

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -23,7 +23,7 @@
         '[:eav #{1} #{2} #{3}]))))
 
 (deftest swap-datalog-cache!
-  (let [store (rs/init-store)
+  (let [store  (rs/init)
         app-id (random-uuid)]
     (testing "store returns cached data"
       (let [q [[:ea (random-uuid)]]]


### PR DESCRIPTION
Design:

- `rs/store-conn` becomes a record w/ 2 fields
- `:sessions` is a datascript conn that stores session info. Shouldn’t have too high concurrent access as it’s only modified on connect/disconnect
- `:conns` is a `ConcurrentHashMap` of `app-id` → datascript conn that store instaql queries, datalog queries, tx-meta and subscriptions.
- All `instant.reactive.store` methods accept opaque `store` argument instead of explicit `conn`/`db`

This way we solve:

- Opening ws conn without app-id is okay, as it only goes into `:sessions` db and stays there
- When we modify any other data in datascript, we _must_ have app-id, so we can always find correct conn in `:conns`
- Current schema design doesn’t use datascript ref to sessions, it uses `.../session-id` (uuid) instead. That makes splitting dbs very easy
- By making `store` opaque, we can change impl further if we feel we need more concurrency or smth