### PR TITLE
Use blob ids for entity maps

### DIFF
--- a/server/scripts/export.sh
+++ b/server/scripts/export.sh
@@ -54,8 +54,7 @@ with app as (
   select * from temp_app where id = :'app_id'
 )
 insert into apps (id, creator_id, title, created_at)
-  select id, (select id from instant_users where email = :'creator_email') creator_id, title, created_at from app
-returning *;
+  select id, (select id from instant_users where email = :'creator_email') creator_id, title, created_at from app;
 
 insert into app_admin_tokens (app_id, token) values (:'app_id', gen_random_uuid());
 

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1746,7 +1746,7 @@
                   query-cache
                   etype
                   eid]
-  (let [datalog-query [[:ea eid (attr-model/attr-ids-for-etype etype attrs)]]
+  (let [datalog-query [[:ea eid (attr-model/blob-ids-for-etype etype attrs)]]
         datalog-result
         (or (get query-cache datalog-query)
             (datalog-query-fn ctx datalog-query))]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1003,7 +1003,7 @@
                             (random-uuid))
         ctx (assoc-in ctx [:sym-placeholders sym] sym-placeholder)
         aggregate (get-in form [:option-map :aggregate])
-        etype-attr-ids (attr-model/blob-ids-for-etype etype (:attrs ctx))
+        etype-attr-ids (attr-model/ea-ids-for-etype etype (:attrs ctx))
         child-patterns (collect-query-one
                         (mapv (partial query-one ctx)
                               (form->child-forms ctx form sym-placeholder)))
@@ -1746,7 +1746,7 @@
                   query-cache
                   etype
                   eid]
-  (let [datalog-query [[:ea eid (attr-model/blob-ids-for-etype etype attrs)]]
+  (let [datalog-query [[:ea eid (attr-model/ea-ids-for-etype etype attrs)]]
         datalog-result
         (or (get query-cache datalog-query)
             (datalog-query-fn ctx datalog-query))]

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -584,13 +584,13 @@
               (update :ids-by-etype update (fwd-etype attr) (fnil conj #{}) (:id attr))
 
 
-              (= :blob (:value-type attr))
-              (update :blob-ids-by-etype update (fwd-etype attr) (fnil conj #{}) (:id attr))))
+              (= :one (:cardinality attr))
+              (update :ea-ids-by-etype update (fwd-etype attr) (fnil conj #{}) (:id attr))))
           {:by-id {}
            :by-fwd-ident {}
            :by-rev-ident {}
            :ids-by-etype {}
-           :blob-ids-by-etype {}}
+           :ea-ids-by-etype {}}
           attrs))
 
 (defprotocol AttrsExtension
@@ -598,7 +598,7 @@
   (seekByFwdIdentName [this fwd-ident])
   (seekByRevIdentName [this revIdent])
   (attrIdsForEtype [this etype])
-  (blobIdsForEtype [this etype])
+  (eaIdsForEtype [this etype])
   (unwrap [this]))
 
 ;; Creates a wrapper over attrs. Makes them act like a regular list, but
@@ -650,9 +650,9 @@
         (get etype #{})))
   (unwrap [_this]
     elements)
-  (blobIdsForEtype [_this etype]
+  (eaIdsForEtype [_this etype]
     (-> @cache
-        :blob-ids-by-etype
+        :ea-ids-by-etype
         (get etype #{}))))
 
 (defn wrap-attrs [attrs]
@@ -704,8 +704,8 @@
 (defn attr-ids-for-etype [etype ^Attrs attrs]
   (.attrIdsForEtype attrs etype))
 
-(defn blob-ids-for-etype [etype ^Attrs attrs]
-  (.blobIdsForEtype attrs etype))
+(defn ea-ids-for-etype [etype ^Attrs attrs]
+  (.eaIdsForEtype attrs etype))
 
 (defn remove-hidden
   "Removes the system attrs that might be confusing for the users."

--- a/server/src/instant/db/model/entity.clj
+++ b/server/src/instant/db/model/entity.clj
@@ -11,7 +11,7 @@
   [{:keys [datalog-query-fn attrs] :as ctx} eid+etypes]
   (let [patterns (map (fn [{:keys [eid etype]}]
                         {:patterns (if etype
-                                     [[:ea eid (attr-model/attr-ids-for-etype etype attrs)]]
+                                     [[:ea eid (attr-model/blob-ids-for-etype etype attrs)]]
                                      [[:ea eid]])})
                       eid+etypes)
         query {:children {:pattern-groups patterns}}
@@ -34,7 +34,7 @@
    If etype is nil, returns all triples across all namespaces for the eid."
   [{:keys [datalog-query-fn attrs] :as ctx} etype eid]
   (let [query (if etype
-                [[:ea eid (attr-model/attr-ids-for-etype etype attrs)]]
+                [[:ea eid (attr-model/blob-ids-for-etype etype attrs)]]
                 [[:ea eid]])
 
         datalog-result (datalog-query-fn ctx query)

--- a/server/src/instant/db/model/entity.clj
+++ b/server/src/instant/db/model/entity.clj
@@ -11,7 +11,7 @@
   [{:keys [datalog-query-fn attrs] :as ctx} eid+etypes]
   (let [patterns (map (fn [{:keys [eid etype]}]
                         {:patterns (if etype
-                                     [[:ea eid (attr-model/blob-ids-for-etype etype attrs)]]
+                                     [[:ea eid (attr-model/ea-ids-for-etype etype attrs)]]
                                      [[:ea eid]])})
                       eid+etypes)
         query {:children {:pattern-groups patterns}}
@@ -34,7 +34,7 @@
    If etype is nil, returns all triples across all namespaces for the eid."
   [{:keys [datalog-query-fn attrs] :as ctx} etype eid]
   (let [query (if etype
-                [[:ea eid (attr-model/blob-ids-for-etype etype attrs)]]
+                [[:ea eid (attr-model/ea-ids-for-etype etype attrs)]]
                 [[:ea eid]])
 
         datalog-result (datalog-query-fn ctx query)

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -3760,9 +3760,9 @@
                        [:vae _ #{:books/$user-creator} #{"eid-alex"}]
                        --
                        [:ea #{"eid-sum"}
-                        #{:books/pageCount :books/isbn13 :books/description :books/id
-                          :books/thumbnail :books/title} _])
-             :triples
+                        #{:books/pageCount :books/$user-creator :books/isbn13
+                          :books/description :books/id :books/thumbnail :books/title} _])
+              :triples
               (("eid-sum" :books/$user-creator "eid-alex")
                ("eid-alex" :$users/email "alex@instantdb.com")
                --
@@ -3770,6 +3770,7 @@
                ("eid-sum"
                 :books/thumbnail
                 "http://books.google.com/books/content?id=-cjWiI8DEywC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api")
+               ("eid-sum" :books/$user-creator "eid-alex")
                ("eid-sum" :books/title "Sum")
                ("eid-sum" :books/id "eid-sum")
                ("eid-sum"


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/instantdb/instant/pull/958

We were still using the all-attrs query to fetch entity maps, so the permission checks weren't getting data from the datalog cache. This causes permission checks to do a ton of additional fetching and can cause queries to time out.