### PR TITLE
[monaco] improve height resize, loading state

### DIFF
--- a/client/www/components/dash/Perms.tsx
+++ b/client/www/components/dash/Perms.tsx
@@ -27,8 +27,8 @@ export function Perms({
   }, [app]);
 
   return (
-    <div className="flex flex-1 flex-col md:flex-row">
-      <div className="flex flex-col gap-4 border-r p-4 text-sm md:basis-96 md:text-base">
+    <div className="flex flex-1 flex-col md:flex-row min-h-0">
+      <div className="flex flex-col gap-4 border-r p-4 text-sm md:basis-96 md:text-base min-h-0">
         <SectionHeading>Permissions</SectionHeading>
         <Content>
           <p>

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -866,6 +866,7 @@ export function CodeEditor(props: {
       }}
       onMount={props.onMount}
       beforeMount={(monaco) => {}}
+      loading={<FullscreenLoading />}
     />
   );
 }
@@ -883,12 +884,12 @@ export function JSONEditor(props: {
   }, [props.value]);
 
   return (
-    <div className="flex flex-col gap-2 h-full">
+    <div className="flex flex-col gap-2 h-full min-h-0">
       <div className="flex items-center gap-4 border-b px-4 py-2">
         <div className="font-mono">{props.label}</div>
         <Button onClick={() => props.onSave(draft)}>Save</Button>
       </div>
-      <div className="flex-grow">
+      <div className="flex-grow min-h-0">
         <CodeEditor
           language="json"
           value={props.value}


### PR DESCRIPTION
When we had an error, we would show an error pane. But our Monaco editor would not resize. I fixed this by adding a few `min-h-0`s.

I also updated our Loading state, so it's a bit less jarring. It used to flash "Loading...". Now it's white background, and does a pulse animation. In most cases users won't see the pulse.

@nezaj @tonsky @dwwoelfel 