### PR TITLE
[cli] add onDelete: cascade annoation

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1011,6 +1011,18 @@ async function waitForIndexingJobsToFinish(appId, data) {
   }
 }
 
+function linkOptsPretty(attr) {
+  const fwdEtype = attrFwdEtype(attr);
+  const revEtype = attrRevEtype(attr);
+  if (attr['on-delete'] === 'cascade') {
+    return `:: onDelete ${revEtype} cascade ${fwdEtype}`;
+  } else if (attr['on-delete-reverse'] === 'cascade') {
+    return `:: onDelete ${fwdEtype} cascade ${revEtype}`;
+  } else {
+    return '';
+  }
+}
+
 async function pushSchema(appId, opts) {
   const res = await readLocalSchemaFileWithErrorLogging();
   if (!res) return { ok: false };
@@ -1061,7 +1073,7 @@ async function pushSchema(appId, opts) {
         }
 
         console.log(
-          `${isAdd ? chalk.green('ADD LINK') : chalk.blue('UPDATE LINK')} ${attrFwdName(attr)} <=> ${attrRevName(attr)}`,
+          `${isAdd ? chalk.green('ADD LINK') : chalk.blue('UPDATE LINK')} ${attrFwdName(attr)} <=> ${attrRevName(attr)} ${linkOptsPretty(attr)}`,
         );
         break;
       }


### PR DESCRIPTION
I realize we didn't annotate when a user added onDelete cascade rules. 

Now we do: 

<img width="727" alt="CleanShot 2025-02-27 at 14 56 24@2x" src="https://github.com/user-attachments/assets/568304ec-7b48-4132-86a8-e02f53a3acc0" />

Note: this has the same issue that prod currently has, where if a user links to the same etype, the onDelete rule will look ambiguous. Going to tackle that in a separate PR 

@tonsky @dwwoelfel @nezaj 