### PR TITLE
Docs for `fields` param

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -205,7 +205,7 @@ jobs:
           safeBranch=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9-]/-/g')
           aliasUrl="instant-www-js-$safeBranch-jsv.vercel.app"
           echo "ALIAS_URL=$aliasUrl" >> $GITHUB_ENV
-          echo "aiasing $deploymentUrl to https://$aliasUrl"
+          echo "aliasing $deploymentUrl to https://$aliasUrl"
           vercel alias $deploymentUrl $aliasUrl --token=${{ secrets.VERCEL_TOKEN }} --scope jsv
         else
             echo "There was an error"

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -205,7 +205,7 @@ jobs:
           safeBranch=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9-]/-/g')
           aliasUrl="instant-www-js-$safeBranch-jsv.vercel.app"
           echo "ALIAS_URL=$aliasUrl" >> $GITHUB_ENV
-          echo "aiasing $deploymentUrl to $aliasUrl"
+          echo "aiasing $deploymentUrl to https://$aliasUrl"
           vercel alias $deploymentUrl $aliasUrl --token=${{ secrets.VERCEL_TOKEN }} --scope jsv
         else
             echo "There was an error"

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -1037,7 +1037,7 @@ console.log(data)
 }
 ```
 
-## Limiting fields
+## Select fields
 
 An InstaQL query will fetch all fields for each object.
 

--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -1037,6 +1037,79 @@ console.log(data)
 }
 ```
 
+## Limiting fields
+
+An InstaQL query will fetch all fields for each object.
+
+If you prefer to select the specific fields that you want your query to return, use the `fields` param:
+
+```javascript
+const query = {
+  goals: {
+    $: {
+      fields: ['status'],
+    },
+  },
+};
+const { isLoading, error, data } = db.useQuery(query);
+```
+
+```javascript
+console.log(data)
+{
+  "goals": [
+    {
+      "id": standupId,
+      "status": "in-progress"
+    },
+    {
+      "id": standId,
+      "status": "completed"
+    }
+  ]
+}
+```
+
+{% callout %}
+The `id` field is always included in the result set.
+{% /callout %}
+
+`fields` also works with nested relations:
+
+```javascript
+const query = {
+  goals: {
+    $: {
+      fields: ['title'],
+    },
+    todos: {
+      $: {
+        fields: ['id'],
+      },
+    },
+  },
+};
+const { isLoading, error, data } = db.useQuery(query);
+```
+
+```javascript
+console.log(data)
+{
+  "goals": [
+    {
+      "id": standupId,
+      "title": "Perform standup!",
+      "todos": [{"id": writeJokesId}, {"id": goToOpenMicId}]
+    },
+    {
+      "id": standId,
+      "title": "Stand up a food truck.",
+      "todos": [{"id": learnToCookId}, {"id": buyATruckId}]
+    }
+  ]
+}
+```
+
 ## Typesafety
 
 By default, `db.useQuery` is permissive. You don't have to tell us your schema upfront, and you can write any kind of query:


### PR DESCRIPTION
Adds docs for the new `fields` param to limit the fields in the result.

Direct link to preview https://instant-www-js-fields-docs-jsv.vercel.app/docs/instaql#limiting-fields

![instant-www-js-fields-docs-jsv vercel app_docs_instaql](https://github.com/user-attachments/assets/04c4e3ad-265b-4bae-b44e-e958e2bf1542)
