### PR TITLE
Fix rule params create with lookup

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/ruleParams.tsx
+++ b/client/sandbox/react-nextjs/pages/play/ruleParams.tsx
@@ -46,12 +46,10 @@ function addDocWithRuleParam() {
 function addDocWithRuleParamAndLookup() {
   const key = `${randInt(10000, 99999)}`;
   return db.transact(
-    tx.playDocs[lookup('key', key)]
-      // .ruleParams({ test: 'foo' }) // <- comment me out
-      .update({
-        title: 'doc ' + key,
-        secret: secrets[randInt(0, 2)],
-      }),
+    tx.playDocs[lookup('key', key)].ruleParams({ test: 'foo' }).update({
+      title: 'doc ' + key,
+      secret: secrets[randInt(0, 2)],
+    }),
   );
 }
 

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -638,7 +638,7 @@
                 tx-data
                 (tx/transact-without-tx-conn-impl! tx-conn (:attrs ctx) app-id grouped-tx-steps {})
 
-                ;; udpate lookups with newly created triples
+                ;; update lookups with newly created triples
                 create-lookups->eid (some->> (concat create-checks (keys rule-params))
                                              (map :eid)
                                              (filter sequential?)

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -167,6 +167,15 @@
           {}
           m))
 
+(defn map-keys
+  "Apply `f` to keys of `m`"
+  [f m]
+  (persistent!
+   (reduce-kv
+    (fn [m k v]
+      (assoc! m (f k) v))
+    (transient (empty m)) m)))
+
 (defn every?-var-args [pred & colls]
   (if (= 1 (count colls))
     (every? pred (first colls))


### PR DESCRIPTION
Fixed `ruleParams` for creates with lookups like

```
tx.docs[lookup('key', key)]
  .ruleParams({ ... })
  .update({ ... });
```