### PR TITLE
Parse content-type and content-disposition in admin sdk

### DIFF
--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -373,10 +373,12 @@
         params (:headers req)
         path (ex/get-param! params ["path"] string-util/coerce-non-blank-str)
         file (ex/get-param! req [:body] identity)
-        content-type (ex/get-optional-param! params [:content-type] string-util/coerce-non-blank-str)
+        content-type (ex/get-optional-param! params ["content-type"] string-util/coerce-non-blank-str)
+        content-disposition (ex/get-optional-param! params ["content-disposition"] string-util/coerce-non-blank-str)
         data (storage-coordinator/upload-file! {:app-id app-id
                                                 :path path
                                                 :content-type content-type
+                                                :content-disposition content-disposition
                                                 :content-length (:content-length req)
                                                 :skip-perms-check? true}
                                                file)]


### PR DESCRIPTION
Clark gave `uploadFile` from the admin SDK a whirl and noticed we weren't parsing content-type correctly. I remember previously I keywordized the params but then got rid of that. Needed to also update the parsing.

Doing that here!