### PR TITLE
create entities from link lookups

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -585,6 +585,58 @@ test('lookup creates unique ref attrs for ref lookup in link value', () => {
   }
 });
 
+test('lookups create entities from links', () => {
+  const bookshelfId = uuid();
+
+  const ops = instatx.tx.users[instatx.lookup('handle', 'bobby_newuser')].link({
+    bookshelves: bookshelfId,
+  });
+
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
+  const expectedLookup = [zenecaAttrToId['users/handle'], 'bobby_newuser'];
+  const expected = [
+    ['add-triple', expectedLookup, zenecaAttrToId['users/id'], expectedLookup],
+    [
+      'add-triple',
+      expectedLookup,
+      zenecaAttrToId['users/bookshelves'],
+      bookshelfId,
+    ],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
+test('lookups create entities from unlinks', () => {
+  const bookshelfId = uuid();
+
+  const ops = instatx.tx.users[
+    instatx.lookup('handle', 'bobby_newuser')
+  ].unlink({
+    bookshelves: bookshelfId,
+  });
+
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
+  const expectedLookup = [zenecaAttrToId['users/handle'], 'bobby_newuser'];
+  const expected = [
+    ['add-triple', expectedLookup, zenecaAttrToId['users/id'], expectedLookup],
+    [
+      'retract-triple',
+      expectedLookup,
+      zenecaAttrToId['users/bookshelves'],
+      bookshelfId,
+    ],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
 test('it throws if you use an invalid link attr', () => {
   expect(() =>
     instaml.transform(

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -122,6 +122,20 @@ function extractLookup(attrs, etype, eid) {
   return [attr.id, value];
 }
 
+function withIdAttrForLookup(attrs, etype, eidA, txSteps) {
+  const lookup = extractLookup(attrs, etype, eidA);
+  if (!Array.isArray(lookup)) {
+    return txSteps;
+  }
+  const idTuple = [
+    'add-triple',
+    lookup,
+    getAttrByFwdIdentName(attrs, etype, 'id').id,
+    lookup,
+  ];
+  return [idTuple].concat(txSteps);
+}
+
 function expandLink(attrs, [etype, eidA, obj]) {
   const addTriples = Object.entries(obj).flatMap(([label, eidOrEids]) => {
     const eids = Array.isArray(eidOrEids) ? eidOrEids : [eidOrEids];
@@ -144,7 +158,7 @@ function expandLink(attrs, [etype, eidA, obj]) {
       return txStep;
     });
   });
-  return addTriples;
+  return withIdAttrForLookup(attrs, etype, eidA, addTriples);
 }
 
 function expandUnlink(attrs, [etype, eidA, obj]) {
@@ -169,7 +183,7 @@ function expandUnlink(attrs, [etype, eidA, obj]) {
       return txStep;
     });
   });
-  return retractTriples;
+  return withIdAttrForLookup(attrs, etype, eidA, retractTriples);
 }
 
 function expandUpdate(attrs, [etype, eid, obj]) {


### PR DESCRIPTION
Consider a transaction like: 

```js
db.tx.users[lookup('handle', 'bobby_newuser')].link({ bookshelves: bookshelfId })
```

If a `user` with handle `bobby_newuser` did not exist, we would: 

1. add triple [user-id :handle "bobby-new-user"]
2. add triple [user-id :bookshelves bookshelfId]


## Problem

In this case, we never added the `id` triple. This means that when writing queries like: 

```
{ users: { } }
```

This newly created `bobby_newuser` would not show up. 

## Solution

I went ahead and inserted the id triple even when we are making links 

@dwwoelfel @nezaj  @tonsky 