### PR TITLE
type-checked -> typed in error message

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -797,13 +797,13 @@
                                 (format "The `%s` attribute is still in the process of indexing. It must finish before ordering by the attribute."
                                         (attr-model/fwd-friendly-name order-attr)))
                               (when (not (:index? order-attr))
-                                (format "The `%s` attribute is not indexed. Only indexed and type-checked attrs can be used to order by."
+                                (format "The `%s` attribute is not indexed. Only indexed and typed attributes can be used to order by."
                                         (attr-model/fwd-friendly-name order-attr)))
                               (when (not (:checked-data-type order-attr))
-                                (format "The `%s` attribute is not type-checked. Only type-checked and indexed attrs can be used to order by."
+                                (format "The `%s` attribute is not typed. Only typed and indexed attributes can be used to order by."
                                         (attr-model/fwd-friendly-name order-attr)))
                               (when (not= :one (:cardinality order-attr))
-                                (format "The `%s` attribute has cardinality `%s`. Only attrs with cardinality `one` can be used to order by."
+                                (format "The `%s` attribute has cardinality `%s`. Only attributes with cardinality `one` can be used to order by."
                                         (attr-model/fwd-friendly-name order-attr)
                                         (name (:cardinality order-attr))))])]
             (when (seq errors)

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -287,7 +287,7 @@
           (is (= '{:expected supported-order?,
                    :in ["etype" :$ :order],
                    :message
-                   "The `etype.unchecked` attribute is not indexed. Only indexed and type-checked attrs can be used to order by."}
+                   "The `etype.unchecked` attribute is not indexed. Only indexed and typed attributes can be used to order by."}
                  (validation-err ctx {:etype {:$ {:order {:unchecked "desc"}}}})))
 
           (is (= '{:expected valid-cursor?,


### PR DESCRIPTION
A user as confused by our `type-checked` error message. It looks like he assumed `type-checked` was different from `typed`. 

I thought might be nicer to have the error message say `typed`. 

https://discord.com/channels/1031957483243188235/1338513223795605564

@dwwoelfel @nezaj @tonsky 