### PR TITLE
[docs] keep the table of contents fixed

### DIFF
--- a/client/www/components/docs/Layout.jsx
+++ b/client/www/components/docs/Layout.jsx
@@ -346,7 +346,7 @@ export function Layout({ children, title, tableOfContents }) {
               <div className="absolute inset-0">
                 <div
                   className={clsx(
-                    'sticky overflow-y-auto p-4',
+                    'fixed overflow-y-auto p-4 w-[16rem]',
                     adj.topHeader,
                     adj.hWithoutHeader,
                   )}


### PR DESCRIPTION
I realized our table of contents wasn't staying sticky. This is because of the `overflow-x-auto` I added to the top element. 

I jigged and jigged, but eventually opted to just use position:fixed. I don't think we really need position:sticky for the table of contents, as it's not something we are 'scrolling' too really.  

@nezaj @dwwoelfel @tonsky 