### PR TITLE
[client] support branded types

### DIFF
--- a/client/packages/core/src/queryTypes.ts
+++ b/client/packages/core/src/queryTypes.ts
@@ -12,7 +12,9 @@ import type {
 
 type BuiltIn = Date | Function | Error | RegExp;
 
-type Expand<T> = T extends BuiltIn
+type Primitive = string | number | boolean | symbol | null | undefined;
+
+type Expand<T> = T extends BuiltIn | Primitive
   ? T
   : T extends object
     ? T extends infer O

--- a/client/sandbox/strong-init-vite/src/typescript_branded.tsx
+++ b/client/sandbox/strong-init-vite/src/typescript_branded.tsx
@@ -1,0 +1,23 @@
+import { i, init } from '@instantdb/react';
+
+type BusinessEmail = string & { readonly __brand: unique symbol };
+
+const schema = i.schema({
+  entities: {
+    leads: i.entity({
+      email: i.string<BusinessEmail>(),
+    }),
+  },
+});
+
+const db = init({
+  appId: 'my-app-id',
+  schema,
+});
+
+const r = db.useQuery({
+  leads: {},
+});
+
+const x = r.data?.leads[0];
+x;


### PR DESCRIPTION
**Context** 

If you use branded types like so: 

```
type BusinessEmail = string & { readonly __brand: unique symbol };

const schema = i.schema({
  entities: {
    leads: i.entity({
      email: i.string<BusinessEmail>(),
    }),
  },
});

const db = init({
  appId: 'my-app-id',
  schema,
});

const r = db.useQuery({
  leads: {},
});

const x = r.data?.leads[0];
```

## Problem 

`InstaQLEntity` would expanded the branded type: it would like so:

{
    id: string;
    email: {
        readonly [x: number]: string;
        toString: () => string;
        charAt: (pos: number) => string;
        charCodeAt: (index: number) => number;
        concat: (...strings: string[]) => string;
        indexOf: (searchString: string, position?: number) => number;
        ... 43 more ...;
        readonly __brand: unique symbol;
    };
} | undefined

## Solution 

I made sure that we don't expand primitives. This short circuits and returns a nice intellisense: 

![image](https://github.com/user-attachments/assets/62d484d7-bbb5-42b9-9272-6c01cdcfd009)

@nezaj @dwwoelfel @tonsky 