### PR TITLE
Fix match topic for comparators with non-numbers

### DIFF
--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -569,7 +569,6 @@
 (defn match-nil
   "nil is always the smallest value and the comparator value can't be nil"
   [op]
-  (println "NIL!" op)
   (case op
     :$gt false
     :$gte false
@@ -621,7 +620,7 @@
                        iv-part))
       (when (contains? dq-part :$not)
         (let [not-val (:$not dq-part)]
-          (ucoll/seek (partial not= not-val) iv-part))))))
+          (ucoll/exists? (partial not= not-val) iv-part))))))
 
 (defn match-topic?
   [[iv-idx iv-e iv-a iv-v]

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -566,6 +566,18 @@
 (defn bool-lte [^Boolean a ^Boolean b]
   (>= 0 (.compareTo a b)))
 
+(defn match-nil
+  "nil is always the smallest value and the comparator value can't be nil"
+  [op]
+  (println "NIL!" op)
+  (case op
+    :$gt false
+    :$gte false
+    :$lt true
+    :$lte true
+    :$like false
+    :$ilike false))
+
 (defn- match-topic-part? [iv-part dq-part]
   (cond
     (keyword? iv-part)
@@ -602,9 +614,11 @@
                         :$gte instant-gte
                         :$lt instant-lt
                         :$lte instant-lte))]
-        (not (nil? (ucoll/seek (fn [v]
-                                 (f v value))
-                               iv-part))))
+        (ucoll/exists? (fn [v]
+                         (if (nil? v)
+                           (match-nil op)
+                           (f v value)))
+                       iv-part))
       (when (contains? dq-part :$not)
         (let [not-val (:$not dq-part)]
           (ucoll/seek (partial not= not-val) iv-part))))))

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -24,6 +24,15 @@
                not-found))
            not-found coll)))
 
+(defn exists?
+  "Returns true if any item in the coll matches (pred item), otherwise false."
+  [pred coll]
+  (reduce (fn [acc x]
+            (if (pred x)
+              (reduced true)
+              acc))
+          false coll))
+
 (defn pad [n val coll]
   (let [cnt (- n (count coll))]
     (concat coll (repeat cnt val))))

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -1,6 +1,6 @@
 (ns instant.reactive.store-test
   (:require
-   [clojure.test :as test :refer [deftest are is testing]]
+   [clojure.test :as test :refer [deftest is testing]]
    [instant.reactive.store :as rs]
    [instant.util.async :as ua])
   (:import
@@ -266,7 +266,11 @@
 
     (is-match-topic-part #{nil} {:$comparator {:op :$ilike
                                                :value "hi%"
-                                               :data-type :string}} false)))
+                                               :data-type :string}} false))
+
+  (testing "$not"
+    (is-match-topic-part #{1} {:$not 2} true)
+    (is-match-topic-part #{1} {:$not 1} false)))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -138,6 +138,7 @@
   (is-match-topic-part :av :ave false)
   (is-match-topic-part #{1} #{1} true)
   (is-match-topic-part #{1} #{0} false)
+
   (is-match-topic-part #{1} {:$comparator {:op :$gte
                                            :value 1
                                            :data-type :number}} true)
@@ -240,7 +241,32 @@
                        {:$comparator {:op :$lte
                                       :value (Instant/parse "2025-02-17T02:00:00Z")
                                       :data-type :date}}
-                       false))
+                       false)
+
+  (testing "nils"
+    (is-match-topic-part #{nil} {:$comparator {:op :$lte
+                                               :value 1
+                                               :data-type :number}} true)
+
+    (is-match-topic-part #{nil} {:$comparator {:op :$lt
+                                               :value 1
+                                               :data-type :number}} true)
+
+    (is-match-topic-part #{nil} {:$comparator {:op :$gte
+                                               :value 1
+                                               :data-type :number}} false)
+
+    (is-match-topic-part #{nil} {:$comparator {:op :$gt
+                                               :value 1
+                                               :data-type :number}} false)
+
+    (is-match-topic-part #{nil} {:$comparator {:op :$like
+                                               :value "hi%"
+                                               :data-type :string}} false)
+
+    (is-match-topic-part #{nil} {:$comparator {:op :$ilike
+                                               :value "hi%"
+                                               :data-type :string}} false)))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -1,8 +1,10 @@
 (ns instant.reactive.store-test
   (:require
-   [clojure.test :as test :refer [deftest is testing]]
+   [clojure.test :as test :refer [deftest are is testing]]
    [instant.reactive.store :as rs]
-   [instant.util.async :as ua]))
+   [instant.util.async :as ua])
+  (:import
+   (java.time Instant)))
 
 (deftest match-topic?
   (is (true?
@@ -125,6 +127,120 @@
                                                :shouldn't-be-executed)
                                              nil
                                              q)))))))
+
+(defmacro is-match-topic-part [iv-part dq-part expected]
+  `(is (= ~expected (#'rs/match-topic-part? ~iv-part ~dq-part))
+       (str "datalog query part: " ~dq-part ", invalidator part: " ~iv-part)))
+
+(deftest match-topic-part?
+  (is-match-topic-part '_ '_ true)
+  (is-match-topic-part :av :av true)
+  (is-match-topic-part :av :ave false)
+  (is-match-topic-part #{1} #{1} true)
+  (is-match-topic-part #{1} #{0} false)
+  (is-match-topic-part #{1} {:$comparator {:op :$gte
+                                           :value 1
+                                           :data-type :number}} true)
+  (is-match-topic-part #{1} {:$comparator {:op :$gt
+                                           :value 1
+                                           :data-type :number}} false)
+  (is-match-topic-part #{-1} {:$comparator {:op :$lt
+                                            :value 1
+                                            :data-type :number}} true)
+  (is-match-topic-part #{-1} {:$comparator {:op :$lte
+                                            :value -1
+                                            :data-type :number}} true)
+  (is-match-topic-part #{-1} {:$comparator {:op :$lte
+                                            :value -2
+                                            :data-type :number}} false)
+
+  (is-match-topic-part #{"b"} {:$comparator {:op :$gte
+                                             :value "b"
+                                             :data-type :string}} true)
+  (is-match-topic-part #{"a"} {:$comparator {:op :$gte
+                                             :value "b"
+                                             :data-type :string}} false)
+  (is-match-topic-part #{"b"} {:$comparator {:op :$gt
+                                             :value "b"
+                                             :data-type :string}} false)
+  (is-match-topic-part #{"b"} {:$comparator {:op :$gt
+                                             :value "a"
+                                             :data-type :string}} true)
+  (is-match-topic-part #{"a"} {:$comparator {:op :$lt
+                                             :value "b"
+                                             :data-type :string}} true)
+  (is-match-topic-part #{"b"} {:$comparator {:op :$lte
+                                             :value "b"
+                                             :data-type :string}} true)
+  (is-match-topic-part #{"b"} {:$comparator {:op :$lte
+                                             :value "a"
+                                             :data-type :string}} false)
+
+  (is-match-topic-part #{"hello"} {:$comparator {:op :$like
+                                                 :value "he%"
+                                                 :data-type :string}} true)
+
+  (is-match-topic-part #{"hello"} {:$comparator {:op :$like
+                                                 :value "wor%"
+                                                 :data-type :string}} false)
+
+  (is-match-topic-part #{true} {:$comparator {:op :$gte
+                                              :value true
+                                              :data-type :boolean}} true)
+  (is-match-topic-part #{false} {:$comparator {:op :$gte
+                                               :value true
+                                               :data-type :boolean}} false)
+  (is-match-topic-part #{true} {:$comparator {:op :$gt
+                                              :value true
+                                              :data-type :boolean}} false)
+  (is-match-topic-part #{true} {:$comparator {:op :$gt
+                                              :value false
+                                              :data-type :boolean}} true)
+  (is-match-topic-part #{false} {:$comparator {:op :$lt
+                                               :value true
+                                               :data-type :boolean}} true)
+  (is-match-topic-part #{true} {:$comparator {:op :$lte
+                                              :value true
+                                              :data-type :boolean}} true)
+  (is-match-topic-part #{true} {:$comparator {:op :$lte
+                                              :value false
+                                              :data-type :boolean}} false)
+
+  (is-match-topic-part #{(Instant/parse "2025-02-17T03:00:00Z")}
+                       {:$comparator {:op :$gte
+                                      :value (Instant/parse "2025-02-17T03:00:00Z")
+                                      :data-type :date}}
+                       true)
+  (is-match-topic-part #{(Instant/parse "2025-02-17T02:00:00Z")}
+                       {:$comparator {:op :$gte
+                                      :value (Instant/parse "2025-02-17T03:00:00Z")
+                                      :data-type :date}}
+                       false)
+  (is-match-topic-part #{(Instant/parse "2025-02-17T03:00:00Z")}
+                       {:$comparator {:op :$gt
+                                      :value (Instant/parse "2025-02-17T03:00:00Z")
+                                      :data-type :date}}
+                       false)
+  (is-match-topic-part #{(Instant/parse "2025-02-17T03:00:00Z")}
+                       {:$comparator {:op :$gt
+                                      :value (Instant/parse "2025-02-17T02:00:00Z")
+                                      :data-type :date}}
+                       true)
+  (is-match-topic-part #{(Instant/parse "2025-02-17T02:00:00Z")}
+                       {:$comparator {:op :$lt
+                                      :value (Instant/parse "2025-02-17T03:00:00Z")
+                                      :data-type :date}}
+                       true)
+  (is-match-topic-part #{(Instant/parse "2025-02-17T03:00:00Z")}
+                       {:$comparator {:op :$lte
+                                      :value (Instant/parse "2025-02-17T03:00:00Z")
+                                      :data-type :date}}
+                       true)
+  (is-match-topic-part #{(Instant/parse "2025-02-17T03:00:00Z")}
+                       {:$comparator {:op :$lte
+                                      :value (Instant/parse "2025-02-17T02:00:00Z")
+                                      :data-type :date}}
+                       false))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Our comparators relied on `<`-like operators and those only work on numbers in Clojure.

Created a set of custom functions for comparing each type we support (bool, string, number, and date).

Also fixes how we handle `nil`, which will become more relevant when I merge in https://github.com/instantdb/instant/pull/869