### PR TITLE
skip null check for `$not` with indexed attrs

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -44,7 +44,7 @@
 
         nrepl/nrepl {:mvn/version "0.9.0"}
         jarohen/chime {:mvn/version "0.3.3"}
-        com.github.seancorfield/honeysql {:mvn/version "2.6.1270"}
+        com.github.seancorfield/honeysql {:mvn/version "2.7.1295"}
         org.clojure/spec.alpha {:mvn/version "0.3.218"}
         circleci/circleci.test {:mvn/version "0.5.0"}
         org.clojure/test.check {:mvn/version "1.1.1"}

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -649,7 +649,7 @@
                                                 :checked_data_type
                                                 [:cast [:inline (name data-type)] :checked_data_type]]
                                                [:not= [(extract-value-fn data-type) :t.value] nil]]
-                                              [:not= :t.value [:cast (->json nil) :jsonb]]))}]]
+                                              [[:not= :t.value [:cast (->json nil) :jsonb]]]))}]]
                   :$comparator (let [{:keys [op value data-type]} val]
                                  [[(case op
                                      :$gt :>

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -216,7 +216,9 @@
     (if (seq rest-path) ;; we're in a link
       (recur (link-etype attrs etype segment)
              rest-path)
-      (:index? (attr-model/seek-by-fwd-ident-name [etype segment] attrs)))))
+      (let [attr (attr-model/seek-by-fwd-ident-name [etype segment] attrs)]
+        (and (:index? attr)
+             (not (:indexing? attr)))))))
 
 (defn- coerce-where-cond
   "Splits keys into segments."
@@ -632,7 +634,8 @@
                 [[(level-sym last-etype last-level)
                   (:id id-attr)
                   {:$isNull {:attr-id (:id value-attr)
-                             :indexed-checked-type (when (:index? value-attr)
+                             :indexed-checked-type (when (and (:index? value-attr)
+                                                              (not (:indexing? value-attr)))
                                                      (:checked-data-type value-attr))
                              :nil? (:$isNull v)
                              :ref? (= :ref (:value-type value-attr))

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -135,34 +135,33 @@
   "Converts {:or [{:or [{:k v}]}]} to its simplest form of {:k v}.
    Will collapse both nested `and`s and `or`s."
   [conds]
-  (distinct
-   (reduce (fn [acc c]
-             (cond (:or c)
-                   (let [cs (reduce (fn [acc cs]
-                                      (if-let [ors (:or cs)]
-                                        (apply conj acc ors)
-                                        (conj acc cs)))
-                                    []
-                                    (collapse-coerced-conds (:or c)))]
-                     (if (= 1 (count cs))
-                       (conj acc (first cs))
-                       (conj acc {:or cs})))
+  (reduce (fn [acc c]
+            (cond (:or c)
+                  (let [cs (reduce (fn [acc cs]
+                                     (if-let [ors (:or cs)]
+                                       (apply conj acc ors)
+                                       (conj acc cs)))
+                                   []
+                                   (collapse-coerced-conds (:or c)))]
+                    (if (= 1 (count cs))
+                      (conj acc (first cs))
+                      (conj acc {:or cs})))
 
-                   (:and c)
-                   (let [cs (reduce (fn [acc cs]
-                                      (if-let [ands (:and cs)]
-                                        (apply conj acc ands)
-                                        (conj acc cs)))
-                                    []
-                                    (collapse-coerced-conds (:and c)))]
-                     (if (= 1 (count cs))
-                       (conj acc (first cs))
-                       (conj acc {:and cs})))
+                  (:and c)
+                  (let [cs (reduce (fn [acc cs]
+                                     (if-let [ands (:and cs)]
+                                       (apply conj acc ands)
+                                       (conj acc cs)))
+                                   []
+                                   (collapse-coerced-conds (:and c)))]
+                    (if (= 1 (count cs))
+                      (conj acc (first cs))
+                      (conj acc {:and cs})))
 
-                   :else
-                   (conj acc c)))
-           []
-           conds)))
+                  :else
+                  (conj acc c)))
+          []
+          conds))
 
 (def sentinel (Object.))
 

--- a/server/src/instant/scratch/backtest.clj
+++ b/server/src/instant/scratch/backtest.clj
@@ -24,7 +24,7 @@
 (defn honeycomb-row->input! [[idx row]]
   (let [app-id (ex/get-param! row ["app_id"] uuid-util/coerce)
         query (ex/get-param! row ["forms"] edn/read-string)
-        _ (iq/->forms! query)]
+        _ (iq/->forms! (attr-model/wrap-attrs []) query)]
     {:idx idx
      :app-id app-id
      :query query}))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -1582,12 +1582,8 @@
           {:users {:$ {:where {:and [{:handle {:$not "alex"}}
                                      {:handle {:$not "nicolegf"}}]}}}})
          '({:topics ([:av _ #{:users/handle} {:$not "alex"}]
-                     [:ea _ #{:users/id} _]
-                     [:ea _ #{:users/handle} _]
                      [:av #{"eid-joe-averbukh" "eid-stepan-parunashvili"} #{:users/handle}
                       {:$not "nicolegf"}]
-                     [:ea #{"eid-joe-averbukh" "eid-stepan-parunashvili"} #{:users/id} _]
-                     [:ea _ #{:users/handle} _]
                      --
                      [:ea #{"eid-joe-averbukh"}
                       #{:users/createdAt :users/email :users/id :users/fullName


### PR DESCRIPTION
When we do `$not`, we also have to check that the attr is not undefined since there might be entities that are missing a triple for the attr. But with indexed attrs, we already insert a `null` for every triple so we can skip that step.

This PR skips adding the `$isNull true` where cond when we know we're checking not on an indexed attr.