### PR TITLE
Fix the return type of query data when using fields

### DIFF
--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -169,11 +169,7 @@ type Exactly<Parent, Child> = Parent & {
 type InstaQLEntitySubqueryResult<
   Schema extends IContainEntitiesAndLinks<EntitiesDef, any>,
   EntityName extends keyof Schema['entities'],
-  Query extends InstaQLEntitySubquery<
-    Schema,
-    EntityName,
-    InstaQLFields<Schema, EntityName>
-  > = {},
+  Query extends InstaQLEntitySubquery<Schema, EntityName> = {},
 > = {
   [QueryPropName in keyof Query]: Schema['entities'][EntityName]['links'][QueryPropName] extends LinkAttrDef<
     infer Cardinality,
@@ -251,11 +247,7 @@ type InstaQLFields<
 type InstaQLEntity<
   Schema extends IContainEntitiesAndLinks<EntitiesDef, any>,
   EntityName extends keyof Schema['entities'],
-  Subquery extends InstaQLEntitySubquery<
-    Schema,
-    EntityName,
-    InstaQLFields<Schema, EntityName>
-  > = {},
+  Subquery extends InstaQLEntitySubquery<Schema, EntityName> = {},
   Fields extends InstaQLFields<Schema, EntityName> | undefined = undefined,
 > = Expand<
   { id: string } & (Extract<Fields[number], string> extends undefined
@@ -314,15 +306,13 @@ type InstaQLResult<
 type InstaQLEntitySubquery<
   Schema extends IContainEntitiesAndLinks<EntitiesDef, any>,
   EntityName extends keyof Schema['entities'],
-  Fields extends InstaQLFields<Schema, EntityName>,
 > = {
   [QueryPropName in keyof Schema['entities'][EntityName]['links']]?:
     | $Option<InstaQLFields<Schema, EntityName>>
     | ($Option<InstaQLFields<Schema, EntityName>> &
         InstaQLEntitySubquery<
           Schema,
-          Schema['entities'][EntityName]['links'][QueryPropName]['entityName'],
-          Fields
+          Schema['entities'][EntityName]['links'][QueryPropName]['entityName']
         >);
 };
 

--- a/client/sandbox/react-nextjs/pages/play/fields.tsx
+++ b/client/sandbox/react-nextjs/pages/play/fields.tsx
@@ -56,6 +56,21 @@ function Example({ appId }: { appId: string }) {
     },
   });
 
+  // Testing types
+  const { data: fieldsData } = db.useQuery({
+    characters: {
+      $: {
+        fields: ['name'],
+        where: { rating: { $gt: 7 } },
+      },
+    },
+  });
+
+  const _name = fieldsData?.characters?.[0].name;
+  const _id = fieldsData?.characters?.[0].id;
+  // @ts-expect-error: description wasn't requested
+  const _description = fieldsData?.characters?.[0].description;
+
   return (
     <div>
       <div>


### PR DESCRIPTION
Updates the return type to pick from the fields param (if the fields param is provided):

<img width="429" alt="image" src="https://github.com/user-attachments/assets/57e67d98-2e2d-4534-a9ff-9933ce24554b" />
