### PR TITLE
[Docs] Flexibile initialization

### DIFF
--- a/client/www/pages/docs/init.md
+++ b/client/www/pages/docs/init.md
@@ -2,7 +2,10 @@
 title: Initializing Instant
 ---
 
-The first step to using Instant in your app is to call `init` before rendering your component tree.
+## Basic Initialization
+
+The first step to using Instant in your app is to call `init`. Here is a simple
+example at the root of your app.
 
 ```javascript
 import { init } from '@instantdb/react';
@@ -18,6 +21,30 @@ function App() {
 ```
 
 With that, you can use `db` to [write data](/docs/instaml), [make queries](/docs/instaql), [handle auth](/docs/auth), and more!
+
+## Flexible Initialization
+
+Instant maintains a single connection regardless of where or how many times you
+call `init` with the same app ID. This means you can safely call `init` multiple
+times without worrying about creating multiple connections or
+performance overhead. So you can call `init` in multiple files or export
+a reference to `db` from a utility file. Here's an example
+
+```javascript
+// util/instant.js
+import { init } from '@instantdb/react';
+
+const APP_ID = '__APP_ID__';
+export const db = init({ appId: APP_ID });
+
+// component.js
+import { db } from './util/instant';
+
+function MyComponent() {
+  // do some instant magic 🪄
+  db.useQuery({ ... });
+}
+```
 
 ## Typesafety
 

--- a/client/www/pages/docs/init.md
+++ b/client/www/pages/docs/init.md
@@ -27,8 +27,8 @@ With that, you can use `db` to [write data](/docs/instaml), [make queries](/docs
 Instant maintains a single connection regardless of where or how many times you
 call `init` with the same app ID. This means you can safely call `init` multiple
 times without worrying about creating multiple connections or
-performance overhead. So you can call `init` in multiple files or export
-a reference to `db` from a utility file. Here's an example
+performance overhead. However we do recommend the pattern of exporting a
+reference from a utility file like so:
 
 ```javascript
 // util/instant.js


### PR DESCRIPTION
We got feedback that it wasn't clear if users had to create a singleton model or if the Instant library already handled this and a user could init the db wherever they needed it.

Add a section to the init docs to clear this up