### PR TITLE
[docs] small scroll improvements

### DIFF
--- a/client/www/components/docs/Layout.jsx
+++ b/client/www/components/docs/Layout.jsx
@@ -309,7 +309,7 @@ export function Layout({ children, title, tableOfContents }) {
             <div className="absolute inset-0">
               <div
                 className={clsx(
-                  'sticky overflow-y-auto px-4',
+                  'sticky overflow-y-auto px-4 pb-4',
                   adj.topHeader,
                   adj.hWithoutHeader,
                 )}

--- a/client/www/components/docs/Navigation.jsx
+++ b/client/www/components/docs/Navigation.jsx
@@ -7,7 +7,7 @@ export function Navigation({ navigation, className }) {
 
   return (
     <nav className={clsx('text-sm', className)}>
-      <ul role="list" className="space-y-9">
+      <ul role="list" className="space-y-6">
         {navigation.map((section) => (
           <li key={section.title}>
             <h2 className="font-medium text-slate-900 dark:text-white">


### PR DESCRIPTION
- Added bottom padding for sidebar
- Reducing the spacing between sidebar sections. This way in at least a 15 inch macbook with bookmarks enabled, there is no need to scroll the sidebar

@nezaj @tonsky @dwwoelfel 