### PR TITLE
[instatx] proxy should return undefined with unknown keys

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -1372,3 +1372,10 @@ test('Schema: populates checked-data-type', () => {
     expect(result).toContainEqual(item);
   }
 });
+
+test('instatx should not be too permissive', () => {
+  const ops = instatx.tx.books[uuid()].update({
+    title: 'New Title',
+  }).this_is_an_unknown_op;
+  expect(ops).toBeUndefined();
+});

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -102,9 +102,9 @@ export interface TransactionChunk<
 }
 
 // This is a hack to get typescript to enforce that
-// `validTransactionChunkCommands` contains all the keys of `TransactionChunk`
-type ValidTransactionChunkKeys = keyof TransactionChunk<any, any>;
-function getAllValidTransactionChunkCommands(): Set<ValidTransactionChunkKeys> {
+// `allTransactionChunkKeys` contains all the keys of `TransactionChunk`
+type TransactionChunkKey = keyof TransactionChunk<any, any>;
+function getAllTransactionChunkKeys(): Set<TransactionChunkKey> {
   const v: any = 1;
   const _dummy: TransactionChunk<any, any> = {
     __ops: v,
@@ -115,9 +115,9 @@ function getAllValidTransactionChunkCommands(): Set<ValidTransactionChunkKeys> {
     merge: v,
     ruleParams: v,
   };
-  return new Set(Object.keys(_dummy)) as Set<ValidTransactionChunkKeys>;
+  return new Set(Object.keys(_dummy)) as Set<TransactionChunkKey>;
 }
-const validTransactionChunkCommands = getAllValidTransactionChunkCommands();
+const allTransactionChunkKeys = getAllTransactionChunkKeys();
 
 export interface ETypeChunk<
   Schema extends IContainEntitiesAndLinks<any, any>,
@@ -138,7 +138,7 @@ function transactionChunk(
   return new Proxy({} as TransactionChunk<any, any>, {
     get: (_target, cmd: keyof TransactionChunk<any, any>) => {
       if (cmd === '__ops') return prevOps;
-      if (!validTransactionChunkCommands.has(cmd)) {
+      if (!allTransactionChunkKeys.has(cmd)) {
         return undefined;
       }
       return (args: Args) => {

--- a/client/packages/core/src/instatx.ts
+++ b/client/packages/core/src/instatx.ts
@@ -101,6 +101,24 @@ export interface TransactionChunk<
   ruleParams: (args: RuleParams) => TransactionChunk<Schema, EntityName>;
 }
 
+// This is a hack to get typescript to enforce that
+// `validTransactionChunkCommands` contains all the keys of `TransactionChunk`
+type ValidTransactionChunkKeys = keyof TransactionChunk<any, any>;
+function getAllValidTransactionChunkCommands(): Set<ValidTransactionChunkKeys> {
+  const v: any = 1;
+  const _dummy: TransactionChunk<any, any> = {
+    __ops: v,
+    update: v,
+    link: v,
+    unlink: v,
+    delete: v,
+    merge: v,
+    ruleParams: v,
+  };
+  return new Set(Object.keys(_dummy)) as Set<ValidTransactionChunkKeys>;
+}
+const validTransactionChunkCommands = getAllValidTransactionChunkCommands();
+
 export interface ETypeChunk<
   Schema extends IContainEntitiesAndLinks<any, any>,
   EntityName extends keyof Schema['entities'],
@@ -120,6 +138,9 @@ function transactionChunk(
   return new Proxy({} as TransactionChunk<any, any>, {
     get: (_target, cmd: keyof TransactionChunk<any, any>) => {
       if (cmd === '__ops') return prevOps;
+      if (!validTransactionChunkCommands.has(cmd)) {
+        return undefined;
+      }
       return (args: Args) => {
         return transactionChunk(etype, id, [
           ...prevOps,


### PR DESCRIPTION
consider: 

```js
tx.users[id].update(...).this_is_an_unsupported_command
```

Right now, we would have returned a `chunk` object. But `this_is_an_unsupported_command` is not a valid command. 

I updated our logic so unless the user calls a valid function command, we return undefined. 

@nezaj @dwwoelfel @tonsky 