### PR TITLE
[storage][clean] move clients from util.s3 to storage.s3

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -46,7 +46,8 @@
    [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
    [ring.middleware.keyword-params :refer [wrap-keyword-params]]
    [ring.middleware.multipart-params :refer [wrap-multipart-params]]
-   [ring.middleware.params :refer [wrap-params]])
+   [ring.middleware.params :refer [wrap-params]]
+   [instant.storage.s3 :as storage-s3])
   (:import
    (io.undertow Undertow UndertowOptions Undertow$Builder Undertow$ListenerInfo)
    (java.text SimpleDateFormat)
@@ -209,6 +210,8 @@
       (jwt/start))
     (with-log-init :aurora
       (aurora/start))
+    (with-log-init :storage-s3 
+      (storage-s3/start)
     (with-log-init :system-catalog
       (ensure-attrs-on-system-catalog-app))
     (with-log-init :reactive-store

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -210,8 +210,8 @@
       (jwt/start))
     (with-log-init :aurora
       (aurora/start))
-    (with-log-init :storage-s3 
-      (storage-s3/start)
+    (with-log-init :storage
+      (storage-s3/start))
     (with-log-init :system-catalog
       (ensure-attrs-on-system-catalog-app))
     (with-log-init :reactive-store

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -14,22 +14,37 @@
 ;; Configuration
 ;; ----------------------
 
-(def ^:private s3-client* (delay (.build (S3Client/builder))))
+(declare s3-client* s3-client s3-async-client* presign-creds*)
+
 (defn s3-client
   "Standard blocking S3 client. We use this for most operations."
   ^S3Client []
-  @s3-client*)
+  s3-client*)
 
-(def ^:private s3-async-client* (delay (-> (S3AsyncClient/crtBuilder)
-                                           (.targetThroughputInGbps 20.0)
-                                           (.build))))
 (defn s3-async-client
   "Async S3 Client. Useful when you want to asynchronously upload streams to S3"
   ^S3AsyncClient []
-  @s3-async-client*)
+  s3-async-client*)
 
-(def ^:private presign-creds*
-  (delay
+(defn presign-creds
+  "Credentials to presign S3 URLs. We use special credentials, because 
+   the default credentials provider creates URLs that expire in 2 days. 
+   
+   These are special credentials that can create URLs that expire in 7 days.
+   
+   Note: you need to make sure that both these credentials, and the default credentials, 
+   have the necessary permissions to access the same S3 bucket."
+  [] presign-creds*)
+
+(def bucket-name config/s3-bucket-name)
+
+(defn start []
+  (def ^:private s3-client* (.build (S3Client/builder)))
+
+  (def ^:private s3-async-client* (-> (S3AsyncClient/crtBuilder)
+                                      (.targetThroughputInGbps 20.0)
+                                      (.build)))
+  (def ^:private presign-creds*
     (let [access-key (config/s3-storage-access-key)
           secret-key (config/s3-storage-secret-key)
           region (.toString (.region (.serviceClientConfiguration (s3-client))))]
@@ -41,17 +56,6 @@
           {:access-key (.accessKeyId creds)
            :secret-key (.secretAccessKey creds)
            :region region})))))
-(defn presign-creds
-  "Credentials to presign S3 URLs. We use special credentials, because 
-   the default credentials provider creates URLs that expire in 2 days. 
-   
-   These are special credentials that can create URLs that expire in 7 days.
-   
-   Note: you need to make sure that both these credentials, and the default credentials, 
-   have the necessary permissions to access the same S3 bucket."
-  [] @presign-creds*)
-
-(def bucket-name config/s3-bucket-name)
 
 ;; S3 path manipulation
 ;; ----------------------

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -15,16 +15,14 @@
 ;; ----------------------
 
 (def ^:private s3-client* (delay (.build (S3Client/builder))))
-
 (defn s3-client
-  "Standard blocking S3 client. We use these for copying objects, and other operations "
+  "Standard blocking S3 client. We use this for most operations."
   ^S3Client []
   @s3-client*)
 
 (def ^:private s3-async-client* (delay (-> (S3AsyncClient/crtBuilder)
                                            (.targetThroughputInGbps 20.0)
                                            (.build))))
-
 (defn s3-async-client
   "Async S3 Client. Useful when you want to asynchronously upload streams to S3"
   ^S3AsyncClient []
@@ -43,7 +41,6 @@
           {:access-key (.accessKeyId creds)
            :secret-key (.secretAccessKey creds)
            :region region})))))
-
 (defn presign-creds
   "Credentials to presign S3 URLs. We use special credentials, because 
    the default credentials provider creates URLs that expire in 2 days. 

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -173,7 +173,7 @@
                  {:continuation-token continuation-token}
                  {})
           {:keys [object-summaries next-continuation-token truncated?]}
-          (s3-util/list-objects opts)]
+          (s3-util/list-objects (s3-client) bucket-name opts)]
       (if truncated?
         (recur (into all-objects object-summaries) next-continuation-token)
         (into all-objects object-summaries)))))

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -120,7 +120,7 @@
 
 (defn delete-file! [app-id location-id]
   (when location-id
-    (s3-util/delete-object s3-client bucket-name (->object-key app-id location-id))))
+    (s3-util/delete-object (s3-client) bucket-name (->object-key app-id location-id))))
 
 (defn bulk-delete-files! [app-id location-ids]
   (let [location-keys (mapv

--- a/server/src/instant/storage/sweeper.clj
+++ b/server/src/instant/storage/sweeper.clj
@@ -84,7 +84,7 @@
            keys-to-delete
            (mapv #(instant-s3/->object-key (:app_id %) (:location_id %)) files)]
        (when (seq keys-to-delete)
-         (s3-util/delete-objects keys-to-delete)
+         (s3-util/delete-objects (instant-s3/s3-client) instant-s3/bucket-name keys-to-delete)
          (delete-files! conn {:ids (mapv :id files)}))))))
 
 (defn warn-too-many-loops!

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -158,11 +158,6 @@
      (->> chunks
           (mapcat #(delete-objects s3-client bucket-name (vec %)))))))
 
-(def signer-creds*
-  (delay))
-
-(defn signer-creds [] @signer-creds*)
-
 (defn generate-presigned-url-get
   [{:keys [access-key secret-key region] :as _signer-creds}
    {:keys [method bucket-name

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -49,16 +49,16 @@
      :next-continuation-token (.nextContinuationToken resp)}))
 
 (defn list-all-objects
-  ([^S3Client s3-client bucket-name opts]
-   (loop [all-objects []
-          continuation-token nil]
-     (let [page-opts (cond-> opts
-                       continuation-token (assoc :continuation-token continuation-token))
-           {:keys [object-summaries next-continuation-token truncated?]}
-           (list-objects s3-client bucket-name page-opts)]
-       (if truncated?
-         (recur (into all-objects object-summaries) next-continuation-token)
-         (into all-objects object-summaries))))))
+  [^S3Client s3-client bucket-name opts]
+  (loop [all-objects []
+         continuation-token nil]
+    (let [page-opts (cond-> opts
+                      continuation-token (assoc :continuation-token continuation-token))
+          {:keys [object-summaries next-continuation-token truncated?]}
+          (list-objects s3-client bucket-name page-opts)]
+      (if truncated?
+        (recur (into all-objects object-summaries) next-continuation-token)
+        (into all-objects object-summaries)))))
 
 (defn head-object
   [^S3Client s3-client bucket-name object-key]
@@ -152,11 +152,11 @@
     nil))
 
 (defn delete-objects-paginated
-  ([^S3Client s3-client bucket-name object-keys]
+  [^S3Client s3-client bucket-name object-keys]
    ;; Limited to 1000 keys per request
-   (let [chunks (partition-all 1000 object-keys)]
-     (->> chunks
-          (mapcat #(delete-objects s3-client bucket-name (vec %)))))))
+  (let [chunks (partition-all 1000 object-keys)]
+    (->> chunks
+         (mapcat #(delete-objects s3-client bucket-name (vec %))))))
 
 (defn generate-presigned-url-get
   [{:keys [access-key secret-key region] :as _signer-creds}

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -1,6 +1,5 @@
 (ns instant.util.s3
   (:require
-   [instant.config :as config]
    [instant.util.async :refer [default-virtual-thread-executor]]
    [instant.util.aws-signature :as aws-sig]
    [instant.util.tracer :as tracer])
@@ -26,76 +25,61 @@
 
 (set! *warn-on-reflection* true)
 
-(def default-bucket config/s3-bucket-name)
 (def default-content-type "application/octet-stream")
 (def default-content-disposition "inline")
 
-(def default-s3-client* (delay (.build (S3Client/builder))))
-
-(defn default-s3-client ^S3Client []
-  @default-s3-client*)
-
-(def default-s3-async-client* (delay (-> (S3AsyncClient/crtBuilder)
-                                         (.targetThroughputInGbps 20.0)
-                                         (.build))))
-
-(defn default-s3-async-client ^S3AsyncClient []
-  @default-s3-async-client*)
-
 (defn list-objects
-  ([opts] (list-objects default-bucket opts))
-  ([bucket-name {:keys [continuation-token prefix]}]
-   (let [^ListObjectsV2Request req (cond-> (ListObjectsV2Request/builder)
-                                     true (.bucket bucket-name)
-                                     prefix (.prefix prefix)
-                                     continuation-token (.continuationToken continuation-token)
-                                     true (.build))
-         ^ListObjectsV2Response resp (.listObjectsV2 (default-s3-client) req)]
-     {:key-count (.keyCount resp)
-      :truncated? (.isTruncated resp)
-      :bucket-name (.name resp)
-      :max-keys (.maxKeys resp)
-      :object-summaries (mapv (fn [^S3Object s3-obj]
-                                {:key (.key s3-obj)
-                                 :size (.size s3-obj)
-                                 :last-modified (.lastModified s3-obj)
-                                 :bucket-name (.name resp)
-                                 :etag (.eTag s3-obj)})
-                              (.contents resp))
-      :next-continuation-token (.nextContinuationToken resp)})))
+  [^S3Client s3-client bucket-name {:keys [continuation-token prefix]}]
+  (let [^ListObjectsV2Request req (cond-> (ListObjectsV2Request/builder)
+                                    true (.bucket bucket-name)
+                                    prefix (.prefix prefix)
+                                    continuation-token (.continuationToken continuation-token)
+                                    true (.build))
+        ^ListObjectsV2Response resp (.listObjectsV2 s3-client req)]
+    {:key-count (.keyCount resp)
+     :truncated? (.isTruncated resp)
+     :bucket-name (.name resp)
+     :max-keys (.maxKeys resp)
+     :object-summaries (mapv (fn [^S3Object s3-obj]
+                               {:key (.key s3-obj)
+                                :size (.size s3-obj)
+                                :last-modified (.lastModified s3-obj)
+                                :bucket-name (.name resp)
+                                :etag (.eTag s3-obj)})
+                             (.contents resp))
+     :next-continuation-token (.nextContinuationToken resp)}))
 
 (defn list-all-objects
-  ([opts] (list-all-objects default-bucket opts))
-  ([bucket-name opts]
+  ([^S3Client s3-client bucket-name opts]
    (loop [all-objects []
           continuation-token nil]
      (let [page-opts (cond-> opts
                        continuation-token (assoc :continuation-token continuation-token))
            {:keys [object-summaries next-continuation-token truncated?]}
-           (list-objects bucket-name page-opts)]
+           (list-objects s3-client bucket-name page-opts)]
        (if truncated?
          (recur (into all-objects object-summaries) next-continuation-token)
          (into all-objects object-summaries))))))
 
 (defn head-object
-  ([object-key] (head-object default-bucket object-key))
-  ([bucket-name object-key]
-   (let [^HeadObjectRequest req (-> (HeadObjectRequest/builder)
-                                    (.bucket bucket-name)
-                                    (.key object-key)
-                                    (.build))
-         ^HeadObjectResponse resp (.headObject (default-s3-client) req)]
-     {:bucket-name bucket-name
-      :key object-key
-      :object-metadata {:content-disposition (.contentDisposition resp)
-                        :content-type (.contentType resp)
-                        :content-length (.contentLength resp)
-                        :version-id (.versionId resp)
-                        :etag (.eTag resp)
-                        :last-modified (.lastModified resp)}})))
+  [^S3Client s3-client bucket-name object-key]
+  (let [^HeadObjectRequest req (-> (HeadObjectRequest/builder)
+                                   (.bucket bucket-name)
+                                   (.key object-key)
+                                   (.build))
+        ^HeadObjectResponse resp (.headObject s3-client req)]
+    {:bucket-name bucket-name
+     :key object-key
+     :object-metadata {:content-disposition (.contentDisposition resp)
+                       :content-type (.contentType resp)
+                       :content-length (.contentLength resp)
+                       :version-id (.versionId resp)
+                       :etag (.eTag resp)
+                       :last-modified (.lastModified resp)}}))
 
 (defn copy-object
-  [{:keys [source-bucket-name
+  [^S3Client s3-client
+   {:keys [source-bucket-name
            destination-bucket-name
            source-key
            destination-key]}]
@@ -105,20 +89,21 @@
                                    (.destinationBucket destination-bucket-name)
                                    (.destinationKey destination-key)
                                    (.build))
-        ^CopyObjectResponse resp (.copyObject (default-s3-client) req)]
+        ^CopyObjectResponse resp (.copyObject s3-client req)]
     resp))
 
 (def user-controlled-metadata-keys
   #{:content-type :content-disposition})
 
 (defn update-object-metadata
-  [{:keys [source-bucket-name
+  [^S3Client s3-client
+   {:keys [source-bucket-name
            destination-bucket-name
            source-key
            destination-key
            content-type
            content-disposition]}]
-  (let [current-metadata (-> (head-object source-bucket-name source-key)
+  (let [current-metadata (-> (head-object s3-client source-bucket-name source-key)
                              :object-metadata
                              (select-keys user-controlled-metadata-keys))
         new-metadata (cond-> current-metadata
@@ -138,98 +123,86 @@
             (.metadataDirective "REPLACE") ;; this will replace all metadata
             (.build))
         ^CopyObjectResponse resp
-        (.copyObject (default-s3-client) req)]
+        (.copyObject s3-client req)]
     resp))
 
 (defn delete-object
-  ([object-key] (delete-object default-bucket object-key))
-  ([bucket-name object-key]
-   (let [^DeleteObjectRequest req (-> (DeleteObjectRequest/builder)
-                                      (.bucket bucket-name)
-                                      (.key object-key)
-                                      (.build))
-         _resp (.deleteObject (default-s3-client) req)]
-     nil)))
+  [^S3Client s3-client bucket-name object-key]
+  (let [^DeleteObjectRequest req (-> (DeleteObjectRequest/builder)
+                                     (.bucket bucket-name)
+                                     (.key object-key)
+                                     (.build))
+        _resp (.deleteObject s3-client req)]
+    nil))
 
 (defn delete-objects
-  ([object-keys] (delete-objects default-bucket object-keys))
-  ([bucket-name object-keys]
-   (let [^java.util.Collection objects (mapv (fn [k]
-                                               (-> (ObjectIdentifier/builder)
-                                                   (.key k)
-                                                   (.build)))
-                                             object-keys)
-         ^Delete delete (-> (Delete/builder)
-                            (.objects objects)
-                            (.build))
-         ^DeleteObjectsRequest req (-> (DeleteObjectsRequest/builder)
-                                       (.bucket bucket-name)
-                                       (.delete delete)
-                                       (.build))
-         _resp (.deleteObjects (default-s3-client) req)]
-     nil)))
+  [^S3Client s3-client bucket-name object-keys]
+  (let [^java.util.Collection objects (mapv (fn [k]
+                                              (-> (ObjectIdentifier/builder)
+                                                  (.key k)
+                                                  (.build)))
+                                            object-keys)
+        ^Delete delete (-> (Delete/builder)
+                           (.objects objects)
+                           (.build))
+        ^DeleteObjectsRequest req (-> (DeleteObjectsRequest/builder)
+                                      (.bucket bucket-name)
+                                      (.delete delete)
+                                      (.build))
+        _resp (.deleteObjects s3-client req)]
+    nil))
 
 (defn delete-objects-paginated
-  ([object-keys] (delete-objects-paginated default-bucket object-keys))
-  ([bucket-name object-keys]
+  ([^S3Client s3-client bucket-name object-keys]
    ;; Limited to 1000 keys per request
    (let [chunks (partition-all 1000 object-keys)]
      (->> chunks
-          (mapcat #(delete-objects bucket-name (vec %)))))))
+          (mapcat #(delete-objects s3-client bucket-name (vec %)))))))
 
 (def signer-creds*
-  (delay
-    (let [access-key (config/s3-storage-access-key)
-          secret-key (config/s3-storage-secret-key)
-          region (.toString (.region (.serviceClientConfiguration (default-s3-client))))]
-      (if (and access-key secret-key)
-        {:access-key access-key
-         :secret-key secret-key
-         :region region}
-        (let [creds (.resolveCredentials (DefaultCredentialsProvider/create))]
-          {:access-key (.accessKeyId creds)
-           :secret-key (.secretAccessKey creds)
-           :region region})))))
+  (delay))
 
 (defn signer-creds [] @signer-creds*)
 
 (defn generate-presigned-url-get
-  ([{:keys [method bucket-name
-            key
-            ^Instant signing-instant
-            ^Duration duration]}]
-   (assert (= :get method)
-           "get presigned urls are only implemented for :get requests")
-   (aws-sig/presign-s3-url
-    {:access-key (:access-key (signer-creds))
-     :secret-key (:secret-key (signer-creds))
-     :region (:region (signer-creds))
-     :method method
-     :bucket bucket-name
-     :signing-instant signing-instant
-     :expires-duration duration
-     :path key})))
+  [{:keys [access-key secret-key region] :as _signer-creds}
+   {:keys [method bucket-name
+           key
+           ^Instant signing-instant
+           ^Duration duration]}]
+  (assert (= :get method)
+          "get presigned urls are only implemented for :get requests")
+  (aws-sig/presign-s3-url
+   {:access-key access-key
+    :secret-key secret-key
+    :region region
+    :method method
+    :bucket bucket-name
+    :signing-instant signing-instant
+    :expires-duration duration
+    :path key}))
 
 (defn generate-presigned-url-put
-  ([{:keys [method bucket-name key ^Instant signing-instant ^Duration duration]}]
-   (assert (= :put method)
-           "put presigned urls are only implemented for :put requests")
-   (aws-sig/presign-s3-url
-    {:access-key (:access-key (signer-creds))
-     :secret-key (:secret-key (signer-creds))
-     :region (:region (signer-creds))
-     :method method
-     :bucket bucket-name
-     :signing-instant signing-instant
-     :expires-duration duration
-     :path key})))
+  [{:keys [access-key secret-key region] :as _signer-creds}
+   {:keys [method bucket-name key ^Instant signing-instant ^Duration duration]}]
+  (assert (= :put method)
+          "put presigned urls are only implemented for :put requests")
+  (aws-sig/presign-s3-url
+   {:access-key access-key
+    :secret-key secret-key
+    :region region
+    :method method
+    :bucket bucket-name
+    :signing-instant signing-instant
+    :expires-duration duration
+    :path key}))
 
 (defn generate-presigned-url
-  ([{:keys [method] :as opts}]
-   (case method
-     :get (generate-presigned-url-get opts)
-     :put (generate-presigned-url-put opts)
-     (throw (ex-info "Unsupported method for presigned url" {:method method})))))
+  [signer-creds {:keys [method] :as opts}]
+  (case method
+    :get (generate-presigned-url-get signer-creds opts)
+    :put (generate-presigned-url-put signer-creds opts)
+    (throw (ex-info "Unsupported method for presigned url" {:method method}))))
 
 (defn- make-s3-put-opts
   [bucket-name {:keys [object-key content-type content-disposition content-length]} file-opts]
@@ -242,28 +215,27 @@
    file-opts))
 
 (defn upload-stream-to-s3
-  ([ctx stream] (upload-stream-to-s3 default-bucket ctx stream))
-  ([bucket-name ctx stream]
-   (let [{:keys [key metadata] :as _opts} (make-s3-put-opts bucket-name ctx {})
-         {:keys [content-disposition content-type content-length]} metadata]
-     (tracer/with-span! {:name "s3/upload-stream-to-s3"
-                         :attributes {:bucket-name bucket-name
-                                      :key key
-                                      :content-type content-type
-                                      :content-disposition content-disposition
-                                      :content-length content-length}}
-       (let [^PutObjectRequest req (cond-> (PutObjectRequest/builder)
-                                     true (.bucket bucket-name)
-                                     true (.key key)
-                                     true (.contentType content-type)
-                                     true (.contentDisposition content-disposition)
-                                     content-length (.contentLength content-length)
-                                     true (.build))]
-         (if content-length
-           (let [body (AsyncRequestBody/fromInputStream stream (long content-length) default-virtual-thread-executor)]
-             (-> (.putObject (default-s3-async-client) req body)
-                 deref))
-           (let [^BlockingInputStreamAsyncRequestBody body (AsyncRequestBody/forBlockingInputStream nil)
-                 resp (.putObject (default-s3-async-client) req body)]
-             (.writeInputStream body stream)
-             (deref resp))))))))
+  [^S3AsyncClient async-client bucket-name ctx stream]
+  (let [{:keys [key metadata] :as _opts} (make-s3-put-opts bucket-name ctx {})
+        {:keys [content-disposition content-type content-length]} metadata]
+    (tracer/with-span! {:name "s3/upload-stream-to-s3"
+                        :attributes {:bucket-name bucket-name
+                                     :key key
+                                     :content-type content-type
+                                     :content-disposition content-disposition
+                                     :content-length content-length}}
+      (let [^PutObjectRequest req (cond-> (PutObjectRequest/builder)
+                                    true (.bucket bucket-name)
+                                    true (.key key)
+                                    true (.contentType content-type)
+                                    true (.contentDisposition content-disposition)
+                                    content-length (.contentLength content-length)
+                                    true (.build))]
+        (if content-length
+          (let [body (AsyncRequestBody/fromInputStream stream (long content-length) default-virtual-thread-executor)]
+            (-> (.putObject async-client req body)
+                deref))
+          (let [^BlockingInputStreamAsyncRequestBody body (AsyncRequestBody/forBlockingInputStream nil)
+                resp (.putObject async-client req body)]
+            (.writeInputStream body stream)
+            (deref resp)))))))

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -5,7 +5,6 @@
    [instant.util.tracer :as tracer])
   (:import
    (java.time Instant Duration)
-   (software.amazon.awssdk.auth.credentials DefaultCredentialsProvider)
    (software.amazon.awssdk.core.async AsyncRequestBody
                                       BlockingInputStreamAsyncRequestBody)
    (software.amazon.awssdk.services.s3 S3AsyncClient


### PR DESCRIPTION
- We currently use 2 kinds of s3 clients, and one special purpose credential arg for presign urls:
  - `s3-client`: for blocking calls, used for most operations
  - `s3-async-client`: used for uploading a stream to s3
  - `presign-creds`: used to generate long-lived presign urls

We had all three in `util.s3`. These are more related to Instant though. Moved them to instant.storage. I also added some comment blocks, to explain the "why" behind each s3-client. 

@nezaj @dwwoelfel @tonsky 

