### PR TITLE
[cel] throw when `view` or `delete` has `newData`

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -304,16 +304,24 @@
 
 ;; n.b. if you edit something here, make sure you make the
 ;;      equivalent change to iql-cel-compiler below
-(def ^:private ^CelCompiler cel-compiler
+
+(def ^:private runtime-compiler-builder
   (-> (CelCompilerFactory/standardCelCompilerBuilder)
       (.addVar "data" type-obj)
       (.addVar "auth" type-obj)
       (.addVar "ruleParams" type-obj)
-      (.addVar "newData" type-obj)
       (.addFunctionDeclarations (ucoll/array-of CelFunctionDecl custom-fn-decls))
       (.setOptions cel-options)
       (.setStandardMacros CelStandardMacro/STANDARD_MACROS)
-      (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings) (CelExtensions/strings)]))
+      (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings) (CelExtensions/strings)]))))
+
+(def ^:private cel-view-delete-compiler
+  (-> runtime-compiler-builder
+      (.build)))
+
+(def ^:private ^CelCompiler cel-create-update-compiler
+  (-> runtime-compiler-builder
+      (.addVar "newData" type-obj)
       (.build)))
 
 ;; n.b. if you edit something here, make sure you make the
@@ -327,8 +335,21 @@
         (.setOptions cel-options)
         (.build))))
 
-(defn ->ast [expr-str] (.getAst (.compile cel-compiler expr-str)))
+(defn action->compiler [action]
+  (case action
+    (:view :delete) cel-view-delete-compiler
+    cel-create-update-compiler))
+
+(defn ->ast2 [^CelCompiler compiler expr-str] (.getAst (.compile compiler expr-str)))
+(defn ->program2 [^CelRuntime runtime ^CelAbstractSyntaxTree ast] (.createProgram runtime ast))
+
+(defn ->ast [expr-str] (.getAst (.compile cel-create-update-compiler expr-str)))
 (defn ->program [ast] (.createProgram cel-runtime ast))
+
+(defn rule->program [action expr-str]
+  (let [compiler (action->compiler action)
+        ast (->ast2 compiler expr-str)]
+    (->program2 cel-runtime ast)))
 
 (defn eval-program!
   [{:keys [cel-program etype action]} bindings]
@@ -916,7 +937,7 @@
       (.addVar "auth" type-obj)
       (.addFunctionDeclarations (ucoll/array-of CelFunctionDecl where-custom-fn-decls))
       (.setOptions where-cel-options)
-      (.setStandardMacros (CelStandardMacro/STANDARD_MACROS))
+      (.setStandardMacros CelStandardMacro/STANDARD_MACROS)
       (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings) (CelExtensions/strings)]))
       (.build)))
 
@@ -1152,7 +1173,7 @@
                              "auth.ref arg must start with `$user.`"))))))))))
 
 (defn validation-errors [^CelAbstractSyntaxTree ast]
-  (-> (CelValidatorFactory/standardCelValidatorBuilder cel-compiler
+  (-> (CelValidatorFactory/standardCelValidatorBuilder cel-create-update-compiler
                                                        cel-runtime)
       (.addAstValidators (ucoll/array-of CelAstValidator [auth-ref-validator]))
       (.build)
@@ -1171,8 +1192,7 @@
             :app-id zeneca-app-id
             :datalog-query-fn d/query
             :attrs attrs})
-  (let [ast (->ast "data.ref('users.handle').exists_one(x, x == 'alex')")
-        program (->program ast)
+  (let [program (rule->program :view "data.ref('users.handle').exists_one(x, x == 'alex')")
         result
         (eval-program! {:cel-program program} {"auth" (->cel-map {} {"email" "stopa@instantdb.com"})
                                                "data" (->cel-map {:ctx ctx

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -340,16 +340,14 @@
     (:view :delete) cel-view-delete-compiler
     cel-create-update-compiler))
 
-(defn ->ast2 [^CelCompiler compiler expr-str] (.getAst (.compile compiler expr-str)))
-(defn ->program2 [^CelRuntime runtime ^CelAbstractSyntaxTree ast] (.createProgram runtime ast))
+(defn ->ast [^CelCompiler compiler expr-str] (.getAst (.compile compiler expr-str)))
 
-(defn ->ast [expr-str] (.getAst (.compile cel-create-update-compiler expr-str)))
 (defn ->program [ast] (.createProgram cel-runtime ast))
 
 (defn rule->program [action expr-str]
   (let [compiler (action->compiler action)
-        ast (->ast2 compiler expr-str)]
-    (->program2 cel-runtime ast)))
+        ast (->ast compiler expr-str)]
+    (->program ast)))
 
 (defn eval-program!
   [{:keys [cel-program etype action]} bindings]

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -1172,8 +1172,8 @@
                                (.id expr))
                              "auth.ref arg must start with `$user.`"))))))))))
 
-(defn validation-errors [^CelAbstractSyntaxTree ast]
-  (-> (CelValidatorFactory/standardCelValidatorBuilder cel-create-update-compiler
+(defn validation-errors [^CelCompiler compiler ^CelAbstractSyntaxTree ast]
+  (-> (CelValidatorFactory/standardCelValidatorBuilder compiler
                                                        cel-runtime)
       (.addAstValidators (ucoll/array-of CelAstValidator [auth-ref-validator]))
       (.build)

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -32,7 +32,8 @@
                          TypeParamType)
    (dev.cel.compiler CelCompiler
                      CelCompilerFactory
-                     CelCompilerLibrary)
+                     CelCompilerLibrary
+                     CelCompilerBuilder)
    (dev.cel.extensions CelExtensions)
    (dev.cel.parser CelStandardMacro
                    CelUnparserFactory
@@ -305,7 +306,7 @@
 ;; n.b. if you edit something here, make sure you make the
 ;;      equivalent change to iql-cel-compiler below
 
-(def ^:private runtime-compiler-builder
+(defn- runtime-compiler-builder ^CelCompilerBuilder []
   (-> (CelCompilerFactory/standardCelCompilerBuilder)
       (.addVar "data" type-obj)
       (.addVar "auth" type-obj)
@@ -316,11 +317,11 @@
       (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings) (CelExtensions/strings)]))))
 
 (def ^:private cel-view-delete-compiler
-  (-> runtime-compiler-builder
+  (-> (runtime-compiler-builder)
       (.build)))
 
 (def ^:private ^CelCompiler cel-create-update-compiler
-  (-> runtime-compiler-builder
+  (-> (runtime-compiler-builder)
       (.addVar "newData" type-obj)
       (.build)))
 
@@ -336,8 +337,9 @@
         (.build))))
 
 (defn action->compiler [action]
-  (case action
-    (:view :delete) cel-view-delete-compiler
+  (case (name action)
+    ("view" "delete")
+    cel-view-delete-compiler
     cel-create-update-compiler))
 
 (defn ->ast [^CelCompiler compiler expr-str] (.getAst (.compile compiler expr-str)))

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -197,7 +197,7 @@
                                ast (cel/->ast compiler expr)
                                ;; create the program to see if it throws
                                _program (cel/->program ast)
-                               errors (cel/validation-errors ast)]
+                               errors (cel/validation-errors compiler ast)]
                            (when (seq errors)
                              (format-errors etype action errors))))
                        (catch CelValidationException e

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -99,7 +99,8 @@
     (if (and (= "$users" etype)
              (= "view" action))
       (let [code "auth.id == data.id"
-            ast (cel/->ast code)]
+            compiler (cel/action->compiler action)
+            ast (cel/->ast2 compiler code)]
         {:etype etype
          :action action
          :code code

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -7,7 +7,8 @@
             [instant.db.cel :as cel]
             [instant.db.datalog :as d]
             [instant.db.transaction :as tx])
-  (:import (dev.cel.parser CelStandardMacro)))
+  (:import (dev.cel.parser CelStandardMacro)
+           (dev.cel.common CelValidationException)))
 
 (deftest test-standard-macros
   (testing "STANDARD_MACROS set contains expected macros"
@@ -17,35 +18,48 @@
 
 (deftest test-cel-evaluation
   (testing "Evaluation of CEL expressions with standard macros"
-    (let [program (cel/->program (cel/->ast "has({'name': 'Alice'}.name)"))]
+    (let [program (cel/rule->program :view "has({'name': 'Alice'}.name)")]
       (is (true? (cel/eval-program! {:cel-program program} {}))))
 
-    (let [program (cel/->program (cel/->ast "[1, 2, 3].all(x, x > 0)"))]
+    (let [program (cel/rule->program :delete "[1, 2, 3].all(x, x > 0)")]
       (is (true? (cel/eval-program! {:cel-program program} {}))))
 
-    (let [program (cel/->program (cel/->ast "[1, 2, 3].exists(x, x > 2)"))]
+    (let [program (cel/rule->program :update "[1, 2, 3].exists(x, x > 2)")]
       (is (true? (cel/eval-program! {:cel-program program} {}))))
 
-    (let [program (cel/->program (cel/->ast "[1, 2, 3].exists_one(x, x > 2)"))]
+    (let [program (cel/rule->program :create "[1, 2, 3].exists_one(x, x > 2)")]
       (is (true? (cel/eval-program! {:cel-program program} {}))))
 
-    (let [program (cel/->program (cel/->ast "[1, 2, 3].map(x, x * 2)"))]
+    (let [program (cel/rule->program :view "[1, 2, 3].map(x, x * 2)")]
       (is (= [2 4 6] (cel/eval-program! {:cel-program program} {}))))
 
-    (let [program (cel/->program (cel/->ast "[1, 2, 3, 4].filter(x, x % 2 == 0)"))]
+    (let [program (cel/rule->program :view "[1, 2, 3, 4].filter(x, x % 2 == 0)")]
       (is (= [2 4] (cel/eval-program! {:cel-program program} {}))))))
 
 (deftest parse-false-correctly
-  (let [program (cel/->program (cel/->ast "data.isFavorite"))
+  (let [program (cel/rule->program :view "data.isFavorite")
         bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
     (is (false? (cel/eval-program! {:cel-program program} bindings))))
-  (let [program (cel/->program (cel/->ast "!data.isFavorite"))
+  (let [program (cel/rule->program :view "!data.isFavorite")
         bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
     (is (true? (cel/eval-program! {:cel-program program} bindings)))))
 
-(deftest unknown-values-are-not-allowed
-  (let [program (cel/->program (cel/->ast "newData.isFavorite"))
-        bindings {} ;; note! newData is not provided
+(deftest view-delete-does-not-allow-newData
+  (is
+   (thrown-with-msg?
+    CelValidationException
+    #"(?i)undeclared reference to 'newData'"
+    (cel/rule->program :view "newData.isFavorite")))
+  (is
+   (thrown-with-msg?
+    CelValidationException
+    #"(?i)undeclared reference to 'newData'"
+    (cel/rule->program :delete "newData.isFavorite"))))
+
+(deftest unknown-results-throw
+  (let [program (cel/rule->program :view "data.isFavorite")
+        bindings {} ;; note! data is not provided. This will cause CEL to return
+                    ;; a CelUnknownSet
         ]
     (is (thrown-with-msg?
          Throwable


### PR DESCRIPTION
Previously it was possible to write a `view` or `delete` rule, with a `newData` var. We never passed this value in though, so it would cause an error. 

I update dour cel-compiler, so we use one without the `newData` field for view and delete checks 

<img width="615" alt="CleanShot 2025-03-21 at 16 57 22@2x" src="https://github.com/user-attachments/assets/e03d2c0d-01ba-465b-81f1-ed3c9475898e" />


I checked to see if there are any rules in prod that does this, and found none: 

```sql
SELECT 
  app_id,
  r.rule_name,
  r.rule_obj->'allow' AS allow_rules
FROM rules,
  jsonb_each(code) AS r(rule_name, rule_obj)
WHERE 
  r.rule_obj ? 'allow'
  AND (
       (r.rule_obj->'allow'->>'view' ILIKE '%newData%')
       OR (r.rule_obj->'allow'->>'delete' ILIKE '%newData%')
  );
```

@dwwoelfel @nezaj @tonsky 