### PR TITLE
[dash] make cmd+click work on tabs

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -66,12 +66,6 @@ export const LogoIcon = ({ size = 'mini' }: { size?: 'mini' | 'normal' }) => {
 
 // controls
 
-export type ToggleItem = {
-  id: string;
-  label: ReactNode;
-  link?: { href: string; target?: '_blank' };
-};
-
 export function ToggleCollection({
   className,
   buttonClassName,
@@ -82,10 +76,10 @@ export function ToggleCollection({
 }: {
   className?: string;
   buttonClassName?: string;
-  items: ToggleItem[];
+  items: TabItem[];
   selectedId?: string;
   disabled?: boolean;
-  onChange: (tab: ToggleItem, e: React.MouseEvent<HTMLButtonElement>) => void;
+  onChange: (tab: TabButton) => void;
 }) {
   return (
     <div className={cn('flex w-full flex-col gap-0.5', className)}>
@@ -109,8 +103,8 @@ export function ToggleCollection({
           <button
             key={a.id}
             disabled={disabled}
-            onClick={(e) => {
-              onChange(a, e);
+            onClick={() => {
+              onChange(a);
             }}
             className={clsx(
               'block cursor-pointer truncate whitespace-nowrap rounded bg-none px-3 py-1 text-left hover:bg-gray-100 disabled:text-gray-400',
@@ -418,11 +412,13 @@ export function Select({
   );
 }
 
-export type TabBarTab = {
+export type TabItem = {
   id: string;
-  label: string;
+  label: ReactNode;
   link?: { href: string; target?: '_blank' };
 };
+
+export type TabButton = Omit<TabItem, 'link'>;
 
 export function TabBar({
   className,
@@ -432,10 +428,10 @@ export function TabBar({
   onSelect,
 }: {
   className?: string;
-  tabs: TabBarTab[];
+  tabs: TabItem[];
   selectedId: string;
   disabled?: boolean;
-  onSelect: (tab: { id: string; label: string }) => void;
+  onSelect: (tab: TabButton) => void;
 }) {
   return (
     <div

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -40,6 +40,7 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import { errorToast, successToast } from '@/lib/toast';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import copy from 'copy-to-clipboard';
+import Link from 'next/link';
 
 // content
 
@@ -65,6 +66,12 @@ export const LogoIcon = ({ size = 'mini' }: { size?: 'mini' | 'normal' }) => {
 
 // controls
 
+export type ToggleItem = {
+  id: string;
+  label: ReactNode;
+  link?: { href: string; target?: '_blank' };
+};
+
 export function ToggleCollection({
   className,
   buttonClassName,
@@ -75,19 +82,18 @@ export function ToggleCollection({
 }: {
   className?: string;
   buttonClassName?: string;
-  items: { id: string; label: ReactNode; link?: string }[];
+  items: ToggleItem[];
   selectedId?: string;
   disabled?: boolean;
-  onChange: (tab: { id: string; label: ReactNode; link?: string }) => void;
+  onChange: (tab: ToggleItem, e: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
   return (
     <div className={cn('flex w-full flex-col gap-0.5', className)}>
       {items.map((a) =>
         a.link ? (
-          <a
+          <Link
             key={a.id}
-            href={a.link}
-            target="_blank"
+            {...a.link}
             rel="noopener noreferer"
             className={clsx(
               'block cursor-pointer truncate whitespace-nowrap rounded bg-none px-3 py-1 text-left hover:bg-gray-100 disabled:text-gray-400',
@@ -98,13 +104,13 @@ export function ToggleCollection({
             )}
           >
             {a.label}
-          </a>
+          </Link>
         ) : (
           <button
             key={a.id}
             disabled={disabled}
-            onClick={() => {
-              onChange(a);
+            onClick={(e) => {
+              onChange(a, e);
             }}
             className={clsx(
               'block cursor-pointer truncate whitespace-nowrap rounded bg-none px-3 py-1 text-left hover:bg-gray-100 disabled:text-gray-400',
@@ -412,7 +418,11 @@ export function Select({
   );
 }
 
-export type TabBarTab = { id: string; label: string; link?: string };
+export type TabBarTab = {
+  id: string;
+  label: string;
+  link?: { href: string; target?: '_blank' };
+};
 
 export function TabBar({
   className,
@@ -436,10 +446,9 @@ export function TabBar({
     >
       {tabs.map((t) =>
         t.link ? (
-          <a
+          <Link
             key={t.id}
-            href={t.link}
-            target="_blank"
+            {...t.link}
             rel="noopener noreferer"
             className={clsx(
               'flex cursor-pointer whitespace-nowrap bg-none px-4 py-0.5 disabled:text-gray-400 rounded hover:bg-gray-100',
@@ -449,7 +458,7 @@ export function TabBar({
             )}
           >
             {t.label}
-          </a>
+          </Link>
         ) : (
           <button
             key={t.id}

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -66,6 +66,14 @@ export const LogoIcon = ({ size = 'mini' }: { size?: 'mini' | 'normal' }) => {
 
 // controls
 
+export type TabItem = {
+  id: string;
+  label: ReactNode;
+  link?: { href: string; target?: '_blank' };
+};
+
+export type TabButton = Omit<TabItem, 'link'>;
+
 export function ToggleCollection({
   className,
   buttonClassName,
@@ -411,14 +419,6 @@ export function Select({
     </select>
   );
 }
-
-export type TabItem = {
-  id: string;
-  label: ReactNode;
-  link?: { href: string; target?: '_blank' };
-};
-
-export type TabButton = Omit<TabItem, 'link'>;
 
 export function TabBar({
   className,

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -298,10 +298,17 @@ function Dashboard() {
         return {
           id: t.id,
           label: t.title,
-          link: app ? `/docs?app=${app.id}` : '/docs',
+          link: {
+            href: app ? `/docs?app=${app.id}` : '/docs',
+            target: '_blank',
+          },
         };
       }
-      return { id: t.id, label: t.title };
+      return {
+        id: t.id,
+        label: t.title,
+        link: { href: `/dash?s=main&app=${appId}&t=${t.id}` },
+      };
     });
   const showAppOnboarding = !apps.length && !dashResponse.data?.invites?.length;
   const showNav = !showAppOnboarding;

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -52,7 +52,7 @@ import {
   Select,
   SubsectionHeading,
   TabBar,
-  TabBarTab,
+  TabItem,
   TextInput,
   ToggleCollection,
   twel,
@@ -60,7 +60,6 @@ import {
 } from '@/components/ui';
 import { AppAuth } from '@/components/dash/AppAuth';
 import Billing from '@/components/dash/Billing';
-import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
 import { QueryInspector } from '@/components/dash/explorer/QueryInspector';
 import { Sandbox } from '@/components/dash/Sandbox';
 import PersonalAccessTokensScreen from '@/components/dash/PersonalAccessTokensScreen';
@@ -291,7 +290,7 @@ function Dashboard() {
   const app = apps?.find((a) => a.id === appId);
 
   // ui
-  const availableTabs: TabBarTab[] = tabs
+  const availableTabs: TabItem[] = tabs
     .filter((t) => isTabAvailable(t, app?.user_app_role))
     .map((t) => {
       if (t.id === 'docs') {
@@ -880,7 +879,7 @@ function Nav({
   nav: (p: { s: string; t?: string; app?: string }, cb?: () => void) => void;
   appId: string;
   tab: TabId;
-  availableTabs: TabBarTab[];
+  availableTabs: TabItem[];
 }) {
   const router = useRouter();
   const currentApp = apps.find((a) => a.id === appId);


### PR DESCRIPTION
A user pointed out that it's a bit annoying you can't cmd + click on our dash menu items. 

I went ahead and upgraded how we use `ToggleCollection` and `TabBar`, so that these are treated as links. 

@nezaj @dwwoelfel @tonsky 

**Note: we _may_ want to do this for our selector, as well as our explorer tabs too. But first, wanted to ship what users actually asked for**

