### PR TITLE
Add pg statistics that help pg choose better indexes

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -101,6 +101,12 @@ psql-dump:
 	echo "Exporting prod db..." && \
 	pg_dump "$${DATABASE_URL}" -f dump.sql
 
+psql-dump-dir:
+	@DATABASE_URL=$$(./scripts/prod_connection_string.sh); \
+	echo "Exporting prod db..." && \
+	pg_dump "$${DATABASE_URL}" -F d -j 8 --compress=zstd:3 -f dump-dir && \
+	echo "Import with \`pg_restore -d LOCAL_DB -j 8 dump-dir\`"
+
 psql-dump-schema:
 	@DATABASE_URL=$$(./scripts/prod_connection_string.sh); \
 	echo "Exporting prod db..." && \

--- a/server/resources/migrations/60_statistics.down.sql
+++ b/server/resources/migrations/60_statistics.down.sql
@@ -1,0 +1,4 @@
+drop statistics triples_attr_value_mcv;
+
+alter table triples alter column attr_id set statistics -1;
+alter table triples alter column value set statistics -1;

--- a/server/resources/migrations/60_statistics.up.sql
+++ b/server/resources/migrations/60_statistics.up.sql
@@ -1,0 +1,6 @@
+create statistics if not exists triples_attr_value_mcv (mcv)
+  on attr_id, checked_data_type, ave, value
+  from triples;
+
+alter table triples alter column attr_id set statistics 2500;
+alter table triples alter column value set statistics 2500;


### PR DESCRIPTION
Adds most common value statistics for attr_id, ave, checked_data_type, and value, which help postgres to choose a better join strategy for nested loops.

https://www.postgresql.org/docs/current/planner-stats.html#PLANNER-STATS-EXTENDED-MCV-LISTS

I chose 2500 as the `set statistics` value because it allows the db to finish analyze in under 30 seconds.