### PR TITLE
Add a cli export script

### DIFF
--- a/server/scripts/export.sh
+++ b/server/scripts/export.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Usage
+#  scripts/export.sh --email 'your-email-address' --app-id 1c0a9039-c387-4315-8471-58979bef93bf
+
+database_url=instant
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --app-id) app_id="$2"; shift ;;
+    --database-url) database_url="$2"; shift ;;
+    --email) creator_email="$2"; shift ;;
+    *) echo "Unknown parameter passed: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+files_dir="$script_dir/export/"
+
+prod_database_url=$("$script_dir/prod_connection_string.sh")
+
+echo 'Follow progress on prod with:'
+
+echo '  with total_tuples as ('
+echo '    select count(*) as total_tuples'
+echo '    from triples'
+echo "    where app_id = '$app_id'"
+echo '  )'
+echo '  select'
+echo '    total_tuples.total_tuples,'
+echo '    tuples_processed,'
+echo '    total_tuples.total_tuples - tuples_processed as remaining_tuples,'
+echo '    (tuples_processed::numeric / total_tuples.total_tuples) * 100 as percent_done'
+echo '  from'
+echo '    pg_stat_progress_copy'
+echo '    join total_tuples on true;'
+echo ''
+
+psql -d $database_url -v app_id="$app_id" -v creator_email="$creator_email" <<EOF
+\set ON_ERROR_STOP on
+BEGIN;
+\echo 'Copying apps'
+\copy apps FROM PROGRAM 'psql -d "$prod_database_url" -v app_id="$app_id" -f $files_dir/copy_apps.sql'
+insert into app_admin_tokens (app_id, token) values (:'app_id', gen_random_uuid());
+update apps set creator_id = (select id from instant_users where email = :'creator_email') where id = :'app_id';
+\echo 'Copying attrs'
+\copy attrs FROM PROGRAM 'psql -d "$prod_database_url" -v app_id="$app_id" -f $files_dir/copy_attrs.sql'
+\echo 'Copying idents'
+\copy idents FROM PROGRAM 'psql -d "$prod_database_url" -v app_id="$app_id" -f $files_dir/copy_idents.sql'
+\echo 'Copying rules'
+\copy rules FROM PROGRAM 'psql -d "$prod_database_url" -v app_id="$app_id" -f $files_dir/copy_rules.sql'
+\echo 'Copying triples'
+\copy triples FROM PROGRAM 'psql -d "$prod_database_url" -v app_id="$app_id" -f $files_dir/copy_triples.sql'
+COMMIT;
+EOF

--- a/server/scripts/export/copy_apps.sql
+++ b/server/scripts/export/copy_apps.sql
@@ -1,0 +1,1 @@
+COPY (SELECT * FROM apps WHERE id = :'app_id') TO STDOUT

--- a/server/scripts/export/copy_attrs.sql
+++ b/server/scripts/export/copy_attrs.sql
@@ -1,0 +1,1 @@
+COPY (SELECT * FROM attrs WHERE app_id = :'app_id') TO STDOUT

--- a/server/scripts/export/copy_idents.sql
+++ b/server/scripts/export/copy_idents.sql
@@ -1,0 +1,1 @@
+COPY (SELECT * FROM idents WHERE app_id = :'app_id') TO STDOUT

--- a/server/scripts/export/copy_rules.sql
+++ b/server/scripts/export/copy_rules.sql
@@ -1,0 +1,1 @@
+COPY (SELECT * FROM rules WHERE app_id = :'app_id') TO STDOUT

--- a/server/scripts/export/copy_triples.sql
+++ b/server/scripts/export/copy_triples.sql
@@ -1,0 +1,1 @@
+COPY (SELECT * FROM triples WHERE app_id = :'app_id') TO STDOUT


### PR DESCRIPTION
Adds a cli script to import an app locally,

Usage is like:

```
scripts/export.sh --email 'dwwoelfel@gmail.com' --app-id 1c0a9039-c387-4315-8471-58979bef93bf
```

Still not super fast, but faster than export.clj and uses a lot less cpu/memory.