### PR TITLE
[cli] detect packages in devDependencies too

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -700,12 +700,13 @@ async function writeTypescript(path, content, encoding) {
 
 async function getInstantModuleName(pkgJson) {
   const deps = pkgJson.dependencies || {};
+  const devDeps = pkgJson.devDependencies || {};
   const instantModuleName = [
     '@instantdb/react',
     '@instantdb/react-native',
     '@instantdb/core',
     '@instantdb/admin',
-  ].find((name) => deps[name]);
+  ].find((name) => deps[name] || devDeps[name]);
   return instantModuleName;
 }
 


### PR DESCRIPTION
Sometimes folk put the instant module in devDependenices. This could happen if they are writing a script for example. 

Updated it so when detecting an instant module, we check both dependencies and devDependencies

@dwwoelfel @nezaj @tonsky 