### PR TITLE
[Docs] Defer query docs

### DIFF
--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -377,6 +377,36 @@ console.log(data)
 }
 ```
 
+## Defer queries
+
+You can also defer queries until a condition is met. This is useful when you
+need to wait for some data to be available before you can run your query. Here's
+an example of deferring a fetch for todos until a user is logged in.
+
+```javascript
+const { isLoading, user, error } = useAuth();
+
+const {
+  isLoading: isLoadingTodos,
+  error,
+  data,
+} = useQuery(
+  user
+    ? {
+        // The query will run once user is populated
+        todos: {
+          $: {
+            where: {
+              userId: user.id,
+            },
+          },
+        },
+      }
+    : // Otherwise skip the query, which sets `isLoading` to true
+      null,
+);
+```
+
 ## Pagination
 
 You can limit the number of items from a top level namespace by adding a `limit` to the option map:


### PR DESCRIPTION
We got a question in [discord](https://discord.com/channels/1031957483243188235/1338329481961803837) about how to pause/disable queries. We don't support pausing but we do support deferring and just haven't added that into the docs.

<img width="637" alt="image" src="https://github.com/user-attachments/assets/d971defd-a9f3-40f3-ad2e-fd12cb6f61cd" />
