### PR TITLE
[self-links] Fix and clauses for self links

### DIFF
--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -288,12 +288,13 @@ function isAndClauses([k, v]) {
 
 // Creates a makeVar that will namespace symbols for or clauses
 // to prevent conflicts, except for the base etype
-function genMakeVar(baseMakeVar, etype, orIdx) {
+function genMakeVar(baseMakeVar, joinSym, orIdx) {
   return (x, lvl) => {
-    if (x == etype) {
-      return baseMakeVar(x, lvl);
+    const base = baseMakeVar(x, lvl);
+    if (joinSym == base) {
+      return base;
     }
-    return `${baseMakeVar(x, lvl)}-${orIdx}`;
+    return `${base}-${orIdx}`;
   };
 }
 
@@ -305,11 +306,11 @@ function parseWhereClauses(
   level,
   whereValue,
 ) {
+  const joinSym = makeVar(etype, level);
   const patterns = whereValue.map((w, i) => {
-    const makeNamespacedVar = genMakeVar(makeVar, etype, i);
+    const makeNamespacedVar = genMakeVar(makeVar, joinSym, i);
     return parseWhere(makeNamespacedVar, store, etype, level, w);
   });
-  const joinSym = makeVar(etype, level);
   return { [clauseType]: { patterns, joinSym } };
 }
 

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -487,10 +487,10 @@
 
 (defn- level-sym-gen
   "Generates a level-sym function that will namespace all but the join variable."
-  [base-level-sym etype idx]
+  [base-level-sym join-sym idx]
   (fn level-sym [x level]
     (let [base (base-level-sym x level)]
-      (if (= x etype)
+      (if (= join-sym base)
         base
         (symbol (str base "-" idx))))))
 
@@ -644,7 +644,10 @@
           (update ret :pats optimize-attr-pats)))
       :or (-> (reduce
                (fn [acc [i conds]]
-                 (let [level-sym (level-sym-gen level-sym (:etype form) i)]
+                 (let [join-sym (attr-pat/default-level-sym
+                                 (:etype form)
+                                 (:level form))
+                       level-sym (level-sym-gen level-sym join-sym i)]
                    (as-> (where-conds->patterns (assoc ctx :level-sym level-sym)
                                                 form
                                                 conds) %
@@ -661,7 +664,10 @@
 
       :and (-> (reduce
                 (fn [acc [i conds]]
-                  (let [level-sym (level-sym-gen level-sym (:etype form) i)]
+                  (let [join-sym (attr-pat/default-level-sym
+                                  (:etype form)
+                                  (:level form))
+                        level-sym (level-sym-gen level-sym join-sym i)]
                     (as-> (where-conds->patterns (assoc ctx :level-sym level-sym)
                                                  form
                                                  conds) %


### PR DESCRIPTION
### Context

Consider a setup like so: 

![image](https://github.com/user-attachments/assets/bb7583b4-0f65-426e-bd3c-dd5820a0ff0a)

![image](https://github.com/user-attachments/assets/bbf3e803-fceb-408a-b2d9-250695ad6dab)

todo { name todo1 } links to blocks {name child1}  and blocks { name child2 } 

### Problem

The following query would fail to return any rows: 

```json
{
  "todos": {
    "$": {
      "where": {
        "and": [
          {
            "blocks.name": "child1"
          },
          {
            "blocks.name": "child2"
          }
        ]
      }
    }
  }
}
```

### Cause

This is because when we generated the datalog, the variable `?blocks-1` was re-used across and conditions: 

```edn
{:children
 {:pattern-groups
  [{:patterns
    [{:and
      [{:and
        [[{:idx-key :ave, :data-type :string}
          ?blocks-1
          #uuid "36410869-50da-442a-86cd-5e75e0143254"
          "child1"]
         [:eav
          ?blocks-1
          #uuid "59b5b318-d71b-47e2-abb5-107004b5ee82"
          ?blocks-0]]}
       {:and
        [[{:idx-key :ave, :data-type :string}
          ?blocks-1
          #uuid "36410869-50da-442a-86cd-5e75e0143254"
          "child2"]
         [:vae
          ?blocks-1
          #uuid "59b5b318-d71b-47e2-abb5-107004b5ee82"
          ?blocks-0]]}]}],
    :children
    {:pattern-groups
     [{:patterns
       [[:ea
         ?blocks-0
         #{#uuid "36410869-50da-442a-86cd-5e75e0143254"
           #uuid "59b5b318-d71b-47e2-abb5-107004b5ee82"
           #uuid "561b04d3-7129-40f3-8738-99daf234de76"}]]}],
     :join-sym ?blocks-0}}]}}
```

### level-sym-gen 

I found the problem in level-sym-gen: 

```clojure
(defn- level-sym-gen
  "Generates a level-sym function that will namespace all but the join variable."
  [base-level-sym etype idx]
  (fn level-sym [x level]
    (let [base (base-level-sym x level)]
      (if (= x etype)
        base
        (symbol (str base "-" idx))))))
```

Since our check said `(= x etype)`, we would use the `base-level-sym` for the child variable names, since the child was the same etype

### Solution

Instead of passing in the etype, we instead pass in the join-sym itself. This way, if we 'generate' the join-sym, we know to leave it alone. 

I am not _100%_ sure that this solution makes the most sense. _Perhaps_ when we are generating the level-sym, it's possible for `base` to be a join-sym value, when it shouldn't be? The tests do pass though.

--- 

@dwwoelfel @nezaj @tonsky 
