### PR TITLE
[reactor] consider adminToken in `globalInstantCoreStore`.

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -193,6 +193,12 @@ function initGlobalInstantCoreStore(): Record<string, any> {
   return globalThis.__instantDbStore;
 }
 
+function reactorKey(config: InstantConfig<any>): string {
+  // @ts-expect-error
+  const adminToken = config.__adminToken;
+  return `${config.appId}_${adminToken || 'client'}`;
+}
+
 const globalInstantCoreStore = initGlobalInstantCoreStore();
 
 /**
@@ -597,7 +603,7 @@ class InstantCoreDatabase<Schema extends InstantSchemaDef<any, any, any>>
   }
 
   shutdown() {
-    delete globalInstantCoreStore[this._reactor.config.appId];
+    delete globalInstantCoreStore[reactorKey(this._reactor.config)];
     this._reactor.shutdown();
   }
 
@@ -654,7 +660,7 @@ function init<
   versions?: { [key: string]: string },
 ): InstantCoreDatabase<Schema> {
   const existingClient = globalInstantCoreStore[
-    config.appId
+    reactorKey(config)
   ] as InstantCoreDatabase<any>;
 
   if (existingClient) {
@@ -673,7 +679,7 @@ function init<
   );
 
   const client = new InstantCoreDatabase<any>(reactor);
-  globalInstantCoreStore[config.appId] = client;
+  globalInstantCoreStore[reactorKey(config)] = client;
 
   handleDevtool(config.appId, config.devtool);
 


### PR DESCRIPTION
We cache reactor instantiations, when users write `const db = init`. 

This was causing a subtle bug with how our feedback component was interacting with our Explorer. 

Here's what would happen: 
1. `feedback/clientDB.ts` was instantiating a db for appId `A` [1]
2. If you viewed Explorer of app `A`, we would try to instantiate a db for `A`, with adminToken `B`. 
  a. _But_ this would hit the cache, and get the previously instantiated Reactor, _without_ the adminToken. 

I updated our code, so we now use a combo of appId, websocketURI, apiURI, and adminToken to cache inits

[1] you may be wondering: why is `clientDB.ts` called at all? It doesn't seem like it should be included in the bundle for dash. Will explore this in a separate PR. 

@dwwoelfel @nezaj @tonsky 