### PR TITLE
[client] no op of undefined

### DIFF
--- a/client/packages/core/__tests__/src/instaml.test.js
+++ b/client/packages/core/__tests__/src/instaml.test.js
@@ -27,6 +27,26 @@ test('simple update transform', () => {
   }
 });
 
+test('undefined is ignored in update', () => {
+  const testId = uuid();
+
+  const ops = instatx.tx.users[testId].update({
+    handle: 'bobby',
+    fullName: undefined,
+  });
+  const result = instaml.transform({ attrs: zenecaAttrs }, ops);
+
+  const expected = [
+    ['add-triple', testId, zenecaAttrToId['users/id'], testId],
+    ['add-triple', testId, zenecaAttrToId['users/handle'], 'bobby'],
+  ];
+
+  expect(result).toHaveLength(expected.length);
+  for (const item of expected) {
+    expect(result).toContainEqual(item);
+  }
+});
+
 test('ignores id attrs', () => {
   const testId = uuid();
 

--- a/client/packages/core/__tests__/src/store.test.js
+++ b/client/packages/core/__tests__/src/store.test.js
@@ -470,3 +470,58 @@ test('ruleParams no-ops', () => {
 
   checkIndexIntegrity(newStore);
 });
+
+test('deepMerge', () => {
+  const gameId = uuid();
+  const gameStore = transact(
+    store,
+    instaml.transform(
+      { attrs: store.attrs },
+      tx.games[gameId].update({
+        state: {
+          score: 100,
+          playerStats: { health: 50, mana: 30, ambitions: { win: true } },
+          inventory: ['sword', 'potion'],
+          level: 2,
+        },
+      }),
+    ),
+  );
+  const updatedStore = transact(
+    gameStore,
+    instaml.transform(
+      { attrs: gameStore.attrs },
+      tx.games[gameId].merge({
+        state: {
+          // Objects update deeply
+          playerStats: {
+            mana: 40,
+            stamina: 20,
+            ambitions: { acquireWisdom: true, find: ['love'] },
+          },
+          // arrays overwrite
+          inventory: ['shield'],
+          // null removes the key
+          score: null,
+          // undefined is ignored
+          level: undefined,
+        },
+      }),
+    ),
+  );
+  const updatedGame = query(
+    { store: updatedStore },
+    { games: { $: { where: { id: gameId } } } },
+  ).data.games[0];
+  expect(updatedGame.state).toEqual({
+    playerStats: {
+      health: 50,
+      mana: 40,
+      stamina: 20,
+      ambitions: { win: true, acquireWisdom: true, find: ['love'] },
+    },
+    level: 2,
+    inventory: ['shield'],
+  });
+  checkIndexIntegrity(updatedGame);
+});

--- a/client/packages/core/__tests__/src/store.test.js
+++ b/client/packages/core/__tests__/src/store.test.js
@@ -482,6 +482,7 @@ test('deepMerge', () => {
           score: 100,
           playerStats: { health: 50, mana: 30, ambitions: { win: true } },
           inventory: ['sword', 'potion'],
+          locations: ['forest', 'castle'],
           level: 2,
         },
       }),
@@ -505,6 +506,8 @@ test('deepMerge', () => {
           score: null,
           // undefined is ignored
           level: undefined,
+          // undefined is kept in arrays
+          locations: ['forest', undefined, 'castle'],
         },
       }),
     ),
@@ -522,6 +525,7 @@ test('deepMerge', () => {
     },
     level: 2,
     inventory: ['shield'],
+    locations: ['forest', undefined, 'castle'],
   });
   checkIndexIntegrity(updatedGame);
 });

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -186,8 +186,8 @@ function expandUnlink(attrs, [etype, eidA, obj]) {
   return withIdAttrForLookup(attrs, etype, eidA, retractTriples);
 }
 
-function expandUpdate(attrs, [etype, eid, _obj]) {
-  const obj = immutableRemoveUndefined(_obj);
+function expandUpdate(attrs, [etype, eid, obj_]) {
+  const obj = immutableRemoveUndefined(obj_);
   const lookup = extractLookup(attrs, etype, eid);
   // id first so that we don't clobber updates on the lookup field
   const attrTuples = [['id', lookup]]

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -204,8 +204,8 @@ function expandDelete(attrs, [etype, eid]) {
   return [['delete-entity', lookup, etype]];
 }
 
-function expandDeepMerge(attrs, [etype, eid, _obj]) {
-  const obj = immutableRemoveUndefined(_obj);
+function expandDeepMerge(attrs, [etype, eid, obj_]) {
+  const obj = immutableRemoveUndefined(obj_);
   const lookup = extractLookup(attrs, etype, eid);
   const attrTuples = Object.entries(obj).map(([identName, value]) => {
     const attr = getAttrByFwdIdentName(attrs, etype, identName);

--- a/client/packages/core/src/instaml.js
+++ b/client/packages/core/src/instaml.js
@@ -1,5 +1,5 @@
 import { getOps, isLookup, parseLookup } from './instatx';
-import { immutableDeepReplace } from './utils/object';
+import { immutableRemoveUndefined } from './utils/object';
 import uuid from './utils/uuid';
 
 // Rewrites optimistic attrs with the attrs we get back from the server.
@@ -186,7 +186,8 @@ function expandUnlink(attrs, [etype, eidA, obj]) {
   return withIdAttrForLookup(attrs, etype, eidA, retractTriples);
 }
 
-function expandUpdate(attrs, [etype, eid, obj]) {
+function expandUpdate(attrs, [etype, eid, _obj]) {
+  const obj = immutableRemoveUndefined(_obj);
   const lookup = extractLookup(attrs, etype, eid);
   // id first so that we don't clobber updates on the lookup field
   const attrTuples = [['id', lookup]]
@@ -203,12 +204,12 @@ function expandDelete(attrs, [etype, eid]) {
   return [['delete-entity', lookup, etype]];
 }
 
-function expandDeepMerge(attrs, [etype, eid, obj]) {
+function expandDeepMerge(attrs, [etype, eid, _obj]) {
+  const obj = immutableRemoveUndefined(_obj);
   const lookup = extractLookup(attrs, etype, eid);
   const attrTuples = Object.entries(obj).map(([identName, value]) => {
     const attr = getAttrByFwdIdentName(attrs, etype, identName);
-    const coercedValue = immutableDeepReplace(value, undefined, null);
-    return ['deep-merge-triple', lookup, attr.id, coercedValue];
+    return ['deep-merge-triple', lookup, attr.id, value];
   });
 
   const idTuple = [

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -298,6 +298,7 @@ function mergeTriple(store, rawTriple) {
   if (!currentTriple) return;
 
   const currentValue = currentTriple[2];
+
   const updatedValue = immutableDeepMerge(currentValue, update);
   const enhancedTriple = [
     eid,

--- a/client/packages/core/src/utils/object.js
+++ b/client/packages/core/src/utils/object.js
@@ -34,24 +34,33 @@ export function areObjectsDeepEqual(obj1, obj2) {
   );
 }
 
+export function immutableRemoveUndefined(obj) {
+  if (!isObject(obj)) {
+    return obj;
+  }
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue;
+
+    result[key] = value;
+  }
+  return result;
+}
+
 export function immutableDeepMerge(target, source) {
   if (!isObject(target) || !isObject(source)) {
     return source;
   }
 
-  const result = {};
-
-  for (const key of Object.keys(target)) {
-    if (source[key] === null) continue;
-
-    result[key] = target[key];
-  }
+  const result = { ...target };
 
   for (const key of Object.keys(source)) {
-    if (source[key] === null) continue;
-
+    if (source[key] === undefined) continue;
+    if (source[key] === null) {
+      delete result[key];
+      continue;
+    }
     const areBothObjects = isObject(target[key]) && isObject(source[key]);
-
     result[key] = areBothObjects
       ? immutableDeepMerge(target[key], source[key])
       : source[key];
@@ -82,6 +91,7 @@ export function isObject(val) {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
+export function immutableOmitValue(obj, v) {}
 /**
  * Like `assocInMutative`, but
  *

--- a/client/sandbox/react-nextjs/pages/play/patch.tsx
+++ b/client/sandbox/react-nextjs/pages/play/patch.tsx
@@ -38,6 +38,9 @@ export default function Patch() {
       <button className="border border-black" onClick={mergeWithDeepUndef}>
         merge `nestedData` with `{`{new_key:undefined}`}`
       </button>
+      <button className="border border-black" onClick={mergeWithUndefArray}>
+        merge `nestedData` with `{`{new_key:[1, undefined, 2]}`}`
+      </button>
       <button className="border border-black" onClick={deleteAttr}>
         delete `nestedData` attribute
       </button>
@@ -72,6 +75,14 @@ export default function Patch() {
     db.transact([
       tx.blocks[singletonIdX].merge({
         nestedData: { new_key: undefined },
+      }),
+    ]);
+  }
+
+  function mergeWithUndefArray() {
+    db.transact([
+      tx.blocks[singletonIdX].merge({
+        nestedData: { new_key: [1, undefined, 2] },
       }),
     ]);
   }

--- a/client/sandbox/react-nextjs/pages/play/save-undefined.tsx
+++ b/client/sandbox/react-nextjs/pages/play/save-undefined.tsx
@@ -6,13 +6,11 @@ const db = init(config);
 
 const itemId = id();
 
-export default function Patch() {
-  const ref = useRef<HTMLTextAreaElement>(null);
+export default function Page() {
   const { isLoading, error, data } = db.useQuery({
     items: {},
   });
   if (isLoading || error) return;
-
   return (
     <div className="p-4 text-sm font-mono flex flex-col mx-auto max-w-md gap-4">
       <button className="border border-black" onClick={() => reset(data.items)}>

--- a/client/sandbox/react-nextjs/pages/play/saveundefined.tsx
+++ b/client/sandbox/react-nextjs/pages/play/saveundefined.tsx
@@ -1,0 +1,47 @@
+import { id, init, tx } from '@instantdb/react';
+import { useRef } from 'react';
+import config from '../../config';
+
+const db = init(config);
+
+const itemId = id();
+
+export default function Patch() {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const { isLoading, error, data } = db.useQuery({
+    items: {},
+  });
+  if (isLoading || error) return;
+
+  return (
+    <div className="p-4 text-sm font-mono flex flex-col mx-auto max-w-md gap-4">
+      <button className="border border-black" onClick={() => reset(data.items)}>
+        reset state
+      </button>
+      <button className="border border-black" onClick={() => create(itemId)}>
+        create item
+      </button>
+      <button
+        className="border border-black"
+        onClick={() => createWithUndefined(itemId)}
+      >
+        create item with undefined
+      </button>
+      <pre className="border border-black overflow-scroll bg-gray-100">
+        {JSON.stringify(data.items, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function reset(items: { id: string }[]) {
+  db.transact(items.map((item) => db.tx.items[item.id].delete()));
+}
+
+function create(itemId: string) {
+  db.transact([tx.items[itemId].update({ title: 'Hello', desc: undefined })]);
+}
+
+function createWithUndefined(itemId: string) {
+  db.transact([tx.items[itemId].update({ title: 'Hello' })]);
+}


### PR DESCRIPTION
Made the following changes to instaml: 

**Updating with `undefined` is a no-op:** 

Previously, writing: 

```js
tx.items[id].update({ foo: 1, bar: undefined })
```

Would generate: 

```js
{ foo: 1, bar: null }
```

Now we no-op undefined: 

```js
{ foo: 1 } 
```

**Undefined is ignored in deepMerge**

Previously `deepMerge` would remove keys that came in as undefined: 

```js
// original
{ a: 1, b: 2 }
// toMerge
{ b: undefined } 
// produced: 
{ a: 1 }
```

Now we ignore undefined. 

--- 

@dwwoelfel @nezaj @tonsky 


