### PR TITLE
[storage] delay storage apis

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -48,8 +48,7 @@
    [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
    [ring.middleware.keyword-params :refer [wrap-keyword-params]]
    [ring.middleware.multipart-params :refer [wrap-multipart-params]]
-   [ring.middleware.params :refer [wrap-params]]
-   [instant.storage.s3 :as storage-s3])
+   [ring.middleware.params :refer [wrap-params]])
   (:import
    (clojure.lang IFn)
    (io.undertow Undertow UndertowOptions Undertow$Builder Undertow$ListenerInfo)
@@ -236,8 +235,6 @@
       (jwt/start))
     (with-log-init :aurora
       (aurora/start))
-    (with-log-init :storage
-      (storage-s3/start))
     (with-log-init :system-catalog
       (ensure-attrs-on-system-catalog-app))
     (with-log-init :reactive-store

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -26,7 +26,8 @@
    [rewrite-clj.zip :as z]
    [zprint.core :as zprint]
    [instant.util.aws-signature :as aws-sig]
-   [instant.model.app-file :as app-file])
+   [instant.model.app-file :as app-file]
+   [instant.storage.s3 :as s3-storage])
   (:import
    (java.time Instant)
    (java.util UUID)))
@@ -4237,7 +4238,8 @@
                            "size" 1024}]
 
         (with-redefs
-         [aws-sig/presign-s3-url (fn [{:keys [path]}]
+         [s3-storage/presign-creds (constantly nil)
+          aws-sig/presign-s3-url (fn [{:keys [path]}]
                                    (str "https://s3-redefed-url-for.aws.com/"
                                         (last (String/.split path "/"))))]
 

--- a/server/test/instant/storage/sweeper_test.clj
+++ b/server/test/instant/storage/sweeper_test.clj
@@ -9,7 +9,8 @@
             [instant.util.s3 :as s3-util]))
 
 (defn with-s3-mock [f]
-  (with-redefs [s3-util/delete-objects (constantly nil)]
+  (with-redefs [s3-util/delete-objects (constantly nil)
+                s3-util/s3-client (constantly nil)]
     (f)))
 
 (use-fixtures :each with-s3-mock)

--- a/server/test/instant/storage/sweeper_test.clj
+++ b/server/test/instant/storage/sweeper_test.clj
@@ -6,11 +6,12 @@
             [instant.jdbc.sql :as sql]
             [instant.fixtures :refer [with-empty-app]]
             [honey.sql :as hsql]
-            [instant.util.s3 :as s3-util]))
+            [instant.util.s3 :as s3-util]
+            [instant.storage.s3 :as s3-storage]))
 
 (defn with-s3-mock [f]
   (with-redefs [s3-util/delete-objects (constantly nil)
-                s3-util/s3-client (constantly nil)]
+                s3-storage/s3-client (constantly nil)]
     (f)))
 
 (use-fixtures :each with-s3-mock)


### PR DESCRIPTION
OS devs reported that they get this error: 

"Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@375bc55f: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@6dbb85bd: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@4a038130: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@37ac16a5: Unable to contact EC2 metadata service.]"}}

I have a hunch this may be because we eagerly load s3 configuration when we start storage/s3. I wrapped the config objects into a delay again, so OS devs don't have to deal with this, unless they want to enable storage.

@dwwoelfel @tonsky @nezaj 