### PR TITLE
Only fetch ids for nested fields in explorer

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -121,15 +121,22 @@ function RefItemTooltip({
   item: Record<string, any>;
 }) {
   const [open, setOpen] = useState(false);
+  const [loadObject, setLoadObject] = useState(false);
 
   const { data, isLoading } = db.useQuery(
-    open ? { [namespace.name]: { $: { where: { id: item.id } } } } : null,
+    open || loadObject
+      ? { [namespace.name]: { $: { where: { id: item.id } } } }
+      : null,
   );
 
   return (
     <Tooltip.Provider>
       <Tooltip.Root delayDuration={0} open={open}>
-        <Tooltip.Trigger asChild={true}>
+        <Tooltip.Trigger
+          asChild={true}
+          onMouseEnter={() => setLoadObject(true)}
+          onTouchStart={() => setLoadObject(true)}
+        >
           <span>
             <Button
               size="mini"

--- a/client/www/lib/hooks/explorer.tsx
+++ b/client/www/lib/hooks/explorer.tsx
@@ -48,7 +48,7 @@ export function useNamespacesQuery(
           ...Object.fromEntries(
             selectedNs.attrs
               .filter((a) => a.type === 'ref')
-              .map((a) => [a.name, {}]),
+              .map((a) => [a.name, { $: { fields: ['id'] } }]),
           ),
           $: {
             ...(where ? { where: where } : {}),


### PR DESCRIPTION
Updates the explorer to fetch ids instead of the full object for fetching links.

I had to update the link editor to fetch the object by its id when you click on the info icon to see the full object. 

Also fixes a bug where the search input for editing links wouldn't show up if the modal content overflowed.