### PR TITLE
[Docs] sm hydration fix

### DIFF
--- a/client/www/pages/docs/patterns.md
+++ b/client/www/pages/docs/patterns.md
@@ -124,38 +124,33 @@ Sometimes you want to let clients know when they are connected or disconnected
 to the DB. You can use `db.subscribeConnectionStatus` in vanilla JS or
 `db.useConnectionStatus` in React to listen to connection changes
 
-```typescript
-
+```javascript
 // Vanilla JS
 const unsub = db.subscribeConnectionStatus((status) => {
- const connectionState =
-   status === 'connecting' || status === 'opened'
-     ? 'authenticating'
-   : status === 'authenticated'
-     ? 'connected'
-   : status === 'closed'
-     ? 'closed'
-   : status === 'errored'
-     ? 'errored'
-   : 'unexpected state';
+  const statusMap = {
+    connecting: 'authenticating',
+    opened: 'authenticating',
+    authenticated: 'connected',
+    closed: 'closed',
+    errored: 'errored',
+  };
 
- console.log('Connection status:', connectionState);
+  const connectionState = statusMap[status] || 'unexpected state';
+  console.log('Connection status:', connectionState);
 });
 
 // React/React Native
 function App() {
- const status = db.useConnectionStatus()
- const connectionState =
-   status === 'connecting' || status === 'opened'
-     ? 'authenticating'
-   : status === 'authenticated'
-     ? 'connected'
-   : status === 'closed'
-     ? 'closed'
-   : status === 'errored'
-     ? 'errored'
-   : 'unexpected state';
+  const statusMap = {
+    connecting: 'authenticating',
+    opened: 'authenticating',
+    authenticated: 'connected',
+    closed: 'closed',
+    errored: 'errored',
+  };
+  const status = db.useConnectionStatus();
 
- return <div>Connection state: {connectionState}</div>
+  const connectionState = statusMap[status] || 'unexpected state';
+  return <div>Connection state: {connectionState}</div>;
 }
 ```


### PR DESCRIPTION
I noticed on the patterns page we'd get an error related to the bottom example

```
client.ts:59 Warning: Expected server HTML to contain a matching text node for "
" in <pre>. Error Component Stack
    at pre (<anonymous>)
    at div (<anonymous>)
    at Highlight (index.js:191:1)
    at Fence (Fence.jsx:8:25)
    at MarkdocComponent (patterns.md:93:25)
    at div (<anonymous>)
    at Prose (Prose.jsx:3:29)
    at article (<anonymous>)
    at PageContent (Layout.jsx:148:24)
    at main (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at Layout (Layout.jsx:264:26)
    at DocsPage (DocsPage.jsx:54:28)
    at ErrorBoundary (ErrorBoundary.tsx:10:5)
    at App (_app.tsx:26:16)
    at PathnameContextProviderAdapter (adapters.tsx:70:3)
    at ErrorBoundary (ErrorBoundary.tsx:11:8)
    at ReactDevOverlay (ReactDevOverlay.tsx:32:3)
    at Container (index.tsx:99:1)
    at AppContainer (index.tsx:298:3)
    at Root (index.tsx:596:3)
```

Was able to get these errors to go away by getting rid of the excessive ternaries