### PR TITLE
[Explorer] Enable setting null

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -877,7 +877,9 @@ export function EditRowDialog({
                         handleNullToggle(attr.name, checked)
                       }
                       label={
-                        <span className="text-xs text-gray-600">null</span>
+                        <span className="text-[10px] text-gray-600 uppercase">
+                          null
+                        </span>
                       }
                     />
                   </div>

--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -643,13 +643,6 @@ export function EditRowDialog({
     setUpdatedBlobValues((prev) => {
       const current = prev[field] || {};
 
-      if (value.trim() === 'null') {
-        return {
-          ...prev,
-          [field]: { type: 'json', value: null, error: null },
-        };
-      }
-
       return {
         ...prev,
         [field]: isValidJson(value)

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -855,7 +855,6 @@ export function Explorer({
         {!!selectedNamespace && !!selectedEditableItem ? (
           <EditRowDialog
             db={db}
-            appId={appId}
             namespace={selectedNamespace}
             item={selectedEditableItem}
             onClose={() => setEditableRowId(null)}
@@ -869,7 +868,6 @@ export function Explorer({
         {selectedNamespace ? (
           <EditRowDialog
             db={db}
-            appId={appId}
             item={{}}
             namespace={selectedNamespace}
             onClose={() => setAddItemDialogOpen(false)}

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -855,6 +855,7 @@ export function Explorer({
         {!!selectedNamespace && !!selectedEditableItem ? (
           <EditRowDialog
             db={db}
+            appId={appId}
             namespace={selectedNamespace}
             item={selectedEditableItem}
             onClose={() => setEditableRowId(null)}
@@ -868,6 +869,7 @@ export function Explorer({
         {selectedNamespace ? (
           <EditRowDialog
             db={db}
+            appId={appId}
             item={{}}
             namespace={selectedNamespace}
             onClose={() => setAddItemDialogOpen(false)}


### PR DESCRIPTION
A user pointed out that you couldn't set json values as `null` I thought this would be straightforward fix but it was a bit more involved. This does the following:

* Introduce a checkbox for setting a value to null
* Restricts fields types when attr is type checked
* Upgrade reset functionality to restore previous values even if you changed the input type

https://github.com/user-attachments/assets/eb45111d-0f8f-422d-a7d7-f00de9090544

