### PR TITLE
Replace eftest with clojure+.test

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -40,8 +40,8 @@ dev-storm:
 test:
 	TEST=true clojure -M:test
 
-eftest:
-	TEST=true clojure -X:test instant.test-core/eftest-main
+test+:
+	TEST=true clojure -X:test instant.test-core/-main+
 
 retest:
 	TEST=true clojure -M:retest

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -28,7 +28,7 @@
         software.amazon.awssdk.crt/aws-crt {:mvn/version "0.33.11"}
 
         juji/editscript {:mvn/version "0.6.4"}
-        io.github.tonsky/clojure-plus {:mvn/version "1.2.0"}
+        io.github.tonsky/clojure-plus {:mvn/version "1.3.1"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 
@@ -88,9 +88,8 @@
                               criterium/criterium           {:mvn/version "0.4.6"}
                               spec-provider/spec-provider   {:mvn/version "0.4.14"}
                               io.github.tonsky/clj-reload   {:mvn/version "0.9.4"}
-                              eftest/eftest                 {:mvn/version "0.6.0"}
                               ;; https://github.com/kkinnear/zprint/pull/351
-                              io.github.tonsky/zprint {:mvn/version "1.2.10"}}
+                              io.github.tonsky/zprint       {:mvn/version "1.2.10"}}
                  :jvm-opts ["-XX:+UseZGC"
                             "-enableassertions"
 
@@ -128,8 +127,8 @@
                    :ns-default build}
            :run {:main-opts ["-m" "instant.core"]}
            :test {:extra-paths ["test" "dev-resources"]
-                  :extra-deps {eftest/eftest {:mvn/version "0.6.0"}
-                               zprint/zprint {:mvn/version "1.2.9"}}
+                  :extra-deps {io.github.tonsky/clj-reload {:mvn/version "0.9.4"}
+                               zprint/zprint               {:mvn/version "1.2.9"}}
                   :main-opts ["-m" "instant.test-core"]
                   :jvm-opts ["-XX:+UseZGC"
                              "-enableassertions"

--- a/server/dev/user.clj
+++ b/server/dev/user.clj
@@ -3,13 +3,14 @@
    [clj-reload.core :as reload]
    [clojure+.error]
    [clojure+.print]
-   [eftest.runner :as eftest]
+   [clojure+.test]
    [tool]))
 
 (.doReset #'*warn-on-reflection* true)
 
-(clojure+.print/install!)
 (clojure+.error/install!)
+(clojure+.print/install!)
+(clojure+.test/install!)
 
 (reload/init
  {:dirs ["src" "dev" "test"]
@@ -21,6 +22,4 @@
 
 (defn test-all []
   (reload/reload {:only #"instant\..*-test"})
-  (-> (reload/find-namespaces #"instant\..*-test")
-      (eftest/find-tests)
-      (eftest/run-tests {:multithread? false})))
+  (clojure+.test/run))

--- a/server/test/instant/test_core.clj
+++ b/server/test/instant/test_core.clj
@@ -1,11 +1,15 @@
 (ns instant.test-core
-  (:require [circleci.test]
-            [eftest.runner :as eftest]
-            [instant.config :as config]
-            [instant.jdbc.aurora :as aurora]
-            [instant.system-catalog-migration :as system-catalog-migration]
-            [instant.util.crypt :as crypt-util]
-            [instant.util.tracer :as tracer]))
+  (:require
+   [circleci.test]
+   [clj-reload.core :as reload]
+   [clojure+.error]
+   [clojure+.print]
+   [clojure+.test]
+   [instant.config :as config]
+   [instant.jdbc.aurora :as aurora]
+   [instant.system-catalog-migration :as system-catalog-migration]
+   [instant.util.crypt :as crypt-util]
+   [instant.util.tracer :as tracer]))
 
 (defn setup-teardown
   "One-time setup before running our test suite and one-time teardown
@@ -23,8 +27,12 @@
 (defn -main [& _args]
   (circleci.test/dir (str ["test"])))
 
-(defn eftest-main [_]
+(defn -main+ [_]
   (setup-teardown
    (fn []
-     (-> (eftest/find-tests "test")
-         (eftest/run-tests {:multithread? false})))))
+     (clojure+.error/install!)
+     (clojure+.print/install!)
+     (clojure+.test/install!)
+     (reload/init {:dirs ["src" "test"], :output :quieter})
+     (reload/reload {:only #"instant\..*-test"})
+     (clojure+.test/run))))


### PR DESCRIPTION
Removes usage of color and right-aligned stack traces that made it hard to scan test output.

Before:

![Screenshot 2025-03-21 at 02 26 45](https://github.com/user-attachments/assets/03b9a084-25c6-42d6-9588-13f46a8630e7)

After:

```
1/21 Testing instant.admin.routes-test... 1640 ms
2/21 Testing instant.config-edn-test... 3 ms
3/21 Testing instant.db.cel-test... 265 ms
4/21 Testing instant.db.datalog-test... 1276 ms
5/21 Testing instant.db.indexing-jobs-test... 4592 ms
6/21 Testing instant.db.instaql-test...
FAIL in instant.db.instaql-test/comparators (instaql_test.clj:2588)
└╴string
  └╴uses index
    ├╴form:     (= "triples_string_trgm_gist_idx" (run-explain :string "2"))
    ├╴expected: "triples_string_trgm_gist_idx"
    └╴actual:   "triples_app_id"
FAIL in instant.db.instaql-test/comparators (instaql_test.clj:2591)
└╴string
  └╴like uses index
    ├╴form:     (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa"))
    ├╴expected: "triples_string_trgm_gist_idx"
    └╴actual:   "triples_app_id"
FAIL in instant.db.instaql-test/comparators (instaql_test.clj:2602)
└╴number
  └╴uses index
    ├╴form:     (= "triples_number_type_idx" (run-explain :number 2))
    ├╴expected: "triples_number_type_idx"
    └╴actual:   "triples_app_id"
FAIL in instant.db.instaql-test/comparators (instaql_test.clj:2614)
└╴date
  └╴uses index
    ├╴form:     (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2)))
    ├╴expected: "triples_date_type_idx"
    └╴actual:   "triples_app_id"
FAIL in instant.db.instaql-test/comparators (instaql_test.clj:2627)
└╴boolean
  └╴uses index
    ├╴form:     (= "triples_boolean_type_idx" (run-explain :boolean true))
    ├╴expected: "triples_boolean_type_idx"
    └╴actual:   "triples_app_id"
Finished instant.db.instaql-test in 11721 ms
7/21 Testing instant.db.transaction-test... 9460 ms
8/21 Testing instant.grouped-queue-test... 1468 ms
9/21 Testing instant.jdbc.sql-test... 229 ms
10/21 Testing instant.model.app-authorized-redirect-origin-test... 4 ms
11/21 Testing instant.reactive.invalidator-test... 660 ms
12/21 Testing instant.reactive.session-test... 7800 ms
13/21 Testing instant.reactive.store-test... 1616 ms
14/21 Testing instant.storage.s3-test... 1 ms
15/21 Testing instant.storage.sweeper-test... 12487 ms
16/21 Testing instant.stripe-test... 0 ms
17/21 Testing instant.util.async-test... 1288 ms
18/21 Testing instant.util.aws-signature-test... 15 ms
19/21 Testing instant.util.hazelcast-test... 1 ms
20/21 Testing instant.util.semver-test... 0 ms
21/21 Testing instant.util.uuid-test... 143 ms
╶───╴
Ran 202 tests containing 1865 assertions in 54677 ms.
5 failures, 0 errors.
```