### PR TITLE
[OAuth] Enable passing hd param

### DIFF
--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -15,6 +15,8 @@
    (instant.util.crypt Secret)
    (java.time Duration Instant)))
 
+(def allowed-extra-params [:hd])
+
 (defprotocol OAuthClient
   (create-authorization-url [this state redirect-url extra-params])
   (get-user-info [this code redirect-url])
@@ -39,7 +41,9 @@
                        :state state
                        :redirect_uri redirect-url
                        :client_id client-id}
-          params (merge base-params (or extra-params {}))]
+          params (merge base-params
+                        (or (select-keys extra-params allowed-extra-params)
+                            {}))]
       (url/add-query-params authorization-endpoint params)))
 
   (get-user-info [_ code redirect-url]


### PR DESCRIPTION
We got an ask for passing through the `hd` param on Google Auth. [[Discord]](https://discord.com/channels/1031957483243188235/1346360958309761125) Thought this could be a nice win!

This enables us to do things like

```
  const [request, _response, promptAsync] = useAuthRequest(
    {
      clientId: 'instant-awedience',
      redirectUri: makeRedirectUri(),
      extraParams: {
        hd: 'tufts.edu',
      },
    },
    discovery,
  );
```

To hook into SSO for domains integrated with google

https://github.com/user-attachments/assets/87d1ef3a-a61e-4b8f-8809-13d1d5fd7d53

