### PR TITLE
Make zeneca normal

### DIFF
--- a/server/src/instant/data/bootstrap.clj
+++ b/server/src/instant/data/bootstrap.clj
@@ -71,9 +71,8 @@
                      (= "id" idn)
                      {:id uuid
                       :forward-identity [(java.util.UUID/randomUUID) nsp "id"]
-                      :reverse-identity [(java.util.UUID/randomUUID) nsp "_id"]
                       :cardinality :one
-                      :value-type :ref
+                      :value-type :blob
                       :unique? true
                       :index? true}
                      :else

--- a/server/src/instant/data/bootstrap.clj
+++ b/server/src/instant/data/bootstrap.clj
@@ -144,7 +144,7 @@
                      :let [{:strs [email id]}
                            (entity-model/triples->map {:attrs attrs} group)]]
                  {:email email
-                  :id id
+                  :id (parse-uuid id)
                   :app-id app-id})]
      (doseq [user users]
        (app-user-model/create! conn user))

--- a/server/src/instant/data/bootstrap.clj
+++ b/server/src/instant/data/bootstrap.clj
@@ -74,7 +74,7 @@
                       :cardinality :one
                       :value-type :blob
                       :unique? true
-                      :index? true}
+                      :index? false}
                      :else
                      (merge
                       {:id uuid

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -612,7 +612,7 @@
         (testing "limit"
           (is-pretty-eq? (query-pretty ctx r {:users {:$ {:limit 2
                                                           :order {:handle :desc}}}})
-                         '({:topics #{[:eav _ #{:users/id} _]
+                         '({:topics #{[:ea _ #{:users/id} _]
                                       --
                                       [:ea #{"eid-stepan-parunashvili"} #{:users/bookshelves
                                                                           :users/createdAt
@@ -695,7 +695,7 @@
                                          :users/fullName
                                          :users/handle}
                                        _]
-                                      [:eav _ #{:users/id} _]
+                                      [:ea _ #{:users/id} _]
                                       [:ave #{"eid-joe-averbukh" "eid-alex"} #{:users/handle} _]
                                       --
                                       [:ea
@@ -732,7 +732,7 @@
               (is-pretty-eq? (query-pretty ctx r {:users {:$ {:limit 1
                                                               :after end-cursor
                                                               :order {:handle :desc}}}})
-                             '({:topics #{[:eav _ #{:users/id} _]
+                             '({:topics #{[:ea _ #{:users/id} _]
                                           --
                                           [:ea #{"eid-nicole"} #{:users/bookshelves
                                                                  :users/createdAt
@@ -752,13 +752,13 @@
               (is-pretty-eq? (query-pretty ctx r {:users {:$ {:limit 1
                                                               :before start-cursor
                                                               :order {:handle :desc}}}})
-                             '({:topics #{[:eav _ #{:users/id} _] [:ave _ #{:users/handle} _]}
+                             '({:topics #{[:ea _ #{:users/id} _] [:ave _ #{:users/handle} _]}
                                 :triples #{}}))
 
               (is-pretty-eq? (query-pretty ctx r {:users {:$ {:limit 1
                                                               :before start-cursor
                                                               :order {:handle "asc"}}}})
-                             '({:topics #{[:eav _ #{:users/id} _]
+                             '({:topics #{[:ea _ #{:users/id} _]
                                           [:ea #{"eid-alex"} #{:users/bookshelves
                                                                :users/createdAt
                                                                :users/email
@@ -778,13 +778,13 @@
               (is-pretty-eq? (query-pretty ctx r {:users {:$ {:limit 1
                                                               :before start-cursor
                                                               :order {:handle :desc}}}})
-                             '({:topics #{[:eav _ #{:users/id} _] [:ave _ #{:users/handle} _]}
+                             '({:topics #{[:ea _ #{:users/id} _] [:ave _ #{:users/handle} _]}
                                 :triples #{}}))
 
               (is-pretty-eq? (query-pretty ctx r {:users {:$ {:last 1
                                                               :before start-cursor
                                                               :order {:handle "asc"}}}})
-                             '({:topics #{[:eav _ #{:users/id} _]
+                             '({:topics #{[:ea _ #{:users/id} _]
                                           --
                                           [:ea #{"eid-nicole"} #{:users/bookshelves
                                                                  :users/createdAt
@@ -3237,10 +3237,9 @@
                :users/handle}
              '_]],
            :triples
-           [[shared-id :users/id shared-id]
+           [[shared-id :users/handle "handle"]
+            [shared-id :users/id (str shared-id)]
             '--
-            [shared-id :users/handle "handle"]
-            [shared-id :users/id shared-id]
             [shared-id :users/email nil]]}])
         (is-pretty-eq?
          (query-pretty ctx r {:books {:$ {:where {:id shared-id}}}})
@@ -3254,10 +3253,9 @@
                                 :books/thumbnail
                                 :books/title} '_]],
            :triples
-           [[shared-id :books/id shared-id]
-            '--
+           ['--
             [shared-id :books/title "title"]
-            [shared-id :books/id shared-id]]}])))))
+            [shared-id :books/id (str shared-id)]]}])))))
 
 (deftest eid-relations
   (testing "forward works on link name"

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -700,7 +700,7 @@
                 user (-> res (get "users") first)]
             (is (= {"handle" "id-test", "email" "id-test@example.com"}
                    (select-keys user ["handle" "email"])))
-            (is (uuid? (get user "id")))))
+            (is (uuid? (parse-uuid (get user "id"))))))
 
         (testing "retractions work"
           (tx/transact! (aurora/conn-pool :write)

--- a/server/test/instant/reactive/invalidator_test.clj
+++ b/server/test/instant/reactive/invalidator_test.clj
@@ -435,15 +435,15 @@
                           "vae" false,
                           "app_id" (str (:id app))
                           "checked_data_type" nil}
-                         {"eav" true,
+                         {"eav" false,
                           "av" true,
-                          "ave" true,
+                          "ave" false,
                           "value_md5" (->md5 (->json (str uid)))
                           "entity_id" (str uid)
                           "attr_id" (str (resolvers/->uuid r :users/id))
                           "ea" true,
                           "value" (->json (str uid))
-                          "vae" true,
+                          "vae" false,
                           "app_id" (str (:id app))
                           "checked_data_type" nil}
                          ;; null that is automatically inserted for the


### PR DESCRIPTION
Zeneca in the tests does a weird thing where it makes ids into refs. No other app behaves like this and it's causing problems for the select-keys PR https://github.com/instantdb/instant/pull/831

This updates the zeneca fixtures to create ids like a normal app and fixes all of the tests.