### PR TITLE
[Docs] Be explicit that transact is atomic

### DIFF
--- a/client/www/pages/docs/instaml.md
+++ b/client/www/pages/docs/instaml.md
@@ -249,6 +249,11 @@ db.transact(
 );
 ```
 
+## Transacts are atomic
+
+When you call `db.transact`, all the transactions are committed atomically. If
+any of the transactions fail, none of them will be committed.
+
 ## Typesafety
 
 By default, `db.transact` is permissive. When you save data, we'll create missing attributes for you:


### PR DESCRIPTION
Got feedback that it wasn't clear that transacts are atomic. I realized we don't mention this in the docs and thought it would be nice to be more explicit.