### PR TITLE
[hotfix] add newData back to view-delete rules

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -318,6 +318,7 @@
 
 (def ^:private cel-view-delete-compiler
   (-> (runtime-compiler-builder)
+      (.addVar "newData" type-obj)
       (.build)))
 
 (def ^:private ^CelCompiler cel-create-update-compiler

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -8,7 +8,7 @@
             [instant.db.datalog :as d]
             [instant.db.transaction :as tx])
   (:import (dev.cel.parser CelStandardMacro)
-           (dev.cel.common CelValidationException)))
+           #_(dev.cel.common CelValidationException)))
 
 (deftest test-standard-macros
   (testing "STANDARD_MACROS set contains expected macros"
@@ -44,17 +44,17 @@
         bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
     (is (true? (cel/eval-program! {:cel-program program} bindings)))))
 
-(deftest view-delete-does-not-allow-newData
-  (is
-   (thrown-with-msg?
-    CelValidationException
-    #"(?i)undeclared reference to 'newData'"
-    (cel/rule->program :view "newData.isFavorite")))
-  (is
-   (thrown-with-msg?
-    CelValidationException
-    #"(?i)undeclared reference to 'newData'"
-    (cel/rule->program :delete "newData.isFavorite"))))
+#_(deftest view-delete-does-not-allow-newData
+    (is
+     (thrown-with-msg?
+      CelValidationException
+      #"(?i)undeclared reference to 'newData'"
+      (cel/rule->program :view "newData.isFavorite")))
+    (is
+     (thrown-with-msg?
+      CelValidationException
+      #"(?i)undeclared reference to 'newData'"
+      (cel/rule->program :delete "newData.isFavorite"))))
 
 (deftest unknown-results-throw
   (let [program (cel/rule->program :view "data.isFavorite")


### PR DESCRIPTION
We automatically prepend all binds to cel rules. This caused an error when using our view-delete compiler. 

@dwwoelfel @nezaj @tonsky 