### PR TITLE
pre-commit hook that checks linting

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -15,6 +15,10 @@ dev-oss:
 	@echo "Starting server..."
 	clojure -M:dev:run
 
+install-hooks:
+	@echo "Installing .git/hooks/pre-commit..."
+	ln -f -s ../../server/dev-resources/hooks/pre-commit ../.git/hooks/pre-commit
+
 docker-compose:
 	$(DC) -f ./docker-compose-dev.yml build && $(DC) -f ./docker-compose-dev.yml up
 

--- a/server/dev-resources/hooks/pre-commit
+++ b/server/dev-resources/hooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# A pre-commit hook to run clj-kondo against changed files
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=$(git hash-object -t tree /dev/null)
+fi
+
+if !(git diff --cached --name-only --diff-filter=AM $against | grep -E '.clj[cs]?$' | xargs -r clj-kondo --lint)
+then
+    echo
+    echo "Error: new clj-kondo errors found. Please fix them, make sure 'make lint' runs without warnings and then commit."
+    exit 1
+fi
+
+exec git diff-index --check --cached $against --

--- a/server/src/tasks.clj
+++ b/server/src/tasks.clj
@@ -7,9 +7,7 @@
             [instant.config :as config]
             [lambdaisland.uri :as uri]
             [next.jdbc.connection :refer [jdbc-url]])
-  (:import (java.nio.file FileAlreadyExistsException Files Path)
-           (java.nio.file.attribute FileAttribute)
-           (java.io BufferedReader InputStreamReader)
+  (:import (java.io BufferedReader InputStreamReader)
            (sun.misc Signal SignalHandler)))
 
 (defn read-input []
@@ -73,14 +71,6 @@
            {:aead-keyset {:encrypted? false
                           :json (crypt-util/generate-unencrypted-aead-keyset)}}))))
 
-(defn copy-hooks []
-  (println "Installing git hooks")
-  (let [src (Path/of "../../server/dev-resources/hooks/pre-commit" (make-array String 0))
-        tgt (Path/of "../.git/hooks/pre-commit" (make-array String 0))]
-    (try
-      (Files/createSymbolicLink tgt src (make-array FileAttribute 0))
-      (catch FileAlreadyExistsException _e #_ignore))))
-
 (defn migrate-database []
   (config/init)
   (let [database-url (-> (config/get-aurora-config)
@@ -99,6 +89,5 @@
   "Helper to setup everything the server needs for its initial run."
   [_args]
   (ensure-override-config)
-  (copy-hooks)
   (println "Migrating database")
   (migrate-database))

--- a/server/src/tasks.clj
+++ b/server/src/tasks.clj
@@ -7,7 +7,9 @@
             [instant.config :as config]
             [lambdaisland.uri :as uri]
             [next.jdbc.connection :refer [jdbc-url]])
-  (:import (java.io BufferedReader InputStreamReader)
+  (:import (java.nio.file FileAlreadyExistsException Files Path)
+           (java.nio.file.attribute FileAttribute)
+           (java.io BufferedReader InputStreamReader)
            (sun.misc Signal SignalHandler)))
 
 (defn read-input []
@@ -71,6 +73,14 @@
            {:aead-keyset {:encrypted? false
                           :json (crypt-util/generate-unencrypted-aead-keyset)}}))))
 
+(defn copy-hooks []
+  (println "Installing git hooks")
+  (let [src (Path/of "../../server/dev-resources/hooks/pre-commit" (make-array String 0))
+        tgt (Path/of "../.git/hooks/pre-commit" (make-array String 0))]
+    (try
+      (Files/createSymbolicLink tgt src (make-array FileAttribute 0))
+      (catch FileAlreadyExistsException _e #_ignore))))
+
 (defn migrate-database []
   (config/init)
   (let [database-url (-> (config/get-aurora-config)
@@ -89,5 +99,6 @@
   "Helper to setup everything the server needs for its initial run."
   [_args]
   (ensure-override-config)
+  (copy-hooks)
   (println "Migrating database")
   (migrate-database))


### PR DESCRIPTION
To install:

```
make bootstrap-oss
```

Looks like this:

```
[~/ws/instant/server] git commit -am "abc"
server/src/instant/db/cel.clj:6:5: warning: namespace clojure.java.io is required but never used
server/src/tasks.clj:82:41: warning: unused binding e
linting took 63ms, errors: 0, warnings: 2

Error: new clj-kondo errors found. Please fix them, make sure 'make lint' runs without warnings and then commit.
[~/ws/instant/server]
[~/ws/instant/server] git commit -am "abc"
server/src/instant/db/cel.clj:6:5: warning: namespace clojure.java.io is required but never used
linting took 32ms, errors: 0, warnings: 1

Error: new clj-kondo errors found. Please fix them, make sure 'make lint' runs without warnings and then commit.
[~/ws/instant/server] git commit -am "abc"
linting took 14ms, errors: 0, warnings: 0
[pre-commit-lint-hook a6fa5269] abc
 1 file changed, 12 insertions(+), 1 deletion(-)
[~/ws/instant/server]
```

Relies on system-wide `clj-kondo`, but I prefer it since clojure one takes three seconds to start and graalvm less than 100 ms