### PR TITLE
Remove the rest of the dependencies on apps in the database for tests

### DIFF
--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -1,7 +1,7 @@
 (ns instant.admin.routes-test
   (:require [clojure.test :as test :refer [deftest is testing]]
-            [instant.fixtures :refer [with-empty-app with-zeneca-app]]
-            [instant.data.constants :refer [movies-app-id zeneca-app-id]]
+            [instant.fixtures :refer [with-empty-app with-zeneca-app with-movies-app]]
+            [instant.data.constants :as constants]
             [instant.admin.routes :as admin-routes]
             [instant.model.app :as app-model]
             [instant.db.model.attr :as attr-model]
@@ -34,148 +34,152 @@
   (= 200 (:status transact-res)))
 
 (deftest query-test
-  (with-zeneca-app
-    (fn [{app-id :id admin-token :admin-token :as _app} _r]
-      (testing "no app-id fails"
-        (let [ret (query-post
-                   {:body {:query {:users {}}}
-                    :headers {"app-id" nil
-                              "authorization" (str "Bearer " admin-token)}})]
-          (is (= 400 (:status ret)))
-          (is (= :param-missing (-> ret :body :type)))))
-      (testing "no token fails"
-        (let [ret (query-post
-                   {:body {:query {:users {}}}
-                    :headers {"app-id" (str app-id)
-                              "authorization" nil}})]
-          (is (= 400 (:status ret)))
-          (is (= :param-missing (-> ret :body :type)))))
-      (testing "wrong combo fails"
-        (let [ret (query-post
-                   {:body {:query {:users {}}}
-                    :headers {"app-id" (str movies-app-id)
-                              "authorization" (str "Bearer " admin-token)}})]
-          (is (= 400 (:status ret)))
-          (is (= :record-not-found (-> ret :body :type)))))
-      (testing "correct combo succeeds"
-        (let [ret (query-post
-                   {:body {:query {:users {}}}
-                    :headers {"app-id" (str app-id)
-                              "authorization" (str "Bearer " admin-token)}})]
-          (is (= 200 (:status ret)))
-          (is
-           #{"alex" "stopa" "joe" "nicolegf"}
-           (set (map #(get % "handle")
-                     (-> ret
-                         :body
-                         (get "users")))))))
-      (testing "a tree is returned"
-        (let [ret (query-post
-                   {:body {:query {:users {:bookshelves {}}}}
-                    :headers {"app-id" (str app-id)
-                              "authorization" (str "Bearer " admin-token)}})]
-          (is (= 200 (:status ret)))
-          (is (->> (-> ret
-                       :body
-                       (get "users"))
-                   (map #(get % "bookshelves"))
-                   (every? seq)))))
-      (testing "invalid queries return an error"
-        (let [ret (query-post
-                   {:body {:query {:users {:bookshelves []}}}
-                    :headers {"app-id" (str app-id)
-                              "authorization" (str "Bearer " admin-token)}})]
-          (is (= 400 (:status ret)))
-          (is (= :validation-failed (-> ret :body :type))))))))
+  (with-movies-app
+    (fn [{movies-app-id :id} _r]
+      (with-zeneca-app
+        (fn [{app-id :id admin-token :admin-token :as _app} _r]
+          (testing "no app-id fails"
+            (let [ret (query-post
+                       {:body {:query {:users {}}}
+                        :headers {"app-id" nil
+                                  "authorization" (str "Bearer " admin-token)}})]
+              (is (= 400 (:status ret)))
+              (is (= :param-missing (-> ret :body :type)))))
+          (testing "no token fails"
+            (let [ret (query-post
+                       {:body {:query {:users {}}}
+                        :headers {"app-id" (str app-id)
+                                  "authorization" nil}})]
+              (is (= 400 (:status ret)))
+              (is (= :param-missing (-> ret :body :type)))))
+          (testing "wrong combo fails"
+            (let [ret (query-post
+                       {:body {:query {:users {}}}
+                        :headers {"app-id" (str movies-app-id)
+                                  "authorization" (str "Bearer " admin-token)}})]
+              (is (= 400 (:status ret)))
+              (is (= :record-not-found (-> ret :body :type)))))
+          (testing "correct combo succeeds"
+            (let [ret (query-post
+                       {:body {:query {:users {}}}
+                        :headers {"app-id" (str app-id)
+                                  "authorization" (str "Bearer " admin-token)}})]
+              (is (= 200 (:status ret)))
+              (is
+               #{"alex" "stopa" "joe" "nicolegf"}
+               (set (map #(get % "handle")
+                         (-> ret
+                             :body
+                             (get "users")))))))
+          (testing "a tree is returned"
+            (let [ret (query-post
+                       {:body {:query {:users {:bookshelves {}}}}
+                        :headers {"app-id" (str app-id)
+                                  "authorization" (str "Bearer " admin-token)}})]
+              (is (= 200 (:status ret)))
+              (is (->> (-> ret
+                           :body
+                           (get "users"))
+                       (map #(get % "bookshelves"))
+                       (every? seq)))))
+          (testing "invalid queries return an error"
+            (let [ret (query-post
+                       {:body {:query {:users {:bookshelves []}}}
+                        :headers {"app-id" (str app-id)
+                                  "authorization" (str "Bearer " admin-token)}})]
+              (is (= 400 (:status ret)))
+              (is (= :validation-failed (-> ret :body :type))))))))))
 
 (comment
   (def app-id #uuid "2f23dfa2-c921-4988-9243-adf602339bab")
   (def admin-token #uuid "af5c8213-a2c4-46fb-a092-f7adae37799a")
   (def app
     (app-model/create! {:title "test app"
-                        :creator-id instant.data.constants/test-user-id
+                        :creator-id constants/test-user-id
                         :id app-id
                         :admin-token admin-token}))
   (app-model/delete-by-id! {:id app-id}))
 
 (deftest transact-test
-  (with-empty-app
-    (fn [{app-id :id admin-token :admin-token :as _app}]
-      (let [steps [["update" "goals"
-                    "8aa64e4c-64f9-472e-8a61-3fa28870e6cb"
-                    {"title" "moop"}]]]
-        (testing "no app-id fails"
-          (let [ret (transact-post
-                     {:body {:steps steps}
-                      :headers {"app-id" nil
-                                "authorization" (str "Bearer " admin-token)}})]
-            (is (= 400 (:status ret)))
-            (is (= :param-missing (-> ret :body :type)))))
-        (testing "no token fails"
-          (let [ret (transact-post
-                     {:body {:steps steps}
-                      :headers {"app-id" (str app-id)
-                                "authorization" nil}})]
-            (is (= 400 (:status ret)))
-            (is (= :param-missing (-> ret :body :type)))))
-        (testing "wrong combo fails"
-          (let [ret (transact-post
-                     {:body {:steps steps}
-                      :headers {"app-id" (str movies-app-id)
-                                "authorization" (str "Bearer " app-id)}})]
-            (is (= 400 (:status ret)))
-            (is (= :record-not-found (-> ret :body :type)))))
-        (testing "correct combo succeeds"
-          (let [ret (transact-post
-                     {:body {:steps steps}
-                      :headers {"app-id" (str app-id)
-                                "authorization" (str "Bearer " admin-token)}})]
-            (is (= 200 (:status ret)))
-            (is (number? (-> ret :body :tx-id)))))
-        (with-zeneca-app
-          (fn [{app-id :id admin-token :admin-token} _r]
-            (testing "invalid transaction return an error"
+  (with-movies-app
+    (fn [{movies-app-id :id} _r]
+      (with-empty-app
+        (fn [{app-id :id admin-token :admin-token :as _app}]
+          (let [steps [["update" "goals"
+                        "8aa64e4c-64f9-472e-8a61-3fa28870e6cb"
+                        {"title" "moop"}]]]
+            (testing "no app-id fails"
               (let [ret (transact-post
-                         {:body {:steps (-> steps
-                                            (assoc-in [0 0] "updatez"))}
-                          :headers {"app-id" (str app-id)
+                         {:body {:steps steps}
+                          :headers {"app-id" nil
                                     "authorization" (str "Bearer " admin-token)}})]
                 (is (= 400 (:status ret)))
-                (is (= :validation-failed (-> ret :body :type)))))))
-        (testing "add-attr works"
-          (let [ret (transact-post
-                     {:body {:steps [["add-attr"
-                                      {:id (UUID/randomUUID)
-                                       :forward-identity [(UUID/randomUUID) "floopy" "flip"]
-                                       :value-type "blob"
-                                       :cardinality "one"
-                                       :unique? false
-                                       :index? false}]]}
-                      :headers {"app-id" (str app-id)
-                                "authorization" (str "Bearer " admin-token)}})]
-            (is (= 200 (:status ret)))
-            (is (number? (-> ret :body :tx-id)))
-            (is (seq (attr-model/seek-by-fwd-ident-name ["floopy" "flip"]
-                                                        (attr-model/get-by-app-id
-                                                         app-id))))))
-        (testing "delete-attr works"
-          (let [eid (UUID/randomUUID)
-                ret (transact-post
-                     {:body {:steps [["add-attr"
-                                      {:id eid
-                                       :forward-identity [(UUID/randomUUID) "floopy" "flop"]
-                                       :value-type "blob"
-                                       :cardinality "one"
-                                       :unique? false
-                                       :index? false}]
-                                     ["delete-attr" eid]]}
-                      :headers {"app-id" (str app-id)
-                                "authorization" (str "Bearer " admin-token)}})]
-            (is (= 200 (:status ret)))
-            (is (number? (-> ret :body :tx-id)))
-            (is (nil? (attr-model/seek-by-fwd-ident-name ["floopy" "flop"]
-                                                         (attr-model/get-by-app-id
-                                                          app-id))))))))))
+                (is (= :param-missing (-> ret :body :type)))))
+            (testing "no token fails"
+              (let [ret (transact-post
+                         {:body {:steps steps}
+                          :headers {"app-id" (str app-id)
+                                    "authorization" nil}})]
+                (is (= 400 (:status ret)))
+                (is (= :param-missing (-> ret :body :type)))))
+            (testing "wrong combo fails"
+              (let [ret (transact-post
+                         {:body {:steps steps}
+                          :headers {"app-id" (str movies-app-id)
+                                    "authorization" (str "Bearer " app-id)}})]
+                (is (= 400 (:status ret)))
+                (is (= :record-not-found (-> ret :body :type)))))
+            (testing "correct combo succeeds"
+              (let [ret (transact-post
+                         {:body {:steps steps}
+                          :headers {"app-id" (str app-id)
+                                    "authorization" (str "Bearer " admin-token)}})]
+                (is (= 200 (:status ret)))
+                (is (number? (-> ret :body :tx-id)))))
+            (with-zeneca-app
+              (fn [{app-id :id admin-token :admin-token} _r]
+                (testing "invalid transaction return an error"
+                  (let [ret (transact-post
+                             {:body {:steps (-> steps
+                                                (assoc-in [0 0] "updatez"))}
+                              :headers {"app-id" (str app-id)
+                                        "authorization" (str "Bearer " admin-token)}})]
+                    (is (= 400 (:status ret)))
+                    (is (= :validation-failed (-> ret :body :type)))))))
+            (testing "add-attr works"
+              (let [ret (transact-post
+                         {:body {:steps [["add-attr"
+                                          {:id (UUID/randomUUID)
+                                           :forward-identity [(UUID/randomUUID) "floopy" "flip"]
+                                           :value-type "blob"
+                                           :cardinality "one"
+                                           :unique? false
+                                           :index? false}]]}
+                          :headers {"app-id" (str app-id)
+                                    "authorization" (str "Bearer " admin-token)}})]
+                (is (= 200 (:status ret)))
+                (is (number? (-> ret :body :tx-id)))
+                (is (seq (attr-model/seek-by-fwd-ident-name ["floopy" "flip"]
+                                                            (attr-model/get-by-app-id
+                                                             app-id))))))
+            (testing "delete-attr works"
+              (let [eid (UUID/randomUUID)
+                    ret (transact-post
+                         {:body {:steps [["add-attr"
+                                          {:id eid
+                                           :forward-identity [(UUID/randomUUID) "floopy" "flop"]
+                                           :value-type "blob"
+                                           :cardinality "one"
+                                           :unique? false
+                                           :index? false}]
+                                         ["delete-attr" eid]]}
+                          :headers {"app-id" (str app-id)
+                                    "authorization" (str "Bearer " admin-token)}})]
+                (is (= 200 (:status ret)))
+                (is (number? (-> ret :body :tx-id)))
+                (is (nil? (attr-model/seek-by-fwd-ident-name ["floopy" "flop"]
+                                                             (attr-model/get-by-app-id
+                                                              app-id))))))))))))
 
 (deftest strong-init-and-inference
   (with-empty-app
@@ -748,35 +752,37 @@
       (-> e ex-data ::ex/hint :errors first))))
 
 (deftest transact-validations
-  (let [attrs (attr-model/get-by-app-id zeneca-app-id)]
-    (is (= '{:expected string?, :in [0 1]}
-           (tx-validation-err
-            attrs [["update" 1 (UUID/randomUUID) {"title" "moop"}]])))
-    (is (= '{:expected map?, :in [0 3]}
-           (tx-validation-err
-            attrs [["update" "goals" (UUID/randomUUID) 2]])))
-    (is (= '{:expected map?, :in [0 1]}
-           (tx-validation-err
-            attrs [["add-attr" "goals" (UUID/randomUUID) 2]])))
-    (is (= {:message "title is not a unique attribute on books"}
-           (tx-validation-err
-            attrs [["update" "books" ["title" "test"] {"title" "test"}]])))
-    (is (= {:message "test.isbn is not a valid lookup attribute."}
-           (tx-validation-err
-            attrs [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))
-    (is (= {:message "lookup value is invalid", :hint {:attribute "linkOn"
-                                                       :value "undefined"}}
-           (tx-validation-err
-            attrs [["link"
-                    "spans"
-                    "6fd7b6eb-6fa2-4943-b5a3-2d73c8bd6904"
-                    {:parentSpan "lookup__linkOn__undefined"}]])))
-    (is (= {:message "test.isbn is not a unique attribute on books"}
-           (tx-validation-err
-            (conj attrs {:id (random-uuid)
-                         :forward-identity [(random-uuid) "books" "test.isbn"]
-                         :unique? false})
-            [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))))
+  (with-zeneca-app
+    (fn [app _r]
+      (let [attrs (attr-model/get-by-app-id (:id app))]
+        (is (= '{:expected string?, :in [0 1]}
+               (tx-validation-err
+                attrs [["update" 1 (UUID/randomUUID) {"title" "moop"}]])))
+        (is (= '{:expected map?, :in [0 3]}
+               (tx-validation-err
+                attrs [["update" "goals" (UUID/randomUUID) 2]])))
+        (is (= '{:expected map?, :in [0 1]}
+               (tx-validation-err
+                attrs [["add-attr" "goals" (UUID/randomUUID) 2]])))
+        (is (= {:message "title is not a unique attribute on books"}
+               (tx-validation-err
+                attrs [["update" "books" ["title" "test"] {"title" "test"}]])))
+        (is (= {:message "test.isbn is not a valid lookup attribute."}
+               (tx-validation-err
+                attrs [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))
+        (is (= {:message "lookup value is invalid", :hint {:attribute "linkOn"
+                                                           :value "undefined"}}
+               (tx-validation-err
+                attrs [["link"
+                        "spans"
+                        "6fd7b6eb-6fa2-4943-b5a3-2d73c8bd6904"
+                        {:parentSpan "lookup__linkOn__undefined"}]])))
+        (is (= {:message "test.isbn is not a unique attribute on books"}
+               (tx-validation-err
+                (conj attrs {:id (random-uuid)
+                             :forward-identity [(random-uuid) "books" "test.isbn"]
+                             :unique? false})
+                [["update" "books" ["test.isbn" "asdf"] {"title" "test"}]])))))))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -142,10 +142,6 @@
     (fn [app r]
       (let [tina-turner-eid (resolvers/->uuid r "eid-tina-turner")]
         (testing "query pads with _"
-          (def -res (d/query
-                     {:db {:conn-pool (aurora/conn-pool :read)}
-                      :app-id (:id app)}
-                     [[:ea tina-turner-eid]]))
           (is (= #{"Tina Turner"
                    "1939-11-26T00:00:00Z"
                    (str tina-turner-eid)}

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -3,12 +3,17 @@
             [instant.jdbc.aurora :as aurora]
             [instant.config :as config]
             [instant.db.datalog :as d]
+            [instant.db.model.attr :as attr-model]
             [instant.data.constants :refer [movies-app-id]]
             [instant.data.resolvers :as resolvers]
             [instant.jdbc.sql :as sql]
-            [instant.fixtures :refer [with-zeneca-app]]))
+            [instant.fixtures :refer [with-movies-app with-zeneca-app]]))
 
-(def ^:private r (delay (resolvers/make-movies-resolver)))
+
+(defn make-ctx [app]
+  {:db {:conn-pool (aurora/conn-pool :read)}
+   :app-id (:id app)
+   :attrs (attr-model/get-by-app-id (:id app))})
 
 (defn- drop-join-rows-created-at [datalog-result]
   (update datalog-result :join-rows
@@ -19,14 +24,10 @@
                      %))))
 (defn- query-pretty
   "Unwraps single element sets and prints friendly names for uuids"
-  [q]
+  [ctx r q]
   (let [res (resolvers/walk-friendly
-             @r
-             (d/query
-              {:db {:conn-pool (aurora/conn-pool :read)}
-               :app-id movies-app-id
-               :datalog-loader (d/make-loader)}
-              q))]
+             r
+             (d/query ctx q))]
     (drop-join-rows-created-at res)))
 
 (deftest patterns
@@ -137,81 +138,96 @@
          [:ea ?d ?e ?f]])))))
 
 (deftest coercions
-  (let [tina-turner-eid (resolvers/->uuid @r "eid-tina-turner")]
-    (testing "query pads with _"
-      (is (= #{"Tina Turner" "1939-11-26T00:00:00Z"}
-             (->> (d/query
-                   {:db {:conn-pool (aurora/conn-pool :read)}
-                    :app-id  movies-app-id}
-                   [[:ea tina-turner-eid]])
-                  :join-rows
-                  (map (comp last drop-last last))
-                  set))))
-    (testing "ref values come back as uuids"
-      (let [vs (->> (d/query
+  (with-movies-app
+    (fn [app r]
+      (let [tina-turner-eid (resolvers/->uuid r "eid-tina-turner")]
+        (testing "query pads with _"
+          (def -res (d/query
                      {:db {:conn-pool (aurora/conn-pool :read)}
-                      :app-id movies-app-id}
-                     [[:eav '?e '?a tina-turner-eid]])
-                    :join-rows
-                    (map (comp last drop-last last)))]
-        (is (seq vs))
-        (is (every? uuid? vs))))))
+                      :app-id (:id app)}
+                     [[:ea tina-turner-eid]]))
+          (is (= #{"Tina Turner"
+                   "1939-11-26T00:00:00Z"
+                   (str tina-turner-eid)}
+                 (->> (d/query
+                       {:db {:conn-pool (aurora/conn-pool :read)}
+                        :app-id (:id app)}
+                       [[:ea tina-turner-eid]])
+                      :join-rows
+                      (map (comp last drop-last last))
+                      set))))
+        (testing "ref values come back as uuids"
+          (let [vs (->> (d/query
+                         {:db {:conn-pool (aurora/conn-pool :read)}
+                          :app-id (:id app)}
+                         [[:eav '?e '?a tina-turner-eid]])
+                        :join-rows
+                        (map (comp last drop-last last)))]
+            (is (seq vs))
+            (is (every? uuid? vs))))))))
 
 (deftest batching-queries
-  (let [app-id movies-app-id
-        ctx {:db {:conn-pool (aurora/conn-pool :read)}
-             :app-id app-id}
-        movie-title-aid (resolvers/->uuid @r :movie/title)
-        movie-director-aid (resolvers/->uuid @r :movie/director)
-        person-name-aid (resolvers/->uuid @r :person/name)
-        patterns-1 [[:ea '?e movie-title-aid "Predator"]
-                    [:eav '?e movie-director-aid '?director]
-                    [:ea '?director person-name-aid '?name]]
+  (with-movies-app
+    (fn [app r]
+      (let [app-id (:id app)
+            ctx {:db {:conn-pool (aurora/conn-pool :read)}
+                 :app-id app-id}
+            movie-title-aid (resolvers/->uuid r :movie/title)
+            movie-director-aid (resolvers/->uuid r :movie/director)
+            person-name-aid (resolvers/->uuid r :person/name)
+            patterns-1 [[:ea '?e movie-title-aid "Predator"]
+                        [:eav '?e movie-director-aid '?director]
+                        [:ea '?director person-name-aid '?name]]
 
-        patterns-2 [[:ea '?director person-name-aid "John McTiernan"]
-                    [:vae '?movie movie-director-aid '?director]
-                    [:ea '?movie movie-title-aid '?title]]
+            patterns-2 [[:ea '?director person-name-aid "John McTiernan"]
+                        [:vae '?movie movie-director-aid '?director]
+                        [:ea '?movie movie-title-aid '?title]]
 
-        named-ps-1 (d/->named-patterns patterns-1)
+            named-ps-1 (d/->named-patterns patterns-1)
 
-        named-ps-2 (d/->named-patterns patterns-2)]
+            named-ps-2 (d/->named-patterns patterns-2)]
 
-    (testing "send-query-single"
-      (is (= #{[["eid-predator" :movie/title "Predator" 1708623782646]
-                ["eid-predator" :movie/director "eid-john-mctiernan" 1708623782646]
-                ["eid-john-mctiernan"
-                 :person/name
-                 "John McTiernan"
-                 1708623782646]]}
-             (resolvers/walk-friendly
-              @r
-              (:join-rows (d/send-query-single ctx (aurora/conn-pool :read) app-id named-ps-1)))))
-      (is (= #{[["eid-john-mctiernan" :person/name "John McTiernan" 1708623782646]
-                ["eid-die-hard" :movie/director "eid-john-mctiernan" 1708623782646]
-                ["eid-die-hard" :movie/title "Die Hard" 1708623782646]]
-               [["eid-john-mctiernan" :person/name "John McTiernan" 1708623782646]
-                ["eid-predator" :movie/director "eid-john-mctiernan" 1708623782646]
-                ["eid-predator" :movie/title "Predator" 1708623782646]]}
-             (resolvers/walk-friendly
-              @r
-              (:join-rows (d/send-query-single ctx (aurora/conn-pool :read) app-id named-ps-2))))))
-    (testing "send-query-batched"
-      (is (= [#{[["eid-predator" :movie/title "Predator" 1708623782646]
-                 ["eid-predator" :movie/director "eid-john-mctiernan" 1708623782646]
-                 ["eid-john-mctiernan"
-                  :person/name
-                  "John McTiernan"
-                  1708623782646]]}
-              #{[["eid-john-mctiernan" :person/name "John McTiernan" 1708623782646]
-                 ["eid-die-hard" :movie/director "eid-john-mctiernan" 1708623782646]
-                 ["eid-die-hard" :movie/title "Die Hard" 1708623782646]]
-                [["eid-john-mctiernan" :person/name "John McTiernan" 1708623782646]
-                 ["eid-predator" :movie/director "eid-john-mctiernan" 1708623782646]
-                 ["eid-predator" :movie/title "Predator" 1708623782646]]}]
-             (resolvers/walk-friendly
-              @r
-              (map :join-rows (d/send-query-batch ctx (aurora/conn-pool :read) [[app-id named-ps-1]
-                                                                          [app-id named-ps-2]]))))))))
+        (testing "send-query-single"
+          (is (= #{[["eid-predator" :movie/title "Predator"]
+                    ["eid-predator" :movie/director "eid-john-mctiernan"]
+                    ["eid-john-mctiernan"
+                     :person/name
+                     "John McTiernan"]]}
+                 (-> (resolvers/walk-friendly
+                      r
+                      (:join-rows (drop-join-rows-created-at
+                                   (d/send-query-single ctx
+                                                        (aurora/conn-pool :read)
+                                                        app-id
+                                                        named-ps-1)))))))
+          (is (= #{[["eid-john-mctiernan" :person/name "John McTiernan"]
+                    ["eid-die-hard" :movie/director "eid-john-mctiernan"]
+                    ["eid-die-hard" :movie/title "Die Hard"]]
+                   [["eid-john-mctiernan" :person/name "John McTiernan"]
+                    ["eid-predator" :movie/director "eid-john-mctiernan"]
+                    ["eid-predator" :movie/title "Predator"]]}
+                 (resolvers/walk-friendly
+                  r
+                  (:join-rows (drop-join-rows-created-at
+                               (d/send-query-single ctx (aurora/conn-pool :read) app-id named-ps-2)))))))
+        (testing "send-query-batched"
+          (is (= [#{[["eid-predator" :movie/title "Predator"]
+                     ["eid-predator" :movie/director "eid-john-mctiernan"]
+                     ["eid-john-mctiernan"
+                      :person/name
+                      "John McTiernan"]]}
+                  #{[["eid-john-mctiernan" :person/name "John McTiernan"]
+                     ["eid-die-hard" :movie/director "eid-john-mctiernan"]
+                     ["eid-die-hard" :movie/title "Die Hard"]]
+                    [["eid-john-mctiernan" :person/name "John McTiernan"]
+                     ["eid-predator" :movie/director "eid-john-mctiernan"]
+                     ["eid-predator" :movie/title "Predator"]]}]
+                 (resolvers/walk-friendly
+                  r
+                  (map :join-rows
+                       (map drop-join-rows-created-at
+                            (d/send-query-batch ctx (aurora/conn-pool :read) [[app-id named-ps-1]
+                                                                              [app-id named-ps-2]])))))))))))
 
 (def ^:dynamic *count-atom* nil)
 
@@ -230,159 +246,164 @@
          ~@body))))
 
 (deftest queries
-  (testing "simple query"
-    (let [tina-turner-eid (resolvers/->uuid @r "eid-tina-turner")]
-      (is (= '{:topics [[:ea #{"eid-tina-turner"} _ _]]
+  (with-movies-app
+    (fn [app r]
+      (let [ctx (make-ctx app)
+            query-pretty (partial query-pretty ctx r)]
+        (testing "simple query"
+          (let [tina-turner-eid (resolvers/->uuid r "eid-tina-turner")]
+            (is (= '{:topics [[:ea #{"eid-tina-turner"} _ _]]
 
-               :symbol-values {?a #{:person/name :person/born}},
+                     :symbol-values {?a #{:person/name :person/born :person/id}},
 
-               :join-rows #{[["eid-tina-turner" :person/name "Tina Turner"]]
-                            [["eid-tina-turner" :person/born "1939-11-26T00:00:00Z"]]}}
+                     :join-rows #{[("eid-tina-turner" :person/id "eid-tina-turner")]
+                                  [["eid-tina-turner" :person/name "Tina Turner"]]
+                                  [["eid-tina-turner" :person/born "1939-11-26T00:00:00Z"]]}}
 
-             (query-pretty
-              [[:ea tina-turner-eid '?a]])))))
+                   (query-pretty
+                    [[:ea tina-turner-eid '?a]])))))
 
-  (testing "attr-jump"
-    (let [movie-title-aid (resolvers/->uuid @r :movie/title)
-          movie-year-aid (resolvers/->uuid @r :movie/year)]
-      (is (= '{:topics [[:ea _ #{:movie/year} #{1987}]
-                        [:ea #{"eid-lethal-weapon" "eid-robocop" "eid-predator"} #{:movie/title} _]],
+        (testing "attr-jump"
+          (let [movie-title-aid (resolvers/->uuid r :movie/title)
+                movie-year-aid (resolvers/->uuid r :movie/year)]
+            (is (= '{:topics [[:ea _ #{:movie/year} #{1987}]
+                              [:ea #{"eid-lethal-weapon" "eid-robocop" "eid-predator"} #{:movie/title} _]],
 
-               :symbol-values {?e #{"eid-lethal-weapon" "eid-robocop" "eid-predator"},
-                               ?title #{"Predator" "RoboCop" "Lethal Weapon"}},
+                     :symbol-values {?e #{"eid-lethal-weapon" "eid-robocop" "eid-predator"},
+                                     ?title #{"Predator" "RoboCop" "Lethal Weapon"}},
 
-               :join-rows #{[["eid-robocop" :movie/year 1987]
-                             ["eid-robocop" :movie/title "RoboCop"]]
-                            [["eid-lethal-weapon" :movie/year 1987]
-                             ["eid-lethal-weapon" :movie/title "Lethal Weapon"]]
-                            [["eid-predator" :movie/year 1987]
-                             ["eid-predator" :movie/title "Predator"]]}}
-             (query-pretty
-              [[:ea '?e movie-year-aid 1987]
-               [:ea '?e movie-title-aid '?title]])))))
-  (testing "refs jump eav"
-    (let [movie-title-aid (resolvers/->uuid @r :movie/title)
-          movie-director-aid (resolvers/->uuid @r :movie/director)
-          person-name-aid (resolvers/->uuid @r :person/name)]
-      (is (= '{:topics [[:ea _ #{:movie/title} #{"Predator"}]
-                        [:eav #{"eid-predator"} #{:movie/director} _]
-                        [:ea _ #{:person/name} _]]
+                     :join-rows #{[["eid-robocop" :movie/year 1987]
+                                   ["eid-robocop" :movie/title "RoboCop"]]
+                                  [["eid-lethal-weapon" :movie/year 1987]
+                                   ["eid-lethal-weapon" :movie/title "Lethal Weapon"]]
+                                  [["eid-predator" :movie/year 1987]
+                                   ["eid-predator" :movie/title "Predator"]]}}
+                   (query-pretty
+                    [[:ea '?e movie-year-aid 1987]
+                     [:ea '?e movie-title-aid '?title]])))))
+        (testing "refs jump eav"
+          (let [movie-title-aid (resolvers/->uuid r :movie/title)
+                movie-director-aid (resolvers/->uuid r :movie/director)
+                person-name-aid (resolvers/->uuid r :person/name)]
+            (is (= '{:topics [[:ea _ #{:movie/title} #{"Predator"}]
+                              [:eav #{"eid-predator"} #{:movie/director} _]
+                              [:ea _ #{:person/name} _]]
 
-               :symbol-values {?e #{"eid-predator"},
-                               ?director #{"eid-john-mctiernan"},
-                               ?name #{"John McTiernan"}},
+                     :symbol-values {?e #{"eid-predator"},
+                                     ?director #{"eid-john-mctiernan"},
+                                     ?name #{"John McTiernan"}},
 
-               :join-rows #{[["eid-predator" :movie/title "Predator"]
-                             ["eid-predator" :movie/director "eid-john-mctiernan"]
-                             ["eid-john-mctiernan" :person/name "John McTiernan"]]}}
+                     :join-rows #{[["eid-predator" :movie/title "Predator"]
+                                   ["eid-predator" :movie/director "eid-john-mctiernan"]
+                                   ["eid-john-mctiernan" :person/name "John McTiernan"]]}}
 
-             (query-pretty
-              [[:ea '?e movie-title-aid "Predator"]
-               [:eav '?e movie-director-aid '?director]
-               [:ea '?director person-name-aid '?name]])))))
+                   (query-pretty
+                    [[:ea '?e movie-title-aid "Predator"]
+                     [:eav '?e movie-director-aid '?director]
+                     [:ea '?director person-name-aid '?name]])))))
 
-  (testing "refs jump vae"
-    (let [movie-title-aid (resolvers/->uuid @r :movie/title)
-          movie-director-aid (resolvers/->uuid @r :movie/director)
-          person-name-aid (resolvers/->uuid @r :person/name)]
-      (is (= '{:topics [[:ea _ #{:person/name} #{"John McTiernan"}]
-                        [:vae _ #{:movie/director} #{"eid-john-mctiernan"}]
-                        [:ea #{"eid-predator" "eid-die-hard"} #{:movie/title} _]],
+        (testing "refs jump vae"
+          (let [movie-title-aid (resolvers/->uuid r :movie/title)
+                movie-director-aid (resolvers/->uuid r :movie/director)
+                person-name-aid (resolvers/->uuid r :person/name)]
+            (is (= '{:topics [[:ea _ #{:person/name} #{"John McTiernan"}]
+                              [:vae _ #{:movie/director} #{"eid-john-mctiernan"}]
+                              [:ea #{"eid-predator" "eid-die-hard"} #{:movie/title} _]],
 
-               :symbol-values {?director #{"eid-john-mctiernan"},
-                               ?movie #{"eid-predator" "eid-die-hard"},
-                               ?title #{"Predator" "Die Hard"}},,
+                     :symbol-values {?director #{"eid-john-mctiernan"},
+                                     ?movie #{"eid-predator" "eid-die-hard"},
+                                     ?title #{"Predator" "Die Hard"}},,
 
-               :join-rows #{[["eid-john-mctiernan" :person/name "John McTiernan"]
-                             ["eid-die-hard" :movie/director "eid-john-mctiernan"]
-                             ["eid-die-hard" :movie/title "Die Hard"]]
-                            [["eid-john-mctiernan" :person/name "John McTiernan"]
-                             ["eid-predator" :movie/director "eid-john-mctiernan"]
-                             ["eid-predator" :movie/title "Predator"]]}}
+                     :join-rows #{[["eid-john-mctiernan" :person/name "John McTiernan"]
+                                   ["eid-die-hard" :movie/director "eid-john-mctiernan"]
+                                   ["eid-die-hard" :movie/title "Die Hard"]]
+                                  [["eid-john-mctiernan" :person/name "John McTiernan"]
+                                   ["eid-predator" :movie/director "eid-john-mctiernan"]
+                                   ["eid-predator" :movie/title "Predator"]]}}
 
-             (query-pretty
-              [[:ea '?director person-name-aid "John McTiernan"]
-               [:vae '?movie movie-director-aid '?director]
-               [:ea '?movie movie-title-aid '?title]])))))
+                   (query-pretty
+                    [[:ea '?director person-name-aid "John McTiernan"]
+                     [:vae '?movie movie-director-aid '?director]
+                     [:ea '?movie movie-title-aid '?title]])))))
 
-  (testing "batching"
-    (with-open [conn-pool (sql/start-pool
-                           (assoc (config/get-aurora-config)
-                                  :maximumPoolSize 1))]
-      ;; Take the only available connection
-      (let [hold-conn (.getConnection conn-pool)
-            loader (d/make-loader)
-            ctx {:db {:conn-pool conn-pool}
-                 :app-id movies-app-id
-                 :datalog-loader loader}
-            movie-title-aid (resolvers/->uuid @r :movie/title)
-            movie-director-aid (resolvers/->uuid @r :movie/director)
-            person-name-aid (resolvers/->uuid @r :person/name)
-            counts (atom 0)]
+        (testing "batching"
+          (with-open [conn-pool (sql/start-pool
+                                 (assoc (config/get-aurora-config)
+                                        :maximumPoolSize 1))]
+            ;; Take the only available connection
+            (let [hold-conn (.getConnection conn-pool)
+                  loader (d/make-loader)
+                  ctx {:db {:conn-pool conn-pool}
+                       :app-id (:id app)
+                       :datalog-loader loader}
+                  movie-title-aid (resolvers/->uuid r :movie/title)
+                  movie-director-aid (resolvers/->uuid r :movie/director)
+                  person-name-aid (resolvers/->uuid r :person/name)
+                  counts (atom 0)]
 
-        (with-count-sql-select-arrays counts
-          (let [q1 (future (as-> (d/query
-                                  ctx
-                                  [[:ea '?director person-name-aid "John McTiernan"]
-                                   [:vae '?movie movie-director-aid '?director]
-                                   [:ea '?movie movie-title-aid '?title]])
-                                 %
-                             (resolvers/walk-friendly @r %)
-                             (drop-join-rows-created-at %)))
-                q2 (future (as-> (d/query
-                                  ctx [[:ea '?e movie-title-aid "Predator"]
-                                       [:eav '?e movie-director-aid '?director]
-                                       [:ea '?director person-name-aid '?name]])
-                                 %
-                             (resolvers/walk-friendly @r %)
-                             (drop-join-rows-created-at %)))]
+              (with-count-sql-select-arrays counts
+                (let [q1 (future (as-> (d/query
+                                        ctx
+                                        [[:ea '?director person-name-aid "John McTiernan"]
+                                         [:vae '?movie movie-director-aid '?director]
+                                         [:ea '?movie movie-title-aid '?title]])
+                                     %
+                                     (resolvers/walk-friendly r %)
+                                     (drop-join-rows-created-at %)))
+                      q2 (future (as-> (d/query
+                                        ctx [[:ea '?e movie-title-aid "Predator"]
+                                             [:eav '?e movie-director-aid '?director]
+                                             [:ea '?director person-name-aid '?name]])
+                                     %
+                                     (resolvers/walk-friendly r %)
+                                     (drop-join-rows-created-at %)))]
 
-            ;; Wait for queries to batch
-            (loop [i 0]
-              (when (not= 2 (count (get-in @loader [conn-pool :items])))
-                (when (> i 10)
-                  (throw
-                   (Exception.
-                    "Queries took too long to batch. Something must be broken.")))
-                (println "waiting")
-                (Thread/sleep i)
-                (recur (inc i))))
+                  ;; Wait for queries to batch
+                  (loop [i 0]
+                    (when (not= 2 (count (get-in @loader [conn-pool :items])))
+                      (when (> i 10)
+                        (throw
+                         (Exception.
+                          "Queries took too long to batch. Something must be broken.")))
+                      (println "waiting")
+                      (Thread/sleep i)
+                      (recur (inc i))))
 
-            ;; Return the connection so that queries can complete
-            (.close hold-conn)
+                  ;; Return the connection so that queries can complete
+                  (.close hold-conn)
 
-            (is (=
-                 '{:topics [[:ea _ #{:person/name} #{"John McTiernan"}]
-                            [:vae _ #{:movie/director} #{"eid-john-mctiernan"}]
-                            [:ea #{"eid-predator" "eid-die-hard"} #{:movie/title} _]],
+                  (is (=
+                       '{:topics [[:ea _ #{:person/name} #{"John McTiernan"}]
+                                  [:vae _ #{:movie/director} #{"eid-john-mctiernan"}]
+                                  [:ea #{"eid-predator" "eid-die-hard"} #{:movie/title} _]],
 
-                   :symbol-values {?director #{"eid-john-mctiernan"},
-                                   ?movie #{"eid-predator" "eid-die-hard"},
-                                   ?title #{"Predator" "Die Hard"}},
+                         :symbol-values {?director #{"eid-john-mctiernan"},
+                                         ?movie #{"eid-predator" "eid-die-hard"},
+                                         ?title #{"Predator" "Die Hard"}},
 
-                   :join-rows #{[["eid-john-mctiernan" :person/name "John McTiernan"]
-                                 ["eid-die-hard" :movie/director "eid-john-mctiernan"]
-                                 ["eid-die-hard" :movie/title "Die Hard"]]
-                                [["eid-john-mctiernan" :person/name "John McTiernan"]
-                                 ["eid-predator" :movie/director "eid-john-mctiernan"]
-                                 ["eid-predator" :movie/title "Predator"]]}}
-                 @q1))
-            (is (=
-                 '{:topics [[:ea _ #{:movie/title} #{"Predator"}]
-                            [:eav #{"eid-predator"} #{:movie/director} _]
-                            [:ea _ #{:person/name} _]]
+                         :join-rows #{[["eid-john-mctiernan" :person/name "John McTiernan"]
+                                       ["eid-die-hard" :movie/director "eid-john-mctiernan"]
+                                       ["eid-die-hard" :movie/title "Die Hard"]]
+                                      [["eid-john-mctiernan" :person/name "John McTiernan"]
+                                       ["eid-predator" :movie/director "eid-john-mctiernan"]
+                                       ["eid-predator" :movie/title "Predator"]]}}
+                       @q1))
+                  (is (=
+                       '{:topics [[:ea _ #{:movie/title} #{"Predator"}]
+                                  [:eav #{"eid-predator"} #{:movie/director} _]
+                                  [:ea _ #{:person/name} _]]
 
-                   :symbol-values {?e #{"eid-predator"},
-                                   ?director #{"eid-john-mctiernan"},
-                                   ?name #{"John McTiernan"}}
+                         :symbol-values {?e #{"eid-predator"},
+                                         ?director #{"eid-john-mctiernan"},
+                                         ?name #{"John McTiernan"}}
 
-                   :join-rows #{[["eid-predator" :movie/title "Predator"]
-                                 ["eid-predator" :movie/director "eid-john-mctiernan"]
-                                 ["eid-john-mctiernan" :person/name "John McTiernan"]]}}
-                 @q2))
+                         :join-rows #{[["eid-predator" :movie/title "Predator"]
+                                       ["eid-predator" :movie/director "eid-john-mctiernan"]
+                                       ["eid-john-mctiernan" :person/name "John McTiernan"]]}}
+                       @q2))
 
-            (testing "we only make a single sql query for both d/query calls"
-              (is (= @counts 1)))))))))
+                  (testing "we only make a single sql query for both d/query calls"
+                    (is (= @counts 1))))))))))))
 
 (deftest lookup-refs
   (with-zeneca-app

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -4,13 +4,12 @@
    [clojure.test :as test :refer [deftest is testing]]
    [datascript.core :as ds]
    [instant.config :as config]
-   [instant.data.constants :refer [movies-app-id zeneca-app-id]]
    [instant.data.resolvers :as resolvers]
    [instant.db.datalog :as d]
    [instant.db.instaql :as iq]
    [instant.db.model.attr :as attr-model]
    [instant.db.transaction :as tx]
-   [instant.fixtures :refer [with-empty-app with-movies-app]]
+   [instant.fixtures :refer [with-empty-app with-movies-app with-zeneca-app]]
    [instant.grouped-queue :as grouped-queue]
    [instant.jdbc.aurora :as aurora]
    [instant.lib.ring.websocket :as ws]
@@ -30,10 +29,6 @@
     (binding [config/*env* :test]
       (f))))
 
-(def ^:private r
-  (delay
-    (resolvers/make-movies-resolver)))
-
 (def ^:private non-existent-app-id
   #uuid "39b33777-3324-42dd-8f47-ce41d246c5a6")
 
@@ -44,59 +39,67 @@
   nil)
 
 (defn- with-session [f]
-  (let [store (rs/init)
+  (with-movies-app
+    (fn [{movies-app-id :id} movies-resolver]
+      (with-zeneca-app
+        (fn [{zeneca-app-id :id} zeneca-resolver]
+          (let [store (rs/init)
 
-        receive-q
-        (grouped-queue/start {:group-key-fn session/group-key
-                              :combine-fn   session/combine
-                              :process-fn   #(session/straight-jacket-process-receive-q-event store %1 %2)
-                              :max-workers  1})
+                receive-q
+                (grouped-queue/start {:group-key-fn session/group-key
+                                      :combine-fn   session/combine
+                                      :process-fn   #(session/straight-jacket-process-receive-q-event store %1 %2)
+                                      :max-workers  1})
 
-        realized-eph?   (atom false)
-        eph-hz          (delay
-                          (reset! realized-eph? true)
-                          @(future ;; avoid pinning vthread
-                             (eph/init-hz :test
-                                          store
-                                          (let [id (+ 100000 (rand-int 900000))]
-                                            {:instance-name (str "test-instance-" id)
-                                             :cluster-name  (str "test-cluster-" id)}))))
-        eph-room-maps   (atom {})
-        socket          {:id               (random-uuid)
-                         :ws-conn          (a/chan 100)
-                         :receive-q        receive-q
-                         :ping-job         (future)
-                         :pending-handlers (atom #{})}
-        socket-2        {:id               (random-uuid)
-                         :ws-conn          (a/chan 100)
-                         :receive-q        receive-q
-                         :ping-job         (future)
-                         :pending-handlers (atom #{})}
-        query-reactive  rq/instaql-query-reactive!]
-    (session/on-open store socket)
-    (session/on-open store socket-2)
+                realized-eph?   (atom false)
+                eph-hz          (delay
+                                  (reset! realized-eph? true)
+                                  @(future ;; avoid pinning vthread
+                                     (eph/init-hz :test
+                                                  store
+                                                  (let [id (+ 100000 (rand-int 900000))]
+                                                    {:instance-name (str "test-instance-" id)
+                                                     :cluster-name  (str "test-cluster-" id)}))))
+                eph-room-maps   (atom {})
+                socket          {:id               (random-uuid)
+                                 :ws-conn          (a/chan 100)
+                                 :receive-q        receive-q
+                                 :ping-job         (future)
+                                 :pending-handlers (atom #{})}
+                socket-2        {:id               (random-uuid)
+                                 :ws-conn          (a/chan 100)
+                                 :receive-q        receive-q
+                                 :ping-job         (future)
+                                 :pending-handlers (atom #{})}
+                query-reactive  rq/instaql-query-reactive!]
+            (session/on-open store socket)
+            (session/on-open store socket-2)
 
-    (binding [*store*                 store
-              *instaql-query-results* (atom {})]
-      (with-redefs [receive-queue/receive-q receive-q
-                    eph/room-maps           eph-room-maps
-                    eph/hz                  eph-hz
-                    ws/send-json!           (fn [_app-id msg fake-ws-conn]
-                                              (a/put! fake-ws-conn msg))
-                    rq/instaql-query-reactive!
-                    (fn [store {:keys [session-id] :as base-ctx} instaql-query return-type]
-                      (let [res (query-reactive store base-ctx instaql-query return-type)]
-                        (swap! *instaql-query-results* assoc-in [session-id instaql-query] res)
-                        res))]
-        (try
-          (f store {:socket   socket
-                    :socket-2 socket-2})
-          (finally
-            (session/on-close store socket)
-            (session/on-close store socket-2)
-            (grouped-queue/stop receive-q)
-            (when @realized-eph?
-              (HazelcastInstance/.shutdown (:hz @eph-hz)))))))))
+            (binding [*store*                 store
+                      *instaql-query-results* (atom {})]
+              (with-redefs [receive-queue/receive-q receive-q
+                            eph/room-maps           eph-room-maps
+                            eph/hz                  eph-hz
+                            ws/send-json!           (fn [_app-id msg fake-ws-conn]
+                                                      (a/put! fake-ws-conn msg))
+                            rq/instaql-query-reactive!
+                            (fn [store {:keys [session-id] :as base-ctx} instaql-query return-type]
+                              (let [res (query-reactive store base-ctx instaql-query return-type)]
+                                (swap! *instaql-query-results* assoc-in [session-id instaql-query] res)
+                                res))]
+                (try
+                  (f store {:socket   socket
+                            :socket-2 socket-2
+                            :movies-app-id movies-app-id
+                            :movies-resolver movies-resolver
+                            :zeneca-app-id zeneca-app-id
+                            :zeneca-resolver zeneca-resolver})
+                  (finally
+                    (session/on-close store socket)
+                    (session/on-close store socket-2)
+                    (grouped-queue/stop receive-q)
+                    (when @realized-eph?
+                      (HazelcastInstance/.shutdown (:hz @eph-hz)))))))))))))
 
 (defn read-msg [{:keys [ws-conn id]}]
   (let [ret (ua/<!!-timeout ws-conn)]
@@ -121,8 +124,8 @@
 
 (deftest anon-auth
   (with-session
-    (fn [store {:keys [socket]
-                     {:keys [id]} :socket}]
+    (fn [store {:keys [socket zeneca-app-id movies-app-id]
+                {:keys [id]} :socket}]
       (testing "non-existent app"
         (is (= 400
                (:status (blocking-send-msg
@@ -133,8 +136,8 @@
         (let [{op :op event-auth :auth} (blocking-send-msg :init-ok socket {:op :init :app-id zeneca-app-id})
               store-auth (-> (rs/session store id) :session/auth)]
           (is (= :init-ok op))
-          (is (= ["Zeneca-ex" nil] (pretty-auth event-auth)))
-          (is (= ["Zeneca-ex" nil] (pretty-auth store-auth)))))
+          (is (= ["test app" nil] (pretty-auth event-auth)))
+          (is (= ["test app" nil] (pretty-auth store-auth)))))
 
       (testing "already authed"
         (is (= 400
@@ -146,6 +149,9 @@
                    {:datalog-result
                     {:join-rows
                      #{#{("eid-lethal-weapon" :movie/title "Lethal Weapon")
+                         ("eid-robocop" :movie/id "eid-robocop")
+                         ("eid-lethal-weapon" :movie/id "eid-lethal-weapon")
+                         ("eid-predator" :movie/id "eid-predator")
                          ("eid-robocop" :movie/year 1987)
                          ("eid-robocop" :movie/title "RoboCop")
                          ("eid-predator" :movie/year 1987)
@@ -192,7 +198,8 @@
    :client-resp '({:data
                    {:datalog-result
                     {:join-rows
-                     #{#{("eid-robocop" :movie/year 1987)
+                     #{#{("eid-robocop" :movie/id "eid-robocop")
+                         ("eid-robocop" :movie/year 1987)
                          ("eid-robocop" :movie/title "RoboCop")}}}},
                    :child-nodes ()})
    :store-resp '[{:data {:k "movie",
@@ -231,12 +238,12 @@
       (update-in [:data :datalog-result] drop-join-rows-created-at)
       (update :child-nodes (partial map remove-created-at))))
 
-(defn- pretty-query [session-id q]
+(defn- pretty-query [r session-id q]
   (let [res (->> *instaql-query-results*
                  deref
                  (#(get-in % [session-id q]))
                  :instaql-result
-                 (resolvers/walk-friendly @r))]
+                 (resolvers/walk-friendly r))]
     (map remove-created-at res)))
 
 (deftest add-query-requires-auth
@@ -249,7 +256,7 @@
 
 (deftest add-malformed-query-rejected
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (testing "malformed query are rejected"
         (is (= 400
@@ -257,7 +264,7 @@
 
 (deftest add-nil-query-rejected
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (testing "nil queries are rejected"
         (is (= 400
@@ -265,7 +272,7 @@
 
 (deftest add-query-works
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id movies-resolver]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
 
       (testing "add query: movies in 1987"
@@ -276,7 +283,7 @@
           (is (= op :add-query-ok))
           (is (= (:kw-q query-1987) q))
           (is (= (:client-resp query-1987)
-                 (resolvers/walk-friendly @r (map remove-created-at result)))))))))
+                 (resolvers/walk-friendly movies-resolver (map remove-created-at result)))))))))
 
 (defn- get-datalog-cache-for-app [store app-id]
   (let [db  @(rs/app-conn store app-id)]
@@ -302,7 +309,7 @@
 
 (deftest add-query-sets-store
   (with-session
-    (fn [store {:keys [socket]
+    (fn [store {:keys [socket movies-app-id movies-resolver]
                      {:keys [id]} :socket}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (blocking-send-msg :add-query-ok
@@ -319,7 +326,8 @@
                    {:pattern-groups
                     [{:patterns [[:ea ?movie-0 :movie/year 1987]],
                       :children
-                      {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/year
+                      {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/id
+                                                                    :movie/year
                                                                     :movie/director
                                                                     :movie/sequel
                                                                     :movie/cast
@@ -330,7 +338,8 @@
                    {:pattern-groups
                     [{:patterns [[:ea ?movie-0 :movie/title "RoboCop"]],
                       :children
-                      {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/year
+                      {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/id
+                                                                    :movie/year
                                                                     :movie/director
                                                                     :movie/sequel
                                                                     :movie/cast
@@ -338,7 +347,7 @@
                                                                     :movie/title}]]}],
                        :join-sym ?movie-0}}]}}}
                (->> (get-datalog-cache-for-app store movies-app-id)
-                    (resolvers/walk-friendly @r)
+                    (resolvers/walk-friendly movies-resolver)
                     keys
                     set))))
 
@@ -348,7 +357,8 @@
                     {:pattern-groups
                      [{:patterns [[:ea ?movie-0 :movie/year 1987]],
                        :children
-                       {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/year
+                       {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/id
+                                                                     :movie/year
                                                                      :movie/director
                                                                      :movie/sequel
                                                                      :movie/cast
@@ -360,7 +370,8 @@
                     {:pattern-groups
                      [{:patterns [[:ea ?movie-0 :movie/title "RoboCop"]],
                        :children
-                       {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/year
+                       {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/id
+                                                                     :movie/year
                                                                      :movie/director
                                                                      :movie/sequel
                                                                      :movie/cast
@@ -368,18 +379,18 @@
                                                                      :movie/title}]]}],
                         :join-sym ?movie-0}}]}}}}
                (->> (get-subscriptions-for-app-id store movies-app-id)
-                    (resolvers/walk-friendly @r)
+                    (resolvers/walk-friendly movies-resolver)
                     pretty-subs))))
 
       (testing "instaql-queries are set"
         (is (= (:client-resp query-1987)
-               (pretty-query id (:kw-q query-1987))))
+               (pretty-query movies-resolver id (:kw-q query-1987))))
         (is (= (:client-resp query-robocop)
-               (pretty-query id (:kw-q query-robocop))))))))
+               (pretty-query movies-resolver id (:kw-q query-robocop))))))))
 
 (deftest add-duplicate-query-returns-query-exists
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (blocking-send-msg :add-query-ok socket {:op :add-query :q (:kw-q query-robocop)})
       (is (= {:op :add-query-exists,
@@ -389,7 +400,7 @@
 
 (deftest remove-query-works
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (blocking-send-msg :add-query-ok
                          socket
@@ -404,7 +415,7 @@
 
 (deftest remove-query-updates-store
   (with-session
-    (fn [store {:keys [socket]}]
+    (fn [store {:keys [socket movies-app-id movies-resolver]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
 
       (blocking-send-msg :add-query-ok
@@ -430,7 +441,8 @@
                    {:pattern-groups
                     [{:patterns [[:ea ?movie-0 :movie/title "RoboCop"]],
                       :children
-                      {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/year
+                      {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/id
+                                                                    :movie/year
                                                                     :movie/director
                                                                     :movie/sequel
                                                                     :movie/cast
@@ -438,7 +450,7 @@
                                                                     :movie/title}]]}],
                        :join-sym ?movie-0}}]}}}
                (->> (get-datalog-cache-for-app store movies-app-id)
-                    (resolvers/walk-friendly @r)
+                    (resolvers/walk-friendly movies-resolver)
                     keys
                     set))))
 
@@ -448,7 +460,8 @@
                     {:pattern-groups
                      [{:patterns [[:ea ?movie-0 :movie/title "RoboCop"]],
                        :children
-                       {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/year
+                       {:pattern-groups [{:patterns [[:ea ?movie-0 #{:movie/id
+                                                                     :movie/year
                                                                      :movie/director
                                                                      :movie/sequel
                                                                      :movie/cast
@@ -457,7 +470,7 @@
                         :join-sym ?movie-0}}]}}}}
                (some->> (get-subscriptions-for-app-id store movies-app-id)
                         seq
-                        (resolvers/walk-friendly @r)
+                        (resolvers/walk-friendly movies-resolver)
                         pretty-subs))))
 
       ;; okay, now for the second query
@@ -715,7 +728,7 @@
 
 (deftest join-room-works
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init
                                           :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
@@ -738,7 +751,7 @@
 
 (deftest leave-room-works
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (send-msg socket {:op :init
                         :app-id movies-app-id})
       (is (= :init-ok (:op (read-msg socket))))
@@ -765,7 +778,7 @@
 
 (deftest patch-presence-works
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (let [rid     (str (UUID/randomUUID))
             sess-id (:id socket)
             d1      {:a "a" :b "b" :c "c" :d "d" :e "e"}
@@ -818,7 +831,8 @@
 (deftest set-presence-two-sessions
   (with-session
     (fn [_store {socket-1 :socket
-                      socket-2 :socket-2}]
+                 socket-2 :socket-2
+                 movies-app-id :movies-app-id}]
       (let [rid       (str (UUID/randomUUID))
             sess-id-1 (:id socket-1)
             sess-id-2 (:id socket-2)
@@ -901,7 +915,7 @@
 
 (deftest set-presence-fails-when-not-in-room
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
             d1 {:hello "world"}
@@ -911,7 +925,7 @@
 
 (deftest broadcast-works
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (let [rid (str (UUID/randomUUID))
             sess-id (:id socket)
             t1 "foo"
@@ -943,7 +957,7 @@
 
 (deftest broadcast-fails-when-not-in-room
   (with-session
-    (fn [_store {:keys [socket]}]
+    (fn [_store {:keys [socket movies-app-id]}]
       (blocking-send-msg :init-ok socket {:op :init :app-id movies-app-id})
       (let [rid (str (UUID/randomUUID))
             t1 "foo"


### PR DESCRIPTION
Follow up to https://github.com/instantdb/instant/pull/952, removes the remaining dependencies on the apps in the db.

Much easier to review when ignoring whitespace (https://github.com/instantdb/instant/pull/955/files?w=1)