### PR TITLE
[dev] Make it easier to view sql queries in portal

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -80,7 +80,7 @@
                                }
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}
 
-        djblue/portal {:mvn/version "0.55.1"}
+        djblue/portal {:mvn/version "0.58.5"}
         dev.weavejester/medley {:mvn/version "1.8.1"}
         com.hazelcast/hazelcast {:mvn/version "5.5.0"}}
  :aliases {:dev {:extra-paths ["dev" "test" "dev-resources"]

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -385,6 +385,9 @@
        ([~'tag ~'conn ~'query ~'additional-opts]
         (tracer/with-span! {:name ~span-name
                             :attributes (span-attrs ~'conn ~'query ~'tag ~'additional-opts)}
+          ;; Uncomment to send sql queries sent to portal
+          ;; (tap> (with-meta ~'query
+          ;;         {:portal.viewer/default :tool/sql-query}))
           (try
             (io/tag-io
               (let [postgres-config# (:postgres-config ~'additional-opts)

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -385,7 +385,7 @@
        ([~'tag ~'conn ~'query ~'additional-opts]
         (tracer/with-span! {:name ~span-name
                             :attributes (span-attrs ~'conn ~'query ~'tag ~'additional-opts)}
-          ;; Uncomment to send sql queries sent to portal
+          ;; Uncomment to send sql queries to portal
           ;; (tap> (with-meta ~'query
           ;;         {:portal.viewer/default :tool/sql-query}))
           (try

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -225,6 +225,28 @@
        res#)
     (cons 'do body)))
 
+(defn copy-unsafe-sql-format-query
+  "Formats the [sql, ...params] query as sql and copies it to the clipboard,
+   returning the query as something that portal will display nicely."
+  [query]
+  (with-meta [(copy (unsafe-sql-format-query query))]
+    {:portal.viewer/default :tool/sql-query}))
+
+;; Adds a :tool/sql-query viewer
+(def portal-sql-query-viewer "
+  (require '[portal.ui.api :as p])
+  (require '[portal.ui.inspector :as ins])
+  (require '[portal.ui.viewer.text :as text])
+  (require '[portal.ui.commands :as cmd])
+
+
+  (p/register-viewer!
+   {:name :tool/sql-query
+    :predicate (fn [x] (and (vector? x) (string? (first x))))
+    :component (fn [query]
+                 [:<>
+                  [text/inspect-text (first query)]])})")
+
 (defn start-portal!
   "Lets you inspect data using Portal.
 
@@ -236,7 +258,9 @@
    https://www.youtube.com/watch?v=Tj-iyDo3bq0"
   []
   (def portal (p/open))
-  (add-tap #'p/submit))
+  (add-tap #'p/submit)
+  (p/register! #'copy-unsafe-sql-format-query)
+  (p/eval-str portal-sql-query-viewer))
 
 (comment
   (start-portal!)


### PR DESCRIPTION
Adds a custom viewer for sql queries and a command to copy them to the clipboard in portal.

There's a line in sql.clj you can uncomment to send the queries to portal.

See it in action:

https://github.com/user-attachments/assets/be4d936a-f0c6-4e84-a249-80f267dea366

