### PR TITLE
Hide system files attrs from CLI

### DIFF
--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -695,8 +695,12 @@
   "Removes the system attrs that might be confusing for the users."
   [^Attrs attrs]
   (remove (fn [a]
-            (and (= :system (:catalog a))
-                 (not (#{"$users" "$files"} (fwd-etype a)))))
+            (or
+             (and (= :system (:catalog a))
+                  (not (#{"$users" "$files"} (fwd-etype a))))
+             (and (= "$files" (fwd-etype a))
+                  (#{"content-type" "content-disposition" "size"
+                     "location-id" "key-version"} (fwd-label a)))))
           attrs))
 
 (defn resolve-attr-id [attrs etype label]

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -149,7 +149,7 @@
         filtered-seq (attr-model/remove-hidden (attr-model/wrap-attrs attrs-seq))]
     (into {}
           (for [attr filtered-seq]
-            [(-> attr :forward-identity (nth 2) keyword) (dissoc attr :catalog)]))))
+            [(keyword (attr-model/fwd-label attr)) attr]))))
 
 (defn defs->schema [defs]
   (let [{entities :entities links :links} defs


### PR DESCRIPTION
Previously when we pulled from the CLI we'd get things like

```
$files: i.entity({
  "content-disposition": i.string().indexed(),
  "content-type": i.string().indexed(),
  "key-version": i.number(),
  "location-id": i.string().unique().indexed(),
  path: i.string().unique().indexed(),
  size: i.number().indexed(),
})
```

But things like `key-version` and `location-id` aren't relevant to users. For most folks`content-type`, `content-disposition` and `size` won't be used either.

With this change pulling from the CLI will return

```
$files: i.entity({
  path: i.string().unique().indexed(),
  url: i.string(),
})
```

If a user does want to leverage fields like `content-type` in their app they can add these fields into `instant.schema.ts` and when they use `instant-cli push` the `plan!` step will ignore the hidden fields, avoiding errors like

```
[error] Failed to update schema.
[error] Validation failed for schema
[error] schema: $files->content-type: Duplicate entry found for attribute. Check your schema file for duplicate link definitions. If it's not in the schema fi
le, it may have been generated by the backend. Check your full schema in the dashboard: https://www.instantdb.com/dash?s=main&t=explorer
```