### PR TITLE
[s3-uploads] pass content-length

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -160,7 +160,7 @@
   (let [{:keys [app]} (get-auth! store sess-id)]
     (rs/remove-query! store (:id app) sess-id q)
     (rs/send-event! store (:id app) sess-id {:op :remove-query-ok :q q
-                                                  :client-event-id client-event-id})))
+                                             :client-event-id client-event-id})))
 
 (defn- recompute-instaql-query!
   [{:keys [store current-user app-id sess-id attrs table-info admin?]}
@@ -224,13 +224,13 @@
                         :attributes tracer-attrs}
       (when (seq computations)
         (rs/send-event! store app-id sess-id (with-meta
-                                                    {:op :refresh-ok
-                                                     :processed-tx-id processed-tx-id
-                                                     :attrs attrs
-                                                     :computations computations}
-                                                    {:tx-id (:tx-id event)
-                                                     :tx-created-at (:tx-created-at event)
-                                                     :session-id sess-id}))))))
+                                               {:op :refresh-ok
+                                                :processed-tx-id processed-tx-id
+                                                :attrs attrs
+                                                :computations computations}
+                                               {:tx-id (:tx-id event)
+                                                :tx-created-at (:tx-created-at event)
+                                                :session-id sess-id}))))))
 
 ;; -----
 ;; transact
@@ -260,12 +260,12 @@
 ;; error
 
 (defn handle-error! [store sess-id {:keys [status
-                                                app-id
-                                                client-event-id
-                                                original-event
-                                                type
-                                                message
-                                                hint]}]
+                                           app-id
+                                           client-event-id
+                                           original-event
+                                           type
+                                           message
+                                           hint]}]
   (rs/send-event! store
                   app-id
                   sess-id
@@ -302,16 +302,16 @@
         current-user (-> auth :user)]
     (eph/join-room! app-id sess-id current-user room-id)
     (rs/send-event! store app-id sess-id {:op :join-room-ok
-                                               :room-id room-id
-                                               :client-event-id client-event-id})))
+                                          :room-id room-id
+                                          :client-event-id client-event-id})))
 
 (defn- handle-leave-room! [store sess-id {:keys [client-event-id room-id] :as _event}]
   (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)]
     (eph/leave-room! app-id sess-id room-id)
     (rs/send-event! store app-id sess-id {:op :leave-room-ok
-                                               :room-id room-id
-                                               :client-event-id client-event-id})))
+                                          :room-id room-id
+                                          :client-event-id client-event-id})))
 
 (defn assert-in-room! [app-id room-id sess-id]
   (when-not (eph/in-room? app-id room-id sess-id)
@@ -327,8 +327,8 @@
         _ (assert-in-room! app-id room-id sess-id)]
     (eph/set-presence! app-id sess-id room-id data)
     (rs/send-event! store app-id sess-id {:op :set-presence-ok
-                                               :room-id room-id
-                                               :client-event-id client-event-id})))
+                                          :room-id room-id
+                                          :client-event-id client-event-id})))
 
 (def patch-presence-min-version (semver/parse "v0.17.5"))
 
@@ -383,15 +383,15 @@
       (eph/broadcast app-id remote-ids base-msg))
 
     (rs/send-event! store app-id sess-id (assoc base-msg
-                                                     :op :client-broadcast-ok
-                                                     :client-event-id client-event-id))))
+                                                :op :client-broadcast-ok
+                                                :client-event-id client-event-id))))
 
 (defn- handle-server-broadcast! [store sess-id {:keys [app-id room-id topic data]}]
   (when (eph/in-room? app-id room-id sess-id)
     (rs/send-event! store app-id sess-id {:op :server-broadcast
-                                               :room-id room-id
-                                               :topic topic
-                                               :data data})))
+                                          :room-id room-id
+                                          :topic topic
+                                          :data data})))
 
 (defn handle-event [store session event debug-info]
   (let [{:keys [op]} event
@@ -709,12 +709,12 @@
 
 (defn start []
   (receive-queue/start
-    (grouped-queue/start
-     {:group-key-fn #'group-key
-      :combine-fn   #'combine
-      :process-fn   #'process
-      :max-workers  num-receive-workers
-      :metrics-path "instant.reactive.session.receive-q"})))
+   (grouped-queue/start
+    {:group-key-fn #'group-key
+     :combine-fn   #'combine
+     :process-fn   #'process
+     :max-workers  num-receive-workers
+     :metrics-path "instant.reactive.session.receive-q"})))
 
 (defn stop []
   (receive-queue/stop))

--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -87,7 +87,7 @@
 
 (defn consume-upload-url!
   "Consume an Instant upload url and if it's valid kicks off our upload process"
-  [{:keys [upload-id content-type]} file]
+  [{:keys [upload-id content-type content-length]} file]
   (let [{app-id :app_id path :path expired-at :expired_at}
         (app-upload-url-model/consume! {:upload-id upload-id})]
     (when (or (not expired-at)
@@ -100,6 +100,7 @@
      {:app-id app-id
       :path path
       :content-type content-type
+      :content-length content-length
       :skip-perms-check? true} file)))
 
 (defn create-download-url

--- a/server/src/instant/storage/routes.clj
+++ b/server/src/instant/storage/routes.clj
@@ -10,8 +10,7 @@
             [clojure.walk :as w]))
 
 (defn req->content-length! [{:keys [content-length] :as _req}]
-  (when content-length
-    (long content-length)))
+  content-length)
 
 (defn req->app-file! [req params]
   (let [app-id (ex/get-param! params [:app_id] uuid-util/coerce)

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -260,7 +260,7 @@
                                      content-length (.contentLength content-length)
                                      true (.build))]
          (if content-length
-           (let [body (AsyncRequestBody/fromInputStream stream content-length default-virtual-thread-executor)]
+           (let [body (AsyncRequestBody/fromInputStream stream (long content-length) default-virtual-thread-executor)]
              (-> (.putObject (default-s3-async-client) req body)
                  deref))
            (let [^BlockingInputStreamAsyncRequestBody body (AsyncRequestBody/forBlockingInputStream nil)

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -2,7 +2,8 @@
   (:require
    [instant.config :as config]
    [instant.util.async :refer [default-virtual-thread-executor]]
-   [instant.util.aws-signature :as aws-sig])
+   [instant.util.aws-signature :as aws-sig]
+   [instant.util.tracer :as tracer])
   (:import
    (java.time Instant Duration)
    (software.amazon.awssdk.auth.credentials DefaultCredentialsProvider)
@@ -231,31 +232,38 @@
      (throw (ex-info "Unsupported method for presigned url" {:method method})))))
 
 (defn- make-s3-put-opts
-  [bucket-name {:keys [object-key content-type content-disposition]} file-opts]
+  [bucket-name {:keys [object-key content-type content-disposition content-length]} file-opts]
   (merge
    {:bucket-name bucket-name
     :key object-key
     :metadata {:content-type (or content-type default-content-type)
-               :content-disposition (or content-disposition default-content-disposition)}}
+               :content-disposition (or content-disposition default-content-disposition)
+               :content-length content-length}}
    file-opts))
 
 (defn upload-stream-to-s3
   ([ctx stream] (upload-stream-to-s3 default-bucket ctx stream))
   ([bucket-name ctx stream]
-   (let [opts (make-s3-put-opts bucket-name ctx {})
-         content-length (:content-length ctx)
-         ^PutObjectRequest req (cond-> (PutObjectRequest/builder)
-                                 true (.bucket (:bucket-name opts))
-                                 true (.key (:key opts))
-                                 true (.contentType (:content-type (:metadata opts)))
-                                 true (.contentDisposition (:content-disposition (:metadata opts)))
-                                 content-length (.contentLength content-length)
-                                 true (.build))]
-     (if content-length
-       (let [body (AsyncRequestBody/fromInputStream stream content-length default-virtual-thread-executor)]
-         (-> (.putObject (default-s3-async-client) req body)
-             deref))
-       (let [^BlockingInputStreamAsyncRequestBody body (AsyncRequestBody/forBlockingInputStream nil)
-             resp (.putObject (default-s3-async-client) req body)]
-         (.writeInputStream body stream)
-         (deref resp))))))
+   (let [{:keys [key metadata] :as _opts} (make-s3-put-opts bucket-name ctx {})
+         {:keys [content-disposition content-type content-length]} metadata]
+     (tracer/with-span! {:name "s3/upload-stream-to-s3"
+                         :attributes {:bucket-name bucket-name
+                                      :key key
+                                      :content-type content-type
+                                      :content-disposition content-disposition
+                                      :content-length content-length}}
+       (let [^PutObjectRequest req (cond-> (PutObjectRequest/builder)
+                                     true (.bucket bucket-name)
+                                     true (.key key)
+                                     true (.contentType content-type)
+                                     true (.contentDisposition content-disposition)
+                                     content-length (.contentLength content-length)
+                                     true (.build))]
+         (if content-length
+           (let [body (AsyncRequestBody/fromInputStream stream content-length default-virtual-thread-executor)]
+             (-> (.putObject (default-s3-async-client) req body)
+                 deref))
+           (let [^BlockingInputStreamAsyncRequestBody body (AsyncRequestBody/forBlockingInputStream nil)
+                 resp (.putObject (default-s3-async-client) req body)]
+             (.writeInputStream body stream)
+             (deref resp))))))))


### PR DESCRIPTION
## Context

We were getting some errors with our async s3 crt client: 

> The service request was not made within 10 seconds of doBlockingWrite being invoked. Make sure to invoke the service request BEFORE invoking doBlockingWrite if your caller is single-threaded.

## What I learned

storage-routes/upload-put was not sending `content-length` to `upload-stream-to-s3!`.

This forced us to use the CRT client, as it can send streams without content-length. You may be wondering: how does the CRT client send the stream without a content length? It chunks the stream, and uses S3's multipart API to sends chunks (with content-length) over. 

**But, we _do_ receive the content-length header.** 

Our http handler receives a content-length header. If we passed it along, we could skip the more error-prone 'no content-length' branch of our code. Plus, it lets us use the Netty client again without many issues. Netty is not amazon specific, and has years of testing behind it. 

## Fix

I first went ahead and 

1. Extract the content-length header, and passed it in 
2. Added logging around stream-to-s3 


I am going to watch stream-to-s3, to make sure that we provided content-length in all scenarios. Once we do, we can remove the "no-content length" branch of the code, and potentially use Netty too if we want. 


@nezaj @dwwoelfel @tonsky 

## FAQ

Some questions that may come to mind: 

**Wait, is `content-length` _always_ provided?** 

In the case of multi-part forms, the content-length header will come in as `0`. **However, our upload API does not handle multi-part forms**. If we tried to send with multipart forms before, we would store the _whole_ multipart stream into one file.

@nezaj @tonsky @dwwoelfel 