### PR TITLE
[devtool] Improve devtool local flow, and add an `X` button 

### DIFF
--- a/client/packages/core/src/devtool.ts
+++ b/client/packages/core/src/devtool.ts
@@ -1,3 +1,5 @@
+import * as flags from './utils/flags';
+
 type Devtool = { dispose: () => void };
 
 let currentDevtool: Devtool | undefined;
@@ -64,9 +66,7 @@ export function createDevtool(appId: string) {
 }
 
 function getSrc(appId: string) {
-  const isDev = (window as any).DEV_DEVTOOL;
-
-  const src = `${isDev ? 'http://localhost:3000' : 'https://instantdb.com'}/_devtool?appId=${appId}`;
+  const src = `${flags.localDevtoolIframe ? 'http://localhost:3000' : 'https://instantdb.com'}/_devtool?appId=${appId}`;
   return src;
 }
 

--- a/client/packages/core/src/devtool.ts
+++ b/client/packages/core/src/devtool.ts
@@ -78,7 +78,6 @@ function createIframe(src: string) {
   Object.assign(element.style, {
     width: '100%',
     height: '100%',
-    borderRadius: '4px',
     backgroundColor: 'white',
     border: 'none',
   } as Partial<CSSStyleDeclaration>);

--- a/client/packages/core/src/devtool.ts
+++ b/client/packages/core/src/devtool.ts
@@ -66,7 +66,8 @@ export function createDevtool(appId: string) {
 }
 
 function getSrc(appId: string) {
-  const src = `${flags.localDevtoolIframe ? 'http://localhost:3000' : 'https://instantdb.com'}/_devtool?appId=${appId}`;
+  const useLocalDashboard = flags.devBackend || flags.devtoolLocalDashboard;
+  const src = `${useLocalDashboard ? 'http://localhost:3000' : 'https://instantdb.com'}/_devtool?appId=${appId}`;
   return src;
 }
 

--- a/client/packages/core/src/utils/flags.ts
+++ b/client/packages/core/src/utils/flags.ts
@@ -1,6 +1,6 @@
 let devBackend = false;
 let instantLogs = false;
-let localDevtoolIframe = false;
+let devtoolLocalDashboard = false;
 
 if (
   typeof window !== 'undefined' &&
@@ -8,7 +8,7 @@ if (
 ) {
   devBackend = !!window.localStorage.getItem('devBackend');
   instantLogs = !!window.localStorage.getItem('__instantLogging');
-  localDevtoolIframe = !!window.localStorage.getItem('__localDevtoolIframe');
+  devtoolLocalDashboard = !!window.localStorage.getItem('__devtoolLocalDash');
 }
 
-export { devBackend, instantLogs, localDevtoolIframe };
+export { devBackend, instantLogs, devtoolLocalDashboard };

--- a/client/packages/core/src/utils/flags.ts
+++ b/client/packages/core/src/utils/flags.ts
@@ -1,0 +1,14 @@
+let devBackend = false;
+let instantLogs = false;
+let localDevtoolIframe = false;
+
+if (
+  typeof window !== 'undefined' &&
+  typeof window.localStorage !== 'undefined'
+) {
+  devBackend = !!window.localStorage.getItem('devBackend');
+  instantLogs = !!window.localStorage.getItem('__instantLogging');
+  localDevtoolIframe = !!window.localStorage.getItem('__localDevtoolIframe');
+}
+
+export { devBackend, instantLogs, localDevtoolIframe };

--- a/client/packages/core/src/utils/log.ts
+++ b/client/packages/core/src/utils/log.ts
@@ -1,12 +1,6 @@
-let isEnabled = false;
-if (
-  typeof window !== 'undefined' &&
-  typeof window.localStorage !== 'undefined'
-) {
-  isEnabled =
-    !!window.localStorage.getItem('devBackend') ||
-    !!window.localStorage.getItem('__instantLogging');
-}
+import * as flags from './flags';
+
+const isEnabled = flags.devBackend || flags.instantLogs;
 
 const log = {
   info: isEnabled ? console.info.bind(console) : () => {},

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -178,7 +178,7 @@ export default function Devtool() {
     <div className="h-full w-full">
       <TokenContext.Provider value={authToken}>
         <div className="flex flex-col h-full w-full">
-          <div className='flex p-2 text-xs bg-gray-100 border-b'>
+          <div className="flex p-2 text-xs bg-gray-100 border-b">
             <div className="flex-1 font-mono">
               Instant Devtools {app?.title ? `• ${app?.title}` : ''}
             </div>

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -178,8 +178,8 @@ export default function Devtool() {
     <div className="h-full w-full">
       <TokenContext.Provider value={authToken}>
         <div className="flex flex-col h-full w-full">
-          <div>
-            <div className="px-3 py-1 text-xs font-mono bg-gray-100 border-b">
+          <div className='flex p-2 text-xs bg-gray-100 border-b'>
+            <div className="flex-1 font-mono">
               Instant Devtools {app?.title ? `• ${app?.title}` : ''}
             </div>
             <XMarkIcon
@@ -195,7 +195,7 @@ export default function Devtool() {
               }}
             />
           </div>
-          <div className="flex gap-2 px-3 py-1 text-xs font-mono bg-gray-50 border-b">
+          <div className="flex gap-2 px-2 py-1 text-xs font-mono bg-gray-50 border-b">
             <span>App ID</span>
             <code
               className="bg-white rounded border px-2"

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui';
 import Auth from '@/components/dash/Auth';
 import { isMinRole } from '@/pages/dash/index';
-import { TrashIcon } from '@heroicons/react/24/solid';
+import { TrashIcon, XMarkIcon } from '@heroicons/react/24/solid';
 
 type InstantReactClient = ReturnType<typeof init>;
 
@@ -178,8 +178,22 @@ export default function Devtool() {
     <div className="h-full w-full">
       <TokenContext.Provider value={authToken}>
         <div className="flex flex-col h-full w-full">
-          <div className="px-3 py-1 text-xs font-mono bg-gray-100 border-b">
-            Instant Devtools {app?.title ? `• ${app?.title}` : ''}
+          <div>
+            <div className="px-3 py-1 text-xs font-mono bg-gray-100 border-b">
+              Instant Devtools {app?.title ? `• ${app?.title}` : ''}
+            </div>
+            <XMarkIcon
+              className="cursor-pointer"
+              height="1rem"
+              onClick={() => {
+                parent.postMessage(
+                  {
+                    type: 'close',
+                  },
+                  '*',
+                );
+              }}
+            />
           </div>
           <div className="flex gap-2 px-3 py-1 text-xs font-mono bg-gray-50 border-b">
             <span>App ID</span>


### PR DESCRIPTION
A few improvements to devtool: 

1. I added a localStorage flag, so when these are on on, we default devtools to open our local dashboard
2. I added an `X` button in the devtools pane. people may not know that you can escape with an `esc` key, so wanted to add the button to be explicit 


<img width="1726" alt="CleanShot 2025-02-07 at 10 28 34@2x" src="https://github.com/user-attachments/assets/46671662-14f8-4667-b99a-161840081bb7" />

@nezaj @tonsky @dwwoelfel 