### PR TITLE
Upgrade heroicons to v2

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -515,8 +515,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@heroicons/react':
-        specifier: ^1.0.6
-        version: 1.0.6(react@18.3.1)
+        specifier: ^2.1.5
+        version: 2.2.0(react@18.3.1)
       '@instantdb/admin':
         specifier: workspace:*
         version: link:../packages/admin
@@ -2088,10 +2088,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  '@heroicons/react@1.0.6':
-    resolution: {integrity: sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==}
+  '@heroicons/react@2.2.0':
+    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
     peerDependencies:
-      react: '>= 16'
+      react: '>= 16 || ^19.0.0-rc'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -10440,7 +10440,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@heroicons/react@1.0.6(react@18.3.1)':
+  '@heroicons/react@2.2.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
 

--- a/client/www/components/dash/PersonalAccessTokensScreen.tsx
+++ b/client/www/components/dash/PersonalAccessTokensScreen.tsx
@@ -7,9 +7,9 @@ import React, {
 } from 'react';
 import {
   ChevronRightIcon,
-  ClipboardCopyIcon,
+  ClipboardDocumentIcon,
   PlusIcon,
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import format from 'date-fns/format';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
@@ -139,7 +139,7 @@ function CopyButton({ value }: { value: string }) {
         size="mini"
         onClick={handleClick}
       >
-        {!isCopied && <ClipboardCopyIcon className="-ml-0.5 h-4 w-4" />}
+        {!isCopied && <ClipboardDocumentIcon className="-ml-0.5 h-4 w-4" />}
         {isCopied ? 'Copied!' : 'Copy'}
       </Button>
     </CopyToClipboard>

--- a/client/www/components/dash/auth/Apple.tsx
+++ b/client/www/components/dash/auth/Apple.tsx
@@ -17,7 +17,7 @@ import {
   PlusIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-} from '@heroicons/react/solid';
+} from '@heroicons/react/24/solid';
 import logo from '../../../public/img/apple_logo_black.svg';
 import Image from 'next/image';
 import { messageFromInstantError } from '@/lib/errors';

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -19,7 +19,7 @@ import {
   PlusIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-} from '@heroicons/react/solid';
+} from '@heroicons/react/24/solid';
 import clerkLogoSvg from '../../../public/img/clerk_logo_black.svg';
 import Image from 'next/image';
 import { messageFromInstantError } from '@/lib/errors';

--- a/client/www/components/dash/auth/Google.tsx
+++ b/client/www/components/dash/auth/Google.tsx
@@ -30,7 +30,7 @@ import {
   PlusIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-} from '@heroicons/react/solid';
+} from '@heroicons/react/24/solid';
 
 export function AddClientForm({
   app,

--- a/client/www/components/dash/auth/Origins.tsx
+++ b/client/www/components/dash/auth/Origins.tsx
@@ -27,8 +27,8 @@ import {
   InformationCircleIcon,
   PlusIcon,
   TrashIcon,
-} from '@heroicons/react/solid';
-import { DeviceMobileIcon, GlobeAltIcon } from '@heroicons/react/outline';
+} from '@heroicons/react/24/solid';
+import { DevicePhoneMobileIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
 import NetlifyIcon from '../../icons/NetlifyIcon';
 import VercelIcon from '../../icons/VercelIcon';
 
@@ -253,7 +253,7 @@ export function originIcon(origin: AuthorizedOrigin) {
     case 'vercel':
       return VercelIcon;
     case 'custom-scheme':
-      return DeviceMobileIcon;
+      return DevicePhoneMobileIcon;
     default:
       return GlobeAltIcon;
   }

--- a/client/www/components/dash/auth/Origins.tsx
+++ b/client/www/components/dash/auth/Origins.tsx
@@ -28,7 +28,10 @@ import {
   PlusIcon,
   TrashIcon,
 } from '@heroicons/react/24/solid';
-import { DevicePhoneMobileIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import {
+  DevicePhoneMobileIcon,
+  GlobeAltIcon,
+} from '@heroicons/react/24/outline';
 import NetlifyIcon from '../../icons/NetlifyIcon';
 import VercelIcon from '../../icons/VercelIcon';
 

--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -1,7 +1,7 @@
 import { id } from '@instantdb/core';
 import { InstantReactWebDatabase } from '@instantdb/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowLeftIcon, PlusIcon, TrashIcon } from '@heroicons/react/solid';
+import { ArrowLeftIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid';
 import { errorToast, successToast } from '@/lib/toast';
 import {
   ActionButton,

--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui';
 import { SchemaAttr, SchemaNamespace } from '@/lib/types';
 import { errorToast, successToast } from '@/lib/toast';
-import { RefreshIcon } from '@heroicons/react/solid';
+import { ArrowPathIcon } from '@heroicons/react/24/solid';
 import { validate } from 'uuid';
 
 type FieldType = 'string' | 'number' | 'boolean' | 'json';
@@ -227,7 +227,7 @@ export function EditRowDialog({
                     variant="subtle"
                     onClick={() => handleUpdateFieldValue('id', id())}
                   >
-                    <RefreshIcon height={14} />
+                    <ArrowPathIcon height={14} />
                   </Button>
                 </div>
               </Label>

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -26,11 +26,11 @@ import {
   ArrowLeftIcon,
   ArrowRightIcon,
   ChevronLeftIcon,
-  MenuIcon,
+  Bars3Icon,
   PlusIcon,
-  XIcon,
-} from '@heroicons/react/solid';
-import { PencilAltIcon } from '@heroicons/react/outline';
+  XMarkIcon,
+} from '@heroicons/react/24/solid';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
 
 import { successToast, errorToast } from '@/lib/toast';
 import {
@@ -735,7 +735,7 @@ export function Explorer({
             setIsNsOpen(true);
           }}
         >
-          <MenuIcon height="1rem" />
+          <Bars3Icon height="1rem" />
         </button>
       </div>
       {selectedNamespace && currentNav && allItems ? (
@@ -751,7 +751,7 @@ export function Explorer({
                   />
                 ) : null}
                 {currentNav?.where ? (
-                  <XIcon
+                  <XMarkIcon
                     className="mr-4 inline cursor-pointer"
                     height="1rem"
                     onClick={() => {
@@ -1100,7 +1100,7 @@ export function Explorer({
                           className="opacity-0 group-hover:opacity-100 transition-opacity"
                           onClick={() => setEditableRowId(item.id)}
                         >
-                          <PencilAltIcon className="h-4 w-4 text-gray-500" />
+                          <PencilSquareIcon className="h-4 w-4 text-gray-500" />
                         </button>
                       )}
                     </td>

--- a/client/www/components/dash/explorer/QueryInspector.tsx
+++ b/client/www/components/dash/explorer/QueryInspector.tsx
@@ -1,8 +1,8 @@
 import JsonParser from 'json5';
 import { useEffect, useState } from 'react';
 import * as Tooltip from '@radix-ui/react-tooltip';
-import { StarIcon, TrashIcon } from '@heroicons/react/outline';
-import { ArrowSmRightIcon } from '@heroicons/react/solid';
+import { StarIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon } from '@heroicons/react/24/solid';
 
 import { Button, CodeEditor, cn } from '@/components/ui';
 import { useSchemaQuery } from '@/lib/hooks/explorer';
@@ -275,7 +275,7 @@ export function QueryInspector({
                         size="mini"
                         onClick={() => run(item.query)}
                       >
-                        <ArrowSmRightIcon className="w-4 h-4 -rotate-45" />
+                        <ArrowRightIcon className="w-4 h-4 -rotate-45" />
                       </Button>
                     </div>
                   </div>
@@ -334,7 +334,7 @@ export function QueryInspector({
                         size="mini"
                         onClick={() => run(item.query)}
                       >
-                        <ArrowSmRightIcon className="w-4 h-4 -rotate-45" />
+                        <ArrowRightIcon className="w-4 h-4 -rotate-45" />
                       </Button>
                     </div>
                   </div>

--- a/client/www/components/docs/Fence.jsx
+++ b/client/www/components/docs/Fence.jsx
@@ -1,6 +1,6 @@
 import { Fragment, useContext } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { ClipboardCopyIcon } from '@heroicons/react/outline';
+import { ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import { useState } from 'react';
 import { SelectedAppContext } from '@/lib/SelectedAppContext';
@@ -55,7 +55,7 @@ export function Fence({ children, language, showCopy }) {
                   className="flex items-center gap-x-1
              bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
                 >
-                  <ClipboardCopyIcon
+                  <ClipboardDocumentIcon
                     className="-ml-0.5 h-4 w-4"
                     aria-hidden="true"
                   />

--- a/client/www/components/docs/MobileNavigation.jsx
+++ b/client/www/components/docs/MobileNavigation.jsx
@@ -6,7 +6,7 @@ import { Dialog } from '@headlessui/react';
 import { Logo } from '@/components/docs/Logo';
 import { Navigation } from '@/components/docs/Navigation';
 
-function MenuIcon(props) {
+function Bars3Icon(props) {
   return (
     <svg
       aria-hidden="true"
@@ -64,7 +64,7 @@ export function MobileNavigation({ navigation }) {
         className="relative"
         aria-label="Open navigation"
       >
-        <MenuIcon className="h-6 w-6 stroke-slate-500" />
+        <Bars3Icon className="h-6 w-6 stroke-slate-500" />
       </button>
       <Dialog
         open={isOpen}

--- a/client/www/components/marketingUi.tsx
+++ b/client/www/components/marketingUi.tsx
@@ -1,6 +1,6 @@
 import { useAuthToken } from '@/lib/auth';
 import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
-import { MenuIcon, XIcon } from '@heroicons/react/solid';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
 import NextLink from 'next/link';
 import { PropsWithChildren, useEffect, useState } from 'react';
@@ -130,7 +130,7 @@ export function MainNav({ children }: PropsWithChildren) {
         <div className="flex justify-between items-center flex-row gap-4 text-lg md:text-base">
           <LogoType />
           <button className="md:hidden" onClick={() => setIsOpen(true)}>
-            <MenuIcon height={'1em'} />
+            <Bars3Icon height={'1em'} />
           </button>
           <div
             onClick={() => setIsOpen(false)}
@@ -155,7 +155,7 @@ export function MainNav({ children }: PropsWithChildren) {
             <div className="md:hidden flex self-stretch justify-between">
               <LogoType />
               <button className="z-50 mt-0.5" onClick={() => setIsOpen(false)}>
-                <XIcon height="1em" />
+                <XMarkIcon height="1em" />
               </button>
             </div>
 

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -31,12 +31,12 @@ require('prismjs/components/prism-clojure');
 
 import {
   CheckCircleIcon,
-  ClipboardCopyIcon,
-  XIcon,
+  ClipboardDocumentIcon,
+  XMarkIcon,
   EyeIcon,
-  EyeOffIcon,
-} from '@heroicons/react/solid';
-import { InformationCircleIcon } from '@heroicons/react/outline';
+  EyeSlashIcon,
+} from '@heroicons/react/24/solid';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import { errorToast, successToast } from '@/lib/toast';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import copy from 'copy-to-clipboard';
@@ -604,7 +604,7 @@ export function Dialog({
       <div className="fixed inset-0 z-50 bg-black/50" aria-hidden="true" />
       <div className="fixed inset-4 z-50 flex flex-col items-center justify-center">
         <HeadlessDialog.Panel className="relative w-full max-w-xl overflow-y-auto rounded bg-white p-3 text-sm shadow">
-          <XIcon
+          <XMarkIcon
             className="absolute right-3 top-[18px] h-4 w-4 cursor-pointer"
             onClick={onClose}
           />
@@ -765,7 +765,7 @@ export function Copyable({
             )}
           >
             {hideValue ? (
-              <EyeOffIcon className="h-4 w-4" aria-hidden="true" />
+              <EyeSlashIcon className="h-4 w-4" aria-hidden="true" />
             ) : (
               <EyeIcon className="h-4 w-4" aria-hidden="true" />
             )}
@@ -784,7 +784,10 @@ export function Copyable({
               { 'text-xs': size === 'normal', 'text-sm': size === 'large' },
             )}
           >
-            <ClipboardCopyIcon className="-ml-0.5 h-4 w-4" aria-hidden="true" />
+            <ClipboardDocumentIcon
+              className="-ml-0.5 h-4 w-4"
+              aria-hidden="true"
+            />
             {copyLabel}
           </button>
         </CopyToClipboard>
@@ -825,7 +828,10 @@ export function Copytext({ value }: { value: string }) {
         {showCopied ? (
           <CheckCircleIcon className="pl-1" height={'1em'} />
         ) : (
-          <ClipboardCopyIcon className="cursor-pointer pl-1" height={'1em'} />
+          <ClipboardDocumentIcon
+            className="cursor-pointer pl-1"
+            height={'1em'}
+          />
         )}
       </CopyToClipboard>
     </span>
@@ -964,7 +970,7 @@ export function Fence({
                 }}
                 className="flex items-center gap-x-1 rounded-sm bg-white px-2 py-1 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 text-xs"
               >
-                <ClipboardCopyIcon
+                <ClipboardDocumentIcon
                   className="-ml-0.5 h-4 w-4"
                   aria-hidden="true"
                 />

--- a/client/www/lib/toast.js
+++ b/client/www/lib/toast.js
@@ -1,7 +1,7 @@
 import { ToastContainer, toast, Flip } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { InformationCircleIcon } from '@heroicons/react/outline';
-import { ExclamationCircleIcon, CheckCircleIcon } from '@heroicons/react/solid';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+import { ExclamationCircleIcon, CheckCircleIcon } from '@heroicons/react/24/solid';
 
 export function infoToast(text, options) {
   toast.info(text, {

--- a/client/www/lib/toast.js
+++ b/client/www/lib/toast.js
@@ -1,7 +1,10 @@
 import { ToastContainer, toast, Flip } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
-import { ExclamationCircleIcon, CheckCircleIcon } from '@heroicons/react/24/solid';
+import {
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+} from '@heroicons/react/24/solid';
 
 export function infoToast(text, options) {
   toast.info(text, {

--- a/client/www/package.json
+++ b/client/www/package.json
@@ -11,7 +11,7 @@
     "@docsearch/css": "3",
     "@docsearch/react": "^3.6.0",
     "@headlessui/react": "^2.2.0",
-    "@heroicons/react": "^1.0.6",
+    "@heroicons/react": "^2.1.5",
     "@instantdb/admin": "workspace:*",
     "@instantdb/core": "workspace:*",
     "@instantdb/react": "workspace:*",

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui';
 import Auth from '@/components/dash/Auth';
 import { isMinRole } from '@/pages/dash/index';
-import { TrashIcon } from '@heroicons/react/solid';
+import { TrashIcon } from '@heroicons/react/24/solid';
 
 type InstantReactClient = ReturnType<typeof init>;
 

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -6,7 +6,7 @@ import Head from 'next/head';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { capitalize } from 'lodash';
-import { PlusIcon, TrashIcon } from '@heroicons/react/solid';
+import { PlusIcon, TrashIcon } from '@heroicons/react/24/solid';
 
 import { StyledToastContainer, errorToast, successToast } from '@/lib/toast';
 import config, { cliOauthParamName, getLocal, setLocal } from '@/lib/config';

--- a/client/www/pages/index.tsx
+++ b/client/www/pages/index.tsx
@@ -28,7 +28,7 @@ import {
   Link,
 } from '@/components/marketingUi';
 
-import { ChevronRightIcon } from '@heroicons/react/solid';
+import { ChevronRightIcon } from '@heroicons/react/24/solid';
 import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
 import config from '@/lib/config';
 import MuxPlayer from '@mux/mux-player-react';


### PR DESCRIPTION
Updates heroicons from v1 to v2. Main motivation is that v2 has an "undo" icon and v1 doesn't.

Icons mostly seem the same, maybe a little dimmer?

Preview URL: https://instant-www-js-icons-v2-jsv.vercel.app


Old:
<img width="147" alt="image" src="https://github.com/user-attachments/assets/8a7fa6dd-81e4-44de-82cd-ee2b0a034410" />

New:
<img width="148" alt="image" src="https://github.com/user-attachments/assets/d6f85942-7365-47fd-aaa1-311804fd62bc" />


Old:
<img width="560" alt="image" src="https://github.com/user-attachments/assets/a78370ed-f67f-4b77-9242-40de7d3a9a0d" />


New:
<img width="559" alt="image" src="https://github.com/user-attachments/assets/4b9ac699-6aee-4954-af21-e6a0787fdbd5" />