### PR TITLE
[cli] exiting -> skipping

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -606,7 +606,7 @@ async function promptCreateApp() {
   const title = _title?.trim();
 
   if (!title) {
-    error('No name provided. Exiting.');
+    error('No name provided.');
     return { ok: false };
   }
   const app = { id, title, admin_token: token };
@@ -1161,7 +1161,7 @@ async function pushPerms(appId) {
     res.perms || {},
   );
   if (!diffedStr.length) {
-    console.log('No perms changes detected. Exiting.');
+    console.log('No perms changes detected. Skipping.');
     return;
   }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d1610c51-48a0-436b-9b59-b2e4adfc1247)

Noticed a little inconsistency -- when we skip schema, we say "skipping", when we skip perms, we say "exiting". But we are not necessarily exiting. 

Thought I'd be fair and just call both "skipping". 

@nezaj @dwwoelfel @tonsky 