### PR TITLE
[apps] mark for deletion

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -385,7 +385,9 @@ function Dashboard() {
   }
 
   async function onDeleteApp(app: InstantApp) {
-    successToast(`${app.title} was deleted!`);
+    successToast(
+      `${app.title} is marked for deletion. We will remove all data in 24 hours. Ping us on Discord if you did not mean to do this.`,
+    );
     const _apps = apps.filter((a) => a.id !== app.id);
     dashResponse.mutate((data) =>
       produce(data, (d) => {
@@ -1396,7 +1398,7 @@ function Admin({
                   onDelete();
                 }}
               >
-                {isDeletingApp ? 'Deleting...' : 'Delete'}
+                Delete
               </Button>
             </div>
           </Dialog>

--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -46,11 +46,11 @@ const graph = i.graph(
       email: i.string(),
     }),
     "welcome-email-config": i.entity({
-      'enabled?': i.boolean(),
-      limit: i.number()
+      "enabled?": i.boolean(),
+      limit: i.number(),
     }),
-    "threading": i.entity({
-      "use-vfutures": i.boolean()
+    threading: i.entity({
+      "use-vfutures": i.boolean(),
     }),
     "storage-migration": i.entity({
       "disableLegacy?": i.boolean(),
@@ -61,16 +61,15 @@ const graph = i.graph(
       isDisabled: i.boolean(),
     }),
     "query-flags": i.entity({
-      'query-hash': i.number(),
-      'setting': i.string(),
-      'value': i.string(),
-      'description': i.string()
-    })
+      "query-hash": i.number(),
+      setting: i.string(),
+      value: i.string(),
+      description: i.string(),
+    }),
+    "app-deletion-sweeper": i.entity({
+      "disabled?": i.boolean(),
+    }),
   },
-  // You can define links here.
-  // For example, if `posts` should have many `comments`.
-  // More in the docs:
-  // https://www.instantdb.com/docs/schema#defining-links
   {}
 );
 

--- a/server/resources/migrations/57_apps_deletion.down.sql
+++ b/server/resources/migrations/57_apps_deletion.down.sql
@@ -1,0 +1,1 @@
+alter table apps drop column if exists deletion_marked_at;

--- a/server/resources/migrations/57_apps_deletion.down.sql
+++ b/server/resources/migrations/57_apps_deletion.down.sql
@@ -1,1 +1,2 @@
-alter table apps drop column if exists deletion_marked_at;
+alter table
+  apps drop column if exists deletion_marked_at;

--- a/server/resources/migrations/57_apps_deletion.up.sql
+++ b/server/resources/migrations/57_apps_deletion.up.sql
@@ -1,0 +1,3 @@
+alter table apps add column deletion_marked_at timestamp with time zone;
+create index idx_apps_deletion_marked_at on apps (deletion_marked_at);
+

--- a/server/resources/migrations/57_apps_deletion.up.sql
+++ b/server/resources/migrations/57_apps_deletion.up.sql
@@ -1,3 +1,6 @@
-alter table apps add column deletion_marked_at timestamp with time zone;
-create index idx_apps_deletion_marked_at on apps (deletion_marked_at);
+alter table
+  apps
+add
+  column deletion_marked_at timestamp with time zone;
 
+create index if not exists idx_apps_deletion_marked_at on apps (deletion_marked_at);

--- a/server/src/instant/app_deletion_sweeper.clj
+++ b/server/src/instant/app_deletion_sweeper.clj
@@ -1,0 +1,73 @@
+(ns instant.app-deletion-sweeper
+  (:require
+   [chime.core :as chime-core]
+   [instant.util.tracer :as tracer]
+   [instant.model.app :as app-model]
+   [instant.jdbc.sql :as sql]
+   [instant.grab :as grab]
+   [instant.util.date :as date-util]
+   [instant.flags :as flags])
+  (:import
+   (java.time Duration Period)))
+
+;; -------- 
+;; Config 
+
+(def grace-period-days 2)
+
+(defn period []
+  (let [now (date-util/pst-now)
+        ten-am (-> now
+                   (.withHour 10)
+                   (.withMinute 0))
+        periodic-seq (chime-core/periodic-seq
+                      ten-am
+                      (Period/ofDays 1))]
+
+    (->> periodic-seq
+         (filter (fn [x] (.isAfter x now))))))
+
+(comment
+  (first (period)))
+
+(def delete-timeout-seconds (.getSeconds (Duration/ofMinutes 5)))
+
+;; ---------- 
+;; Sweep 
+
+(defn straight-jacket-delete-app! [{:keys [id] :as app}]
+  (tracer/with-span! {:name "app-deletion-sweeper/delete-app"
+                      :attributes app}
+    (try
+      (binding [sql/*query-timeout-seconds* delete-timeout-seconds]
+        (app-model/delete-immediately-by-id!
+         {:id id}))
+      (catch Throwable e
+        (tracer/add-exception! e {:escaping? false})))))
+
+(defn handle-sweep [_]
+  (tracer/with-span! {:name "app-deletion-sweeper/sweep"}
+    (when-not (flags/app-deletion-sweeper-disabled?)
+      (let [maximum-marked-date (-> (date-util/pst-now)
+                                    (.minus (Duration/ofDays grace-period-days)))
+
+            apps-to-delete (app-model/get-apps-to-delete {:maximum-deletion-marked-at
+                                                          (.toInstant maximum-marked-date)})]
+        (tracer/add-data! {:attributes {:count (count apps-to-delete)}})
+        (doseq [{:keys [id] :as app} apps-to-delete]
+          (grab/run-once!
+           (format "delete-app-%s-%s" id (date-util/numeric-date-str maximum-marked-date))
+           (fn [] (straight-jacket-delete-app! app))))))))
+
+(defn start []
+  (tracer/record-info! {:name "app-deletion-sweeper/schedule"})
+  (def schedule (chime-core/chime-at (period) handle-sweep)))
+
+(defn stop []
+  (tracer/record-info! {:name "app-deletion-sweeper/stop"})
+  (.close schedule))
+
+(defn restart []
+  (stop)
+  (start))
+

--- a/server/src/instant/app_deletion_sweeper.clj
+++ b/server/src/instant/app_deletion_sweeper.clj
@@ -67,6 +67,12 @@
   (tracer/record-info! {:name "app-deletion-sweeper/stop"})
   (.close schedule))
 
+(defn before-ns-unload []
+  (stop))
+
+(defn after-ns-reload []
+  (start))
+
 (defn restart []
   (stop)
   (start))

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -40,6 +40,7 @@
    [instant.util.crypt :as crypt-util]
    [instant.util.http :as http-util]
    [instant.util.tracer :as tracer]
+   [instant.app-deletion-sweeper :as app-deletion-sweeper]
    [ring.middleware.cookies :refer [CookieDateTime]]
    [ring.middleware.cors :refer [wrap-cors]]
    [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
@@ -237,6 +238,8 @@
       (indexing-jobs/start))
     (with-log-init :storage-sweeper
       (storage-sweeper/start))
+    (with-log-init :app-deletion-sweeper
+      (app-deletion-sweeper/start))
     (when (= (config/get-env) :prod)
       (with-log-init :analytics
         (analytics/start)))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -369,11 +369,11 @@
 
   (app-model/get-all-for-user {:user-id (:id u)})
 
-  (app-model/delete-by-id! {:id app-id}))
+  (app-model/delete-immediately-by-id! {:id app-id}))
 
 (defn apps-delete [req]
   (let [{{app-id :id} :app} (req->app-and-user! req)]
-    (app-model/delete-by-id! {:id app-id})
+    (app-model/mark-for-deletion! {:id app-id})
     (response/ok {:ok true})))
 
 (defn apps-clear [req]

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -78,7 +78,7 @@
        (with-fail-on-warn-io
          (~f app#))
        (finally
-         (app-model/delete-by-id! {:id app-id#})))))
+         (app-model/delete-immediately-by-id! {:id app-id#})))))
 
 (defmacro with-movies-app [f]
   `(with-empty-app
@@ -167,7 +167,7 @@
           :owner owner
           :owner-req owner-req})
       (finally
-        (app-model/delete-by-id! {:id app-id})))))
+        (app-model/delete-immediately-by-id! {:id app-id})))))
 
 (defn with-team-app [owner invitee role f]
   (let [app-id (UUID/randomUUID)
@@ -205,6 +205,6 @@
           :owner-req owner-req
           :invitee-req invitee-req})
       (finally
-        (app-model/delete-by-id! {:id app-id})
+        (app-model/delete-immediately-by-id! {:id app-id})
         (instant-app-members/delete-by-id! {:id (:id member)})
         (instant-app-member-invites/delete-by-id! {:id (:id invite)})))))

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -59,7 +59,7 @@
 
 (defn app-delete [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
-        app (app-model/delete-immediately-by-id! {:id app-id})]
+        app (app-model/mark-for-deletion! {:id app-id})]
     (response/ok {:app app})))
 
 ;; ---------

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -59,7 +59,7 @@
 
 (defn app-delete [req]
   (let [{{app-id :id} :app} (req->superadmin-user-and-app! req)
-        app (app-model/delete-by-id! {:id app-id})]
+        app (app-model/delete-immediately-by-id! {:id app-id})]
     (response/ok {:app app})))
 
 ;; ---------

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -114,7 +114,7 @@
                         :creator-id constants/test-user-id
                         :id app-id
                         :admin-token admin-token}))
-  (app-model/delete-by-id! {:id app-id}))
+  (app-model/delete-immediately-by-id! {:id app-id}))
 
 (deftest transact-test
   (with-movies-app

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -112,8 +112,7 @@
          %)
     (zprint/zprint-str % {:map {:comma? false
                                 :sort? false}
-                          :set {:sort? false
-                                }})
+                          :set {:sort? false}})
     (str "'" %)
     (pad-block offset %)
     (z/of-string %)
@@ -1328,7 +1327,6 @@
                    ("eid-stepan-parunashvili" :users/handle "stopa")
                    ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))})))))))))
 
-
 (deftest multiple-where
   (with-zeneca-app
     (fn [app r]
@@ -1435,20 +1433,20 @@
                         #{:users/createdAt :users/email :users/id :users/fullName
                           :users/handle} _])
               :triples
-                (("eid-joe-averbukh" :users/handle "joe")
-                  ("eid-stepan-parunashvili" :users/handle "stopa")
-                  --
-                  ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
-                  ("eid-stepan-parunashvili" :users/createdAt "2021-01-07 18:50:43.447955")
-                  ("eid-stepan-parunashvili" :users/fullName "Stepan Parunashvili")
-                  ("eid-stepan-parunashvili" :users/handle "stopa")
-                  ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
-                  --
-                  ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
-                  ("eid-joe-averbukh" :users/email "joe@instantdb.com")
-                  ("eid-joe-averbukh" :users/handle "joe")
-                  ("eid-joe-averbukh" :users/fullName "Joe Averbukh")
-                  ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637"))})))))))
+              (("eid-joe-averbukh" :users/handle "joe")
+               ("eid-stepan-parunashvili" :users/handle "stopa")
+               --
+               ("eid-stepan-parunashvili" :users/email "stopa@instantdb.com")
+               ("eid-stepan-parunashvili" :users/createdAt "2021-01-07 18:50:43.447955")
+               ("eid-stepan-parunashvili" :users/fullName "Stepan Parunashvili")
+               ("eid-stepan-parunashvili" :users/handle "stopa")
+               ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili")
+               --
+               ("eid-joe-averbukh" :users/id "eid-joe-averbukh")
+               ("eid-joe-averbukh" :users/email "joe@instantdb.com")
+               ("eid-joe-averbukh" :users/handle "joe")
+               ("eid-joe-averbukh" :users/fullName "Joe Averbukh")
+               ("eid-joe-averbukh" :users/createdAt "2021-01-07 18:51:23.742637"))})))))))
 
 (deftest where-$like
   (with-zeneca-checked-data-app
@@ -2797,40 +2795,40 @@
                    (get "bookshelves")
                    (#(map (fn [x] (get x "order")) %)))))))))
 
-  (deftest order-by-with-ors-and-ands
-    (with-zeneca-checked-data-app
-      (fn [app _r]
-        (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
-                   :app-id (:id app)
-                   :attrs (attr-model/get-by-app-id (:id app))}]
-          (is (= [[0 1 2 3 4 5 6 7 8 9 10] [0 1]]
-                 (-> (instaql-nodes->object-tree
-                      ctx
-                      (iq/query ctx
-                                {:users
-                                 {:$ {:where {:or [{:handle "alex"}
-                                                   {:handle "nicolegf"}]}
-                                      :order {:handle "desc"}}
-                                  :bookshelves {:$ {:order {:order "asc"}}}}}))
+(deftest order-by-with-ors-and-ands
+  (with-zeneca-checked-data-app
+    (fn [app _r]
+      (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
+                 :app-id (:id app)
+                 :attrs (attr-model/get-by-app-id (:id app))}]
+        (is (= [[0 1 2 3 4 5 6 7 8 9 10] [0 1]]
+               (-> (instaql-nodes->object-tree
+                    ctx
+                    (iq/query ctx
+                              {:users
+                               {:$ {:where {:or [{:handle "alex"}
+                                                 {:handle "nicolegf"}]}
+                                    :order {:handle "desc"}}
+                                :bookshelves {:$ {:order {:order "asc"}}}}}))
 
-                     (get "users")
-                     (#(map (fn [u] (map (fn [b] (get b "order"))
-                                         (get u "bookshelves")))
-                            %)))))
-          (is (= [15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0]
-                 (-> (instaql-nodes->object-tree
-                      ctx
-                      (iq/query ctx
-                                {:users
-                                 {:$ {:where {:and [{:handle "stopa"}
-                                                    {:bookshelves.order 0}
-                                                    {:email "stopa@instantdb.com"}]}}
-                                  :bookshelves {:$ {:order {:order "desc"}}}}}))
+                   (get "users")
+                   (#(map (fn [u] (map (fn [b] (get b "order"))
+                                       (get u "bookshelves")))
+                          %)))))
+        (is (= [15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0]
+               (-> (instaql-nodes->object-tree
+                    ctx
+                    (iq/query ctx
+                              {:users
+                               {:$ {:where {:and [{:handle "stopa"}
+                                                  {:bookshelves.order 0}
+                                                  {:email "stopa@instantdb.com"}]}}
+                                :bookshelves {:$ {:order {:order "desc"}}}}}))
 
-                     (get "users")
-                     first
-                     (get "bookshelves")
-                     (#(map (fn [x] (get x "order")) %)))))))))
+                   (get "users")
+                   first
+                   (get "bookshelves")
+                   (#(map (fn [x] (get x "order")) %)))))))))
 
 (deftest child-forms
   (with-zeneca-app
@@ -3334,7 +3332,7 @@
                         :id app-id
                         :admin-token (UUID/randomUUID)}))
   (bootstrap/add-zeneca-to-app! app-id)
-  (app-model/delete-by-id! {:id app-id}))
+  (app-model/delete-immediately-by-id! {:id app-id}))
 
 (deftest default-perms
   (doseq [[app-fn description] [[(fn [f]
@@ -3374,7 +3372,6 @@
 
            {:$default {:allow {:$default "false" :view "true"}}}
            #{"alex" "joe" "stopa" "nicolegf"}))))))
-
 
 (deftest read-perms
   (doseq [[app-fn description] [[(fn [f]
@@ -3518,9 +3515,9 @@
            (is
             (= ::ex/permission-evaluation-failed
                (::ex/type (instant-ex-data
-                            (pretty-perm-q
-                             {:app-id app-id :current-user {:handle "stopa"}}
-                             {:users {}})))))))))))
+                           (pretty-perm-q
+                            {:app-id app-id :current-user {:handle "stopa"}}
+                            {:users {}})))))))))))
 
 (deftest coarse-topics
   (with-zeneca-app
@@ -3557,7 +3554,6 @@
                (resolvers/walk-friendly
                 r
                 (d/pats->coarse-topics patterns))))))))
-
 
 (deftest aggregates
   (with-zeneca-app

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -976,7 +976,7 @@
                         :admin-token (UUID/randomUUID)}))
   (bootstrap/add-zeneca-to-app! app-id)
   (def r (resolvers/make-zeneca-resolver app-id))
-  (app-model/delete-by-id! {:id app-id}))
+  (app-model/delete-immediately-by-id! {:id app-id}))
 
 (defmacro perm-err? [& body]
   `(is (= ::ex/permission-denied (::ex/type (test-util/instant-ex-data ~@body)))))
@@ -1598,31 +1598,31 @@
           (testing "create"
             (let [id (random-uuid)]
               (is (perm-err?
-                    (permissioned-tx/transact! (make-ctx)
-                                               [[:add-triple id id-attr-id (str id)]
-                                                [:add-triple id handle-attr-id "a"]])))))
+                   (permissioned-tx/transact! (make-ctx)
+                                              [[:add-triple id id-attr-id (str id)]
+                                               [:add-triple id handle-attr-id "a"]])))))
 
           (testing "update"
             (is (perm-err?
-                  (permissioned-tx/transact! (make-ctx)
-                                             [[:add-triple existing-id handle-attr-id "b"]])))))
+                 (permissioned-tx/transact! (make-ctx)
+                                            [[:add-triple existing-id handle-attr-id "b"]])))))
 
         (testing "lookup fail"
           (testing "create"
             (is (perm-err?
-                  (permissioned-tx/transact! (make-ctx)
-                                             [[:add-triple [handle-attr-id "a"] id-attr-id [handle-attr-id "a"]]])))
+                 (permissioned-tx/transact! (make-ctx)
+                                            [[:add-triple [handle-attr-id "a"] id-attr-id [handle-attr-id "a"]]])))
 
             ;; n.b. if this validation-err? is fixed, make sure that this is still a permisison error
             ;;      right now you can't edit a lookup attr in the same transaction you create the lookup attr
             (is (validation-err?
-                  (permissioned-tx/transact! (make-ctx)
-                                             [[:add-triple [handle-attr-id "a"] id-attr-id [handle-attr-id "a"]]
-                                              [:add-triple [handle-attr-id "a"] handle-attr-id "c"]]))))
+                 (permissioned-tx/transact! (make-ctx)
+                                            [[:add-triple [handle-attr-id "a"] id-attr-id [handle-attr-id "a"]]
+                                             [:add-triple [handle-attr-id "a"] handle-attr-id "c"]]))))
           (testing "update"
             (is (perm-err?
-                  (permissioned-tx/transact! (make-ctx)
-                                             [[:add-triple [handle-attr-id "c"] handle-attr-id "b"]])))))))))
+                 (permissioned-tx/transact! (make-ctx)
+                                            [[:add-triple [handle-attr-id "c"] handle-attr-id "b"]])))))))))
 
 (deftest rejects-bad-lookups
   (with-zeneca-app
@@ -2137,17 +2137,17 @@
           (is
            (string/includes?
             (::ex/message (test-util/instant-ex-data (tx/transact!
-                                            (aurora/conn-pool :write)
-                                            (attr-model/get-by-app-id app-id)
-                                            app-id
-                                            [[:add-attr
-                                              {:id info-attr-id
-                                               :forward-identity [buds-fwd-ident "users" "buds"]
-                                               :value-type :ref
-                                               :cardinality :one
-                                               :unique? false
-                                               :index? false}]
-                                             [:deep-merge-triple target-eid info-attr-id {:name "Patchy"}]])))
+                                                      (aurora/conn-pool :write)
+                                                      (attr-model/get-by-app-id app-id)
+                                                      app-id
+                                                      [[:add-attr
+                                                        {:id info-attr-id
+                                                         :forward-identity [buds-fwd-ident "users" "buds"]
+                                                         :value-type :ref
+                                                         :cardinality :one
+                                                         :unique? false
+                                                         :index? false}]
+                                                       [:deep-merge-triple target-eid info-attr-id {:name "Patchy"}]])))
 
             "merge operation is not supported for links")))))))
 
@@ -2349,8 +2349,8 @@
                       [:add-triple book-id book-id-attr-id book-id]
                       [:add-triple book-id book-creator-attr-id user-id]]]
         (app-user-model/create! (aurora/conn-pool :write) {:app-id app-id
-                                                    :id user-id
-                                                    :email "test@example.com"})
+                                                           :id user-id
+                                                           :email "test@example.com"})
         (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
         (is (permissioned-tx/transact! (assoc (make-ctx)
                                               :current-user {:id user-id}) tx-steps))))))
@@ -2396,8 +2396,8 @@
                 [:add-triple book-id book-id-attr-id book-id]
                 [:add-triple book-id book-isbn-attr-id "1234"]])
             _ (app-user-model/create! (aurora/conn-pool :write) {:app-id app-id
-                                                          :id user-id
-                                                          :email "test@example.com"})
+                                                                 :id user-id
+                                                                 :email "test@example.com"})
             tx-steps [[:add-triple
                        [book-isbn-attr-id "1234"]
                        book-creator-attr-id
@@ -2470,8 +2470,8 @@
                              :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
                              :current-user nil})
             user (app-user-model/create! (aurora/conn-pool :write) {:app-id app-id
-                                                             :id user-id
-                                                             :email "test@example.com"})
+                                                                    :id user-id
+                                                                    :email "test@example.com"})
             _ (tx/transact!
                (aurora/conn-pool :write)
                (attr-model/get-by-app-id app-id)


### PR DESCRIPTION
A user had a really large app, and our "delete" button was starting to time out. 

Changed our system to schedule apps for deletion. The way it works: 
1. Added an `deletion_marked_at` flag on apps 
2. When a user deletes an app, we only mark this flag
3. A worker runs every day. we pick up the app and run the operation in the background, with a 5 minute timeout 
4. You can disable this using the `app-deletion-sweeper` flag in instant-flags 

Deploy plan:
1. push instant-config
2. push migration
3. deploy

@dwwoelfel @nezaj @tonsky 