### PR TITLE
[Perms] Null-safe operations

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -255,13 +255,6 @@
       (.addFunctionBindings (ucoll/array-of CelRuntime$CelFunctionBinding custom-fn-bindings))
       (.build)))
 
-(defn transform-not-expr [expr-str]
-  (clojure-string/replace expr-str #"(?<!\!)!(?:\(([^)]+)\)|([a-zA-Z0-9_.]+))"
-                          (fn [[_ paren-expr prop-expr]]
-                            (if paren-expr
-                              (str "safeNot(" paren-expr ")")
-                              (str "safeNot(" prop-expr ")")))))
-
 (defn transform-null-expr [expr-str]
   (-> expr-str
       ;; Replace "prop == null" with "prop == false"

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -257,10 +257,12 @@
 
 (defn transform-null-expr [expr-str]
   (-> expr-str
-      ;; Replace "prop == null" with "prop == false"
+      ;; Replace equality checks
       (clojure-string/replace #"([a-zA-Z0-9_.]+)\s*==\s*null" "$1 == false")
-      ;; Replace "null == prop" with "false == prop"
-      (clojure-string/replace #"null\s*==\s*([a-zA-Z0-9_.]+)" "false == $1")))
+      (clojure-string/replace #"null\s*==\s*([a-zA-Z0-9_.]+)" "false == $1")
+      ;; Replace inequality checks
+      (clojure-string/replace #"([a-zA-Z0-9_.]+)\s*!=\s*null" "$1 != false")
+      (clojure-string/replace #"null\s*!=\s*([a-zA-Z0-9_.]+)" "false != $1")))
 
 (defn ->ast [expr-str]
   (let [clean-expr-str (-> expr-str transform-null-expr)]

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -41,6 +41,11 @@
           bindings {"data" (cel/->cel-map {} {})}]
       (is (true? (cel/eval-program! {:cel-program program} bindings))))
 
+    ;; You can check not null
+    (let [program (cel/->program (cel/->ast "data.isVerified != null"))
+          bindings {"data" (cel/->cel-map {} {})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))
+
     ;; Direct comparison with null works
     (let [program (cel/->program (cel/->ast "data.isVerified == null"))
           bindings {"data" (cel/->cel-map {} {"isVerified" nil})}]

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -29,13 +29,94 @@
     (let [program (cel/->program (cel/->ast "[1, 2, 3, 4].filter(x, x % 2 == 0)"))]
       (is (= [2 4] (cel/eval-program! {:cel-program program} {}))))))
 
-(deftest parse-false-correctly
-  (let [program (cel/->program (cel/->ast "data.isFavorite"))
-        bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
-    (is (false? (cel/eval-program! {:cel-program program} bindings))))
-  (let [program (cel/->program (cel/->ast "!data.isFavorite"))
-        bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
-    (is (true? (cel/eval-program! {:cel-program program} bindings)))))
+(deftest test-nulls-work
+  (testing "nulls are safe"
+    ;; Missing properties are treated as false
+    (let [program (cel/->program (cel/->ast "data.isFavorite"))
+          bindings {"data" (cel/->cel-map {} {})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Null values are treated as false
+    (let [program (cel/->program (cel/->ast "data.isVerified == null"))
+          bindings {"data" (cel/->cel-map {} {})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Direct comparison with null works
+    (let [program (cel/->program (cel/->ast "data.isVerified == null"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+    (let [program (cel/->program (cel/->ast "data.isVerified == null"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" true})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))))
+
+(deftest test-nullsafe-not
+  (testing "! operator handles null values correctly"
+    ;; not is null-safe when property is missing
+    (let [program (cel/->program (cel/->ast "!data.isFavorite"))
+          bindings {"data" (cel/->cel-map {} {})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; not is null-safe when property is null
+    (let [program (cel/->program (cel/->ast "!data.isFavorite"))
+          bindings {"data" (cel/->cel-map {} {"isFavorite" nil})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; not works with booleans
+    (let [program (cel/->program (cel/->ast "!data.isFavorite"))
+          bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+    (let [program (cel/->program (cel/->ast "!data.isFavorite"))
+          bindings {"data" (cel/->cel-map {} {"isFavorite" true})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; double negation works
+    (let [program (cel/->program (cel/->ast "!!data.isFavorite"))
+          bindings {"data" (cel/->cel-map {} {"isFavorite" true})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; not works with nested properties
+    (let [program (cel/->program (cel/->ast "!(data.isFavorite || data.isPopular)"))
+          bindings {"data" (cel/->cel-map {} {"isFavorite" nil, "isPopular" nil})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Test and with both null values
+    (let [program (cel/->program (cel/->ast "!data.isVerified && !data.isActive"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil, "isActive" nil})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))))
+
+(deftest test-nullsafe-or
+  (testing "or operator handles null values correctly"
+    ;; Test with one null value
+    (let [program (cel/->program (cel/->ast "data.isVerified || data.isActive"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil, "isActive" true})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Test and with both null values
+    (let [program (cel/->program (cel/->ast "data.isVerified || data.isActive"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil, "isActive" nil})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Works with explcit null check
+    (let [program (cel/->program (cel/->ast "data.isVerified == null || data.isActive == null"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" true})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))))
+
+(deftest test-nullsafe-and
+  (testing "and operator handles null values correctly"
+    ;; Test with one null value
+    (let [program (cel/->program (cel/->ast "data.isVerified && data.isActive"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil, "isActive" true})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Test and with both null values
+    (let [program (cel/->program (cel/->ast "data.isVerified && data.isActive"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil, "isActive" nil})}]
+      (is (false? (cel/eval-program! {:cel-program program} bindings))))
+
+    ;; Works with explcit null check
+    (let [program (cel/->program (cel/->ast "data.isVerified == null && data.isActive == null"))
+          bindings {"data" (cel/->cel-map {} {"isVerified" nil})}]
+      (is (true? (cel/eval-program! {:cel-program program} bindings))))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Makes `!`, `||`, `&&` null safe in CEL rules. This works by 1) treating `nulls` as `false` and 2) rewriting any explicit null checks (`data.owner == null` or `null == data.owner`) into checking for false.

Originally I wanted to see if we could overload the `!` operator to safely handle nulls

```
(def null-safe-not-operator
  {:decl (CelFunctionDecl/newFunctionDeclaration
          "!"
          (ucoll/array-of
           CelOverloadDecl
           [(CelOverloadDecl/newGlobalOverload
             "null_safe_logical_not"  ; This is a descriptive name for the overload
             SimpleType/BOOL
             (ucoll/array-of CelType [SimpleType/DYN]))]))
   :runtime (let [impl (reify CelFunctionOverload$Unary
                         (apply [_ val]
                           (if (or (nil? val) (= val NullValue/NULL_VALUE))
                             true  ; if null, treat as falsy
                             (not (Boolean/valueOf (str val))))))]
              ;; Use the CelFunctionBinding for unary functions - adjust based on your CEL version
              (CelRuntime$CelFunctionBinding/from
               "null_safe_logical_not"  ; Function name
               Object         ; Parameter type (can handle any object)
               impl))})
```

I could get this working but there were issues with nulls for `&&` and `||` -- those operators expect booleans on both sides.

> ; (out) Caused by: dev.cel.runtime.CelEvaluationException: evaluation error at <input>:24: expected boolean value, found: NULL_VALUE


I tried overloading those but it would still fail

```
(def null-safe-or-operator
  {:decl (CelFunctionDecl/newFunctionDeclaration
          "||"
          (ucoll/array-of
           CelOverloadDecl
           [(CelOverloadDecl/newGlobalOverload
             "null_safe_logical_or"
             SimpleType/BOOL
             (ucoll/array-of CelType [SimpleType/DYN SimpleType/DYN]))]))
   :runtime (let [impl (reify CelFunctionOverload$Binary
                         (apply [_ left right]
                           ;; If either is truthy, return true
                           (if (or (and (not= left NullValue/NULL_VALUE)
                                        (not= left nil)
                                        (Boolean/valueOf (str left)))
                                   (and (not= right NullValue/NULL_VALUE)
                                        (not= right nil)
                                        (Boolean/valueOf (str right))))
                             true
                             false)))]
              (CelRuntime$CelFunctionBinding/from
               "null_safe_logical_or"
               Object
               Object
               impl))})

(def null-safe-and-operator
  {:decl (CelFunctionDecl/newFunctionDeclaration
          "&&"
          (ucoll/array-of
           CelOverloadDecl
           [(CelOverloadDecl/newGlobalOverload
             "null_safe_logical_and"
             SimpleType/BOOL
             (ucoll/array-of CelType [SimpleType/DYN SimpleType/DYN]))]))
   :runtime (let [impl (reify CelFunctionOverload$Binary
                         (apply [_ left right]
                           ;; Both must be truthy for true result
                           ;; Null values are treated as falsy
                           (if (and (not= left NullValue/NULL_VALUE)
                                    (not= left nil)
                                    (Boolean/valueOf (str left))
                                    (not= right NullValue/NULL_VALUE)
                                    (not= right nil)
                                    (Boolean/valueOf (str right)))
                             true
                             false)))]
              (CelRuntime$CelFunctionBinding/from
               "null_safe_logical_and"
               Object
               Object
               impl))})
```

However by treating `null` as `false` all the operations are happy as is.

I checked rules to see if there were some instances where folks explicitly check against null. Indeed there are so added some logic to rewrite null checks into false checks