### PR TITLE
Better check for null attrs

### DIFF
--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -778,6 +778,9 @@
                                            :attrs.is_indexed
                                            :attrs.checked_data_type]
                                   :from :triples
+                                  ;; The `for update` should prevent a concurrent
+                                  ;; query from deleting the entity while we're
+                                  ;; doing our insert
                                   :for :update
                                   :join [:attrs [:and
                                                  [:= :triples.app_id :attrs.app_id]

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -778,6 +778,7 @@
                                            :attrs.is_indexed
                                            :attrs.checked_data_type]
                                   :from :triples
+                                  :for :update
                                   :join [:attrs [:and
                                                  [:= :triples.app_id :attrs.app_id]
                                                  [:= :attrs.id attr_id]]]

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -360,8 +360,8 @@
 (defn missing-null-triple-wheres
   "Where clauses that return the id triples that are missing a value for the
    indexed attr."
-  [{:keys [app_id attr_id]}]
-  (let [attrs (attr-model/get-by-app-id app_id)
+  [conn stage {:keys [app_id attr_id]}]
+  (let [attrs (attr-model/get-by-app-id conn app_id)
         etype (attr-model/fwd-etype (attr-model/seek-by-id attr_id attrs))
         _ (assert etype "Attribute has no etype")
         id-attr-id (:id (attr-model/seek-by-fwd-ident-name [etype "id"] attrs))
@@ -374,9 +374,14 @@
       [:and
        [:= :triples.app-id app_id]
        [:= :triples.attr-id id-attr-id]
-       [:not [:exists {:select :*
+       [:not [:exists {:select :1
                        :from [[:triples :attr-triples]]
                        :where [:and
+                               (if (= stage :estimate)
+                                 ;; If we're estimating, then the triples won't
+                                 ;; be ave yet
+                                 true
+                                 :attr-triples.ave)
                                [:= :attr-triples.app-id app_id]
                                [:= :attr-triples.attr-id attr_id]
                                [:= :attr-triples.entity-id :triples.entity-id]]}]]])))
@@ -396,7 +401,7 @@
                                      :where (if (= "index" (:job_type job))
                                               [:or
                                                default-where
-                                               (missing-null-triple-wheres job)]
+                                               (missing-null-triple-wheres conn :estimate job)]
                                               default-where)}))
                       :count)]
      (sql/execute-one! ::estimate-work-estimate!
@@ -772,16 +777,12 @@
                                            :attrs.is_unique
                                            :attrs.is_indexed
                                            :attrs.checked_data_type]
-                                  ;; The `for update` should prevent a concurrent
-                                  ;; query from deleting the entity while we're
-                                  ;; doing our insert
-                                  :for :update
                                   :from :triples
                                   :join [:attrs [:and
                                                  [:= :triples.app_id :attrs.app_id]
                                                  [:= :attrs.id attr_id]]]
-                                  :limit batch-size
-                                  :where (missing-null-triple-wheres job)}}]}
+                                  :where (missing-null-triple-wheres conn :update job)
+                                  :limit batch-size}}]}
          res (sql/do-execute! ::insert-nulls-next-batch! conn (hsql/format q))]
      (:next.jdbc/update-count (first res)))))
 
@@ -1261,9 +1262,10 @@
                                                 [:not :indexing]]}))]
     (doseq [attr attrs]
       (loop [total 0]
-        (let [update-count (insert-nulls-next-batch! {:attr_id (:id attr)
-                                                      :app_id (:app_id attr)
-                                                      :job_type "index"})]
+        (println "Starting" (str "app_id=" (:app_id attr)) (str "attr_id=" (:id attr)))
+        (let [update-count (time (insert-nulls-next-batch! {:attr_id (:id attr)
+                                                            :app_id (:app_id attr)
+                                                            :job_type "index"}))]
           (println "Updated" (+ total update-count) "for" (str "app_id=" (:app_id attr)) (str "attr_id=" (:id attr)))
           (when (pos? update-count)
             (recur (+ total update-count))))))))

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -389,9 +389,10 @@
                                    [:= :needs-null-triple.attr-id :id-attr.id]
                                    ;; No existing triple for this attr
                                    ;; This should always be null here, but just in case...
-                                   [:not [:exists {:select :*
+                                   [:not [:exists {:select :1
                                                    :from :triples
                                                    :where [:and
+                                                           :triples.ave
                                                            [:= :triples.app-id app-id]
                                                            [:= :triples.attr-id :attr-inserts.id]
                                                            [:= :triples.entity-id :needs-null-triple.entity-id]]}]]]]}]

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -494,9 +494,10 @@
                                                       :from :idents
                                                       :where [:= :idents.id :needs-null-attr.forward-ident]}]
                                  ;; No existing triple for this attr
-                                 [:not [:exists {:select :*
+                                 [:not [:exists {:select :1
                                                  :from :triples
                                                  :where [:and
+                                                         :triples.ave
                                                          [:= :triples.app-id app-id]
                                                          [:= :triples.attr-id :needs-null-attr.id]
                                                          [:= :triples.entity-id :new-entities.entity-id]]}]]]]


### PR DESCRIPTION
I'm running into timeouts when trying to insert nulls for the indexing jobs (https://github.com/instantdb/instant/blob/main/server/src/instant/db/indexing_jobs.clj#L1252)

Two small improvements for the check:

1. `select 1` instead of `select :*` on the exists check. 
2. Check for `ave` when we're looking for triples with the attr.

I'll also have to briefly add an `ave` index that has the `entity_id`. I think we should probably re-evaluate whether we put the `entity_id` back in those indexes after merging in https://github.com/instantdb/instant/pull/905

Deployment plan:
1. Wait for this to deploy
2. Temporarily add the index:
```sql
CREATE INDEX concurrently ave_index_with_e ON triples(app_id uuid_ops,attr_id uuid_ops,value jsonb_ops, entity_id) WHERE ave;
```
3. Run the migration `(indexing-jobs/insert-nulls-for-existing-indexed-blob-attrs)`
4. Drop the index `drop index ave_index_with_e`

