### PR TITLE
Update transactions link in modeling-data.md

### DIFF
--- a/client/www/pages/docs/modeling-data.md
+++ b/client/www/pages/docs/modeling-data.md
@@ -346,7 +346,7 @@ const db = init({
 });
 ```
 
-When you do this, all [queries](/docs/instaql) and [transactions](/docs/instaql) will come with typesafety out of the box.
+When you do this, all [queries](/docs/instaql) and [transactions](/docs/instaml) will come with typesafety out of the box.
 
 {% callout %}
 


### PR DESCRIPTION
Since `queries` and `transactions` both linked to the same place I figured this was a typo.