### PR TITLE
Revert "[hotfix] add newData back to view-delete rules (#1044)"

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -319,7 +319,6 @@
 
 (def ^:private cel-view-delete-compiler
   (-> (runtime-compiler-builder)
-      (.addVar "newData" type-obj)
       (.build)))
 
 (def ^:private ^CelCompiler cel-create-update-compiler

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -8,7 +8,7 @@
             [instant.db.datalog :as d]
             [instant.db.transaction :as tx])
   (:import (dev.cel.parser CelStandardMacro)
-           #_(dev.cel.common CelValidationException)))
+           (dev.cel.common CelValidationException)))
 
 (deftest test-standard-macros
   (testing "STANDARD_MACROS set contains expected macros"
@@ -44,17 +44,17 @@
         bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
     (is (true? (cel/eval-program! {:cel-program program} bindings)))))
 
-#_(deftest view-delete-does-not-allow-newData
-    (is
-     (thrown-with-msg?
-      CelValidationException
-      #"(?i)undeclared reference to 'newData'"
-      (cel/rule->program :view "newData.isFavorite")))
-    (is
-     (thrown-with-msg?
-      CelValidationException
-      #"(?i)undeclared reference to 'newData'"
-      (cel/rule->program :delete "newData.isFavorite"))))
+(deftest view-delete-does-not-allow-newData
+  (is
+   (thrown-with-msg?
+    CelValidationException
+    #"(?i)undeclared reference to 'newData'"
+    (cel/rule->program :view "newData.isFavorite")))
+  (is
+   (thrown-with-msg?
+    CelValidationException
+    #"(?i)undeclared reference to 'newData'"
+    (cel/rule->program :delete "newData.isFavorite"))))
 
 (deftest unknown-results-throw
   (let [program (cel/rule->program :view "data.isFavorite")


### PR DESCRIPTION
Reverts the hotfix from https://github.com/instantdb/instant/pull/1044

Should no longer be needed after https://github.com/instantdb/instant/pull/1057