### PR TITLE
Add `id` import in `Writing data` docs

### DIFF
--- a/client/www/pages/docs/instaml.md
+++ b/client/www/pages/docs/instaml.md
@@ -9,7 +9,7 @@ Instant uses a **Firebase-inspired** interface for mutations. We call our mutati
 We use the `update` action to create entities.
 
 ```typescript
-import { init } from '@instantdb/react';
+import { init, id } from '@instantdb/react';
 
 const db = init({
   appId: process.env.NEXT_PUBLIC_INSTANT_APP_ID!,


### PR DESCRIPTION
Hello, this is a fix in the `Writing data` docs where `id` fn was omitted from import. It is important as it took me 10 minutes to find out where this was imported from. Initially, I thought `id` was something that just works inside `transact` as some kind of remarkable js macro.

Current docs: 
<img width="536" alt="image" src="https://github.com/user-attachments/assets/786ffb16-42ab-4ee8-9b98-0e12271bec41" />

Hope this helps 👍 