### PR TITLE
Small cel refactor

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -264,9 +264,6 @@
   (withCtx [_ new-ctx]
     (AuthCelMap. new-ctx m)))
 
-(defn create-cel-type [^String name]
-  (OpaqueType/create name (ImmutableList/of (TypeParamType/create name))))
-
 (def ^MapType type-obj (MapType/create SimpleType/STRING SimpleType/DYN))
 
 (def ^ListType type-ref-return (ListType/create SimpleType/DYN))
@@ -512,6 +509,9 @@
     (str where-clause)))
 
 ;; custom cel types
+
+(defn create-cel-type [^String name]
+  (OpaqueType/create name (ImmutableList/of (TypeParamType/create name))))
 
 (def datakey-cel-type (create-cel-type "DataKey"))
 (def whereclause-cel-type (create-cel-type "WhereClause"))
@@ -1331,7 +1331,7 @@
              :datalog-query-fn d/query
              :attrs -attrs
              :current-user {"email" "stopa@instantdb.com"}})
-  (let [program (rule->program :view "data.ref('users.handle').exists_one(x, x == 'alex')")
+  (let [program (rule->program :view "data.ref('users.handle').exists_one(x, x == 'alex') && data.name == 'Nonfiction'")
         result
         (eval-program! -ctx {:cel-program program
                              :etype "bookshelves"}
@@ -1340,6 +1340,8 @@
                                :name "Nonfiction"}})]
     result))
 
+;; Helper for dev so that `rules.clj` can clear its cache when this
+;; namespace is reloaded and the deftypes change
 (defonce after-load (atom nil))
 
 (defn set-afterload [f]

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -208,9 +208,6 @@
      (get m k)
      (get m (keyword k)))))
 
-(defprotocol IWithCtx
-  (withCtx [this ctx]))
-
 (definterface IRef
   (ref [path-str]))
 
@@ -238,11 +235,7 @@
 
   IRef
   (ref [_ path-str]
-    (ref-impl ctx m etype path-str))
-
-  IWithCtx
-  (withCtx [_ new-ctx]
-    (DataCelMap. new-ctx etype m)))
+    (ref-impl ctx m etype path-str)))
 
 (deftype AuthCelMap [ctx ^CelMap m]
   java.util.Map
@@ -258,11 +251,7 @@
     (let [path (clojure-string/replace path-str
                                        #"^\$user\."
                                        "")]
-      (ref-impl ctx m "$users" path)))
-
-  IWithCtx
-  (withCtx [_ new-ctx]
-    (AuthCelMap. new-ctx m)))
+      (ref-impl ctx m "$users" path))))
 
 (def ^MapType type-obj (MapType/create SimpleType/STRING SimpleType/DYN))
 

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -240,6 +240,9 @@
   (withCtx [_ new-ctx]
     (AuthCelMap. new-ctx m)))
 
+(defn create-cel-type [^String name]
+  (OpaqueType/create name (ImmutableList/of (TypeParamType/create name))))
+
 (def ^MapType type-obj (MapType/create SimpleType/STRING SimpleType/DYN))
 (def ^CelType datamap-cel-type (create-cel-type "DataMap"))
 (def ^CelType authmap-cel-type (create-cel-type "AuthMap"))
@@ -292,7 +295,7 @@
 ;; Normal evaluation pipeline
 ;; --------------------------
 
-(defn ref-impl [ctx {:strs [id] :as ^CelMap m} ^String etype ^String path-str]
+(defn ref-impl [ctx {:strs [id] :as ^CelMap _m} ^String etype ^String path-str]
   (if (= id NullValue/NULL_VALUE)
     []
     (let [ref-data {:eid (parse-uuid id)
@@ -515,9 +518,6 @@
     (str where-clause)))
 
 ;; custom cel types
-
-(defn create-cel-type [^String name]
-  (OpaqueType/create name (ImmutableList/of (TypeParamType/create name))))
 
 (def datakey-cel-type (create-cel-type "DataKey"))
 (def whereclause-cel-type (create-cel-type "WhereClause"))

--- a/server/src/instant/db/dataloader.clj
+++ b/server/src/instant/db/dataloader.clj
@@ -25,9 +25,13 @@
                  {:requests (conj requests request)
                   :schedule-delay (or schedule-delay
                                       (delay
-                                        (ua/vfuture
-                                         (Thread/sleep (long delay-ms))
-                                         (run-batch! dataloader-opts k))))}))
+                                        ;; store/swap-datalog-cache! has a future
+                                        ;; that will be canceled if all of its "watchers"
+                                        ;; are canceled. Something like that would be a
+                                        ;; nice improvement over severed-vfuture here.
+                                        (ua/severed-vfuture
+                                          (Thread/sleep (long delay-ms))
+                                          (run-batch! dataloader-opts k))))}))
         schedule-delay (get-in v [k :schedule-delay])]
     @schedule-delay))
 

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1976,16 +1976,10 @@
                         ctx (assoc ctx :preloaded-refs preloaded-refs)
                         res  (io/warn-io :instaql/eval-program
                                          (cel/eval-program!
+                                          ctx
                                           program
-                                          {"ruleParams" (cel/->cel-map {} rule-params)
-                                           "auth" (cel/->cel-map {:ctx ctx
-                                                                  :type :auth
-                                                                  :etype "$users"}
-                                                                 current-user)
-                                           "data" (cel/->cel-map {:ctx ctx
-                                                                  :type :data
-                                                                  :etype etype}
-                                                                 em)}))]
+                                          {:rule-params rule-params
+                                           :data em}))]
                     (when-let [rule-where (get rule-wheres etype)]
                       (when (and (not res)
                                  ;; TODO(dww): remove check once we've figured

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -1948,7 +1948,7 @@
                 {}
                 (:data result))))))
 
-(defn get-etype+eid-check-result! [{:keys [current-user rule-wheres] :as ctx}
+(defn get-etype+eid-check-result! [{:keys [rule-wheres] :as ctx}
                                    {:keys [etype->eids+program query-cache]}
                                    rule-params]
   (tracer/with-span! {:name "instaql/get-eid-check-result!"}

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -83,7 +83,7 @@
    tx-steps))
 
 (defn object-upsert-check-fn [{:keys [action program etype eid data] :as _check}
-                              {:keys [current-user rule-params] :as ctx}]
+                              {:keys [rule-params] :as ctx}]
   (let [{:keys [original updated]} data
         rule-params (get rule-params {:eid eid :etype etype})]
     (cond
@@ -106,7 +106,7 @@
 
 (defn object-delete-check-fn
   [{:keys [program etype eid data] :as _check}
-   {:keys [current-user rule-params] :as ctx}]
+   {:keys [rule-params] :as ctx}]
   (let [{:keys [original]} data
         rule-params (get rule-params {:eid eid :etype etype})]
     (if-not program
@@ -117,7 +117,7 @@
                           :rule-params rule-params}))))
 
 (defn object-view-check-fn [{:keys [program etype eid data] :as _check}
-                            {:keys [current-user rule-params] :as ctx}]
+                            {:keys [rule-params] :as ctx}]
   (let [{:keys [original]} data
         rule-params (get rule-params {:eid eid :etype etype})]
     (if-not program
@@ -298,7 +298,7 @@
           {:groups {} :rule-params-to-copy {}}
           tx-steps))
 
-(defn attr-create-check-fn [{:keys [program data]} {:keys [current-user] :as ctx}]
+(defn attr-create-check-fn [{:keys [program data]} ctx]
   (let [{:keys [updated]} data]
     (if program
       (cel/eval-program! ctx

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -91,20 +91,18 @@
       true
 
       (= :create action)
-      (cel/eval-program!
-       program
-       {"auth"       (cel/->cel-map {:ctx ctx, :type :auth, :etype "$users"} current-user)
-        "data"       (cel/->cel-map {:ctx ctx, :type :data, :etype etype} updated)
-        "newData"    (cel/->cel-map {} updated)
-        "ruleParams" (cel/->cel-map {} rule-params)})
+      (cel/eval-program! ctx
+                         program
+                         {:data updated
+                          :new-data updated
+                          :rule-params rule-params})
 
       (= :update action)
-      (cel/eval-program!
-       program
-       {"auth"       (cel/->cel-map {:ctx ctx, :type :auth, :etype "$users"} current-user)
-        "data"       (cel/->cel-map {:ctx ctx, :type :data, :etype etype} original)
-        "newData"    (cel/->cel-map {} updated)
-        "ruleParams" (cel/->cel-map {} rule-params)}))))
+      (cel/eval-program! ctx
+                         program
+                         {:data original
+                          :new-data updated
+                          :rule-params rule-params}))))
 
 (defn object-delete-check-fn
   [{:keys [program etype eid data] :as _check}
@@ -113,11 +111,10 @@
         rule-params (get rule-params {:eid eid :etype etype})]
     (if-not program
       true
-      (cel/eval-program!
-       program
-       {"auth"       (cel/->cel-map {:ctx ctx, :type :auth, :etype "$users"} current-user)
-        "data"       (cel/->cel-map {:ctx ctx, :type :data, :etype etype} original)
-        "ruleParams" (cel/->cel-map {} rule-params)}))))
+      (cel/eval-program! ctx
+                         program
+                         {:data original
+                          :rule-params rule-params}))))
 
 (defn object-view-check-fn [{:keys [program etype eid data] :as _check}
                             {:keys [current-user rule-params] :as ctx}]
@@ -125,11 +122,10 @@
         rule-params (get rule-params {:eid eid :etype etype})]
     (if-not program
       true
-      (cel/eval-program!
-       program
-       {"auth"       (cel/->cel-map {:ctx ctx, :type :auth, :etype "$users"} current-user)
-        "data"       (cel/->cel-map {:ctx ctx, :type :data, :etype etype} original)
-        "ruleParams" (cel/->cel-map {} rule-params)}))))
+      (cel/eval-program! ctx
+                         program
+                         {:data original
+                          :rule-params rule-params}))))
 
 (defn object-checks
   "Creates check commands for each object in the transaction.
@@ -305,15 +301,9 @@
 (defn attr-create-check-fn [{:keys [program data]} {:keys [current-user] :as ctx}]
   (let [{:keys [updated]} data]
     (if program
-      (cel/eval-program!
-       program
-       {"auth" (cel/->cel-map {:type :auth
-                               :ctx ctx
-                               :etype "$users"}
-                              current-user)
-        "data" (cel/->cel-map {:type :data
-                               :ctx ctx}
-                              updated)})
+      (cel/eval-program! ctx
+                         program
+                         {:data updated})
       true)))
 
 (defn check-fn [{:keys [scope action] :as check} ctx]

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -148,6 +148,12 @@
 
 (def program-cache (cache/lru-cache-factory {} :threshold 2048))
 
+;; If you load the cel ns, the deftypes will get wiped out and the
+;; rules in the cache will stop working. This clears the cache when its loaded
+(cel/set-afterload (fn []
+                     (reset! program-cache
+                             @(cache/lru-cache-factory {} :threshold 2048))))
+
 (defn get-program!* [rules etype action]
   (or
    (when-let [expr (get-expr (:code rules) etype action)]

--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -13,7 +13,6 @@
 
 (defn assert-storage-permission! [action {:keys [app-id
                                                  path
-                                                 current-user
                                                  rules-override]
                                           :as ctx}]
   (let [rules (if rules-override

--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -27,15 +27,9 @@
        ;; deny access by default if no permissions are currently set
        false
        ;; otherwise, evaluate the permissions code
-       (cel/eval-program! program
-                          {"auth" (cel/->cel-map {:type :auth
-                                                  :ctx ctx
-                                                  :etype "$users"}
-                                                 current-user)
-                           "data" (cel/->cel-map {:type :data
-                                                  :ctx ctx
-                                                  :etype "$files"}
-                                                 {"path" path})})))))
+       (cel/eval-program! ctx
+                          program
+                          {:data {"path" path}})))))
 
 (defn upload-file!
   "Uploads a file to S3 and tracks it in Instant. Returns a file id"

--- a/server/src/instant/util/async.clj
+++ b/server/src/instant/util/async.clj
@@ -150,6 +150,12 @@
   [& body]
   `(future-call default-virtual-thread-executor nil (^{:once true} fn* [] ~@body)))
 
+(defmacro severed-vfuture
+  "Like vfuture, but won't get canceled if the parent is canceled."
+  [& body]
+  `(binding [*child-vfutures* nil]
+     (future-call default-virtual-thread-executor nil (^{:once true} fn* [] ~@body))))
+
 (defn pmap
   "Like pmap, but uses vfutures to parallelize the work.
 

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -19,30 +19,30 @@
 (deftest test-cel-evaluation
   (testing "Evaluation of CEL expressions with standard macros"
     (let [program (cel/rule->program :view "has({'name': 'Alice'}.name)")]
-      (is (true? (cel/eval-program! {:cel-program program} {}))))
+      (is (true? (cel/eval-program! {} {:cel-program program} {}))))
 
     (let [program (cel/rule->program :delete "[1, 2, 3].all(x, x > 0)")]
-      (is (true? (cel/eval-program! {:cel-program program} {}))))
+      (is (true? (cel/eval-program! {} {:cel-program program} {}))))
 
     (let [program (cel/rule->program :update "[1, 2, 3].exists(x, x > 2)")]
-      (is (true? (cel/eval-program! {:cel-program program} {}))))
+      (is (true? (cel/eval-program! {} {:cel-program program} {}))))
 
     (let [program (cel/rule->program :create "[1, 2, 3].exists_one(x, x > 2)")]
-      (is (true? (cel/eval-program! {:cel-program program} {}))))
+      (is (true? (cel/eval-program! {} {:cel-program program} {}))))
 
     (let [program (cel/rule->program :view "[1, 2, 3].map(x, x * 2)")]
-      (is (= [2 4 6] (cel/eval-program! {:cel-program program} {}))))
+      (is (= [2 4 6] (cel/eval-program! {} {:cel-program program} {}))))
 
     (let [program (cel/rule->program :view "[1, 2, 3, 4].filter(x, x % 2 == 0)")]
-      (is (= [2 4] (cel/eval-program! {:cel-program program} {}))))))
+      (is (= [2 4] (cel/eval-program! {} {:cel-program program} {}))))))
 
 (deftest parse-false-correctly
   (let [program (cel/rule->program :view "data.isFavorite")
         bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
-    (is (false? (cel/eval-program! {:cel-program program} bindings))))
+    (is (false? (cel/eval-program! {} {:cel-program program} bindings))))
   (let [program (cel/rule->program :view "!data.isFavorite")
         bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
-    (is (true? (cel/eval-program! {:cel-program program} bindings)))))
+    (is (true? (cel/eval-program! {} {:cel-program program} bindings)))))
 
 (deftest view-delete-does-not-allow-newData
   (is
@@ -64,7 +64,7 @@
     (is (thrown-with-msg?
          Throwable
          #"Could not evaluate permission rule"
-         (cel/eval-program! {:cel-program program} bindings)))))
+         (cel/eval-program! {} {:cel-program program} bindings)))))
 
 (defn dummy-attrs [specs]
   (attr-model/wrap-attrs (mapv (fn [{:keys [etype

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -57,8 +57,8 @@
     (cel/rule->program :delete "newData.isFavorite"))))
 
 (deftest unknown-results-throw
-  (let [program (cel/rule->program :view "data.isFavorite")
-        bindings {} ;; note! data is not provided. This will cause CEL to return
+  (let [program (cel/rule->program :write "newData.isFavorite")
+        bindings {} ;; note! new-data is not provided. This will cause CEL to return
                     ;; a CelUnknownSet
         ]
     (is (thrown-with-msg?

--- a/server/test/instant/db/cel_test.clj
+++ b/server/test/instant/db/cel_test.clj
@@ -38,10 +38,10 @@
 
 (deftest parse-false-correctly
   (let [program (cel/rule->program :view "data.isFavorite")
-        bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
+        bindings {:data {"isFavorite" false}}]
     (is (false? (cel/eval-program! {} {:cel-program program} bindings))))
   (let [program (cel/rule->program :view "!data.isFavorite")
-        bindings {"data" (cel/->cel-map {} {"isFavorite" false})}]
+        bindings {:data {"isFavorite" false}}]
     (is (true? (cel/eval-program! {} {:cel-program program} bindings)))))
 
 (deftest view-delete-does-not-allow-newData


### PR DESCRIPTION
Refactors the cel code a bit in preparation for changing how we do prefetching.

Main changes:

1.  We no longer expect callers to construct `CelMap`s. Now that is all internal to `cel.clj`.

    **Before**

    ```clojure
    (cel/eval-program!
      program
      {"auth"       (cel/->cel-map {:ctx ctx, :type :auth, :etype "$users"} current-user)
       "data"       (cel/->cel-map {:ctx ctx, :type :data, :etype etype} updated)
       "newData"    (cel/->cel-map {} updated)
       "ruleParams" (cel/->cel-map {} rule-params)})
    ```
    **After**

    ```clojure
    (cel/eval-program!
      ctx
      program
      ;; Don't have to provide auth, cel.clj will pull it from `ctx` for you
      {:data updated
       :new-data updated
       :rule-params rule-params})
    ```


2.  Introduces a new `severed-vfuture` to fix a bug in dataloader where the dataload might get canceled if a parent `vfuture` is canceled.


### A note about upcoming prefetching change

Right now our prefetching works like this: We walk the cel ast and find any `data.ref` and `auth.ref` calls, collecting the `path-str` from each call. Before running the rules, we fetch all of the `ref` calls in a single big query. Then the `ref` function looks up the prefetched data when the rule executes.

I want to change the prefetching to use cel's unknown tracking feature. The new strategy works like this: First we run the rules for all of the entities with unknown tracking enabled and return `unknown` from any `data.ref` or `auth.ref` calls. Then we fetch all of the data in one big query. Then we run the rules through another pass and this time the ref function will find the data we fetched. Usually it will just take one pass, but if not we'll keep making passes until all of the data is resolved.

The new approach has a couple of benefits:

1. We will fetch less data that we don't need. If you have a rule that would short-circuit before getting to a `data.ref`, right now we'll still fetch that data even though we won't use it. If you had `true || data.ref('owner.id') == []`, then with the unknown tracking enabled, cel will just return true and we won't have to fetch anything. 
1. It works better with the rule-wheres
  i. We won't have to special-case the prefetching to just fetch auth data--we can use the same functions to prefetch for both paths
  ii. It makes it easier to re-use the prefetched data if we still need to run the rules on the entities we get back
