### PR TITLE
[cli] do not infer system catalog attrs, add checked data types to system catalog attrs

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1677,8 +1677,9 @@ export default rules;
   `.trim();
 }
 
-function inferredType(config) {
-  const inferredList = config['inferred-types'];
+function inferredType(attr) {
+  if (attr.catalog === 'system') return null;
+  const inferredList = attr['inferred-types'];
   const hasJustOne = inferredList?.length === 1;
   if (!hasJustOne) return null;
   return inferredList[0];
@@ -1820,6 +1821,7 @@ function generateSchemaTypescriptFile(
   const entitiesObjCode = `{\n${entitiesEntriesCode}\n}`;
   const etypes = Object.keys(newSchema.blobs);
   const hasOnlyUserTable = etypes.length === 1 && etypes[0] === '$users';
+
   const entitiesComment =
     inferredAttrs.length > 0
       ? `// We inferred ${inferredAttrs.length} ${easyPlural('attribute', inferredAttrs.length)}!

--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -301,7 +301,8 @@
               :checked-data-type :number)
    (make-attr "$files" "url"
               :unique? false
-              :index? false)])
+              :index? false
+              :checked-data-type :string)])
 
 (def all-attrs (concat $users-attrs
                        $magic-code-attrs


### PR DESCRIPTION
I noticed we would write: 
'We inferred 1 attribute' 

This was because $files.url was not typed. 

This PR: 

1. Adds the checked data type to the system_catalog.clj file
2. Makes sure we ignore system catalog attrs in cli inference

@nezaj @tonsky @dwwoelfel 

Once landed, I will run the following sql on prod, to update the files system catalog to have a checked data type :

```sql
UPDATE attrs 
SET checked_data_type = 'string'
WHERE attrs.id = '96653230-13ff-ffff-2a35-48afffffffff'::uuid;

UPDATE triples
SET checked_data_type = 'string'
WHERE triples.attr_id = '96653230-13ff-ffff-2a35-48afffffffff'::uuid;
```


