### PR TITLE
[devtool]  allowedHosts

### DIFF
--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -29,5 +29,20 @@ export type DevtoolPosition =
   | 'top-left';
 
 export type DevtoolConfig = {
+  /**
+   * Position of the devtool panel on the screen
+   * @default 'bottom-right'
+   */
+  position?: DevtoolPosition;
+
+  /**
+   * Hosts where the devtool should be shown
+   * @default ['localhost']
+   */
+  allowedHosts?: string[];
+};
+
+export type StrictDevtoolConfig = {
   position: DevtoolPosition;
+  allowedHosts: string[];
 };

--- a/client/packages/core/src/devtool.ts
+++ b/client/packages/core/src/devtool.ts
@@ -1,11 +1,15 @@
-import { DevtoolConfig, DevtoolPosition } from './coreTypes';
+import {
+  DevtoolConfig,
+  DevtoolPosition,
+  StrictDevtoolConfig,
+} from './coreTypes';
 import * as flags from './utils/flags';
 
 type Devtool = { dispose: () => void };
 
 let currentDevtool: Devtool | undefined;
 
-export function createDevtool(appId: string, config: DevtoolConfig) {
+export function createDevtool(appId: string, config: StrictDevtoolConfig) {
   currentDevtool?.dispose();
 
   const iframeContrainer = createIframeContainer(config);

--- a/client/www/pages/docs/devtool.md
+++ b/client/www/pages/docs/devtool.md
@@ -8,7 +8,7 @@ When you load your app in development, you'll notice a little "Instant" Icon sho
 
 This is your handy `devtool` shortcut. Once you click it, you'll see a widget that lets you make changes to your app.
 
-Use the `Explorer` to make changes to your data and schema:
+Use the `Explorer` to change up your data and schema:
 
 {% screenshot src="/img/docs/devtool-explorer.png" /%}
 
@@ -18,7 +18,7 @@ Or the `Sandbox` to try out different queries and transactions:
 
 ## Changing Positions
 
-You can choose where your devtool is positioned. Pass in the `devtool` configuration in `init`:
+You can choose where to position your devtool as well. Pass in the `devtool` configuration in `init`:
 
 ```typescript
 import { init } from '@instantdb/react';
@@ -36,9 +36,27 @@ const db = init({
 
 You can set `bottom-left`, `top-left`, `top-right`, `bottom-right`.
 
-## Disabling the Devtool
+## Custom Hosts
 
-If you would like to hide the devtool, you can add `devtool: false` in `init`:
+By default, the devtool only shows up on `localhost`. But you can decide which hosts to show it on too. Pass in the `allowedHosts` option:
+
+```typescript
+import { init } from '@instantdb/react';
+
+import schema from '../instant.schema.ts';
+
+const db = init({
+  appId: process.env.NEXT_PUBLIC_INSTANT_APP_ID!,
+  schema,
+  devtool: {
+    allowedHosts: ['localhost', 'site.local'],
+  },
+});
+```
+
+## Disabling the devtool
+
+If you would like to hide the devtool completely, you can add `devtool: false` in `init`:
 
 ```typescript
 import { init } from '@instantdb/react';
@@ -58,4 +76,4 @@ To quickly toggle the window, you can use the shortcut `ctrl` + `shit` + `0` (ze
 
 ## Feedback?
 
-If you have any feedback for the devtool, let us know on [Discord](https://discord.com/invite/VU53p7uQcE)
+If you have any feedback, let us know on [Discord](https://discord.com/invite/VU53p7uQcE)


### PR DESCRIPTION
This adds an `allowedHosts` config key. It can be useful if a user has a custom scheme for loading dev pages -- i.e `site.local`, etc 


@nezaj @tonsky @dwwoelfel 