### PR TITLE
[rule-params] two client-side bugs, and transact in sandbox

### DIFF
--- a/client/packages/core/__tests__/src/store.test.js
+++ b/client/packages/core/__tests__/src/store.test.js
@@ -455,3 +455,18 @@ test('JSON serialization round-trips', () => {
   const newStore = fromJSON(toJSON(store));
   expect(store).toEqual(newStore);
 });
+
+test('ruleParams no-ops', () => {
+  const id = uuid();
+  const chunk = tx.users[id]
+    .ruleParams({ guestId: 'bobby' })
+    .update({ handle: 'bobby' });
+
+  const txSteps = instaml.transform({ attrs: store.attrs }, chunk);
+  const newStore = transact(store, txSteps);
+  expect(
+    query({ store: newStore }, { users: {} }).data.users.map((x) => x.handle),
+  ).contains('bobby');
+
+  checkIndexIntegrity(newStore);
+});

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -436,6 +436,8 @@ function applyTxStep(store, txStep) {
     case 'update-attr':
       updateAttr(store, args);
       break;
+    case 'rule-params':
+      break;
     default:
       throw new Error(`unhandled transaction action: ${action}`);
   }


### PR DESCRIPTION
Been playing with ruleParams, and found some bugs. Fixed two, but have 2 more two fix (updated our ruleParams sandbox to transact with ruleParams too)

### Bugs fixed

1. store.js was failing, because it was not able to handle the `rule-params` tx-step.
  a. Fixed this by no-oping the `rule-params` tx-step on the client
1. validation-failed for `params`, because it expected a `map-of string?`, but got `map-of keyword`
  a. Fixed by accepting both string and keyword 

### Sandbox change

Updated the `ruleParams` sandbox, so we test a) `tx.foo[id].ruleParams` and `tx.foo[lookup].ruleParams`

### Bugs remaining

After fixing these bugs I notice more `validation-failed` in permissioned-transaction. Going to dive deeper on those shortly. 

@tonsky @nezaj @dwwoelfel 