### PR TITLE
[bugfix] instant.rules -> instant.perms

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1349,17 +1349,17 @@ function getPermsReadCandidates() {
   if (existing) return [{ files: existing, transform: transformImports }];
   return [
     {
-      files: 'instant.rules',
+      files: 'instant.perms',
       extensions: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs'],
       transform: transformImports,
     },
     {
-      files: 'src/instant.rules',
+      files: 'src/instant.perms',
       extensions: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs'],
       transform: transformImports,
     },
     {
-      files: 'app/instant.rules',
+      files: 'app/instant.perms',
       extensions: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs'],
       transform: transformImports,
     },


### PR DESCRIPTION
Ah, the search was looking for `instant.rules`, rather than `instant.perms`. Introduced this bug in `0.17.16` onwards

@nezaj @tonsky @dwwoelfel 