### PR TITLE
[admin] only set `no-store` for nextjs 13 and 14

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -166,7 +166,6 @@ async function jsonFetch(
   init: RequestInit | undefined,
 ): Promise<any> {
   const defaultFetchOpts = getDefaultFetchOpts();
-  console.log('defaultFetchOpts', defaultFetchOpts);
   const headers = {
     ...(init.headers || {}),
     'Instant-Admin-Version': version,

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -150,7 +150,7 @@ function authorizedHeaders(
 // Once NextJS 13 and 14 are no longer common, we can remove this code.
 function isNextJSVersionThatCachesFetchByDefault() {
   return (
-    // NextJS 13 onwards added a `__nextPatched` property to the fetch functuon
+    // NextJS 13 onwards added a `__nextPatched` property to the fetch function
     fetch['__nextPatched'] &&
     // NextJS 15 onwards _also_ added a global `next-patch` symbol.
     !globalThis[Symbol.for('next-patch')]

--- a/client/sandbox/react-nextjs/app/play/check-admin-cache/page.tsx
+++ b/client/sandbox/react-nextjs/app/play/check-admin-cache/page.tsx
@@ -1,10 +1,10 @@
 import { init } from '@instantdb/admin';
-const APP_ID = '137ace7a-efdd-490f-b0dc-a3c73a14f892';
-const ADMIN_TOKEN = '82900c15-faac-495b-b385-9f9e7743b629';
+
+import config from '../../../config';
+
 const db = init({
-  appId: APP_ID,
-  adminToken: ADMIN_TOKEN,
-  apiURI: 'http://localhost:8888',
+  ...config,
+  adminToken: process.env.INSTANT_ADMIN_TOKEN!,
 });
 
 export default async function Page() {

--- a/client/sandbox/react-nextjs/app/play/check-admin-cache/page.tsx
+++ b/client/sandbox/react-nextjs/app/play/check-admin-cache/page.tsx
@@ -7,6 +7,8 @@ const db = init({
   adminToken: process.env.INSTANT_ADMIN_TOKEN!,
 });
 
+export const dynamic = 'force-dynamic';
+
 export default async function Page() {
   const query = await db.query({
     goals: {},


### PR DESCRIPTION
Right now, we explicitly set `cache: no-store` in the admin API.

We did this, because NextJS 13 & 14 made it so all fetch requests were cached _by default_. 

**However, NextJS 15 onwards** has reverted this, so all fetch request are 'no-store' by default. 

Because we explicitly set `cache: 'no-store'`, folks can't use admin.query in [ISR](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration#:~:text=If%20any%20of%20the%20fetch%20requests%20used%20on%20a%20route%20have%20a%20revalidate%20time%20of%200%2C%20or%20an%20explicit%20no-store%2C%20the%20route%20will%20be%20dynamically%20rendered.). 

--- 

What I did: 
- I changed our logic so we _only_ add the `no-store` flag, if we are inside nextjs 13 and 14. This way ISR works 'out-of-the-box' with NextJS 15 onwards 


@nezaj @tonsky @dwwoelfel 