### PR TITLE
[ex] be a bit harsher on how we parse magic codes 

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -242,7 +242,7 @@
 
 (defn verify-magic-code-post [req]
   (let [email (ex/get-param! req [:body :email] email/coerce)
-        code (ex/get-param! req [:body :code] string/trim)
+        code (ex/get-param! req [:body :code] string-util/ensure-non-blank-str)
         {user-id :user_id} (instant-user-magic-code-model/consume!
                             {:code code :email email})
         {refresh-token-id :id} (instant-user-refresh-token-model/create!
@@ -290,19 +290,19 @@
 
 (defn admin-overview-daily-get [req]
   (let [{:keys [email]} (req->auth-user! req)
-          _ (assert-admin-email! email)
-          conn (aurora/conn-pool :read)
-          overview (metrics/overview-metrics conn)
-          rev-subs (dash-admin/get-revenue-generating-subscriptions)
-          overview-with-b64-charts
-          (update overview :charts (partial medley/map-vals
-                                            (fn [chart] (metrics/chart->base64-png chart
-                                                                                   500 400))))
-          subscription-info {:num-subs (count rev-subs)
-                             :total-monthly-revenue (reduce + (map :monthly-revenue rev-subs))}]
+        _ (assert-admin-email! email)
+        conn (aurora/conn-pool :read)
+        overview (metrics/overview-metrics conn)
+        rev-subs (dash-admin/get-revenue-generating-subscriptions)
+        overview-with-b64-charts
+        (update overview :charts (partial medley/map-vals
+                                          (fn [chart] (metrics/chart->base64-png chart
+                                                                                 500 400))))
+        subscription-info {:num-subs (count rev-subs)
+                           :total-monthly-revenue (reduce + (map :monthly-revenue rev-subs))}]
 
-      (response/ok (assoc overview-with-b64-charts
-                          :subscription-info subscription-info))))
+    (response/ok (assoc overview-with-b64-charts
+                        :subscription-info subscription-info))))
 
 (defn admin-overview-minute-get [req]
   (let [{:keys [email]} (req->auth-user! req)
@@ -355,7 +355,7 @@
     (response/ok {:profile profile})))
 
 (defn apps-post [req]
-  (let [title (ex/get-param! req [:body :title] string/trim)
+  (let [title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         id (ex/get-param! req [:body :id] uuid-util/coerce)
         token (ex/get-param! req [:body :admin_token] uuid-util/coerce)
         {creator-id :id} (req->auth-user! req)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -242,7 +242,7 @@
 
 (defn verify-magic-code-post [req]
   (let [email (ex/get-param! req [:body :email] email/coerce)
-        code (ex/get-param! req [:body :code] string-util/ensure-non-blank-str)
+        code (ex/get-param! req [:body :code] string-util/safe-trim)
         {user-id :user_id} (instant-user-magic-code-model/consume!
                             {:code code :email email})
         {refresh-token-id :id} (instant-user-refresh-token-model/create!

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -163,7 +163,7 @@
 
 (defn verify-magic-code-post [req]
   (let [email (ex/get-param! req [:body :email] email/coerce)
-        code (ex/get-param! req [:body :code] string-util/ensure-non-blank-str)
+        code (ex/get-param! req [:body :code] string-util/safe-trim)
 
         app-id (ex/get-param! req [:body :app-id] uuid-util/coerce)
         m (app-user-magic-code-model/consume!

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -163,7 +163,8 @@
 
 (defn verify-magic-code-post [req]
   (let [email (ex/get-param! req [:body :email] email/coerce)
-        code (ex/get-param! req [:body :code] string/trim)
+        code (ex/get-param! req [:body :code] string-util/ensure-non-blank-str)
+
         app-id (ex/get-param! req [:body :app-id] uuid-util/coerce)
         m (app-user-magic-code-model/consume!
            {:app-id app-id
@@ -354,16 +355,16 @@
   {:status 200
    :headers {"content-type" "text/html"}
    :body (str (h/html (h/raw "<!DOCTYPE html>")
-                [:html {:lang "en"}
-                 [:head
-                  [:meta {:charset "UTF-8"}]
-                  [:meta {:name "viewport"
-                          :content "width=device-width, initial-scale=1.0"}]
-                  [:meta {:http-equiv "refresh"
-                          :content (format "0; url=%s" redirect-url)}]
+                      [:html {:lang "en"}
+                       [:head
+                        [:meta {:charset "UTF-8"}]
+                        [:meta {:name "viewport"
+                                :content "width=device-width, initial-scale=1.0"}]
+                        [:meta {:http-equiv "refresh"
+                                :content (format "0; url=%s" redirect-url)}]
 
-                  [:title "Finish Sign In"]
-                  [:style "
+                        [:title "Finish Sign In"]
+                        [:style "
                            body {
                              margin: 0;
                              height: 100vh;
@@ -404,17 +405,17 @@
                                background-color: black;
                              }
                            }"]]
-                 [:body
-                  [:p "Logged in as " email]
-                  [:p
-                   [:a {:class "button"
-                        :href redirect-url}
-                    "Open app"]]
-                  [:p [:a {:onclick "(function() { window.close();})()"} "Close"]]
-                  [:script {:type "text/javascript"
-                            :id "redirect-script"
-                            :data-redirect-uri redirect-url}
-                   (h/raw "window.open(document.getElementById('redirect-script').getAttribute('data-redirect-uri'), '_self')")]]]))})
+                       [:body
+                        [:p "Logged in as " email]
+                        [:p
+                         [:a {:class "button"
+                              :href redirect-url}
+                          "Open app"]]
+                        [:p [:a {:onclick "(function() { window.close();})()"} "Close"]]
+                        [:script {:type "text/javascript"
+                                  :id "redirect-script"
+                                  :data-redirect-uri redirect-url}
+                         (h/raw "window.open(document.getElementById('redirect-script').getAttribute('data-redirect-uri'), '_self')")]]]))})
 
 (defn oauth-callback [{:keys [params] :as req}]
   (try

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -13,7 +13,8 @@
             [instant.model.app-member-invites :as instant-app-member-invites-model]
             [clojure.walk :as w]
             [instant.model.rule :as rule-model]
-            [instant.model.schema :as schema-model])
+            [instant.model.schema :as schema-model]
+            [instant.util.string :as string-util])
 
   (:import
    (java.util UUID)))
@@ -40,7 +41,7 @@
 
 (defn apps-create-post [req]
   (let [{user-id :id} (req->superadmin-user! req)
-        title (ex/get-param! req [:body :title] string/trim)
+        title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         app (app-model/create! {:id (UUID/randomUUID)
                                 :title title
                                 :creator-id user-id
@@ -53,7 +54,7 @@
 
 (defn app-update-post [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
-        title (ex/get-param! req [:body :title] string/trim)
+        title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         app (app-model/rename-by-id! {:id app-id :title title})]
     (response/ok {:app app})))
 

--- a/server/src/instant/util/string.clj
+++ b/server/src/instant/util/string.clj
@@ -24,6 +24,10 @@
     (.update ^CRC32 crc bytes)
     (.getValue ^CRC32 crc)))
 
+(defn ensure-non-blank-str [s]
+  (and (string? s)
+       (string/trim s)))
+
 (defn coerce-non-blank-str [s]
   (cond
     (number? s) (str s)

--- a/server/src/instant/util/string.clj
+++ b/server/src/instant/util/string.clj
@@ -24,7 +24,7 @@
     (.update ^CRC32 crc bytes)
     (.getValue ^CRC32 crc)))
 
-(defn ensure-non-blank-str [s]
+(defn safe-trim [s]
   (and (string? s)
        (string/trim s)))
 


### PR DESCRIPTION
Previous we used string/trim to parse magic codes. This threw a 500 error. 

I instead added a `safe-trim` function, which a) guarantees the input is a string, and then trims it. 

I also updated a few other places to use `coerce-non-blank-str` 

@dwwoelfel @nezaj @tonsky 


