### PR TITLE
Remove setting_required for now

### DIFF
--- a/server/resources/migrations/59_is_required.down.sql
+++ b/server/resources/migrations/59_is_required.down.sql
@@ -1,2 +1,1 @@
 alter table attrs drop column is_required;
-alter table attrs drop column setting_required;

--- a/server/resources/migrations/59_is_required.up.sql
+++ b/server/resources/migrations/59_is_required.up.sql
@@ -1,2 +1,1 @@
 alter table attrs add column is_required boolean not null default false;
-alter table attrs add column setting_required boolean;

--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -81,7 +81,6 @@
 (s/def ::indexing? boolean?)
 (s/def ::checking-data-type? boolean?)
 (s/def ::setting-unique? boolean?)
-(s/def ::setting-required? boolean?)
 
 (s/def ::attr-common (s/keys :req-un
                              [::id
@@ -95,8 +94,7 @@
                               ::checked-data-type
                               ::indexing?
                               ::checking-data-type?
-                              ::setting-unique?
-                              ::setting-required?]))
+                              ::setting-unique?]))
 
 (s/def ::blob-attr ::attr-common)
 
@@ -553,8 +551,7 @@
            checked_data_type
            checking_data_type
            indexing
-           setting_unique
-           setting_required]}]
+           setting_unique]}]
   (cond-> {:id id
            :value-type (keyword value_type)
            :cardinality (keyword cardinality)
@@ -573,8 +570,7 @@
     checked_data_type (assoc :checked-data-type (keyword checked_data_type))
     checking_data_type (assoc :checking-data-type? true)
     indexing (assoc :indexing? true)
-    setting_unique (assoc :setting-unique? true)
-    setting_required (assoc :setting-required? true)))
+    setting_unique (assoc :setting-unique? true)))
 
 (defn index-attrs
   "Groups attrs by common lookup patterns so that we can efficiently look them up."

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -168,9 +168,7 @@
                              [:= 'idents/app-id app-id]
                              [:= 'idents/etype 'idents/etype]]
                     'attrs [:= 'idents/id 'attrs/forward-ident]]
-             :where [:or
-                     [:= 'attrs/is_required true]
-                     [:= 'attrs/setting_required true]]
+             :where [:= 'attrs/is_required true]
              :select-distinct ['entity-id ['attrs/id 'attr-id] 'idents/etype 'idents/label]}
 
             missing-required


### PR DESCRIPTION
It might be that we won’t need it at all, so let’s not add it just yet—it’s not required for #1049 anyways