### PR TITLE
[Perms] Allow bool rules

### DIFF
--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -121,10 +121,12 @@
    (when-let [expr (get-expr (:code rules) etype action)]
      (try
        (let [code (with-binds (:code rules) etype expr)
-             ast (cel/->ast code)]
+             ;; Don't bork if the perm check is a simple boolean
+             code-str (if (boolean? code) (str code) code)
+             ast (cel/->ast code-str)]
          {:etype etype
           :action action
-          :code code
+          :code code-str
           :display-code expr
           :cel-ast ast
           :cel-program (cel/->program ast)})


### PR DESCRIPTION
I was testing some perms things and forgot that we need to wrap bools in a string. Unfortunately the error we give is not helpful. Seems like it would be nice to just make the bool a string for users.

![CleanShot 2025-03-07 at 11 30 09@2x](https://github.com/user-attachments/assets/2906923c-aa51-4917-ab6b-f2a2fe9ac65a)
