### PR TITLE
Fix store snapshot when no store for app

### DIFF
--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -343,7 +343,13 @@
 (defn- store-snapshot [store app-id]
   (rs/->ReactiveStore
    (ds/conn-from-db @(:sessions store))
-   (ConcurrentHashMap. {app-id (-> store :conns (Map/.get app-id) deref ds/conn-from-db)})))
+   (ConcurrentHashMap. (if-let [conn (some-> store
+                                             :conns
+                                             (Map/.get app-id)
+                                             deref
+                                             ds/conn-from-db)]
+                         {app-id conn}
+                         {}))))
 
 (defn wal-latency-ms [{:keys [tx-created-at]}]
   (when tx-created-at


### PR DESCRIPTION
If there's no conn in the store for the given app, we'll get a `Cannot invoke "java.util.concurrent.Future.get()" because "fut" is null` error.

