### PR TITLE
Treat json nulls as postgres nulls in the unique index

### DIFF
--- a/server/resources/migrations/53_change_indexing_of_triple_nulls.down.sql
+++ b/server/resources/migrations/53_change_indexing_of_triple_nulls.down.sql
@@ -1,0 +1,10 @@
+create unique index if not exists av_index_temp_name
+  on triples(app_id, attr_id, value)
+  include (entity_id)
+  where av;
+
+drop index av_index;
+
+drop function public.json_null_to_null(v jsonb);
+
+alter index av_index_temp_name rename to av_index;

--- a/server/resources/migrations/53_change_indexing_of_triple_nulls.up.sql
+++ b/server/resources/migrations/53_change_indexing_of_triple_nulls.up.sql
@@ -1,0 +1,20 @@
+-- XXX: Create this before deploying
+create or replace function public.json_null_to_null(v jsonb) returns jsonb
+  language sql immutable
+  as $$
+    select case
+      when v = 'null'::jsonb then null
+      else v
+  end;
+$$;
+
+-- XXX: Create this concurrently first
+-- XXX: Is this going to break queries that use the index??
+create unique index if not exists av_ignore_nulls_index
+  on triples(app_id, attr_id, json_null_to_null(value))
+  include (entity_id)
+  where av;
+
+drop index av_index;
+
+alter index av_ignore_nulls_index rename to av_index;

--- a/server/resources/migrations/53_change_indexing_of_triple_nulls.up.sql
+++ b/server/resources/migrations/53_change_indexing_of_triple_nulls.up.sql
@@ -1,4 +1,3 @@
--- XXX: Create this before deploying
 create or replace function public.json_null_to_null(v jsonb) returns jsonb
   language sql immutable
   as $$
@@ -8,8 +7,6 @@ create or replace function public.json_null_to_null(v jsonb) returns jsonb
   end;
 $$;
 
--- XXX: Create this concurrently first
--- XXX: Is this going to break queries that use the index??
 create unique index if not exists av_ignore_nulls_index
   on triples(app_id, attr_id, json_null_to_null(value))
   include (entity_id)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -585,7 +585,7 @@
                     :from :triples
                     :where [:and
                             [:= :app-id app-id]
-                            [:= :value [:cast (->json (second lookup)) :jsonb]]
+                            [:= [:json_null_to_null :value] [:cast (->json (second lookup)) :jsonb]]
                             [:= :attr-id [:cast (first lookup) :uuid]]
                             :av]}])))
     :a (in-or-eq :attr-id v)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -552,7 +552,11 @@
                     :keyword nil
                     :map (:data-type idx-val))]
     (if-not data-type
-      [:not= :value (value->jsonb val)]
+      [:not=
+       (if (= idx-val :av)
+         [:json_null_to_null :value]
+         :value)
+       (value->jsonb val)]
       [:and
        [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
        [:not= [(extract-value-fn data-type) :value] val]])))
@@ -565,7 +569,10 @@
     (if (empty? v-set)
       [:= 0 1]
       (if-not data-type
-        (in-or-eq :value (map value->jsonb v-set))
+        (in-or-eq (if (= idx-val :av)
+                    [:json_null_to_null :value]
+                    :value)
+                  (map value->jsonb v-set))
 
         (list* :or (map (fn [v]
                           [:and

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -554,6 +554,7 @@
     (if-not data-type
       [:not=
        (if (= idx-val :av)
+         ;; Make sure it uses the av_index
          [:json_null_to_null :value]
          :value)
        (value->jsonb val)]
@@ -570,6 +571,7 @@
       [:= 0 1]
       (if-not data-type
         (in-or-eq (if (= idx-val :av)
+                    ;; Make sure it uses the av_index
                     [:json_null_to_null :value]
                     :value)
                   (map value->jsonb v-set))
@@ -592,7 +594,11 @@
                     :from :triples
                     :where [:and
                             [:= :app-id app-id]
-                            [:= [:json_null_to_null :value] [:cast (->json (second lookup)) :jsonb]]
+
+                            [:=
+                             ;; Make sure it uses the av_index
+                             [:json_null_to_null :value]
+                             [:cast (->json (second lookup)) :jsonb]]
                             [:= :attr-id [:cast (first lookup) :uuid]]
                             :av]}])))
     :a (in-or-eq :attr-id v)

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -58,7 +58,7 @@
                              (list* :or
                                     (map
                                      (fn [[a v]]
-                                       [:and [:= :attr-id a] [:= :value [:cast (->json v) :jsonb]]])
+                                       [:and [:= :attr-id a] [:= [:json_null_to_null :value] [:cast (->json v) :jsonb]]])
                                      lookups-set))]}))
 
           lookups->eid (->> triples
@@ -216,7 +216,7 @@
                                                          [:and
                                                           :av
                                                           [:= :attr-id a]
-                                                          [:= :value [:cast (->json v) :jsonb]]]))]}]}]])
+                                                          [:= [:json_null_to_null :value] [:cast (->json v) :jsonb]]]))]}]}]])
                   [[[:input-triples
                      {:columns [:idx :app-id :entity-id :attr-id :value]}]
                     {:values input-triples-values}
@@ -351,7 +351,7 @@
                                                              [:and
                                                               :av
                                                               [:= :attr-id a]
-                                                              [:= :value [:cast (->json v) :jsonb]]]))]}]}]])
+                                                              [:= [:json_null_to_null :value] [:cast (->json v) :jsonb]]]))]}]}]])
                       [[[:input-triples
                          {:columns [:idx :app-id :entity-id :attr-id :value]}]
                         {:values (map-indexed
@@ -386,7 +386,7 @@
                                                                            :av
                                                                            [:= :app-id app-id]
                                                                            [:= :attr-id (first v)]
-                                                                           [:= :value [:cast (->json (second v)) :jsonb]]]}]}
+                                                                           [:= [:json_null_to_null :value] [:cast (->json (second v)) :jsonb]]]}]}
                                                      :lookups]]
                                                    [[{:select :entity-id
                                                       :from :triples
@@ -394,7 +394,7 @@
                                                               :av
                                                               [:= :app-id app-id]
                                                               [:= :attr-id (first v)]
-                                                              [:= :value [:cast (->json (second v)) :jsonb]]]}
+                                                              [:= [:json_null_to_null :value] [:cast (->json (second v)) :jsonb]]]}
                                                      :lookups]])
                                            :limit 1}
                                           :else (->json v)]]])])

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -201,7 +201,7 @@
                       {:insert-into [[:triples triple-cols]
                                      {:select triple-cols
                                       :from :enhanced-lookup-refs}]
-                       :on-conflict [:app-id :attr-id :value {:where :av}]
+                       :on-conflict [:app-id :attr-id [:json_null_to_null :value] {:where :av}]
                        :do-nothing true
                        :returning :*}]
 
@@ -331,7 +331,7 @@
                           {:insert-into [[:triples triple-cols]
                                          {:select triple-cols
                                           :from :enhanced-lookup-refs}]
-                           :on-conflict [:app-id :attr-id :value {:where :av}]
+                           :on-conflict [:app-id :attr-id [:json_null_to_null :value] {:where :av}]
                            :do-nothing true
                            :returning :*}]
 

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -351,7 +351,10 @@
                                                              [:and
                                                               :av
                                                               [:= :attr-id a]
-                                                              [:= [:json_null_to_null :value] [:cast (->json v) :jsonb]]]))]}]}]])
+                                                              [:=
+                                                               ;; Make sure it can lookup just from the av_index
+                                                               [:json_null_to_null :value]
+                                                               [:cast (->json v) :jsonb]]]))]}]}]])
                       [[[:input-triples
                          {:columns [:idx :app-id :entity-id :attr-id :value]}]
                         {:values (map-indexed
@@ -386,7 +389,10 @@
                                                                            :av
                                                                            [:= :app-id app-id]
                                                                            [:= :attr-id (first v)]
-                                                                           [:= [:json_null_to_null :value] [:cast (->json (second v)) :jsonb]]]}]}
+                                                                           [:=
+                                                                            ;; Make sure it can lookup just from the av_index
+                                                                            [:json_null_to_null :value]
+                                                                            [:cast (->json (second v)) :jsonb]]]}]}
                                                      :lookups]]
                                                    [[{:select :entity-id
                                                       :from :triples
@@ -394,7 +400,10 @@
                                                               :av
                                                               [:= :app-id app-id]
                                                               [:= :attr-id (first v)]
-                                                              [:= [:json_null_to_null :value] [:cast (->json (second v)) :jsonb]]]}
+                                                              [:=
+                                                               ;; Make sure it can lookup just from the av_index
+                                                               [:json_null_to_null :value]
+                                                               [:cast (->json (second v)) :jsonb]]]}
                                                      :lookups]])
                                            :limit 1}
                                           :else (->json v)]]])])

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -77,8 +77,8 @@
 (defn extract-unique-triple-data [pg-data]
   (when (and (= "triples" (:table pg-data))
              (= "av_index" (:constraint pg-data))
-             (string/starts-with? (:detail pg-data) "Key (app_id, attr_id, value)="))
-    (let [prefix "Key (app_id, attr_id, value)=(00000000-0000-0000-0000-000000000000, "
+             (string/starts-with? (:detail pg-data) "Key (app_id, attr_id, json_null_to_null(value))="))
+    (let [prefix "Key (app_id, attr_id, json_null_to_null(value))=(00000000-0000-0000-0000-000000000000, "
           attr-id (-> (subs (:detail pg-data)
                             (count prefix)
                             (+ (count prefix) 36))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -370,8 +370,8 @@
 
   (testing "makes sure we use distinct"
     (is-pretty-eq? (-> (iq/query @ctx {:users {:$ {:where {:bookshelves {:in
-                                                                         ;; `eid-worldview` and `eid-the-way-of-the-gentleman` 
-                                                                         ;; both match `stopa` 
+                                                                         ;; `eid-worldview` and `eid-the-way-of-the-gentleman`
+                                                                         ;; both match `stopa`
                                                                          ;; limit `3` should _still_ return joe, stopa, alex
                                                                          [(resolvers/->uuid @r "eid-worldview")
                                                                           (resolvers/->uuid @r "eid-the-way-of-the-gentleman")
@@ -2638,6 +2638,75 @@
 
           (testing "uses index"
             (is (= "triples_boolean_type_idx" (run-explain :boolean true)))))))))
+
+(deftest lookup-unique-uses-the-av-index
+  (with-empty-app
+    (fn [app]
+      (let [attr-ids {:id (random-uuid)
+                      :handle (random-uuid)}
+            make-ctx (fn []
+                       (let [attrs (attr-model/get-by-app-id (:id app))]
+                         {:db {:conn-pool (aurora/conn-pool :read)}
+                          :app-id (:id app)
+                          :attrs attrs}))
+            _ (tx/transact! (aurora/conn-pool :write)
+                            (attr-model/get-by-app-id (:id app))
+                            (:id app)
+                            (concat [[:add-attr {:id (:id attr-ids)
+                                                 :forward-identity [(random-uuid) "user" "id"]
+                                                 :unique? true
+                                                 :index? false
+                                                 :value-type :blob
+                                                 :cardinality :one}]
+                                     [:add-attr {:id (:handle attr-ids)
+                                                 :forward-identity [(random-uuid) "user" "handle"]
+                                                 :unique? true
+                                                 :index? false
+                                                 :value-type :blob
+                                                 :cardinality :one}]]
+                                    (let [id (random-uuid)]
+                                      [[:add-triple id (:id attr-ids) (str id)]
+                                       [:add-triple id (:handle attr-ids) (str "a")]])
+                                    (let [id (random-uuid)]
+                                      [[:add-triple id (:id attr-ids) (str id)]
+                                       [:add-triple id (:handle attr-ids) (str "b")]])))]
+        (testing "query on unique attr"
+          (let [{:keys [patterns]} (iq/instaql-query->patterns
+                                    (make-ctx)
+                                    {:user {:$ {:where {:handle "a"}}}})
+                explain (d/explain (make-ctx) patterns)
+                plan (-> explain
+                         (get "QUERY PLAN")
+                         first
+                         (get-in ["Plan" "Plans"])
+                         first)
+                ;; Make sure it's using the full index
+                expected-index-cond (format "((triples.app_id = '%s'::uuid) AND (triples.attr_id = '%s'::uuid) AND (CASE WHEN (triples.value = 'null'::jsonb) THEN NULL::jsonb ELSE triples.value END = '\"a\"'::jsonb))"
+                                            (:id app)
+                                            (:handle attr-ids))]
+
+            (is (= expected-index-cond (get plan "Index Cond")))
+            (is (= "av_index" (get plan "Index Name")))))
+
+        (testing "query with lookup"
+          (let [explain (d/explain (make-ctx) {:children
+                                               {:pattern-groups
+                                                [{:patterns
+                                                  [[:ea [(:handle attr-ids) "a"]]]}]}})
+                plan (-> explain
+                         (get "QUERY PLAN")
+                         first
+                         (get-in ["Plan" "Plans"])
+                         first
+                         (get "Plans")
+                         first)
+                ;; Make sure it's using the full index
+                expected-index-cond (format "((triples.app_id = '%s'::uuid) AND (triples.attr_id = '%s'::uuid) AND (CASE WHEN (triples.value = 'null'::jsonb) THEN NULL::jsonb ELSE triples.value END = '\"a\"'::jsonb))"
+                                            (:id app)
+                                            (:handle attr-ids))]
+
+            (is (= expected-index-cond (get plan "Index Cond")))
+            (is (= "av_index" (get plan "Index Name")))))))))
 
 (deftest arbitrary-order-by-all-types
   (with-empty-app


### PR DESCRIPTION
Part 1 of fast paginated queries across many entities.

Also fixes a bug reported at https://discord.com/channels/1031957483243188235/1304944961380286515

After this change, users will be able to store multiple entities that have null as the value for a unique attribute.

As part of making pagination queries faster, we need all the null values to already be in the index. We'll have to auto-populate the null values ourselves if they're undefined. We don't want to break users' `unique` indexes by inserting nulls, so we treat jsonb nulls like postgres null and postgres automatically treats them as distinct values.

We do this by converting `'null'::jsonb` into a postgres `NULL` in an index expression. That way postgres treats the null just like postgres nulls in the index.

Other alternatives we considered:

1. Make the `value` column nullable. Decided against this because the size of the change is a lot bigger and scarier.
2. Use a partial index that filters "null". Decided against this because it might be handy to be able to look up null things in the index.

Deployment plan:

1. Create the index concurrently:

```
create or replace function public.json_null_to_null(v jsonb) returns jsonb
  language sql immutable
  as $$
    select case
      when v = 'null'::jsonb then null
      else v
  end;
$$;

create unique index concurrently av_ignore_nulls_index
  on triples(app_id, attr_id, json_null_to_null(value))
  include (entity_id)
  where av;
```

3. Deploy the backend and wait for it to fully deploy

4. Run the migration

We need both indexes to be active while both versions of the code are active. The migration replaces the av_index with the new one, so we want to wait until all instances are on the new version before running the migation.


