### PR TITLE
Use a left-join for ors when possible

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -144,14 +144,13 @@
   "Converts {:or [{:a 1} {:a 2}] -> {:or [{:a {:in [1 2]}}]}"
   [conds]
   (let [{:keys [uncombined optimized]}
-        (reduce (fn [acc cond]
-                  (if-not (and (= (count cond) 1)
-                               (where-value-valid? (second (first cond))))
-                    (update acc :uncombined conj cond)
-                    (let [[k v] (first cond)
+        (reduce (fn [acc c]
+                  (if-not (and (= (count c) 1)
+                               (where-value-valid? (second (first c))))
+                    (update acc :uncombined conj c)
+                    (let [[k v] (first c)
                           existing (get-in acc [:optimized k] sentinel)]
                       (if (= existing sentinel)
-                        ;; XXX: Need to do something about values that we can't combine
                         (assoc-in acc [:optimized k] {:in [v]})
                         (update-in acc [:optimized k :in] conj v)))))
 

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2285,8 +2285,7 @@
      (query-pretty
       {:users {:$ {:where {:or [{:handle "joe"}
                                 {:handle "stopa"}]}}}})
-     '({:topics ([:av _ #{:users/handle} #{"stopa"}]
-                 [:av _ #{:users/handle} #{"joe"}]
+     '({:topics ([:av _ #{:users/handle} #{"stopa" "joe"}]
                  --
                  [:ea #{"eid-stepan-parunashvili"} #{:users/bookshelves
                                                      :users/createdAt
@@ -2322,9 +2321,7 @@
       {:users {:$ {:where {:or [{:handle "somebody"}
                                 {:handle "joe"}
                                 {:handle "nobody"}]}}}})
-     '({:topics ([:av _ #{:users/handle} #{"somebody"}]
-                 [:av _ #{:users/handle} #{"joe"}]
-                 [:av _ #{:users/handle} #{"nobody"}]
+     '({:topics ([:av _ #{:users/handle} #{"joe" "nobody" "somebody"}]
                  --
                  [:ea #{"eid-joe-averbukh"} #{:users/bookshelves
                                               :users/createdAt
@@ -2489,16 +2486,14 @@
                                                      :users/fullName
                                                      :users/handle} _]
                  [:av _ #{:users/handle} #{"stopa"}]
-                 [:av _ #{:users/handle} #{"somebody"}]
+                 [:av _ #{:users/handle} #{"stopa" "somebody" "joe" "nobody"}]
                  --
-                 [:av _ #{:users/handle} #{"joe"}]
                  [:ea #{"eid-joe-averbukh"} #{:users/bookshelves
                                               :users/createdAt
                                               :users/email
                                               :users/id
                                               :users/fullName
-                                              :users/handle} _]
-                 [:av _ #{:users/handle} #{"nobody"}]),
+                                              :users/handle} _]),
         :triples (("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
                   ("eid-joe-averbukh" :users/fullName "Joe Averbukh")
                   ("eid-joe-averbukh" :users/handle "joe")
@@ -3037,8 +3032,7 @@
                               :users/handle} _]
          --
          [:eav #{"eid-alex"} #{:users/bookshelves} _]
-         [:ea _ #{:bookshelves/name} #{"Nonfiction"}]
-         [:ea _ #{:bookshelves/name} #{"Fiction"}]
+         [:ea _ #{:bookshelves/name} #{"Fiction" "Nonfiction"}]
          --
          [:ea #{"eid-nonfiction"} #{:bookshelves/desc
                                     :bookshelves/name

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2671,7 +2671,12 @@
                                            [:add-triple id (:handle attr-ids) "a"]])
                                         (let [id (random-uuid)]
                                           [[:add-triple id (:id attr-ids) (str id)]
-                                           [:add-triple id (:handle attr-ids) "b"]])))]
+                                           [:add-triple id (:handle attr-ids) "b"]])
+                                        (mapcat (fn [i]
+                                                  (let [id (random-uuid)]
+                                                    [[:add-triple id (:id attr-ids) (str id)]
+                                                     [:add-triple id (:handle attr-ids) (str i)]]))
+                                                (range 5000))))]
             (sql/select (aurora/conn-pool :write) ["ANALYZE triples"])
             (testing "query on unique attr"
               (let [{:keys [patterns]} (iq/instaql-query->patterns


### PR DESCRIPTION
When we're joining to a previous CTE in the or gather, we can use a left join instead of a full join, which reduces the number of rows that postgres has to filter.

There are a couple of other small improvements:

1. We check if offset is 0 instead of just if it's nil to allow us to skip the has-prev query
2. We materialize any CTE that shows up in the `json_build_object`. This prevents postgres from running some queries twice.
3. If we see multiple ors on the same field, we'll combine them into an in `{:or [{field: value}, {field: value}]}` -> `{:or [{field: {in: [value, value]}]}`. This had huge improvement for one of the queries in production.

For the backtesting, I did a distinct by query_hash, only compared queries whose sql query changed, and got the time from `explain` instead of running the query. I think that made the backtesting much more consistent:

| :old-ms | :new-ms | :improvement |
|---------|---------|--------------|
|     908 |     922 |          -14 |
|      83 |      87 |           -3 |
|      73 |      76 |           -3 |
|       1 |       4 |           -3 |
|       4 |       5 |            0 |
|       2 |       3 |            0 |
|       5 |       5 |            0 |
|      22 |      22 |            0 |
|       2 |       1 |            0 |
|       3 |       2 |            1 |
|      29 |      27 |            1 |
|     327 |     321 |            5 |
|      24 |      16 |            8 |
|     332 |     317 |           15 |
|      43 |      26 |           17 |
|      91 |      63 |           28 |
|      82 |      47 |           35 |
|     327 |     236 |           91 |
|    4641 |     889 |         3751 |
|    4661 |     877 |         3783 |
|    9415 |    1435 |         7979 |