### PR TITLE
[Dashboard] Reverse sort icons

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -1320,9 +1320,9 @@ export function Explorer({
                             (sortAttr === 'serverCreatedAt' &&
                               attr.name === 'id') ? (
                               sortAsc ? (
-                                '↓'
-                              ) : (
                                 '↑'
+                              ) : (
+                                '↓'
                               )
                             ) : (
                               <span className="text-gray-400">↓</span>


### PR DESCRIPTION
User pointed out our icons in explorer are confusing. Seems like the convention is indeed to be reverse of what we currently have. [[Discord]](https://discord.com/channels/1031957483243188235/1148284450992574535/1351718429924659294)