### PR TITLE
[client] Disable devtool in non-DOM contexts (React Native)

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -678,7 +678,11 @@ function init<
 }
 
 function handleDevtool(appId: string, devtool: boolean | DevtoolConfig) {
-  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.location === 'undefined' ||
+    typeof document === 'undefined'
+  ) {
     return;
   }
 


### PR DESCRIPTION
The devtool uses the Browser Object Model API, which is not available in react-native. This change tests for the existance of `document` in the global namespace chain and aborts devtool creation if it does not exist.

This allows usage in react native without explicitly passing `devtool: false` to `init`.
