### PR TITLE
[cli] make sure to check that the default export is a schema export

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1409,6 +1409,17 @@ async function readLocalSchemaFileWithErrorLogging() {
     return;
   }
 
+  if (schema?.constructor?.name !== 'InstantSchemaDef') {
+    error("We couldn't find your schema export.");
+    error(
+      'In your ' +
+        chalk.green('`instant.schema.ts`') +
+        ' file, make sure you ' +
+        chalk.green('`export default schema`'),
+    );
+    return;
+  }
+
   return schema;
 }
 


### PR DESCRIPTION
A user reported that they would get 'no changes' whenever they ran schema push.

It's because they did not export the `schema`. Right now adding a detection for it, and erroring out: 

![image](https://github.com/user-attachments/assets/f6f0b205-abe2-4d52-8fb8-6d619a668999)

We may want to be more forgiving in the future (for example by detecting if the export includes a { schema } 

@dwwoelfel @nezaj @tonsky 
