### PR TITLE
make delete-row sticky

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -961,33 +961,33 @@ export function Explorer({
             </button>
           </div>
           <div className="relative flex flex-1 overflow-x-auto overflow-y-scroll">
-            <div
-              className={clsx(
-                'absolute top-0 right-0 left-[48px] z-30 flex items-center gap-1.5 overflow-hidden bg-white px-4 py-1.5',
-                {
-                  hidden: !Object.keys(checkedIds).length,
-                },
-              )}
-            >
-              <Button
-                disabled={readOnlyNs}
-                title={
-                  readOnlyNs
-                    ? `The ${selectedNamespace?.name} namespace is read-only.`
-                    : undefined
-                }
-                variant="destructive"
-                size="mini"
-                className="flex px-2 py-0 text-xs"
-                onClick={() => {
-                  setDeleteDataConfirmationOpen(true);
-                }}
-              >
-                Delete {rowText}
-              </Button>
-            </div>
             <table className="z-0 w-full flex-1 text-left font-mono text-xs text-gray-500">
               <thead className="sticky top-0 z-20 bg-white text-gray-700 shadow">
+                <div
+                  className={clsx(
+                    'absolute top-0 right-0 left-[48px] z-30 flex items-center gap-1.5 overflow-hidden bg-white px-4 py-2',
+                    {
+                      hidden: !Object.keys(checkedIds).length,
+                    },
+                  )}
+                >
+                  <Button
+                    disabled={readOnlyNs}
+                    title={
+                      readOnlyNs
+                        ? `The ${selectedNamespace?.name} namespace is read-only.`
+                        : undefined
+                    }
+                    variant="destructive"
+                    size="mini"
+                    className="flex px-2 py-0 text-xs"
+                    onClick={() => {
+                      setDeleteDataConfirmationOpen(true);
+                    }}
+                  >
+                    Delete {rowText}
+                  </Button>
+                </div>
                 <tr>
                   <th className="px-2 py-2" style={{ width: '48px' }}>
                     <Checkbox

--- a/server/src/instant/scratch/export.clj
+++ b/server/src/instant/scratch/export.clj
@@ -59,18 +59,13 @@
                                                                            [:cast (json/->json v) :jsonb]))))
                                                     triples)})))))
 
-(defn prod-conn-str []
-  (string/trim (:out (shell/sh "./scripts/prod_connection_string.sh"))))
-
 (defn import!
-  [{:keys [prod-db-uri local-user-email prod-app-id]}]
-  (let [_ (assert prod-db-uri "prod-db-uri is required")
-        _ (assert local-user-email "local-user-email is required")
+  [{:keys [local-user-email prod-app-id]}]
+  (let [_ (assert local-user-email "local-user-email is required")
         _ (assert prod-app-id "prod-app-id is required")
 
         _ (println (format  "Export app_id = %s" prod-app-id))
-        exported-data (with-open [pool (sql/start-pool (assoc (config/db-url->config prod-db-uri)
-                                                              :maximumPoolSize 1))]
+        exported-data (tool/with-prod-conn [pool]
                         (export-app pool prod-app-id))
 
         _ (println "Exported")
@@ -87,8 +82,7 @@
 
 (comment
   (binding [sql/*query-timeout-seconds* 300]
-    (import! {:prod-db-uri (prod-conn-str)
-              :local-user-email "stopa@instantdb.com"
+    (import! {:local-user-email "stopa@instantdb.com"
               :prod-app-id nil})))
 
 


### PR DESCRIPTION
A user reported that delete row did not show up, when you kept scrolling in the explorer. 

This makes delete row sticky, so the no matter how low you scroll, it shows up at the header. 

@dwwoelfel @nezaj @tonsky 

https://github.com/user-attachments/assets/9ae74de0-0f70-4d53-af21-6420dcd91db2