### PR TITLE
[landing] improve our social previews

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -375,7 +375,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^5.3.7
-        version: 5.7.5(next@15.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.7.5(next@15.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@instantdb/admin':
         specifier: workspace:*
         version: link:../../packages/admin
@@ -396,7 +396,7 @@ importers:
         version: 1.2.5(react@18.3.1)
       next:
         specifier: latest
-        version: 15.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -559,6 +559,9 @@ importers:
       '@uiw/react-json-view':
         specifier: 2.0.0-alpha.24
         version: 2.0.0-alpha.24(@babel/runtime@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vercel/og':
+        specifier: ^0.6.5
+        version: 0.6.5
       algoliasearch:
         specifier: ^4.24.0
         version: 4.24.0
@@ -2134,7 +2137,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.20.3':
     resolution: {integrity: sha512-+nL2f6ZPV6e4yXS0P02jChstSJePihfFluapqnRM8+4pH4wsBOL1GoOc7hVFfwsP0vRE3HDqn5EEzrO+ZaCbpQ==}
@@ -2642,8 +2645,8 @@ packages:
   '@next/env@15.1.6':
     resolution: {integrity: sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==}
 
-  '@next/env@15.1.7':
-    resolution: {integrity: sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==}
+  '@next/env@15.2.2':
+    resolution: {integrity: sha512-yWgopCfA9XDR8ZH3taB5nRKtKJ1Q5fYsTOuYkzIIoS8TJ0UAUKAGF73JnGszbjk2ufAQDj6mDdgsJAFx5CLtYQ==}
 
   '@next/swc-darwin-arm64@15.1.6':
     resolution: {integrity: sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==}
@@ -2651,8 +2654,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@15.1.7':
-    resolution: {integrity: sha512-hPFwzPJDpA8FGj7IKV3Yf1web3oz2YsR8du4amKw8d+jAOHfYHYFpMkoF6vgSY4W6vB29RtZEklK9ayinGiCmQ==}
+  '@next/swc-darwin-arm64@15.2.2':
+    resolution: {integrity: sha512-HNBRnz+bkZ+KfyOExpUxTMR0Ow8nkkcE6IlsdEa9W/rI7gefud19+Sn1xYKwB9pdCdxIP1lPru/ZfjfA+iT8pw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2663,8 +2666,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.1.7':
-    resolution: {integrity: sha512-2qoas+fO3OQKkU0PBUfwTiw/EYpN+kdAx62cePRyY1LqKtP09Vp5UcUntfZYajop5fDFTjSxCHfZVRxzi+9FYQ==}
+  '@next/swc-darwin-x64@15.2.2':
+    resolution: {integrity: sha512-mJOUwp7al63tDpLpEFpKwwg5jwvtL1lhRW2fI1Aog0nYCPAhxbJsaZKdoVyPZCy8MYf/iQVNDuk/+i29iLCzIA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2675,8 +2678,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@15.1.7':
-    resolution: {integrity: sha512-sKLLwDX709mPdzxMnRIXLIT9zaX2w0GUlkLYQnKGoXeWUhcvpCrK+yevcwCJPdTdxZEUA0mOXGLdPsGkudGdnA==}
+  '@next/swc-linux-arm64-gnu@15.2.2':
+    resolution: {integrity: sha512-5ZZ0Zwy3SgMr7MfWtRE7cQWVssfOvxYfD9O7XHM7KM4nrf5EOeqwq67ZXDgo86LVmffgsu5tPO57EeFKRnrfSQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2687,8 +2690,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.1.7':
-    resolution: {integrity: sha512-zblK1OQbQWdC8fxdX4fpsHDw+VSpBPGEUX4PhSE9hkaWPrWoeIJn+baX53vbsbDRaDKd7bBNcXRovY1hEhFd7w==}
+  '@next/swc-linux-arm64-musl@15.2.2':
+    resolution: {integrity: sha512-cgKWBuFMLlJ4TWcFHl1KOaVVUAF8vy4qEvX5KsNd0Yj5mhu989QFCq1WjuaEbv/tO1ZpsQI6h/0YR8bLwEi+nA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2699,8 +2702,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.1.7':
-    resolution: {integrity: sha512-GOzXutxuLvLHFDAPsMP2zDBMl1vfUHHpdNpFGhxu90jEzH6nNIgmtw/s1MDwpTOiM+MT5V8+I1hmVFeAUhkbgQ==}
+  '@next/swc-linux-x64-gnu@15.2.2':
+    resolution: {integrity: sha512-c3kWSOSsVL8rcNBBfOq1+/j2PKs2nsMwJUV4icUxRgGBwUOfppeh7YhN5s79enBQFU+8xRgVatFkhHU1QW7yUA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2711,8 +2714,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.1.7':
-    resolution: {integrity: sha512-WrZ7jBhR7ATW1z5iEQ0ZJfE2twCNSXbpCSaAunF3BKcVeHFADSI/AW1y5Xt3DzTqPF1FzQlwQTewqetAABhZRQ==}
+  '@next/swc-linux-x64-musl@15.2.2':
+    resolution: {integrity: sha512-PXTW9PLTxdNlVYgPJ0equojcq1kNu5NtwcNjRjHAB+/sdoKZ+X8FBu70fdJFadkxFIGekQTyRvPMFF+SOJaQjw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2723,8 +2726,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@15.1.7':
-    resolution: {integrity: sha512-LDnj1f3OVbou1BqvvXVqouJZKcwq++mV2F+oFHptToZtScIEnhNRJAhJzqAtTE2dB31qDYL45xJwrc+bLeKM2Q==}
+  '@next/swc-win32-arm64-msvc@15.2.2':
+    resolution: {integrity: sha512-nG644Es5llSGEcTaXhnGWR/aThM/hIaz0jx4MDg4gWC8GfTCp8eDBWZ77CVuv2ha/uL9Ce+nPTfYkSLG67/sHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2735,8 +2738,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.1.7':
-    resolution: {integrity: sha512-dC01f1quuf97viOfW05/K8XYv2iuBgAxJZl7mbCKEjMgdQl5JjAKJ0D2qMKZCgPWDeFbFT0Q0nYWwytEW0DWTQ==}
+  '@next/swc-win32-x64-msvc@15.2.2':
+    resolution: {integrity: sha512-52nWy65S/R6/kejz3jpvHAjZDPKIbEQu4x9jDBzmB9jJfuOy5rspjKu4u77+fI4M/WzLXrrQd57hlFGzz1ubcQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3305,6 +3308,10 @@ packages:
   '@remix-run/web-stream@1.1.0':
     resolution: {integrity: sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==}
 
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+
   '@rollup/rollup-android-arm-eabi@4.34.1':
     resolution: {integrity: sha512-kwctwVlswSEsr4ljpmxKrRKp1eG1v2NAhlzFzDf1x1OdYaMjBYjDCbHkzWm57ZXzTwqn8stMXgROrnMw8dJK3w==}
     cpu: [arm]
@@ -3402,6 +3409,11 @@ packages:
 
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -3749,6 +3761,10 @@ packages:
     peerDependencies:
       '@urql/core': ^5.0.0
 
+  '@vercel/og@0.6.5':
+    resolution: {integrity: sha512-GFXtgid3+TcVHTd668a10vGpzAh4Ty/yBZPRxKf1UicI8Vi8EthfvSxcaLW0KvQBBe1+d7TcjecLZHRT8JzQ4g==}
+    engines: {node: '>=16'}
+
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -4070,6 +4086,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4494,12 +4514,22 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
   css-box-model@1.2.1:
     resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
 
   css-color-keywords@1.0.0:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.16:
+    resolution: {integrity: sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==}
+    engines: {node: '>=16'}
 
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
@@ -5332,6 +5362,9 @@ packages:
   fetch-retry@4.1.1:
     resolution: {integrity: sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==}
 
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -5641,6 +5674,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   hls.js@1.5.20:
     resolution: {integrity: sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==}
@@ -6383,6 +6420,9 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -6879,8 +6919,8 @@ packages:
       sass:
         optional: true
 
-  next@15.1.7:
-    resolution: {integrity: sha512-GNeINPGS9c6OZKCvKypbL8GTsT5GhWPp4DM0fzkXJuXMilOO2EeFxuAY6JZbtk6XIl6Ws10ag3xRINDjSO5+wg==}
+  next@15.2.2:
+    resolution: {integrity: sha512-dgp8Kcx5XZRjMw2KNwBtUzhngRaURPioxoNIVl5BOyJbhi9CUgEtKDO7fx5wh8Z8vOVX1nYZ9meawJoRrlASYA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -7121,9 +7161,15 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
@@ -7780,6 +7826,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  satori@0.12.1:
+    resolution: {integrity: sha512-0SbjchvDrDbeXeQgxWVtSWxww7qcFgk3DtSE2/blHOSlLsSHwIqO2fCrtVa/EudJ7Eqno8A33QNx56rUyGbLuw==}
+    engines: {node: '>=16'}
+
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
@@ -8069,6 +8119,9 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string.prototype.padend@3.1.6:
     resolution: {integrity: sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==}
     engines: {node: '>= 0.4'}
@@ -8267,6 +8320,9 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -8500,6 +8556,9 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -8968,6 +9027,9 @@ packages:
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
+
+  yoga-wasm-web@0.3.3:
+    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10093,14 +10155,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.4.1
 
-  '@clerk/nextjs@5.7.5(next@15.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@5.7.5(next@15.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 1.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.26.0
       crypto-js: 4.2.0
-      next: 15.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       server-only: 0.0.1
@@ -11339,54 +11401,54 @@ snapshots:
 
   '@next/env@15.1.6': {}
 
-  '@next/env@15.1.7': {}
+  '@next/env@15.2.2': {}
 
   '@next/swc-darwin-arm64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-arm64@15.1.7':
+  '@next/swc-darwin-arm64@15.2.2':
     optional: true
 
   '@next/swc-darwin-x64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-x64@15.1.7':
+  '@next/swc-darwin-x64@15.2.2':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.1.7':
+  '@next/swc-linux-arm64-gnu@15.2.2':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.1.7':
+  '@next/swc-linux-arm64-musl@15.2.2':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.1.7':
+  '@next/swc-linux-x64-gnu@15.2.2':
     optional: true
 
   '@next/swc-linux-x64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.1.7':
+  '@next/swc-linux-x64-musl@15.2.2':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.1.7':
+  '@next/swc-win32-arm64-msvc@15.2.2':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.1.7':
+  '@next/swc-win32-x64-msvc@15.2.2':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -12186,6 +12248,8 @@ snapshots:
     dependencies:
       web-streams-polyfill: 3.3.3
 
+  '@resvg/resvg-wasm@2.4.0': {}
+
   '@rollup/rollup-android-arm-eabi@4.34.1':
     optional: true
 
@@ -12247,6 +12311,11 @@ snapshots:
     dependencies:
       component-type: 1.2.2
       join-component: 1.1.0
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -12660,6 +12729,12 @@ snapshots:
       '@urql/core': 5.1.0
       wonka: 6.3.4
 
+  '@vercel/og@0.6.5':
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.12.1
+      yoga-wasm-web: 0.3.3
+
   '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@22.13.0)(lightningcss@1.27.0)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.26.7
@@ -13063,6 +13138,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
+
+  base64-js@0.0.8: {}
 
   base64-js@1.5.1: {}
 
@@ -13510,11 +13587,17 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-background-parser@0.1.0: {}
+
   css-box-model@1.2.1:
     dependencies:
       tiny-invariant: 1.3.3
 
+  css-box-shadow@1.0.0-3: {}
+
   css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.16: {}
 
   css-in-js-utils@3.1.0:
     dependencies:
@@ -14528,6 +14611,8 @@ snapshots:
 
   fetch-retry@4.1.1: {}
 
+  fflate@0.7.4: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -14842,6 +14927,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hex-rgb@4.3.0: {}
 
   hls.js@1.5.20: {}
 
@@ -15823,6 +15910,11 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   lines-and-columns@1.2.4: {}
 
   load-json-file@4.0.0:
@@ -16479,9 +16571,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.1.7
+      '@next/env': 15.2.2
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -16491,14 +16583,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.26.7)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.7
-      '@next/swc-darwin-x64': 15.1.7
-      '@next/swc-linux-arm64-gnu': 15.1.7
-      '@next/swc-linux-arm64-musl': 15.1.7
-      '@next/swc-linux-x64-gnu': 15.1.7
-      '@next/swc-linux-x64-musl': 15.1.7
-      '@next/swc-win32-arm64-msvc': 15.1.7
-      '@next/swc-win32-x64-msvc': 15.1.7
+      '@next/swc-darwin-arm64': 15.2.2
+      '@next/swc-darwin-x64': 15.2.2
+      '@next/swc-linux-arm64-gnu': 15.2.2
+      '@next/swc-linux-arm64-musl': 15.2.2
+      '@next/swc-linux-x64-gnu': 15.2.2
+      '@next/swc-linux-x64-musl': 15.2.2
+      '@next/swc-win32-arm64-msvc': 15.2.2
+      '@next/swc-win32-x64-msvc': 15.2.2
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -16745,9 +16837,16 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@0.2.9: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse-json@4.0.0:
     dependencies:
@@ -17504,6 +17603,20 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  satori@0.12.1:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.16
+      css-to-react-native: 3.2.0
+      emoji-regex: 10.4.0
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-wasm-web: 0.3.3
+
   sax@1.4.1: {}
 
   saxes@6.0.0:
@@ -17840,6 +17953,8 @@ snapshots:
       get-east-asian-width: 1.3.0
       strip-ansi: 7.1.0
 
+  string.prototype.codepointat@0.2.1: {}
+
   string.prototype.padend@3.1.6:
     dependencies:
       call-bind: 1.0.8
@@ -18116,6 +18231,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-inflate@1.0.3: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -18364,6 +18481,11 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unified@11.0.5:
     dependencies:
@@ -18819,5 +18941,7 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  yoga-wasm-web@0.3.3: {}
 
   zwitch@2.0.4: {}

--- a/client/www/package.json
+++ b/client/www/package.json
@@ -25,6 +25,7 @@
     "@sindresorhus/slugify": "^2.1.0",
     "@stripe/stripe-js": "^3.3.0",
     "@uiw/react-json-view": "2.0.0-alpha.24",
+    "@vercel/og": "^0.6.5",
     "algoliasearch": "^4.24.0",
     "ansi-to-html": "^0.7.2",
     "canvas-confetti": "^1.9.2",
@@ -70,12 +71,12 @@
     "@types/ws": "^8.5.3",
     "autoprefixer": "^10.4.0",
     "csv-parse": "^5.1.0",
+    "instant-cli": "workspace:*",
     "jest": "28.1.0",
     "jest-environment-jsdom": "29.7.0",
     "postcss": "^8.4.5",
     "prettier-plugin-tailwindcss": "^0.1.1",
     "tailwindcss": "^3.0.7",
-    "typescript": "5.5.4",
-    "instant-cli": "workspace:*"
+    "typescript": "5.5.4"
   }
 }

--- a/client/www/pages/_app.tsx
+++ b/client/www/pages/_app.tsx
@@ -140,14 +140,14 @@ function AppHead() {
         content="width=device-width, initial-scale=1, maximum-scale=1"
       />
       <meta name="theme-color" content="#ffffff" />
-      <meta property="og:type" content="website" />
-      <meta property="og:url" content="https://www.instantdb.com" />
-      <meta property="og:title" content="InstantDB: A Modern Firebase" />
+      <meta key="og:type" property="og:type" content="website" />
       <meta
-        property="og:description"
-        content="We make you productive by giving your frontend a real-time database."
+        key="og:url"
+        property="og:url"
+        content="https://www.instantdb.com"
       />
       <meta
+        key="og:image"
         property="og:image"
         content="https://www.instantdb.com/img/og_preview.png"
       />

--- a/client/www/pages/_app.tsx
+++ b/client/www/pages/_app.tsx
@@ -142,11 +142,6 @@ function AppHead() {
       <meta name="theme-color" content="#ffffff" />
       <meta key="og:type" property="og:type" content="website" />
       <meta
-        key="og:url"
-        property="og:url"
-        content="https://www.instantdb.com"
-      />
-      <meta
         key="og:image"
         property="og:image"
         content="https://www.instantdb.com/img/og_preview.png"

--- a/client/www/pages/api/og/essay.tsx
+++ b/client/www/pages/api/og/essay.tsx
@@ -1,0 +1,91 @@
+import { ImageResponse } from '@vercel/og';
+import { NextRequest } from 'next/server';
+
+export const config = {
+  runtime: 'edge',
+};
+
+export default async function handler(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get('title');
+  if (!title) {
+    return new Response('Title is required', { status: 400 });
+  }
+
+  const res = await fetch(
+    new URL(
+      'https://stopaio.s3.amazonaws.com/public/BerkeleyMono-Regular.ttf',
+      import.meta.url,
+    ),
+  );
+  const fontData = await res.arrayBuffer();
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background:
+            'linear-gradient(120deg, #e7e7e7 40%, #fee7de 70%, #e4e4e4 100%)',
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          textAlign: 'center',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          flexWrap: 'nowrap',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            justifyItems: 'center',
+          }}
+        >
+          <svg
+            width="80"
+            height="80"
+            viewBox="0 0 512 512"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect width="512" height="512" fill="black" />
+            <rect
+              x="97.0973"
+              y="91.3297"
+              width="140"
+              height="330"
+              fill="white"
+            />
+          </svg>
+        </div>
+        <div
+          style={{
+            fontSize: 50,
+            fontStyle: 'normal',
+            fontFamily: 'Berkeley Mono',
+            marginTop: 30,
+            padding: '0 10px',
+            lineHeight: 1.4,
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {title}
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        {
+          name: 'Berkeley Mono',
+          data: fontData,
+          style: 'normal',
+        },
+      ],
+    },
+  );
+}

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -404,7 +404,6 @@ function Dashboard() {
       <div className="flex h-full w-full flex-col overflow-hidden md:flex-row">
         <Head>
           <title>Instant - {tabIndex.get(tab)?.title}</title>
-          <meta name="description" content="Welcome to Instant." />
         </Head>
         <StyledToastContainer />
         <PersonalAccessTokensScreen />
@@ -415,7 +414,6 @@ function Dashboard() {
     <div className="flex h-full w-full flex-col overflow-hidden md:flex-row">
       <Head>
         <title>Instant - {tabIndex.get(tab)?.title}</title>
-        <meta name="description" content="Welcome to Instant." />
       </Head>
       <StyledToastContainer />
       {showNav ? (

--- a/client/www/pages/dash/oauth/callback.tsx
+++ b/client/www/pages/dash/oauth/callback.tsx
@@ -157,7 +157,6 @@ export default function OAuthCallback() {
     <div className="flex h-screen w-full flex-col overflow-hidden md:flex-row">
       <Head>
         <title>Instant - Log in with Google</title>
-        <meta name="description" content="Welcome to Instant." />
       </Head>
       <CallbackScreen state={state} />
       <StyledToastContainer />

--- a/client/www/pages/essays/[slug].tsx
+++ b/client/www/pages/essays/[slug].tsx
@@ -20,7 +20,7 @@ function Prose({ html }: { html: string }) {
 }
 
 const Post = ({ post }: { post: Post }) => {
-  const { title, date, mdHTML, desc, authors } = post;
+  const { title, date, mdHTML, authors } = post;
   return (
     <LandingContainer>
       <Head>
@@ -29,12 +29,11 @@ const Post = ({ post }: { post: Post }) => {
         <meta property="og:description" content={title} />
         <meta
           property="og:image"
-          content={`https://og-image.vercel.app/${encodeURIComponent(title)}.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fwww.instantdb.com%2Fimg%2Ficon%2Ffavicon-32x32.png`}
+          content={`/api/og/essay?title=${encodeURIComponent(title)}`}
         />
-        + <meta property="og:type" content="article" />
-        + <meta property="og:url" content={url} />
-        + <meta property="article:published_time" content={date} />
-        +{' '}
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={url} />
+        <meta property="article:published_time" content={date} />+{' '}
         <meta
           property="article:author"
           content={authors.map((author) => author.name).join(', ')}

--- a/client/www/pages/essays/[slug].tsx
+++ b/client/www/pages/essays/[slug].tsx
@@ -25,16 +25,20 @@ const Post = ({ post }: { post: Post }) => {
     <LandingContainer>
       <Head>
         <title>{title}</title>
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={title} />
+        <meta key="og:title" property="og:title" content={title} />
         <meta
+          key="og:image"
           property="og:image"
           content={`/api/og/essay?title=${encodeURIComponent(title)}`}
         />
-        <meta property="og:type" content="article" />
-        <meta property="og:url" content={url} />
-        <meta property="article:published_time" content={date} />+{' '}
+        <meta key="og:type" property="og:type" content="article" />
         <meta
+          key="article:published_time"
+          property="article:published_time"
+          content={date}
+        />
+        <meta
+          key="og:article:author"
           property="article:author"
           content={authors.map((author) => author.name).join(', ')}
         />

--- a/client/www/pages/essays/[slug].tsx
+++ b/client/www/pages/essays/[slug].tsx
@@ -33,11 +33,6 @@ const Post = ({ post }: { post: Post }) => {
         />
         <meta key="og:type" property="og:type" content="article" />
         <meta
-          key="article:published_time"
-          property="article:published_time"
-          content={date}
-        />
-        <meta
           key="og:article:author"
           property="article:author"
           content={authors.map((author) => author.name).join(', ')}

--- a/client/www/pages/essays/[slug].tsx
+++ b/client/www/pages/essays/[slug].tsx
@@ -20,14 +20,24 @@ function Prose({ html }: { html: string }) {
 }
 
 const Post = ({ post }: { post: Post }) => {
-  const { title, date, mdHTML, authors } = post;
+  const { title, date, mdHTML, desc, authors } = post;
   return (
     <LandingContainer>
       <Head>
         <title>{title}</title>
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={title} />
         <meta
-          name="description"
-          content="Relational Database, on the client."
+          property="og:image"
+          content={`https://og-image.vercel.app/${encodeURIComponent(title)}.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fwww.instantdb.com%2Fimg%2Ficon%2Ffavicon-32x32.png`}
+        />
+        + <meta property="og:type" content="article" />
+        + <meta property="og:url" content={url} />
+        + <meta property="article:published_time" content={date} />
+        +{' '}
+        <meta
+          property="article:author"
+          content={authors.map((author) => author.name).join(', ')}
         />
       </Head>
       <MainNav />

--- a/client/www/pages/essays/index.tsx
+++ b/client/www/pages/essays/index.tsx
@@ -22,7 +22,6 @@ export default function Page({ posts }: { posts: Post[] }) {
     <LandingContainer>
       <Head>
         <title>Essays</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/essays/index.tsx
+++ b/client/www/pages/essays/index.tsx
@@ -21,7 +21,7 @@ export default function Page({ posts }: { posts: Post[] }) {
   return (
     <LandingContainer>
       <Head>
-        <title>Essays</title>
+        <title>Instant Essays</title>
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/examples.tsx
+++ b/client/www/pages/examples.tsx
@@ -154,7 +154,6 @@ function Main({ files }: { files: File[] }) {
     <LandingContainer>
       <Head>
         <title>Instant Examples</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <ToastContainer />
 

--- a/client/www/pages/hiring.tsx
+++ b/client/www/pages/hiring.tsx
@@ -224,7 +224,6 @@ export default function Page() {
     <LandingContainer>
       <Head>
         <title>Hiring</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/index.tsx
+++ b/client/www/pages/index.tsx
@@ -841,6 +841,11 @@ export default function Landing2024() {
           property="og:title"
           content="InstantDB: A Modern Firebase"
         />
+        <meta
+          key="og:description"
+          property="og:description"
+          content="We make you productive by giving your frontend a real-time database."
+        />
       </Head>
       <GlowBackground>
         {/* 

--- a/client/www/pages/index.tsx
+++ b/client/www/pages/index.tsx
@@ -836,7 +836,11 @@ export default function Landing2024() {
     <LandingContainer>
       <Head>
         <title>Instant</title>
-        <meta name="description" content="A Graph Database on the Client" />
+        <meta
+          key="og:title"
+          property="og:title"
+          content="InstantDB: A Modern Firebase"
+        />
       </Head>
       <GlowBackground>
         {/* 

--- a/client/www/pages/intern/signup.tsx
+++ b/client/www/pages/intern/signup.tsx
@@ -10,7 +10,6 @@ const AdminIndex = () => {
     <div className="h-screen w-screen">
       <Head>
         <title>Instant Dashboard</title>
-        <meta name="description" content="Welcome to Instant." />
       </Head>
       <AdminRoot />
     </div>

--- a/client/www/pages/intern/top.jsx
+++ b/client/www/pages/intern/top.jsx
@@ -162,7 +162,6 @@ function Page() {
     <div>
       <Head>
         <title>Instant Top Users</title>
-        <meta name="description" content="Welcome to Instant." />
       </Head>
       <div className="flex space-x-0 space-y-4 md:space-x-8 md:space-y-0 m-4 flex-wrap md:flex-nowrap">
         <div className="flex flex-col space-y-2">

--- a/client/www/pages/pricing/index.tsx
+++ b/client/www/pages/pricing/index.tsx
@@ -203,7 +203,6 @@ export default function Page() {
     <LandingContainer>
       <Head>
         <title>Instant Pricing</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <div className="flex min-h-screen justify-between flex-col">
         <div>

--- a/client/www/pages/privacy.tsx
+++ b/client/www/pages/privacy.tsx
@@ -457,7 +457,7 @@ export default function Page() {
   return (
     <LandingContainer>
       <Head>
-        <title>Essays</title>
+        <title>Instant Privacy Policy</title>
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/privacy.tsx
+++ b/client/www/pages/privacy.tsx
@@ -458,7 +458,6 @@ export default function Page() {
     <LandingContainer>
       <Head>
         <title>Essays</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/terms.tsx
+++ b/client/www/pages/terms.tsx
@@ -170,7 +170,6 @@ export default function Page() {
     <LandingContainer>
       <Head>
         <title>Essays</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/terms.tsx
+++ b/client/www/pages/terms.tsx
@@ -169,7 +169,7 @@ export default function Page() {
   return (
     <LandingContainer>
       <Head>
-        <title>Essays</title>
+        <title>Instant Terms of Service</title>
       </Head>
       <div className="flex min-h-screen flex-col justify-between">
         <MainNav />

--- a/client/www/pages/tutorial.tsx
+++ b/client/www/pages/tutorial.tsx
@@ -45,7 +45,6 @@ export default function Page({ files }: { files: FilesRecord }) {
     <div className="bg-[#F8F9FA] min-h-full">
       <Head>
         <title>Instant Tutorial</title>
-        <meta name="description" content="A Graph Database on the Client" />
       </Head>
       <ToastContainer />
       <div className="flex min-h-screen flex-col justify-between">


### PR DESCRIPTION
Made a series of improvements to our social link improvements. 

## Main Change: Title + Custom OG Image Preview for Blog Posts

![image](https://github.com/user-attachments/assets/6c9887b3-0539-4c87-a8ca-eedfe87b6b33)

- I use the actual blog post title for the og title 
- I leave off the description, so og properly loads a preview of the text
- I made a custom og image generator

## Other change: removed defaults

In `_app.js` we set defaults like:  `title`, `description`, and `url`. But this doesn't quite make sense. If you loaded pricing for example: 

**Before**

<img width="763" alt="CleanShot 2025-03-17 at 11 02 31@2x" src="https://github.com/user-attachments/assets/4ebb2e05-afe5-4658-b6ac-3d6f1fd48a27" />

- You got a non-descriptive title and description
- The og:url was wrong here, saying it was the same as the home page. 

**After** 

![image](https://github.com/user-attachments/assets/49c5a4cd-8ba0-461a-8138-451a22ba41e6)

@tonsky @nezaj @dwwoelfel 