### PR TITLE
[sm] make sure html bg matches content bg

### DIFF
--- a/client/www/components/docs/Layout.jsx
+++ b/client/www/components/docs/Layout.jsx
@@ -283,7 +283,15 @@ export function Layout({ children, title, tableOfContents }) {
 
   return (
     <SelectedAppContext.Provider value={selectedAppData}>
-      <div className="min-h-[100dvh] bg-[#F8F9FA]">
+      <style jsx global>
+        {`
+          html,
+          body {
+            background-color: #f8f9fa;
+          }
+        `}
+      </style>
+      <div className="min-h-[100dvh]">
         {/* Header */}
         <div
           className={clsx(

--- a/client/www/components/marketingUi.tsx
+++ b/client/www/components/marketingUi.tsx
@@ -175,12 +175,20 @@ export function MainNav({ children }: PropsWithChildren) {
 }
 
 export const LandingContainer = ({ children }: PropsWithChildren) => (
-  <div className="min-h-full overflow-x-hidden bg-[#F8F9FA]">{children}</div>
+  <div className="min-h-full overflow-x-hidden">{children}</div>
 );
 
 export function LandingFooter() {
   return (
     <div className="text-xs text-gray-500">
+      <style jsx global>
+        {`
+          html,
+          body {
+            background-color: #f8f9fa;
+          }
+        `}
+      </style>
       <SectionWide>
         <hr className="h-px border-0 bg-gray-200" />
         <div className="flex flex-col gap-2 py-6">


### PR DESCRIPTION
**Before**
We had this weird bug, where if you 'overscrolled' our marketing and docs pages, you would see a jarring white bg:

https://github.com/user-attachments/assets/2658435e-1079-4b08-bf25-753e7edd0634

**After**
This was because our html element had a white background. Updated so for those pages, we set html to have the correct background color. 

https://github.com/user-attachments/assets/60023eb6-1551-4700-bab5-f4d9bcee882d


@nezaj @dwwoelfel @tonsky 