### PR TITLE
Faster join CTE

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1489,8 +1489,11 @@
                                                               symbol-map
                                                               {:e [:variable join-sym]})]
                                         (if-let [single-field (when (and (= 1 (count conds))
-                                                                         (= [:= :entity-id] (take 2 (first conds))))
+                                                                         (= [:= :entity-id]
+                                                                            (take 2 (first conds))))
                                                                 (last (first conds)))]
+                                          ;; If we're only joining on a single col, we can just grab
+                                          ;; that col directly from the CTE
                                           {:select [[[:distinct single-field] (kw prefix next-idx :-entity-id)]]
                                            :from (kw prefix (dec next-idx))}
                                           {:select [[[:distinct :entity-id] (kw prefix next-idx :-entity-id)]]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1485,13 +1485,19 @@
                                    :table (:from query)}))
                       (let [join-sym (get-in pattern-group [:children :join-sym])
                             join-cte [(kw prefix next-idx)
-                                      {:select [[[:distinct :entity-id] (kw prefix next-idx :-entity-id)]]
-                                       :from [:triples (kw prefix (dec next-idx))]
-                                       :where (list* :and
-                                                     [:= :app-id app-id]
-                                                     (join-conds prefix
-                                                                 symbol-map
-                                                                 {:e [:variable join-sym]}))}
+                                      (let [conds (join-conds prefix
+                                                              symbol-map
+                                                              {:e [:variable join-sym]})]
+                                        (if-let [single-field (when (and (= 1 (count conds))
+                                                                         (= [:= :entity-id] (take 2 (first conds))))
+                                                                (last (first conds)))]
+                                          {:select [[[:distinct single-field] (kw prefix next-idx :-entity-id)]]
+                                           :from (kw prefix (dec next-idx))}
+                                          {:select [[[:distinct :entity-id] (kw prefix next-idx :-entity-id)]]
+                                           :from [:triples (kw prefix (dec next-idx))]
+                                           :where (list* :and
+                                                         [:= :app-id app-id]
+                                                         conds)}))
                                       :materialized]
                             child-res (accumulate-nested-match-query (-> next-acc
                                                                          (update :ctes conj join-cte)


### PR DESCRIPTION
We use a "join CTE" to connect separate datalog queries into a single postgres query.

For a instaql query like `{:users {:$ {where {:name "daniel"}}}`, we'll generate two datalog queries:

```clojure
;; Query to get the user ids
[[:ea ?e ?eid-attr ?e]
 [:av ?e ?name-attr "daniel"]]
;; Query to get the attrs
[[:ea ?e]]
```

The CTEs look something like:

```sql
--[:ea ?e ?eid-attr ?e]
with match_0 as (
  select * from triples where attr_id = :eid-attr:
),
-- [:av ?e ?name-attr "daniel"]
match_1 as (
  select * from triples join match_0 on entity_id = match_0.entity_id where attr_id = :name-attr: and value = 'daniel'
),
-- get all of the entity_ids
match_2 as (
  select distinct entity_id from triples join match_1 on entity_id = match_1.entity_id
),
-- now we can get all of the attrs for the entity
match_3 as (
  select * from triples join match_2 where entity_id = match_2.entity_id and ea
)
```

Sometimes we need to join into triples in `match_2` if we have a complex join query, but if we're just joining on a single col, then we can just grab all of those cols directly from the CTE without doing a join on triples. So `match_2` would look like:

```sql
select distinct entity_id from match_1
```

For the complex case, it's also possible we could do a union or something instead of the join, but I'll look into that later.

Benchmarks:


| :old-ms | :new-ms | :improvement |
|---------|---------|--------------|
|     802 |     807 |           -5 |
|     105 |     109 |           -3 |
|       1 |       4 |           -2 |
|       3 |       5 |           -1 |
|       1 |       3 |           -1 |
|      59 |      60 |            0 |
|       2 |       3 |            0 |
|       3 |       4 |            0 |
|      16 |      17 |            0 |
|       2 |       2 |            0 |
|       2 |       2 |            0 |
|       1 |       1 |            0 |
|       5 |       5 |            0 |
|       1 |       1 |            0 |
|       1 |       1 |            0 |
|       2 |       2 |            0 |
|      18 |      17 |            0 |
|       4 |       4 |            0 |
|       3 |       2 |            0 |
|      23 |      22 |            1 |
|      27 |      25 |            1 |
|       9 |       7 |            1 |
|      15 |      13 |            1 |
|       7 |       5 |            1 |
|      29 |      26 |            2 |
|      30 |      26 |            4 |
|      82 |      50 |           31 |
|     891 |     856 |           34 |
|     295 |     256 |           38 |
|      80 |      19 |           61 |
|      78 |      11 |           67 |
|     243 |     114 |          128 |
|     420 |     285 |          134 |
|     325 |      92 |          232 |
|     334 |      94 |          240 |
|     388 |       2 |          386 |
|     693 |     197 |          496 |
|     693 |     195 |          498 |
|     955 |     248 |          707 |
|     905 |       3 |          902 |


