### PR TITLE
[aws] stable presign urls

### DIFF
--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -3,8 +3,8 @@
             [instant.util.s3 :as s3-util]
             [instant.util.date :as date-util])
   (:import
-   [java.time ZonedDateTime Duration DayOfWeek]
-   [java.time.temporal TemporalAdjusters ChronoUnit]))
+   [java.time Duration]
+   [java.time.temporal ChronoUnit]))
 
 ;; S3 path manipulation
 ;; ----------------------

--- a/server/src/instant/util/aws_signature.clj
+++ b/server/src/instant/util/aws_signature.clj
@@ -285,11 +285,11 @@
                               method
                               region
                               bucket
-                              path]
-                       :or {signing-instant (Instant/now)}}]
+                              ^String path]}]
 
-  (let [host (s3-host region bucket)
-        path-with-slash (if  (.startsWith path "/")
+  (let [signing-instant (or signing-instant (Instant/now))
+        host (s3-host region bucket)
+        path-with-slash (if (.startsWith path "/")
                           path
                           (str "/" path))
         amz-expires (str (.getSeconds expires-duration))

--- a/server/src/instant/util/date.clj
+++ b/server/src/instant/util/date.clj
@@ -6,6 +6,10 @@
 
 (def ^ZoneRegion pst-zone (ZoneId/of "America/Los_Angeles"))
 (def ^ZoneRegion est-zone (ZoneId/of "America/New_York"))
+(def ^ZoneRegion utc-zone (ZoneId/of "UTC"))
+
+(defn utc-now ^ZonedDateTime []
+  (ZonedDateTime/now utc-zone))
 
 (defn pst-now ^ZonedDateTime []
   (ZonedDateTime/now pst-zone))

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -4,7 +4,7 @@
    [instant.util.async :refer [default-virtual-thread-executor]]
    [instant.util.aws-signature :as aws-sig])
   (:import
-   (java.time Duration)
+   (java.time Instant Duration)
    (software.amazon.awssdk.auth.credentials DefaultCredentialsProvider)
    (software.amazon.awssdk.core.async AsyncRequestBody
                                       BlockingInputStreamAsyncRequestBody)
@@ -193,7 +193,10 @@
 (defn signer-creds [] @signer-creds*)
 
 (defn generate-presigned-url-get
-  ([{:keys [method bucket-name key ^Duration duration]}]
+  ([{:keys [method bucket-name
+            key
+            ^Instant signing-instant
+            ^Duration duration]}]
    (assert (= :get method)
            "get presigned urls are only implemented for :get requests")
    (aws-sig/presign-s3-url
@@ -202,11 +205,12 @@
      :region (:region (signer-creds))
      :method method
      :bucket bucket-name
+     :signing-instant signing-instant
      :expires-duration duration
      :path key})))
 
 (defn generate-presigned-url-put
-  ([{:keys [method bucket-name key ^Duration duration]}]
+  ([{:keys [method bucket-name key ^Instant signing-instant ^Duration duration]}]
    (assert (= :put method)
            "put presigned urls are only implemented for :put requests")
    (aws-sig/presign-s3-url
@@ -215,6 +219,7 @@
      :region (:region (signer-creds))
      :method method
      :bucket bucket-name
+     :signing-instant signing-instant
      :expires-duration duration
      :path key})))
 

--- a/server/test/instant/storage/s3_test.clj
+++ b/server/test/instant/storage/s3_test.clj
@@ -5,9 +5,9 @@
   (:import [java.time ZonedDateTime]))
 
 (deftest bucketed-zdate
-  (let [mon-9am (ZonedDateTime/parse "2025-03-04T21:19:48.467889Z[UTC]")
+  (let [tue-9-30-pm (ZonedDateTime/parse "2025-03-04T21:30:48.467889Z[UTC]")
         start-of-day-instant (.toInstant (ZonedDateTime/parse "2025-03-04T00:00:00.000000Z[UTC]"))]
-    (with-redefs [date-util/utc-now (fn [] mon-9am)]
+    (with-redefs [date-util/utc-now (fn [] tue-9-30-pm)]
       (is (= start-of-day-instant (storage-s3/bucketed-signing-instant))))))
 
 (comment

--- a/server/test/instant/storage/s3_test.clj
+++ b/server/test/instant/storage/s3_test.clj
@@ -1,39 +1,14 @@
 (ns instant.storage.s3-test
-  (:require [clojure.test :as test :refer [deftest are]]
-            [instant.storage.s3 :as storage-s3])
+  (:require [clojure.test :as test :refer [deftest is]]
+            [instant.storage.s3 :as storage-s3]
+            [instant.util.date :as date-util])
   (:import [java.time ZonedDateTime]))
 
 (deftest bucketed-zdate
-  (let [start-of-week (ZonedDateTime/parse
-                       "2025-03-03T00:00-08:00[America/Los_Angeles]")
-        mid-week (ZonedDateTime/parse
-                  "2025-03-06T12:00-08:00[America/Los_Angeles]")
-        mon-9am (ZonedDateTime/parse
-                 "2025-03-03T09:00-08:00[America/Los_Angeles]")
-        tue-3pm (ZonedDateTime/parse
-                 "2025-03-04T15:00-08:00[America/Los_Angeles]")
-        wed-11pm (ZonedDateTime/parse
-                  "2025-03-05T23:00-08:00[America/Los_Angeles]")
-        thu-1am (ZonedDateTime/parse
-                 "2025-03-06T01:00-08:00[America/Los_Angeles]")
-        thu-2pm (ZonedDateTime/parse
-                 "2025-03-06T14:00-08:00[America/Los_Angeles]")
-        sat-11pm (ZonedDateTime/parse
-                  "2025-03-08T23:00-08:00[America/Los_Angeles]")
-        sun-midnight (ZonedDateTime/parse
-                      "2025-03-09T00:00-08:00[America/Los_Angeles]")]
-
-    (are
-     [date expected] (= expected (storage-s3/bucketed-zdate date))
-      start-of-week start-of-week
-      mon-9am start-of-week
-      tue-3pm start-of-week
-      wed-11pm start-of-week
-      thu-1am start-of-week
-      mid-week mid-week
-      thu-2pm mid-week
-      sat-11pm mid-week
-      sun-midnight mid-week)))
+  (let [mon-9am (ZonedDateTime/parse "2025-03-04T21:19:48.467889Z[UTC]")
+        start-of-day-instant (.toInstant (ZonedDateTime/parse "2025-03-04T00:00:00.000000Z[UTC]"))]
+    (with-redefs [date-util/utc-now (fn [] mon-9am)]
+      (is (= start-of-day-instant (storage-s3/bucketed-signing-instant))))))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/storage/s3_test.clj
+++ b/server/test/instant/storage/s3_test.clj
@@ -1,0 +1,39 @@
+(ns instant.storage.s3-test
+  (:require [clojure.test :as test :refer [deftest are]]
+            [instant.storage.s3 :as storage-s3])
+  (:import [java.time ZonedDateTime]))
+
+(deftest bucketed-zdate
+  (let [start-of-week (ZonedDateTime/parse
+                       "2025-03-03T00:00-08:00[America/Los_Angeles]")
+        mid-week (ZonedDateTime/parse
+                  "2025-03-06T12:00-08:00[America/Los_Angeles]")
+        mon-9am (ZonedDateTime/parse
+                 "2025-03-03T09:00-08:00[America/Los_Angeles]")
+        tue-3pm (ZonedDateTime/parse
+                 "2025-03-04T15:00-08:00[America/Los_Angeles]")
+        wed-11pm (ZonedDateTime/parse
+                  "2025-03-05T23:00-08:00[America/Los_Angeles]")
+        thu-1am (ZonedDateTime/parse
+                 "2025-03-06T01:00-08:00[America/Los_Angeles]")
+        thu-2pm (ZonedDateTime/parse
+                 "2025-03-06T14:00-08:00[America/Los_Angeles]")
+        sat-11pm (ZonedDateTime/parse
+                  "2025-03-08T23:00-08:00[America/Los_Angeles]")
+        sun-midnight (ZonedDateTime/parse
+                      "2025-03-09T00:00-08:00[America/Los_Angeles]")]
+
+    (are
+     [date expected] (= expected (storage-s3/bucketed-zdate date))
+      start-of-week start-of-week
+      mon-9am start-of-week
+      tue-3pm start-of-week
+      wed-11pm start-of-week
+      thu-1am start-of-week
+      mid-week mid-week
+      thu-2pm mid-week
+      sat-11pm mid-week
+      sun-midnight mid-week)))
+
+(comment
+  (test/run-tests *ns*))


### PR DESCRIPTION
AWS URLs depend on the signing-instant.  
  
We want to keep URLs stable: repeated calls to the same object should return 
the same URL, so that browsers can cache the object. 
To do this, we bucket dates to the start of the day. 

This gives about 24 hours where URLs are stable

@nezaj @dwwoelfel @tonsky 