### PR TITLE
Fix import script when creator does not exist

### DIFF
--- a/server/scripts/export/copy_apps.sql
+++ b/server/scripts/export/copy_apps.sql
@@ -1,1 +1,1 @@
-COPY (SELECT * FROM apps WHERE id = :'app_id') TO STDOUT
+COPY (SELECT id, title, created_at FROM apps WHERE id = :'app_id') TO STDOUT


### PR DESCRIPTION
The script would previously fail with a foreign key violation if the `creator_id` didn't already exist locally. Now we insert into a temp table so that we can filter out the creator_id.