### PR TITLE
[presence] handle arrays when doing `+` and `-` patches

### DIFF
--- a/client/packages/core/__tests__/src/utils/object.test.js
+++ b/client/packages/core/__tests__/src/utils/object.test.js
@@ -1,6 +1,10 @@
 import { test, expect, describe } from 'vitest';
 
-import { assocInMutative, dissocInMutative } from '../../../src/utils/object';
+import {
+  assocInMutative,
+  dissocInMutative,
+  insertInMutative,
+} from '../../../src/utils/object';
 
 describe('assocInMutative', () => {
   test('adds value at a shallow path', () => {
@@ -16,6 +20,44 @@ describe('assocInMutative', () => {
   });
 });
 
+describe('insertInMutative', () => {
+  test('it works on normal objects', () => {
+    const obj1 = { a: 1 };
+    insertInMutative(obj1, ['b'], 2);
+    expect(obj1).toEqual({ a: 1, b: 2 });
+
+    const obj2 = { a: {} };
+    assocInMutative(obj2, ['a', 'b', 'c'], 3);
+    expect(obj2).toEqual({ a: { b: { c: 3 } } });
+  });
+
+  test('inserts on arrays', () => {
+    const obj0 = [];
+    insertInMutative(obj0, [0], 'a');
+    expect(obj0).toEqual(['a']);
+
+    const obj1 = ['b'];
+    insertInMutative(obj1, [0], 'a');
+    expect(obj1).toEqual(['a', 'b']);
+
+    const obj2 = ['b'];
+    insertInMutative(obj2, [1], 'a');
+    expect(obj2).toEqual(['b', 'a']);
+
+    const obj3 = { x: ['b'] };
+    insertInMutative(obj3, ['x', 0], 'a');
+    expect(obj3).toEqual({ x: ['a', 'b'] });
+
+    const obj4 = { w: { x: { y: ['a', 'b', 'c', 'd'], z: 4 } } };
+    insertInMutative(obj4, ['w', 'x', 'y', 1], 'a');
+    expect(obj4).toEqual({ w: { x: { y: ['a', 'a', 'b', 'c', 'd'], z: 4 } } });
+
+    const obj5 = { w: { x: { y: ['a', 'b', 'c', 'd'], z: 4 } } };
+    insertInMutative(obj5, ['w', 'x', 'z'], 'a');
+    expect(obj5).toEqual({ w: { x: { y: ['a', 'b', 'c', 'd'], z: 'a' } } });
+  });
+});
+
 describe('dissocInMutative', () => {
   test('deletes a shallow property', () => {
     const obj = { a: 1, b: 2 };
@@ -27,5 +69,10 @@ describe('dissocInMutative', () => {
     const obj = { a: { b: { c: 3, d: 4 } } };
     dissocInMutative(obj, ['a', 'b', 'c']);
     expect(obj).toEqual({ a: { b: { d: 4 } } });
+  });
+  test('works on arrays', () => {
+    const obj = { a: { b: { c: ['a', 'b', 'c', 'd'] } } };
+    dissocInMutative(obj, ['a', 'b', 'c', 1]);
+    expect(obj).toEqual({ a: { b: { c: ['a', 'c', 'd'] } } });
   });
 });

--- a/client/packages/core/src/utils/object.js
+++ b/client/packages/core/src/utils/object.js
@@ -82,6 +82,36 @@ export function isObject(val) {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
+/**
+ * Like `assocInMutative`, but
+ *
+ * - for arrays: inserts the value at the specified index, instead of replacing it
+ */
+export function insertInMutative(obj, path, value) {
+  if (!obj) {
+    return;
+  }
+  if (path.length === 0) {
+    return;
+  }
+
+  let current = obj || {};
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    if (!(key in current) || typeof current[key] !== 'object') {
+      current[key] = typeof path[i + 1] === 'number' ? [] : {};
+    }
+    current = current[key];
+  }
+
+  const key = path[path.length - 1];
+  if (Array.isArray(current) && typeof key === 'number') {
+    current.splice(key, 0, value);
+  } else {
+    current[key] = value;
+  }
+}
+
 export function assocInMutative(obj, path, value) {
   if (!obj) {
     return;
@@ -100,7 +130,6 @@ export function assocInMutative(obj, path, value) {
   }
 
   current[path[path.length - 1]] = value;
-  return;
 }
 
 export function dissocInMutative(obj, path) {
@@ -118,7 +147,11 @@ export function dissocInMutative(obj, path) {
   }
 
   if (restPath.length === 0) {
-    delete obj[key];
+    if (Array.isArray(obj)) {
+      obj.splice(key, 1);
+    } else {
+      delete obj[key];
+    }
     return;
   }
 
@@ -126,8 +159,6 @@ export function dissocInMutative(obj, path) {
   if (isEmpty(obj[key])) {
     delete obj[key];
   }
-
-  return;
 }
 
 function isEmpty(obj) {

--- a/client/sandbox/react-nextjs/pages/play/presence-arrays.tsx
+++ b/client/sandbox/react-nextjs/pages/play/presence-arrays.tsx
@@ -1,0 +1,286 @@
+import { i, init, tx } from '@instantdb/react';
+import React, { useCallback, useEffect, useRef, useState, FC } from 'react';
+import config from '../../config';
+
+// ---------------------------------------------------------------------
+// Schema & DB initialization
+// ---------------------------------------------------------------------
+const schema = i.schema({
+  entities: {
+    colors: i.entity({ color: i.string() }),
+  },
+});
+const db = init({ ...config, schema });
+
+// ---------------------------------------------------------------------
+// Types & Utility Functions
+// ---------------------------------------------------------------------
+type Point = { x: number; y: number };
+type Dimension = Point & { width: number; height: number };
+
+const pointsToDimension = (p1: Point, p2: Point): Dimension => {
+  const left = Math.min(p1.x, p2.x);
+  const right = Math.max(p1.x, p2.x);
+  const top = Math.min(p1.y, p2.y);
+  const bottom = Math.max(p1.y, p2.y);
+  return { x: left, y: top, width: right - left, height: bottom - top };
+};
+
+const isIntersecting = (rectA: Dimension, rectB: Dimension): boolean => {
+  return !(
+    rectB.x > rectA.x + rectA.width ||
+    rectB.x + rectB.width < rectA.x ||
+    rectB.y > rectA.y + rectA.height ||
+    rectB.y + rectB.height < rectA.y
+  );
+};
+
+const stringToHslColor = (
+  str: string | undefined,
+  saturation: number = 85,
+  lightness: number = 68,
+): string => {
+  if (!str) return `hsl(0, ${saturation}%, ${lightness}%)`;
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};
+
+// ---------------------------------------------------------------------
+// SelectionArea Component
+// ---------------------------------------------------------------------
+const SelectionArea: FC<{ area: Dimension | null; color?: string }> = ({
+  area,
+  color = '#2972f6',
+}) => {
+  if (!area) return null;
+  return (
+    <div
+      data-testid="selectionArea"
+      className="absolute rounded z-[1000]"
+      style={{
+        transform: `matrix(1, 0, 0, 1, ${area.x}, ${area.y})`,
+        width: area.width,
+        height: area.height,
+        backgroundColor: color,
+        opacity: 0.2,
+      }}
+    />
+  );
+};
+
+// ---------------------------------------------------------------------
+// useSelectionArea Hook (replacing jotai atoms)
+// ---------------------------------------------------------------------
+const useSelectionArea = (
+  canvasRef: React.RefObject<HTMLDivElement>,
+): Dimension | null => {
+  const [selectionArea, setSelectionArea] = useState<Dimension | null>(null);
+  const selectionStateStart = useRef<Point | null>(null);
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent) => {
+      const canvasRect = canvasRef.current?.getBoundingClientRect();
+      const point = {
+        x: event.clientX - (canvasRect?.x ?? 0),
+        y: event.clientY - (canvasRect?.y ?? 0),
+      };
+      selectionStateStart.current = point;
+    },
+    [canvasRef],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      const startPoint = selectionStateStart.current;
+      if (!startPoint) return;
+      event.stopPropagation();
+      const canvasRect = canvasRef.current?.getBoundingClientRect();
+      const point = {
+        x: event.clientX - (canvasRect?.x ?? 0),
+        y: event.clientY - (canvasRect?.y ?? 0),
+      };
+      setSelectionArea(pointsToDimension(startPoint, point));
+    },
+    [canvasRef],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    selectionStateStart.current = null;
+    setSelectionArea(null);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const opt = { passive: true };
+    canvas.addEventListener('pointerdown', handlePointerDown, opt);
+    canvas.addEventListener('pointermove', handlePointerMove, opt);
+    canvas.addEventListener('pointerup', handlePointerUp, opt);
+    return () => {
+      canvas.removeEventListener('pointerdown', handlePointerDown);
+      canvas.removeEventListener('pointermove', handlePointerMove);
+      canvas.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [canvasRef, handlePointerDown, handlePointerMove, handlePointerUp]);
+
+  return selectionArea;
+};
+
+// ---------------------------------------------------------------------
+// Canvas Component (with presence and sticker selection)
+// ---------------------------------------------------------------------
+const stickers: (Dimension & { id: string })[] = Array(36)
+  .fill(0)
+  .map((_, index) => ({
+    id: `sticker-${index}`,
+    x: 10 + 87 * (index % 6),
+    y: 10 + 87 * Math.floor(index / 6),
+    width: 50,
+    height: 50,
+  }));
+
+const Canvas: FC = () => {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const selectionArea = useSelectionArea(canvasRef);
+
+  const [selectedStickerIds, setSelectedStickerIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [remoteSelectedStickerIds, setRemoteSelectedStickerIds] = useState<
+    Set<string>
+  >(new Set());
+
+  // Set up InstantDB room and presence (using the "canvas" room with a fake id)
+  const room = db.room('canvas', 'fake-id');
+  const { isLoading, publishPresence, user, peers } =
+    db.rooms.usePresence(room);
+
+  // Update local sticker selection based on the drawn selection area
+  useEffect(() => {
+    if (selectionArea) {
+      const newSelectedStickerIds = new Set<string>();
+      stickers.forEach((sticker) => {
+        if (isIntersecting(selectionArea, sticker)) {
+          newSelectedStickerIds.add(sticker.id);
+        }
+      });
+      setSelectedStickerIds((prev) => {
+        const hasAdded = Array.from(newSelectedStickerIds).some(
+          (id) => !prev.has(id),
+        );
+        const hasRemoved = Array.from(prev).some(
+          (id) => !newSelectedStickerIds.has(id),
+        );
+        return hasAdded || hasRemoved ? newSelectedStickerIds : prev;
+      });
+    }
+  }, [selectionArea]);
+
+  // Publish presence with current selection state
+  useEffect(() => {
+    if (!isLoading) {
+      publishPresence({
+        // selectionArea: selectionArea || undefined,
+        selectedIds: Array.from(selectedStickerIds),
+      });
+    }
+  }, [isLoading, publishPresence, selectedStickerIds]);
+
+  // Merge remote selected sticker ids from peers
+  useEffect(() => {
+    const merged = new Set<string>(
+      Object.values(peers).flatMap((peer: any) => peer.selectedIds || []),
+    );
+    setRemoteSelectedStickerIds((prev) => {
+      const hasAdded = Array.from(merged).some((id) => !prev.has(id));
+      const hasRemoved = Array.from(prev).some((id) => !merged.has(id));
+      return hasAdded || hasRemoved ? merged : prev;
+    });
+  }, [peers]);
+
+  const hasPeers = Object.keys(peers).length > 0;
+
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Canvas with Instant Presence</h2>
+      <div
+        ref={canvasRef}
+        className="overflow-hidden w-full h-[50vh] bg-[#333] relative select-none"
+      >
+        {stickers.map((sticker) => {
+          const isSelected = selectedStickerIds.has(sticker.id);
+          const isRemoteSelected = remoteSelectedStickerIds.has(sticker.id);
+          return (
+            <div
+              key={sticker.id}
+              className={`absolute bg-[#663399] ${
+                isSelected
+                  ? 'outline outline-4 outline-[#2972f6]'
+                  : isRemoteSelected
+                    ? 'outline outline-4 outline-white'
+                    : ''
+              }`}
+              style={{
+                width: sticker.width,
+                height: sticker.height,
+                transform: `translate(${sticker.x}px, ${sticker.y}px)`,
+              }}
+            />
+          );
+        })}
+        {selectionArea && <SelectionArea area={selectionArea} />}
+        {hasPeers &&
+          Object.values(peers).map((peer: any) => (
+            <SelectionArea
+              key={peer.peerId}
+              area={peer.selectionArea}
+              color={stringToHslColor(peer.peerId)}
+            />
+          ))}
+      </div>
+      <div className="flex">
+        <div className="flex-1">
+          <p>
+            <strong>Me</strong>
+          </p>
+          <pre>{JSON.stringify(user?.selectedIds, null, 2)}</pre>
+        </div>
+        <div className="flex-1">
+          {hasPeers ? (
+            Object.values(peers).map((peer) => {
+              return (
+                <div key={peer.peerId}>
+                  <p>
+                    <strong>Peer</strong>
+                  </p>
+                  <pre>{JSON.stringify(peer?.selectedIds, null, 2)}</pre>
+                </div>
+              );
+            })
+          ) : (
+            <pre className="text-center mb-4">
+              No peers connected, open a second window
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------
+// Main App Component
+// ---------------------------------------------------------------------
+const App: FC = () => {
+  return (
+    <div>
+      <Canvas />
+    </div>
+  );
+};
+
+export default App;

--- a/client/sandbox/react-nextjs/pages/play/presence-arrays.tsx
+++ b/client/sandbox/react-nextjs/pages/play/presence-arrays.tsx
@@ -1,20 +1,9 @@
-import { i, init, tx } from '@instantdb/react';
+import { init } from '@instantdb/react';
 import React, { useCallback, useEffect, useRef, useState, FC } from 'react';
 import config from '../../config';
 
-// ---------------------------------------------------------------------
-// Schema & DB initialization
-// ---------------------------------------------------------------------
-const schema = i.schema({
-  entities: {
-    colors: i.entity({ color: i.string() }),
-  },
-});
-const db = init({ ...config, schema });
+const db = init({ ...config });
 
-// ---------------------------------------------------------------------
-// Types & Utility Functions
-// ---------------------------------------------------------------------
 type Point = { x: number; y: number };
 type Dimension = Point & { width: number; height: number };
 
@@ -49,9 +38,6 @@ const stringToHslColor = (
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
 };
 
-// ---------------------------------------------------------------------
-// SelectionArea Component
-// ---------------------------------------------------------------------
 const SelectionArea: FC<{ area: Dimension | null; color?: string }> = ({
   area,
   color = '#2972f6',
@@ -72,9 +58,6 @@ const SelectionArea: FC<{ area: Dimension | null; color?: string }> = ({
   );
 };
 
-// ---------------------------------------------------------------------
-// useSelectionArea Hook (replacing jotai atoms)
-// ---------------------------------------------------------------------
 const useSelectionArea = (
   canvasRef: React.RefObject<HTMLDivElement>,
 ): Dimension | null => {
@@ -130,9 +113,6 @@ const useSelectionArea = (
   return selectionArea;
 };
 
-// ---------------------------------------------------------------------
-// Canvas Component (with presence and sticker selection)
-// ---------------------------------------------------------------------
 const stickers: (Dimension & { id: string })[] = Array(36)
   .fill(0)
   .map((_, index) => ({
@@ -184,11 +164,11 @@ const Canvas: FC = () => {
   useEffect(() => {
     if (!isLoading) {
       publishPresence({
-        // selectionArea: selectionArea || undefined,
+        selectionArea: selectionArea || undefined,
         selectedIds: Array.from(selectedStickerIds),
       });
     }
-  }, [isLoading, publishPresence, selectedStickerIds]);
+  }, [isLoading, publishPresence, selectionArea, selectedStickerIds]);
 
   // Merge remote selected sticker ids from peers
   useEffect(() => {

--- a/server/.clj-kondo/imports/babashka/sci/config.edn
+++ b/server/.clj-kondo/imports/babashka/sci/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:macroexpand {sci.core/copy-ns sci.core/copy-ns}}}

--- a/server/.clj-kondo/imports/babashka/sci/sci/core.clj
+++ b/server/.clj-kondo/imports/babashka/sci/sci/core.clj
@@ -1,0 +1,9 @@
+(ns sci.core)
+
+(defmacro copy-ns
+  ([ns-sym sci-ns]
+   `(copy-ns ~ns-sym ~sci-ns nil))
+  ([ns-sym sci-ns opts]
+   `[(quote ~ns-sym)
+     ~sci-ns
+     (quote ~opts)]))


### PR DESCRIPTION
Consider a presence state that uses arrays: 

```
{ selectedIds: []
```

We had two bugs:

**1. `+` operations**

If machine1 sent: 

```
// Machine1
set-persence ['sticker-5']
set-persence ['sticker-4', 'sticker-5']
```

machine2 would receive: 

```
// Machine2
patch-presence  [peerId, 'data', 'selectedIds'], 'r', ['sticker-5']
patch-presence  [peerId, 'data', 'selectedIds', 0], '+', 'sticker-4' // Uh oh
```

In the case where we had a `+`, we actually want to _insert_ at index 0, but instead we replaced it: 

```
// Desired: ['sticker-4', 'sticker-5']
// Got ['sticker-5']
```

Fixed this by created an `insertInMutative` function, which splices at index N rather than replace


**1. `-` operations**

Now imagine if `machine-1` sent: 

```
set-persence ['sticker-5']
set-persence ['sticker-4', 'sticker-5']
set-persence ['sticker-5']
```

Machine two would receive: 

```
patch-presence  [peerId, 'data', 'selectedIds'], 'r', ['sticker-5']
patch-presence  [peerId, 'data', 'selectedIds', 0], '+', 'sticker-4'
patch-presence  [peerId, 'data', 'selectedIds', 0], '-', 
```

In this case dissocInMutative would set the value to undefined:

```
// Desired: ['sticker-5']
// Got [undefined, 'sticker-5']
```

Fixed this by updating `dissocInMutative` to handle arrays. 

--- 

Imported the great repro user sent over here! 

![image](https://github.com/user-attachments/assets/461b31e1-550c-4093-8c84-870eeb9ce549)

@tonsky @dwwoelfel @nezaj