### PR TITLE
[presence] ensure we don't mutate `this._presence`

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -1203,22 +1203,6 @@ test('fields', () => {
     ],
   });
 
-  console.log(
-    JSON.stringify(
-      query(
-        { store },
-        {
-          users: {
-            $: { where: { handle: 'alex' }, fields: ['handle'] },
-            bookshelves: { $: { fields: ['name'] } },
-          },
-        },
-      ).data,
-      null,
-      2,
-    ),
-  );
-
   expect(
     query(
       { store },

--- a/client/packages/core/__tests__/src/utils/object.test.js
+++ b/client/packages/core/__tests__/src/utils/object.test.js
@@ -1,0 +1,31 @@
+import { test, expect, describe } from 'vitest';
+
+import { assocInMutative, dissocInMutative } from '../../../src/utils/object';
+
+describe('assocInMutative', () => {
+  test('adds value at a shallow path', () => {
+    const obj = { a: 1 };
+    assocInMutative(obj, ['b'], 2);
+    expect(obj).toEqual({ a: 1, b: 2 });
+  });
+
+  test('adds value at a nested path', () => {
+    const obj = { a: {} };
+    assocInMutative(obj, ['a', 'b', 'c'], 3);
+    expect(obj).toEqual({ a: { b: { c: 3 } } });
+  });
+});
+
+describe('dissocInMutative', () => {
+  test('deletes a shallow property', () => {
+    const obj = { a: 1, b: 2 };
+    dissocInMutative(obj, ['a']);
+    expect(obj).toEqual({ b: 2 });
+  });
+
+  test('deletes a nested property', () => {
+    const obj = { a: { b: { c: 3, d: 4 } } };
+    dissocInMutative(obj, ['a', 'b', 'c']);
+    expect(obj).toEqual({ a: { b: { d: 4 } } });
+  });
+});

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1717,10 +1717,10 @@ export default class Reactor {
       draft[this._sessionId] = { data: this._presence[roomId]?.result?.user };
       for (let [path, op, value] of edits) {
         if (op === '+' || op === 'r') {
-          draft = assocInMutative(draft, path, value);
+          assocInMutative(draft, path, value);
         }
         if (op === '-') {
-          draft = dissocInMutative(draft, path);
+          dissocInMutative(draft, path);
         }
       }
     });

--- a/client/packages/core/src/utils/object.js
+++ b/client/packages/core/src/utils/object.js
@@ -82,7 +82,7 @@ export function isObject(val) {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
-export function assocIn(obj, path, value) {
+export function assocInMutative(obj, path, value) {
   if (path.length === 0) {
     return value;
   }
@@ -100,7 +100,7 @@ export function assocIn(obj, path, value) {
   return obj;
 }
 
-export function dissocIn(obj, path) {
+export function dissocInMutative(obj, path) {
   if (path.length === 0) {
     return undefined;
   }
@@ -116,7 +116,7 @@ export function dissocIn(obj, path) {
     return isEmpty(obj) ? undefined : obj;
   }
 
-  const child = dissocIn(obj[key], restPath);
+  const child = dissocInMutative(obj[key], restPath);
 
   if (child === undefined) {
     delete obj[key];

--- a/client/packages/core/src/utils/object.js
+++ b/client/packages/core/src/utils/object.js
@@ -83,8 +83,11 @@ export function isObject(val) {
 }
 
 export function assocInMutative(obj, path, value) {
+  if (!obj) {
+    return;
+  }
   if (path.length === 0) {
-    return value;
+    return;
   }
 
   let current = obj || {};
@@ -97,33 +100,34 @@ export function assocInMutative(obj, path, value) {
   }
 
   current[path[path.length - 1]] = value;
-  return obj;
+  return;
 }
 
 export function dissocInMutative(obj, path) {
+  if (!obj) {
+    return;
+  }
   if (path.length === 0) {
-    return undefined;
+    return;
   }
 
   const [key, ...restPath] = path;
 
   if (!(key in obj)) {
-    return obj;
+    return;
   }
 
   if (restPath.length === 0) {
     delete obj[key];
-    return isEmpty(obj) ? undefined : obj;
+    return;
   }
 
-  const child = dissocInMutative(obj[key], restPath);
-
-  if (child === undefined) {
+  dissocInMutative(obj[key], restPath);
+  if (isEmpty(obj[key])) {
     delete obj[key];
-    return isEmpty(obj) ? undefined : obj;
   }
 
-  return obj;
+  return;
 }
 
 function isEmpty(obj) {

--- a/client/sandbox/react-nextjs/pages/play/ephemeral-counts.tsx
+++ b/client/sandbox/react-nextjs/pages/play/ephemeral-counts.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from 'react';
+import Head from 'next/head';
+import { init, Cursors } from '@instantdb/react';
+import config from '../../config';
+
+const db = init(config);
+const room = db.room('main', '123');
+
+function App() {
+  const interval = useRef<NodeJS.Timer | null>(null);
+  const { peers, user, publishPresence } = db.rooms.usePresence(room);
+  const sendUpdates = () => {
+    if (interval.current) clearInterval(interval.current);
+    let n = 0;
+    interval.current = setInterval(() => {
+      n++;
+      publishPresence({ count: { n } });
+    }, 1000);
+  };
+  return (
+    <div>
+      <button className="bg-black text-white" onClick={sendUpdates}>
+        Send Updates
+      </button>
+      <pre>Me: {JSON.stringify(user, null, 2)}</pre>
+      <pre>Peers: {JSON.stringify(Object.values(peers), null, 2)}</pre>
+      <div className="space-y-2">
+        <div>Open up two tabs. Click "send update" on one tab.</div>
+        <div>
+          <strong>
+            Make sure that the updates show up. They may not show up if Reactor
+            mutates `peers`.
+          </strong>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Page() {
+  return (
+    <div>
+      <Head>
+        <title>Instant Example App: Cursors Counts</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <App />
+    </div>
+  );
+}
+
+export default Page;


### PR DESCRIPTION
**Bug** 

If a user published:

```
publishPresence({ item: { n: 1 } })
publishPresence({ item: { n: 2 } })
```

The `patch-presence` for `n: 2` would not get propagated to `subscribePresence`. 

**Root cause** 

We received a `patch-presence` command. We would run: 

```
sessions = assocIn(sessions, path, value);
```

The path would look something like `['item', 'n']`

This would mutate the original `item`. 

Then, when `hasPresenceResponseChanged` would run, we would see that in fact nothing had changed, and skip the update. 

**This only happened when the user had a deeply nested presence.** 

**Fix** 

1. Updated it so that `assocIn` and `dissocIn` are explicit about being mutative
2. Then, used `mutative` to generate new `session` objects.

--- 

@dwwoelfel @nezaj @tonsky 






