### PR TITLE
[devtool] add sign out buttons, and more descriptive errors

### DIFF
--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -200,7 +200,7 @@ export default function Auth(props: {
     }));
   };
   return (
-    <div className="flex h-screen items-center justify-center p-4">
+    <div className="flex h-full items-center justify-center p-4">
       <div className="max-w-sm">
         <span className="inline-flex items-center space-x-2">
           <LogoIcon />

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -130,7 +130,7 @@ export default function Devtool() {
       </div>
     );
   }
-  
+
   if (dashResponse.error) {
     const message = dashResponse.error.message;
     return (
@@ -236,7 +236,9 @@ export default function Devtool() {
       <DevtoolWindow>
         <div className="h-full w-full flex justify-center items-center">
           <div className="max-w-md mx-auto space-y-4">
-            <ScreenHeading>🤕 Failed connect to Instant's backend</ScreenHeading>
+            <ScreenHeading>
+              🤕 Failed connect to Instant's backend
+            </ScreenHeading>
             {message ? (
               <div className="mx-auto flex w-full max-w-2xl flex-col">
                 <div className="rounded bg-red-100 p-4 text-red-700">
@@ -246,8 +248,8 @@ export default function Devtool() {
             ) : null}
             <AppIdLabel appId={appId} />
             <p>
-              We had some trouble connect to Instant's backend. Please ping us on discord
-              with details.
+              We had some trouble connect to Instant's backend. Please ping us
+              on discord with details.
             </p>
             <Button
               className="w-full"

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -132,7 +132,7 @@ export default function Devtool() {
   }
 
   if (dashResponse.error) {
-    const message = dashResponse.error?.message;
+    const message = dashResponse.error.message;
     return (
       <DevtoolWindow>
         <div className="h-full w-full flex justify-center items-center">

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -132,7 +132,7 @@ export default function Devtool() {
   }
 
   if (dashResponse.error) {
-    const message = dashResponse.error.message;
+    const message = dashResponse.error?.message;
     return (
       <DevtoolWindow>
         <div className="h-full w-full flex justify-center items-center">
@@ -146,7 +146,14 @@ export default function Devtool() {
               </div>
             ) : null}
             <p>
-              We had some trouble loading your app. Please ping us on discord
+              We had some trouble loading your app. Please ping us on{' '}
+              <a
+                className="font-bold text-blue-500"
+                href="https://discord.com/invite/VU53p7uQcE"
+                target="_blank"
+              >
+                discord
+              </a>{' '}
               with details.
             </p>
             <Button
@@ -249,7 +256,15 @@ export default function Devtool() {
             <AppIdLabel appId={appId} />
             <p>
               We had some trouble connect to Instant's backend. Please ping us
-              on discord with details.
+              on{' '}
+              <a
+                className="font-bold text-blue-500"
+                href="https://discord.com/invite/VU53p7uQcE"
+                target="_blank"
+              >
+                discord
+              </a>{' '}
+              with details.
             </p>
             <Button
               className="w-full"
@@ -510,6 +525,7 @@ function Help() {
         <a
           className="font-bold text-blue-500"
           href="https://discord.com/invite/VU53p7uQcE"
+          target="_blank"
         >
           Discord
         </a>


### PR DESCRIPTION
Made the following changes: 
1. Added a window around error states, so the user always sees a `Close` button 
2. Made sure we had a sign out button in every state (error, signed in, etc)
3. Made some of the error messages more descriptive. 


<img width="1728" alt="CleanShot 2025-02-11 at 12 18 40@2x" src="https://github.com/user-attachments/assets/3ec13810-826c-41d2-ba51-96484610b300" />

<img width="1725" alt="CleanShot 2025-02-11 at 12 19 31@2x" src="https://github.com/user-attachments/assets/d85b4838-5186-4ce6-933b-2fc7eca712d0" />

<img width="1725" alt="CleanShot 2025-02-11 at 12 19 51@2x" src="https://github.com/user-attachments/assets/b005fc4a-b914-4acc-8097-761cd2bb9b44" />

<img width="1726" alt="CleanShot 2025-02-11 at 12 19 07@2x" src="https://github.com/user-attachments/assets/2e93235b-d55b-4d98-bb9d-f505984f0c41" />

<img width="1728" alt="CleanShot 2025-02-11 at 12 17 32@2x" src="https://github.com/user-attachments/assets/c80b1250-ba39-482f-babe-1cec74167c28" />
