### PR TITLE
[CEL] Parse false values correctly

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -154,6 +154,12 @@
                          (.format ^Date x))
     :else              x))
 
+(defn get-cel-value [m k]
+  (stringify
+   (if (contains? m k)
+     (get m k)
+     (get m (keyword k)))))
+
 (deftype CelList [xs]
   java.util.List
   (get [_ i]
@@ -169,10 +175,7 @@
 (deftype CelMap [metadata m]
   java.util.Map
   (get [_ k]
-    (stringify
-     (if (contains? m k)
-       (get m k)
-       (get m (keyword k)))))
+    (get-cel-value m k))
 
   ;; CEL throws if a key doesn't exist. We don't want this
   ;; behavior -- we'd rather just return null when a key is
@@ -183,7 +186,9 @@
 
   ;; for printing
   (entrySet [_]
-    (set (seq (or m {}))))
+    (->> (keys (or m {}))
+         (map (fn [k] [k (get-cel-value m k)]))
+         set))
 
   CelMapExtension
   (getMeta [_]

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -170,7 +170,9 @@
   java.util.Map
   (get [_ k]
     (stringify
-     (or (get m k) (get m (keyword k)))))
+     (if (contains? m k)
+       (get m k)
+       (get m (keyword k)))))
 
   ;; CEL throws if a key doesn't exist. We don't want this
   ;; behavior -- we'd rather just return null when a key is

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -29,5 +29,13 @@
     (let [program (cel/->program (cel/->ast "[1, 2, 3, 4].filter(x, x % 2 == 0)"))]
       (is (= [2 4] (cel/eval-program! {:cel-program program} {}))))))
 
+(deftest parse-false-correctly
+  (let [program (cel/->program (cel/->ast "data.isFavorite"))
+        bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
+    (is (false? (cel/eval-program! {:cel-program program} bindings))))
+  (let [program (cel/->program (cel/->ast "!data.isFavorite"))
+        bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
+    (is (true? (cel/eval-program! {:cel-program program} bindings)))))
+
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
We've been getting error reports when folks do things like `!data.isFavorite`

Turns out we weren't parsing `false` values correctly and they would get coerced into null values. And doing a logical not on null throws an error.

Now we check whether our cel-map contains the key and if it does we extract the value from the map. Adding in a test too to verify this behavior