### PR TITLE
Fix lots of nested ands and ors

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -376,6 +376,16 @@ test.each([
     },
     ['joe', 'stopa'],
   ],
+  [
+    'with ands in ors in ands',
+    {
+      and: [
+        { or: [{ and: [{ handle: 'stopa' }] }] },
+        { or: [{ and: [{ or: [{ handle: 'stopa' }] }] }] },
+      ],
+    },
+    ['stopa'],
+  ],
 ])('Where OR %s', (_, whereQuery, expected) => {
   expect(
     query(

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -820,22 +820,22 @@
 
         (set? origin-paths)
         [(list* :or (mapcat (fn [o]
-                              (new-or-join-conds prefix o dest-paths))
+                              (or-join-conds-for-or-gather prefix o dest-paths))
                             origin-paths))]
 
         (set? dest-paths)
         [(list* :or (mapcat (fn [d]
-                              (new-or-join-conds prefix origin-paths d))
+                              (or-join-conds-for-or-gather prefix origin-paths d))
                             dest-paths))]
 
         (single-path? origin-paths)
         [(list* :and (mapcat (fn [d]
-                               (new-or-join-conds prefix origin-paths d))
+                               (or-join-conds-for-or-gather prefix origin-paths d))
                              dest-paths))]
 
         :else
         [(list* :and (mapcat (fn [o]
-                               (new-or-join-conds prefix o dest-paths))
+                               (or-join-conds-for-or-gather prefix o dest-paths))
                              origin-paths))]))
 
 (defn join-conds-for-or-gather
@@ -844,7 +844,7 @@
   (let [ors (doall (for [or-symbol-map or-symbol-maps
                          :let [dest-paths (get symbol-map join-sym)
                                origin-paths (get or-symbol-map join-sym)
-                               ands (new-or-join-conds prefix origin-paths dest-paths)]
+                               ands (or-join-conds-for-or-gather prefix origin-paths dest-paths)]
                          :when (seq ands)]
                      (list* :and ands)))]
     (when (seq ors)

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -134,7 +134,6 @@
   "Converts {:or [{:or [{:handle \"Jack\"}]}]} -> {:or [{:handle \"Jack\"}]}"
   [conds]
   (reduce (fn [acc [_k v :as c]]
-            (println (or-where-cond? c) c)
             (if (or-where-cond? c)
               (apply conj acc (mapcat collapse-or-where-conds v))
               (conj acc c)))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2448,6 +2448,55 @@
                ("eid-stepan-parunashvili" :users/handle "stopa")
                ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))})))))))
 
+(deftest or-stress-test
+  (with-zeneca-app
+    (fn [app r]
+      (let [ctx (make-ctx app)
+            query-pretty (partial query-pretty ctx r)]
+        (is-pretty-eq?
+         (query-pretty
+          {:users {:$ {:where {:and [{:or [{:and [{:handle "stopa"}]}]}
+                                     {:or [{:and [{:or [{:handle "stopa"}]}]}]}]}}}})
+         '({:topics ([:av _ #{:users/handle} #{"stopa"}]
+                     [:av #{"eid-stepan-parunashvili"} #{:users/handle} #{"stopa"}]
+                     --
+                     [:ea #{"eid-stepan-parunashvili"}
+                      #{:users/createdAt :users/email :users/id :users/fullName
+                        :users/handle} _])
+            :triples
+            (("eid-stepan-parunashvili" :users/handle "stopa")
+             ("eid-stepan-parunashvili" :users/handle "stopa")
+             --
+             ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
+             ("eid-stepan-parunashvili" :users/createdAt "2021-01-07 18:50:43.447955")
+             ("eid-stepan-parunashvili" :users/fullName "Stepan Parunashvili")
+             ("eid-stepan-parunashvili" :users/handle "stopa")
+             ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))}))
+
+        (is-pretty-eq?
+         (query-pretty
+          {:users {:$ {:where {:and [{:or [{:or [{:handle "stopa"}
+                                                 {:or [{:handle "stopa"} {:handle "stopa"}]}]}
+                                           {:handle "stopa"}]}
+                                     {:or [{:or [{:handle "stopa"}
+                                                 {:or [{:handle "stopa"} {:handle "stopa"}]}]}
+                                           {:handle "stopa"}]}]}}}})
+         '({:topics ([:av _ #{:users/handle} #{"stopa"}]
+                     [:av #{"eid-stepan-parunashvili"} #{:users/handle} #{"stopa"}]
+                     --
+                    [:ea #{"eid-stepan-parunashvili"}
+                      #{:users/createdAt :users/email :users/id :users/fullName
+                        :users/handle} _])
+            :triples
+            (("eid-stepan-parunashvili" :users/handle "stopa")
+             ("eid-stepan-parunashvili" :users/handle "stopa")
+             --
+             ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
+             ("eid-stepan-parunashvili" :users/createdAt "2021-01-07 18:50:43.447955")
+             ("eid-stepan-parunashvili" :users/fullName "Stepan Parunashvili")
+             ("eid-stepan-parunashvili" :users/handle "stopa")
+             ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))}))))))
+
 (deftest comparators
   (with-zeneca-checked-data-app
     ;; We don't use the zeneca app here, but we need its triples


### PR DESCRIPTION
Ran into this bug while working on cel -> instaql, where we can generate lots of nested ORs.

Three fixes in this PR:

1. If there's a single AND or OR, then we just strip it out (`[{:or [{handle: 'dww'}]}]` is the same as `{handle: 'dww'}`)
2. Collapse the ors properly, so that `[{:or [{:or [cond-a, cond-b]}, cond-c]]}]` generates `{:or [cond-a, cond-b, cond-c]}` instead of `{:or [[cond-a, cond-b], cond-c]}`.
3. Fix in datalog.clj to handle ORs in the destination path. I simplified the logic to only do recursion for generating the join conds in one place.

There is still a remaining issue where we could potentially include the same cte twice, leading to postgres complaints about ambiguous columns. I can't reproduce it without disabling the `or` collapsing, so I'm ignoring it for now. I think it might have something to do with how we generate join syms for the different groups of ors and ands. We might need to increment the level?