### PR TITLE
Fix join queries not using the av-index

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -657,6 +657,18 @@
 (defn- function-clauses [named-pattern]
   (value-function-clauses (:idx named-pattern) (:v named-pattern)))
 
+(defn patch-values-for-av-index
+  "Make sure we wrap :value in [:json_null_to_null :value] when using :av
+   or postgres won't use the index."
+  [idx-key clauses]
+  (if-not (= idx-key :av)
+    clauses
+    (map (fn [clause]
+           (if (and (vector? clause)
+                    (= (nth clause 1) :value))
+             (update clause 1 (fn [v] [:json_null_to_null v]))))
+         clauses)))
+
 (defn- where-clause
   "
     Given a named pattern, return a where clause with the constants:
@@ -678,7 +690,7 @@
                 (map (fn [[component-type v]]
                        (constant->where-part idx app-id component-type v))))
            (function-clauses named-pattern)
-           additional-clauses)))
+           (patch-values-for-av-index (idx-key idx) additional-clauses))))
 
 (comment
   (where-clause

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -666,7 +666,8 @@
     (map (fn [clause]
            (if (and (vector? clause)
                     (= (nth clause 1) :value))
-             (update clause 1 (fn [v] [:json_null_to_null v]))))
+             (update clause 1 (fn [v] [:json_null_to_null v]))
+             clause))
          clauses)))
 
 (defn- where-clause


### PR DESCRIPTION
Not the greatest fix, but this should fix the slow queries people are reporting.

The issue is that we generate a join clause that looks like this:

```
match_0_1 AS MATERIALIZED (
  SELECT
    match_0_0.*,
    ...
  FROM
    triples,
    match_0_0
  WHERE
    app_id = 'app-id'
    AND (av = true)
    AND (attr_id = 'attr-id')
    -- join clause to parent here
    AND (value = TO_JSONB(match_0_0_entity_id))
)
````

That won't use the av_index without nulls, because it has json_null_to_null(value) stored in the index.

When we generate the join clause, we don't know that it's an av index, so we don't know to wrap in `json_null_to_null`. As a hack, this pr maps through the extra join clauses and wraps `:value` in `[:json_null_to_null :value]` when it knows that it's using the :av index.