### PR TITLE
Reduce amount of warnings printed on startup

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -32,7 +32,12 @@
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
         incanter/incanter {:mvn/version "1.9.3"
                            :exclusions [bouncycastle/bctsp-jdk14
-                                        postgresql/postgresql]}
+                                        postgresql/postgresql
+                                        net.mikera/vectorz-clj]}
+        net.mikera/core.matrix {:mvn/version "0.63.0"}
+        ;; https://github.com/mikera/vectorz-clj/pull/75
+        io.github.tonsky/vectorz-clj {:mvn/version "0.48.1"}
+        net.mikera/vectorz {:mvn/version "0.67.0"}
         com.taoensso/nippy {:mvn/version "3.4.2"}
 
         nrepl/nrepl {:mvn/version "0.9.0"}

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -30,14 +30,14 @@
         io.github.tonsky/clojure-plus {:mvn/version "1.0.0"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
-        incanter/incanter {:mvn/version "1.9.3"
-                           :exclusions [bouncycastle/bctsp-jdk14
-                                        postgresql/postgresql
-                                        net.mikera/vectorz-clj]}
-        net.mikera/core.matrix {:mvn/version "0.63.0"}
+
+        ;; https://github.com/incanter/incanter/pull/429
         ;; https://github.com/mikera/vectorz-clj/pull/75
+        io.github.tonsky/incanter-charts {:mvn/version "1.9.4"}
         io.github.tonsky/vectorz-clj {:mvn/version "0.48.1"}
         net.mikera/vectorz {:mvn/version "0.67.0"}
+        net.mikera/core.matrix {:mvn/version "0.63.0"}
+
         com.taoensso/nippy {:mvn/version "3.4.2"}
 
         nrepl/nrepl {:mvn/version "0.9.0"}

--- a/server/src/instant/intern/metrics.clj
+++ b/server/src/instant/intern/metrics.clj
@@ -27,7 +27,7 @@
   (:import [org.jfree.chart.renderer.category BarRenderer]
            [org.jfree.chart.labels StandardCategoryItemLabelGenerator]
            [org.jfree.chart.axis CategoryLabelPositions]
-           [org.jfree.ui RectangleInsets]
+           [org.jfree.chart.ui RectangleInsets]
            [java.io File ByteArrayOutputStream]
            [java.awt Color]
            [javax.imageio ImageIO]
@@ -253,7 +253,7 @@
     (.setBasePositiveItemLabelPosition renderer
                                        (org.jfree.chart.labels.ItemLabelPosition.
                                         org.jfree.chart.labels.ItemLabelAnchor/OUTSIDE12
-                                        org.jfree.ui.TextAnchor/BOTTOM_CENTER))
+                                        org.jfree.chart.ui.TextAnchor/BOTTOM_CENTER))
 
     ;; Set bar background to white and border to black
     (.setRenderer plot renderer)


### PR DESCRIPTION
Before:

```
[~/ws/instant/server] make dev
Booting up backend w/ local db...
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix.impl.mathsops, being replaced by: #'clojure.core.matrix.impl.mathsops/abs
Warning: protocol #'clojure.core.matrix.protocols/PMathsFunctions is overwriting function abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix.protocols, being replaced by: #'clojure.core.matrix.protocols/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix, being replaced by: #'clojure.core.matrix/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix.dataset, being replaced by: #'clojure.core.matrix/abs
WARNING: abs already refers to: #'clojure.core.matrix/abs in namespace: mikera.vectorz.matrix-api, being replaced by: #'clojure.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.core, being replaced by: #'incanter.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.charts, being replaced by: #'incanter.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.stats, being replaced by: #'incanter.core/abs
```

Now:

```
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.core, being replaced by: #'incanter.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.charts, being replaced by: #'incanter.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.stats, being replaced by: #'incanter.core/abs
```

See also

- https://github.com/incanter/incanter/pull/429
- https://github.com/mikera/vectorz-clj/pull/75

Publishing custom version of incanter is possible, but it’s also a lot. If it’s here to stay and upstream ignores us for a few weeks, maybe I’ll do it