### PR TITLE
Encode instant in json

### DIFF
--- a/server/src/instant/util/json.clj
+++ b/server/src/instant/util/json.clj
@@ -1,13 +1,16 @@
 (ns instant.util.json
   (:require [cheshire.core :as cheshire]
-            [cheshire.generate :refer [add-encoder encode-nil]])
+            [cheshire.generate :refer [add-encoder encode-nil encode-str]])
   (:import (com.google.protobuf NullValue)
            (dev.cel.expr Value)
            (com.fasterxml.jackson.core JsonGenerator)
-           (com.google.protobuf.util JsonFormat)))
+           (com.google.protobuf.util JsonFormat)
+           (java.time Instant)))
 
 ;; Encode NullValue as nil
 (add-encoder NullValue encode-nil)
+
+(add-encoder Instant encode-str)
 
 (defn encode-cel-expr-value
   "Encode cel expression values using the protobuf json encoder"


### PR DESCRIPTION
`refresh` timeouts are getting "can't encode Instant as JSON" errors because we inject a `java.time.Instant` as `tx-created-at` into the event that we try to encode as the ":original-event" when a `refresh` fails.

This PR tells the json encoder how to handle Instants as a quick fix.

A better fix would be to refactor `session.clj` to not put our internal stuff inside the event itself, but that's a bigger project.