### PR TITLE
[like] handle regex chars

### DIFF
--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -94,11 +94,15 @@ function makeLikeMatcher(caseSensitive, pattern) {
       return false;
     };
   }
-  const regexPattern = pattern.replace(/%/g, '.*').replace(/_/g, '.');
+
+  const escapedPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regexPattern = escapedPattern.replace(/%/g, '.*').replace(/_/g, '.');
+
   const regex = new RegExp(
     `^${regexPattern}$`,
     caseSensitive ? undefined : 'i',
   );
+
   return function likeMatcher(value) {
     if (typeof value !== 'string') {
       return false;


### PR DESCRIPTION
Previously, if you wrote a query like: 

```
{
  "posts": {
    "$": {
      "where": {
        "slug": {
          "$like": "%2)"
        }
      }
    }
  }
}
```

You would get an error: 

```

SyntaxError: Invalid regular expression: /^.*2)$/: Unmatched ')'

Source
new RegExp
<anonymous> (0:0)
../packages/core/dist/module/instaql.js (79:1) @ makeLikeMatcher

  77 |     }
  78 |     const regexPattern = pattern.replace(/%/g, '.*').replace(/_/g, '.');
> 79 |     const regex = new RegExp(^${regexPattern}$, caseSensitive ? undefined : 'i');
     | ^
```

This is because we did not escape special regex chars when creating our like matcher. I updated it so we do. 

@dwwoelfel @nezaj @tonsky 