### PR TITLE
[devtool] let folks set positions, and set z-index

### DIFF
--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -21,3 +21,13 @@ export interface IInstantDatabase<
 > {
   tx: TxChunk<Schema>;
 }
+
+export type DevtoolPosition =
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'top-right'
+  | 'top-left';
+
+export type DevtoolConfig = {
+  position: DevtoolPosition;
+};

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -21,7 +21,7 @@ import type {
   PresenceSlice,
   RoomSchemaShape,
 } from './presence';
-import type { IDatabase, IInstantDatabase } from './coreTypes';
+import type { DevtoolConfig, IDatabase, IInstantDatabase } from './coreTypes';
 import type {
   Query,
   QueryResponse,
@@ -89,14 +89,14 @@ export type Config = {
   appId: string;
   websocketURI?: string;
   apiURI?: string;
-  devtool?: boolean;
+  devtool?: boolean | DevtoolConfig;
 };
 
 export type InstantConfig<S extends InstantSchemaDef<any, any, any>> = {
   appId: string;
   websocketURI?: string;
   apiURI?: string;
-  devtool?: boolean;
+  devtool?: boolean | DevtoolConfig;
   schema?: S;
 };
 
@@ -662,7 +662,11 @@ function init<
       !Boolean((globalThis as any)._nodevtool);
 
     if (showDevtool) {
-      createDevtool(config.appId);
+      const devtoolOptions =
+        typeof config.devtool === 'object'
+          ? config.devtool
+          : { position: 'bottom-right' as const };
+      createDevtool(config.appId, devtoolOptions);
     }
   }
 

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -385,12 +385,16 @@ function DevtoolWindow({
   app?: InstantApp;
   children: React.ReactNode;
 }) {
+  const isLocalHost =
+    typeof window !== 'undefined' && window.location.hostname === 'localhost';
+
   return (
     <div className="h-full w-full">
       <div className="flex flex-col h-full w-full">
         <div className="flex p-2 text-xs bg-gray-100 border-b">
           <div className="flex-1 font-mono">
             Instant Devtools {app?.title ? `• ${app?.title}` : ''}
+            {isLocalHost ? ' • localhost' : ''}
           </div>
           <XMarkIcon
             className="cursor-pointer"


### PR DESCRIPTION
1. Set the toggler to a high z-index, so it still shows up if the user writes some code that uses absolute positons
2. Set the default to be bottom-right (nextjs also has a button that shows up on the bottom left
3. Added a little (* localhost) flag in our iframe. This is mainly for us, as it's hard to quickly know when loading the iframe, if we are loading localhost:3000 dash or instantdb.com/dash

I am going to follow up with a docs page. I realize we don't have docs for devtool 

@dwwoelfel @nezaj @tonsky 