### PR TITLE
[Storage] Enable json uploads

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -110,9 +110,9 @@
               wrap-keyword-params
               wrap-params
               wrap-multipart-params
-              (wrap-json-body-except #{[:put "/dash/apps/.*/storage/upload"]
-                                       [:put "/storage/upload"]
-                                       [:put "/admin/storage/upload"]})
+              (wrap-json-body-except #{[:put #"/dash/apps/.*/storage/upload"]
+                                       [:put #"/storage/upload"]
+                                       [:put #"/admin/storage/upload"]})
 
               http-util/wrap-errors
 

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -52,6 +52,18 @@
    (java.util Locale TimeZone)))
 
 ;; --------
+;; Middleware
+
+(defn wrap-json-body-except [handler method-paths]
+  (fn [request]
+    (if (some (fn [[method pattern]]
+                (and (= method (:request-method request))
+                     (re-matches pattern (:uri request))))
+              method-paths)
+      (handler request)
+      ((wrap-json-body handler {:keywords? true}) request))))
+
+;; --------
 ;; Wrappers
 
 (defn get-index [& _args]
@@ -98,7 +110,9 @@
               wrap-keyword-params
               wrap-params
               wrap-multipart-params
-              (wrap-json-body {:keywords? true})
+              (wrap-json-body-except #{[:put "/dash/apps/.*/storage/upload"]
+                                       [:put "/storage/upload"]
+                                       [:put "/admin/storage/upload"]})
 
               http-util/wrap-errors
 


### PR DESCRIPTION
We got a report that json uploads were blocked and indeed it was because of our middleware which would parse the upload as json instead of an input stream.

This PR updates our middleware to conditionally `wrap-json-body`