### PR TITLE
[rules] Only include binds that are used

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1045,7 +1045,7 @@
                            ;; won't be able to find the entity
                            (conj fields "id"))]
       (if (contains? attr-ids $file-url-attr-id)
-        ;; If the user asked for the url, we need to make sure to 
+        ;; If the user asked for the url, we need to make sure to
         ;; include `location-id` too; we use location-id to generate the url.
         (conj attr-ids $file-location-id-attr-id)
         attr-ids))

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1836,10 +1836,7 @@
    Returns: [{:etype string, :path-str string, :eids #{uuid}}]"
   [user-id etype->eids+program]
   (reduce-kv (fn [acc etype {:keys [eids program]}]
-               (if-let [refs (some-> program
-                                     :cel-ast
-                                     cel/collect-ref-uses
-                                     seq)]
+               (if-let [refs (seq (:ref-uses program))]
                  (reduce (fn [acc {:keys [obj path]}]
                            (case obj
                              "data" (conj acc {:etype etype

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -236,7 +236,7 @@
 
    And we group them by `eid`, `etype`, and `action`.
 
-   :groups 
+   :groups
     {{:eid joe-eid
       :etype \"users\"
       :action :update} [[:add-triple joe-eid :users/name \"Joe\"]
@@ -245,8 +245,8 @@
       :etype \"users\"
       :action :update} [[:add-triple stopa-eid :users/name \"Stopa\"]
                         [:add-triple stopa-eid :users/age 30]] }
-   :rule-params-to-copy 
-   {{:eid joe-id 
+   :rule-params-to-copy
+   {{:eid joe-id
      :etype \"users\"} [{:eid post-id :etype \"posts\"}]}"
   [ctx tx-steps]
   (reduce (fn [acc tx-step]
@@ -436,7 +436,7 @@
    (reduce (fn [acc check]
              (if (and (= :object (:scope check))
                       (:program check))
-               (let [refs (cel/collect-ref-uses (:cel-ast (:program check)))]
+               (let [refs (:ref-uses (:program check))]
                  (reduce (fn [acc {:keys [obj path]}]
                            ;; group by etype + ref-path so we can collect all eids
                            ;; for each group

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -152,13 +152,12 @@
   (or
    (when-let [expr (get-expr (:code rules) etype action)]
      (try
-       (let [code (with-binds (:code rules) etype action expr)
-             code-str (patch-code code)
+       (let [code (with-binds (:code rules) etype action (patch-code expr))
              compiler (cel/action->compiler action)
-             ast (cel/->ast compiler code-str)]
+             ast (cel/->ast compiler code)]
          {:etype etype
           :action action
-          :code code-str
+          :code code
           :display-code expr
           :cel-ast ast
           :cel-program (cel/->program ast)

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -154,7 +154,8 @@
           :code code-str
           :display-code expr
           :cel-ast ast
-          :cel-program (cel/->program ast)})
+          :cel-program (cel/->program ast)
+          :ref-uses (cel/collect-ref-uses ast)})
        (catch CelValidationException e
          (ex/throw-validation-err!
           :permission

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -250,7 +250,7 @@
                              (format-errors etype action errors))))
                        (catch CelValidationException e
                          (get-issues etype action e))
-                       (catch Exception e
+                       (catch Exception _e
                          [{:message "There was an unexpected error evaluating the rules"
                            :in [etype :allow action]}])))))
        (keep identity)))

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -105,8 +105,13 @@
    (get-in rule ["$default" "allow" action])
    (get-in rule ["$default" "allow" "$default"])))
 
+(defn patch-code
+  "Don't break if the perm check is a simple boolean"
+  [code]
+  (if (boolean? code) (str code) code))
+
 (defn extract [rule etype action]
-  (when-let [expr (get-in rule [etype "allow" action])]
+  (when-let [expr (patch-code (get-in rule [etype "allow" action]))]
     (with-binds rule etype action expr)))
 
 (defn format-errors [etype action errors]
@@ -148,8 +153,7 @@
    (when-let [expr (get-expr (:code rules) etype action)]
      (try
        (let [code (with-binds (:code rules) etype action expr)
-             ;; Don't bork if the perm check is a simple boolean
-             code-str (if (boolean? code) (str code) code)
+             code-str (patch-code code)
              compiler (cel/action->compiler action)
              ast (cel/->ast compiler code-str)]
          {:etype etype

--- a/server/test/instant/model/rule_test.clj
+++ b/server/test/instant/model/rule_test.clj
@@ -1,5 +1,5 @@
 (ns instant.model.rule-test
-  (:require [clojure.test :as test :refer [deftest is testing]]
+  (:require [clojure.test :as test :refer [deftest is]]
             [instant.model.rule :as rule]))
 
 

--- a/server/test/instant/model/rule_test.clj
+++ b/server/test/instant/model/rule_test.clj
@@ -1,0 +1,53 @@
+(ns instant.model.rule-test
+  (:require [clojure.test :as test :refer [deftest is testing]]
+            [instant.model.rule :as rule]))
+
+
+(deftest binds-works
+  (is (= "cel.bind(test, true, test)"
+         (:code
+          (rule/get-program! {:code {"myetype"
+                                     {"bind" ["test" "true"]
+                                      "allow" {"view" "test"}}}}
+                             "myetype"
+                             "view"))))
+
+  (is (= "cel.bind(test, true, cel.bind(test2, false, test && test2))"
+         (:code
+          (rule/get-program! {:code {"myetype"
+                                     {"bind" ["test" "true"
+                                              "test2" "false"]
+                                      "allow" {"view" "test && test2"}}}}
+                             "myetype"
+                             "view")))))
+
+(deftest binds-can-reference-other-binds
+  (is (= "cel.bind(parent, true, cel.bind(child, parent || true, child))"
+         (:code
+          (rule/get-program! {:code {"myetype"
+                                     {"bind" ["parent" "true"
+                                              "child" "parent || true"]
+                                      "allow" {"view" "child"}}}}
+                             "myetype"
+                             "view")))))
+
+(deftest ignores-unused-binds
+  (is (= "true"
+         (:code
+          (rule/get-program! {:code {"myetype"
+                                     {"bind" ["parent" "true"
+                                              "child" "parent || true"]
+                                      "allow" {"view" "true"}}}}
+                             "myetype"
+                             "view"))))
+  (is (= "cel.bind(parent, true, parent)"
+         (:code
+          (rule/get-program! {:code {"myetype"
+                                     {"bind" ["parent" "true"
+                                              "child" "parent || true"]
+                                      "allow" {"view" "parent"}}}}
+                             "myetype"
+                             "view")))))
+
+(comment
+  (test/run-tests *ns*))

--- a/server/test/instant/model/rule_test.clj
+++ b/server/test/instant/model/rule_test.clj
@@ -2,6 +2,16 @@
   (:require [clojure.test :as test :refer [deftest is]]
             [instant.model.rule :as rule]))
 
+(deftest allow-booleans
+  (let [code {"myetype"
+              {"allow" {"view" true}}}]
+    (is (= "true"
+           (:code
+            (rule/get-program! {:code code}
+                               "myetype"
+                               "view"))))
+
+    (is (= () (rule/validation-errors code)))))
 
 (deftest binds-works
   (is (= "cel.bind(test, true, test)"


### PR DESCRIPTION
Only adds a `bind` when the rule actually uses the bind.


For this rule, we don't need to include the `isOwner` bind:

```json
{"myns": {"bind": ["isOwner", "data.ownerId == auth.id"], "allow": {"view": "true"}}}
```

Before:
```
cel.bind(isOwner, data.ownerId == auth.id, true)
```

After:
```
true
```

This should fix the problem we had with `newData` showing up in `view` rules.

I also added a cache for the converting the rule to a program, since we're doing a little extra work each time we parse the rule now.