### PR TITLE
Refactor indexing_jobs

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -133,4 +133,4 @@ encrypt-secret-prod:
 	clj -X:encrypt-secret :env :prod
 
 lint:
-	clojure -M:lint
+	if command -v clj-kondo >/dev/null 2>&1; then clj-kondo --lint src test; else clojure -M:lint; fi

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -152,6 +152,6 @@
            :oss-bootstrap {:extra-deps {org.clojure/tools.cli {:mvn/version "1.1.230"}}
                            :exec-fn tasks/bootstrap-for-oss
                            :jvm-opts ["-Dclojure.main.report=stderr"]}
-           :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2025.01.16"}}
-           :main-opts ["-m" "clj-kondo.main" "--lint" "src" "test"]}}
+           :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2025.04.07"}}
+                  :main-opts ["-m" "clj-kondo.main" "--lint" "src" "test"]}}
  :main-opts ["-m" "instant.core"]}

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1053,38 +1053,19 @@
                                 :attrs
                                 {:attr-id attr-id})
 
-        job (ex/assert-record! (case job-type
-                                 "check-data-type"
-                                 (indexing-jobs/create-check-data-type-job!
-                                  {:app-id app-id
-                                   :attr-id (:id attr)
-                                   :checked-data-type
-                                   (ex/get-param! req
-                                                  [:body :checked-data-type]
-                                                  string-util/coerce-non-blank-str)})
-
-                                 "remove-data-type"
-                                 (indexing-jobs/create-remove-data-type-job!
-                                  {:app-id app-id :attr-id (:id attr)})
-
-                                 "index"
-                                 (indexing-jobs/create-index-job!
-                                  {:app-id app-id :attr-id (:id attr)})
-
-                                 "remove-index"
-                                 (indexing-jobs/create-remove-index-job!
-                                  {:app-id app-id :attr-id (:id attr)})
-
-                                 "unique"
-                                 (indexing-jobs/create-unique-job!
-                                  {:app-id app-id :attr-id (:id attr)})
-
-                                 "remove-unique"
-                                 (indexing-jobs/create-remove-unique-job!
-                                  {:app-id app-id :attr-id (:id attr)}))
-                               :indexing-job
-                               {:attr-id attr-id
-                                :job-type job-type})]
+        job (ex/assert-record!
+             (indexing-jobs/create-job!
+              (cond-> {:app-id app-id
+                       :attr-id (:id attr)
+                       :job-type job-type}
+                (= "check-data-type" job-type)
+                (assoc :checked-data-type
+                       (ex/get-param! req
+                                      [:body :checked-data-type]
+                                      string-util/coerce-non-blank-str))))
+             :indexing-job
+             {:attr-id attr-id
+              :job-type job-type})]
     (indexing-jobs/enqueue-job job)
     (response/ok {:job (indexing-jobs/job->client-format job)})))
 

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -18,69 +18,21 @@
    [instant.jdbc.sql :as sql]
    [next.jdbc :as next-jdbc])
   (:import
+   (clojure.lang ExceptionInfo)
    (java.lang AutoCloseable)
    (java.sql Timestamp)
    (java.time Duration Instant)
    (java.time.temporal ChronoUnit)))
 
-(declare job-queue)
-
-(def job-types #{"check-data-type"
-                 "remove-data-type"
-                 "index"
-                 "remove-index"
-                 "unique"
-                 "remove-unique"})
-
-;; This is the key we use for checking to ensure we don't set the type
-;; to two values simultaneously
-(def check-serial-key "check")
-;; This is the key we use for checking to ensure we don't start multiple indexing
-;; jobs for the same attr
-(def index-serial-key "index")
-(def unique-serial-key "unique")
-
-(def check-data-type-stages ["validate" ;; make sure this will work
-                             "update-attr-start" ;; update attr to prevent adding invalid data
-                             "revalidate" ;; recheck that no invalid data was added
-                             "estimate-work"
-                             "update-triples" ;; add checked-data-type to triples
-                             "update-attr-done" ;; update attr to mark checking finished
-                             ])
-
-(def remove-data-type-stages ["update-attr-start" ;; update attr to prevent adding invalid data
-                              "estimate-work"
-                              "update-triples" ;; remove checked-data-type from triples
-                              "update-attr-done" ;; update attr to mark checking finished
-                              ])
-
-(def index-stages ["update-attr-start"
-                   "estimate-work"
-                   "update-triples"
-                   "insert-nulls"
-                   "update-attr-done"])
-
-(def remove-index-stages ["update-attr-start"
-                          "estimate-work"
-                          "update-triples"
-                          "update-attr-done"])
-
-(def unique-stages ["update-attr-start"
-                    "estimate-work"
-                    "update-triples"
-                    "update-attr-done"])
-
-(def remove-unique-stages ["update-attr-start"
-                           "estimate-work"
-                           "update-triples"
-                           "update-attr-done"])
-
+(declare job-queue jobs)
 
 (def invalid-triple-error "invalid-triple-error")
 (def triple-too-large-error "triple-too-large-error")
 (def triple-not-unique-error "triple-not-unique-error")
 (def invalid-attr-state-error "invalid-attr-state-error")
 (def unexpected-error "unexpected-error")
+
+(def batch-size 1000)
 
 (defn ms-since [^Timestamp t ^Instant now]
   (.between ChronoUnit/MILLIS (.toInstant t) now))
@@ -214,111 +166,41 @@
 (defn create-job!
   ([params]
    (create-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
+  ([conn args]
+   (let [{:keys [app-id
                  group-id
                  attr-id
-                 job-serial-key
                  job-type
                  job-dependency
-                 job-stage
-                 checked-data-type]}]
-   (assert app-id)
-   (assert attr-id)
-   (when (= job-type "check-data-type")
-     (assert checked-data-type "checked-data-type must be provided if job type is check-data-type"))
-   (sql/execute-one! ::create-job!
-                     conn (hsql/format {:insert-into :indexing-jobs
-                                        :values [{:id (random-uuid)
-                                                  :group-id group-id
-                                                  :app-id app-id
-                                                  :attr-id attr-id
-                                                  :job-serial-key job-serial-key
-                                                  :job-type job-type
-                                                  :checked-data-type [:cast checked-data-type :checked_data_type]
-                                                  :job-dependency job-dependency
-                                                  :job-stage job-stage
-                                                  :job-status "waiting"}]}))))
+                 checked-data-type]} args
+         {:keys [serial-key stages]} (get jobs job-type)
+         stage  (-> stages first :stage)]
+     (assert app-id)
+     (assert attr-id)
 
-(defn create-check-data-type-job!
-  ([params]
-   (create-check-data-type-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
-                 group-id
-                 attr-id
-                 checked-data-type]}]
-   (assert checked-data-type "checked-data-type must be provided if job type is check-data-type")
-   (create-job! conn {:app-id app-id
-                      :group-id group-id
-                      :attr-id attr-id
-                      :job-serial-key check-serial-key
-                      :job-type "check-data-type"
-                      :checked-data-type checked-data-type
-                      :job-stage "validate"})))
+     (when-not (contains? jobs job-type)
+       (ex/throw+ {::ex/type ::ex/param-malformed
+                   ::ex/mesasge (str "Unexpected job type: " job-type)
+                   ::ex/hint args}))
 
-(defn create-remove-data-type-job!
-  ([params]
-   (create-remove-data-type-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
-                 group-id
-                 attr-id]}]
-   (create-job! conn {:app-id app-id
-                      :group-id group-id
-                      :attr-id attr-id
-                      :job-serial-key check-serial-key
-                      :job-type "remove-data-type"
-                      :job-stage "update-attr-start"})))
+     (when (and (= "check-data-type" job-type)
+                (nil? checked-data-type))
+       (ex/throw+ {::ex/type ::ex/param-missing
+                   ::ex/message "checked-data-type must be provided if job type is check-data-type"}))
 
-(defn create-index-job!
-  ([params]
-   (create-index-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
-                 group-id
-                 attr-id]}]
-   (create-job! conn {:app-id app-id
-                      :group-id group-id
-                      :attr-id attr-id
-                      :job-serial-key index-serial-key
-                      :job-type "index"
-                      :job-stage "update-attr-start"})))
-
-(defn create-remove-index-job!
-  ([params]
-   (create-remove-index-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
-                 group-id
-                 attr-id]}]
-   (create-job! conn {:app-id app-id
-                      :group-id group-id
-                      :attr-id attr-id
-                      :job-serial-key index-serial-key
-                      :job-type "remove-index"
-                      :job-stage "update-attr-start"})))
-
-(defn create-unique-job!
-  ([params]
-   (create-unique-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
-                 group-id
-                 attr-id]}]
-   (create-job! conn {:app-id app-id
-                      :group-id group-id
-                      :attr-id attr-id
-                      :job-serial-key unique-serial-key
-                      :job-type "unique"
-                      :job-stage "update-attr-start"})))
-
-(defn create-remove-unique-job!
-  ([params]
-   (create-remove-unique-job! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id
-                 group-id
-                 attr-id]}]
-   (create-job! conn {:app-id app-id
-                      :group-id group-id
-                      :attr-id attr-id
-                      :job-serial-key unique-serial-key
-                      :job-type "remove-unique"
-                      :job-stage "update-attr-start"})))
+     (sql/execute-one! ::create-job!
+                       conn (hsql/format {:insert-into :indexing-jobs
+                                          :values [(cond-> {:id             (random-uuid)
+                                                            :group-id       group-id
+                                                            :app-id         app-id
+                                                            :attr-id        attr-id
+                                                            :job-serial-key serial-key
+                                                            :job-type       job-type
+                                                            :job-dependency job-dependency
+                                                            :job-stage      stage
+                                                            :job-status     "waiting"}
+                                                     (= "check-data-type" job-type)
+                                                     (assoc :checked-data-type [:cast checked-data-type :checked_data_type]))]})))))
 
 (defn job-available-wheres
   "Where clauses that select jobs that are available for taking."
@@ -326,7 +208,7 @@
   (list* :and
          [:= :worker-id nil]
          ;; Ensure we don't grab a job we can't handle
-         [:in :job-type job-types]
+         [:in :job-type (keys jobs)]
          [:or
           [:= :job-dependency nil]
           [:= "completed" {:select :job-status
@@ -386,43 +268,37 @@
                                [:= :attr-triples.attr-id attr_id]
                                [:= :attr-triples.entity-id :triples.entity-id]]}]]])))
 
-(defn update-work-estimate!
-  ([job next-stage]
-   (update-work-estimate! (aurora/conn-pool :write) next-stage job))
-  ([conn next-stage job]
-   (let [default-where [:and
-                        [:= :app-id (:app_id job)]
-                        [:= :attr-id (:attr_id job)]]
-         estimate (-> (sql/select-one
-                       ::get-work-estimate!
-                       conn
-                       (hsql/format {:select :%count.*
-                                     :from :triples
-                                     :where (if (= "index" (:job_type job))
-                                              [:or
-                                               default-where
-                                               (missing-null-triple-wheres conn :estimate job)]
-                                              default-where)}))
-                      :count)]
-     (sql/execute-one! ::estimate-work-estimate!
-                       conn (hsql/format {:update :indexing-jobs
-                                          :where (job-update-wheres
-                                                  [:= :id (:id job)])
-                                          :set {:work-estimate estimate
-                                                :job-stage next-stage}})))))
+(defn update-work-estimate! [conn job]
+  (let [default-where [:and
+                       [:= :app-id (:app_id job)]
+                       [:= :attr-id (:attr_id job)]]
+        estimate (-> (sql/select-one
+                      ::get-work-estimate!
+                      conn
+                      (hsql/format {:select :%count.*
+                                    :from :triples
+                                    :where (if (= "index" (:job_type job))
+                                             [:or
+                                              default-where
+                                              (missing-null-triple-wheres conn :estimate job)]
+                                             default-where)}))
+                     :count)]
+    (sql/execute-one! ::estimate-work-estimate!
+                      conn (hsql/format {:update :indexing-jobs
+                                         :where (job-update-wheres
+                                                 [:= :id (:id job)])
+                                         :set {:work-estimate estimate}}))))
 
-(defn add-work-completed!
-  ([completed-count job]
-   (add-work-completed! (aurora/conn-pool :write) completed-count job))
-  ([conn completed-count job]
-   (sql/execute-one! ::add-work-completed!
-                     conn (hsql/format {:update :indexing-jobs
-                                        :where (job-update-wheres
-                                                [:= :id (:id job)])
-                                        :set {:work-completed
-                                              [:+
-                                               [:coalesce :work-completed 0]
-                                               completed-count]}}))))
+(defn add-work-completed! [conn completed-count job]
+  (when (pos? completed-count)
+    (sql/execute-one! ::add-work-completed!
+                      conn (hsql/format {:update :indexing-jobs
+                                         :where (job-update-wheres
+                                                 [:= :id (:id job)])
+                                         :set {:work-completed
+                                               [:+
+                                                [:coalesce :work-completed 0]
+                                                completed-count]}}))))
 
 (defn release-job!
   ([job] (release-job! (aurora/conn-pool :write) job))
@@ -472,9 +348,9 @@
                                                       props)})))))
 
 (defn mark-error-from-ex-info!
-  ([^clojure.lang.ExceptionInfo e job]
+  ([^ExceptionInfo e job]
    (mark-error-from-ex-info! (aurora/conn-pool :write) e job))
-  ([conn ^clojure.lang.ExceptionInfo e job]
+  ([conn ^ExceptionInfo e job]
    (let [error-data (ex-data e)
          validation-error (some-> error-data
                                   ::ex/hint
@@ -507,65 +383,6 @@
                             {:error unexpected-error})]
      (mark-error! conn job-error-fields job))))
 
-(def batch-size 1000)
-
-(defn check-next-batch!
-  ([job]
-   (check-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [app_id attr_id job_type checked_data_type]}]
-   (assert (= "check-data-type" job_type))
-   (assert checked_data_type)
-   (let [q {:update :triples
-            :set {:checked-data-type [:cast checked_data_type :checked_data_type]}
-            :where [:in :ctid
-                    {:select :ctid
-                     :for :update
-                     :from :triples
-                     :limit batch-size
-                     :where [:and
-                             [:= :app-id app_id]
-                             [:= :attr-id attr_id]
-                             [:or
-                              [:not=
-                               :checked-data-type
-                               [:cast checked_data_type :checked_data_type]]
-                              [:= :checked-data-type nil]]]}]}
-         res (sql/do-execute! ::check-next-batch! conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
-
-(defn check-batch-and-update-job!
-  ([job]
-   (check-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "check-batch" job)
-     (let [update-count (check-next-batch! conn job)]
-       (tracer/add-data! {:attributes {:update-count update-count}})
-       (cond->> job
-         (not (zero? update-count)) (add-work-completed! conn update-count)
-         (< update-count batch-size) (set-next-stage! conn "update-attr-done"))))))
-
-(defn has-invalid-row?
-  ([job]
-   (has-invalid-row? (aurora/conn-pool :read) job))
-  ([conn {:keys [app_id attr_id checked_data_type]}]
-   (->> (hsql/format
-         {:select [[[:exists {:select :*
-                              :from :triples
-                              :limit 1
-                              :where [:and
-                                      [:= :app-id app_id]
-                                      [:= :attr-id attr_id]
-                                      [:or
-                                       [:not=
-                                        :checked-data-type
-                                        [:cast checked_data_type :checked_data_type]]
-                                       [:= :checked-data-type nil]]
-                                      [:not [:triples_valid_value
-                                             [:cast checked_data_type :checked_data_type]
-                                             :value]]]}]]]})
-        (sql/select-one ::has-invalid-row? conn)
-        :exists)))
-
 (defn update-attr! [conn {:keys [app-id attr-id set where]}]
   (attr-model/with-cache-invalidation app-id
     (next-jdbc/with-transaction [conn conn]
@@ -580,215 +397,141 @@
                                  where)
                    :set set}))]
         (transaction-model/create! conn {:app-id app-id})
-        res))))
-
-(defn update-attr-for-check-start!
-  ([job]
-   (update-attr-for-check-start! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :set {:checked-data-type [:cast (:checked_data_type job) :checked_data_type]
-                                 :checking-data-type true}})
-     (set-next-stage! conn "revalidate" job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
-
-(defn update-attr-for-check-done!
-  ([job]
-   (update-attr-for-check-done! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :where [[:= :checked-data-type [:cast (:checked_data_type job) :checked_data_type]]
-                                   [:= :checking-data-type true]]
-                           :set {:checking-data-type false}})
-     (mark-job-completed! conn job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
-
-(defn rollback-attr-for-check!
-  ([job]
-   (rollback-attr-for-check! (aurora/conn-pool :write) job))
-  ([conn job]
-   (update-attr! conn {:app-id (:app_id job)
-                       :attr-id (:attr_id job)
-                       :where [[:= :checked-data-type [:cast (:checked_data_type job) :checked_data_type]]
-                               [:= :checking-data-type true]]
-                       :set {:checking-data-type false
-                             :checked-data-type nil}})))
-
-(defn validate-check!
-  ([next-stage job]
-   (validate-check! (aurora/conn-pool :write) next-stage job))
-  ([conn next-stage job]
-   (if (has-invalid-row? conn job)
-     (do
-       (rollback-attr-for-check! conn job)
-       (mark-error! conn {:error invalid-triple-error} job))
-     (set-next-stage! conn next-stage job))))
-
-(defn run-next-check-step
-  ([job]
-   (run-next-check-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (case (:job_stage job)
-     ;; make sure this will work
-     "validate" (validate-check! conn "update-attr-start" job)
-     ;; update attr to prevent adding invalid data
-     "update-attr-start" (update-attr-for-check-start! conn job)
-     ;; recheck that no invalid data was added
-     "revalidate" (validate-check! conn "estimate-work" job)
-     "estimate-work" (update-work-estimate! conn "update-triples" job)
-     ;; set checked_data_type on triples
-     "update-triples" (check-batch-and-update-job! conn job)
-     ;; set attr checking? to false and mark job complete
-     "update-attr-done" (update-attr-for-check-done! conn job))))
-
-(defn update-attr-for-remove-data-type-start!
-  ([job]
-   (update-attr-for-remove-data-type-start! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :set {:checked-data-type nil
-                                 :checking-data-type true}})
-     (set-next-stage! conn "estimate-work" job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
-
-(defn update-attr-for-remove-data-type-done!
-  ([job]
-   (update-attr-for-remove-data-type-done! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :where [[:= :checked-data-type nil]
-                                   [:= :checking-data-type true]]
-                           :set {:checking-data-type false}})
-     (mark-job-completed! conn job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
-
-(defn remove-data-type-next-batch!
-  ([job]
-   (remove-data-type-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [app_id attr_id job_type checked_data_type]}]
-   (assert (= "remove-data-type" job_type))
-   (assert (nil? checked_data_type))
-   (let [q {:update :triples
-            :set {:checked-data-type nil}
-            :where [:in :ctid
-                    {:select :ctid
-                     :for :update
-                     :from :triples
-                     :limit batch-size
-                     :where [:and
-                             [:= :app-id app_id]
-                             [:= :attr-id attr_id]
-                             [:not= nil :checked-data-type]]}]}
-         res (sql/do-execute! ::remove-data-type-next-batch!
-                              conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
-
-(defn remove-data-type-batch-and-update-job!
-  ([job]
-   (check-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "remove-data-type-batch" job)
-     (let [update-count (remove-data-type-next-batch! conn job)]
-       (tracer/add-data! {:attributes {:update-count update-count}})
-       (cond->> job
-         (not (zero? update-count)) (add-work-completed! conn update-count)
-         (< update-count batch-size) (set-next-stage! conn "update-attr-done"))))))
+        (when-not res
+          [::error invalid-attr-state-error])))))
 
 
-(defn run-next-remove-data-type-step
-  ([job]
-   (run-next-remove-data-type-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (case (:job_stage job)
-     "update-attr-start" (update-attr-for-remove-data-type-start! conn job)
-     "estimate-work" (update-work-estimate! conn "update-triples" job)
-     "update-triples" (remove-data-type-batch-and-update-job! conn job)
-     "update-attr-done" (update-attr-for-remove-data-type-done! conn job))))
+;; "check-data-type" ----------------------------------------------------------
 
-(defn update-attr-for-index-start!
-  ([job]
-   (update-attr-for-index-start! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :set {:is-indexed true
-                                 :indexing true}})
-     (set-next-stage! conn "estimate-work" job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+(defn check-data-type--validate [conn job]
+  (let [{:keys [app_id attr_id checked_data_type]} job
+        has-invalid-row? (->> (hsql/format
+                               {:select [[[:exists {:select :*
+                                                    :from :triples
+                                                    :limit 1
+                                                    :where [:and
+                                                            [:= :app-id app_id]
+                                                            [:= :attr-id attr_id]
+                                                            [:or
+                                                             [:not=
+                                                              :checked-data-type
+                                                              [:cast checked_data_type :checked_data_type]]
+                                                             [:= :checked-data-type nil]]
+                                                            [:not [:triples_valid_value
+                                                                   [:cast checked_data_type :checked_data_type]
+                                                                   :value]]]}]]]})
+                              (sql/select-one ::has-invalid-row? conn)
+                              :exists)]
+    (when has-invalid-row?
+      (update-attr! conn {:app-id (:app_id job)
+                          :attr-id (:attr_id job)
+                          :where [[:= :checked-data-type [:cast (:checked_data_type job) :checked_data_type]]
+                                  [:= :checking-data-type true]]
+                          :set {:checking-data-type false
+                                :checked-data-type nil}})
+      [::error invalid-triple-error])))
 
-(defn update-attr-for-index-done!
-  ([job]
-   (update-attr-for-index-done! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :where [[:= :is-indexed true]
-                                   [:= :indexing true]]
-                           :set {:indexing false}})
-     (mark-job-completed! conn job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+(defn check-data-type--update-attr-start [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :set {:checked-data-type [:cast (:checked_data_type job) :checked_data_type]
+                            :checking-data-type true}}))
 
-(defn index-next-batch!
-  ([job]
-   (index-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [app_id attr_id job_type]}]
-   (assert (= "index" job_type))
-   (let [q {:update :triples
-            :set {:ave true}
-            :where [:in :ctid
-                    {:select :ctid
-                     :for :update
-                     :from :triples
-                     :limit batch-size
-                     :where [:and
-                             [:= :app-id app_id]
-                             [:= :attr-id attr_id]
-                             [:not :ave]]}]}
-         res (sql/do-execute! ::index-next-batch! conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
+(defn check-data-type--update-triples [conn job]
+  (tracer/with-span! (job-span-attrs "check-batch" job)
+    (let [{:keys [app_id attr_id checked_data_type]} job
+          _ (assert checked_data_type)
+          q {:update :triples
+             :set {:checked-data-type [:cast checked_data_type :checked_data_type]}
+             :where [:in :ctid
+                     {:select :ctid
+                      :for :update
+                      :from :triples
+                      :limit batch-size
+                      :where [:and
+                              [:= :app-id app_id]
+                              [:= :attr-id attr_id]
+                              [:or
+                               [:not=
+                                :checked-data-type
+                                [:cast checked_data_type :checked_data_type]]
+                               [:= :checked-data-type nil]]]}]}
+          res (sql/do-execute! ::check-next-batch! conn (hsql/format q))
+          update-count (:next.jdbc/update-count (first res))]
+      (tracer/add-data! {:attributes {:update-count update-count}})
+      (add-work-completed! conn update-count job)
+      (when (<= batch-size update-count)
+        [::repeat]))))
 
-(defn insert-nulls-next-batch!
-  "Inserts nulls for indexed blob attrs so that we can efficiently scan the
-   index with pagination queries."
-  ([job]
-   (insert-nulls-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [attr_id job_type] :as job}]
-   (assert (= "index" job_type))
-   (let [q {:insert-into [[:triples triple-model/triple-cols]
-                          {:select [[:app_id :app_id]
-                                    [:entity_id :entity_id]
-                                    [attr_id :attr_id]
-                                    [[:cast "null" :jsonb] :value]
-                                    [[:inline json-null-md5] :value_md5]
-                                    [[:= :cardinality [:inline "one"]] :ea]
-                                    [[:= :value_type [:inline "ref"]] :eav]
-                                    [:is_unique :av]
-                                    [:is_indexed :ave]
-                                    [[:= :value_type [:inline "ref"]] :vae]
-                                    :checked_data_type]
-                           :from {:select [:triples.app_id
-                                           :triples.entity_id
-                                           :attrs.cardinality
-                                           :attrs.value_type
-                                           :attrs.is_unique
-                                           :attrs.is_indexed
-                                           :attrs.checked_data_type]
-                                  :from :triples
-                                  ;; The `for update` should prevent a concurrent
-                                  ;; query from deleting the entity while we're
-                                  ;; doing our insert
-                                  :for :update
-                                  :join [:attrs [:and
-                                                 [:= :triples.app_id :attrs.app_id]
-                                                 [:= :attrs.id attr_id]]]
-                                  :where (missing-null-triple-wheres conn :update job)
-                                  :limit batch-size}}]}
-         res (sql/do-execute! ::insert-nulls-next-batch! conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
+(defn check-data-type--update-attr-done [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :checked-data-type [:cast (:checked_data_type job) :checked_data_type]]
+                              [:= :checking-data-type true]]
+                      :set {:checking-data-type false}}))
+
+(def check-data-type--stages
+  [{:stage "validate",          :fn #'check-data-type--validate}
+   {:stage "update-attr-start", :fn #'check-data-type--update-attr-start}
+   {:stage "revalidate",        :fn #'check-data-type--validate}
+   {:stage "estimate-work",     :fn #'update-work-estimate!}
+   {:stage "update-triples",    :fn #'check-data-type--update-triples}
+   {:stage "update-attr-done",  :fn #'check-data-type--update-attr-done}])
+
+
+;; "remove-data-type" ---------------------------------------------------------
+
+(defn remove-data-type--update-attr-start [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :set {:checked-data-type nil
+                            :checking-data-type true}}))
+
+(defn remove-data-type--update-triples [conn job]
+  (tracer/with-span! (job-span-attrs "remove-data-type-batch" job)
+    (let [{:keys [app_id attr_id checked_data_type]} job
+          _ (assert (nil? checked_data_type))
+          q {:update :triples
+             :set {:checked-data-type nil}
+             :where [:in :ctid
+                     {:select :ctid
+                      :for :update
+                      :from :triples
+                      :limit batch-size
+                      :where [:and
+                              [:= :app-id app_id]
+                              [:= :attr-id attr_id]
+                              [:not= nil :checked-data-type]]}]}
+          res (sql/do-execute! ::remove-data-type-next-batch!
+                               conn (hsql/format q))
+
+          update-count (:next.jdbc/update-count (first res))]
+      (tracer/add-data! {:attributes {:update-count update-count}})
+      (add-work-completed! conn update-count job)
+      (when (<= batch-size update-count)
+        [::repeat]))))
+
+(defn remove-data-type--update-attr-done [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :checked-data-type nil]
+                              [:= :checking-data-type true]]
+                      :set {:checking-data-type false}}))
+
+(def remove-data-type--stages
+  [{:stage "update-attr-start", :fn #'remove-data-type--update-attr-start}
+   {:stage "estimate-work",     :fn #'update-work-estimate!}
+   {:stage "update-triples",    :fn #'remove-data-type--update-triples}
+   {:stage "update-attr-done",  :fn #'remove-data-type--update-attr-done}])
+
+
+;; "index" --------------------------------------------------------------------
+
+(defn index--update-attr-start [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :set {:is-indexed true
+                            :indexing true}}))
 
 (defn abort-index! [conn job]
   (update-attr! conn {:app-id (:app_id job)
@@ -808,274 +551,276 @@
                                          [:= :attr-id (:attr_id job)]
                                          :ave]})))
 
-(defn index-batch-and-update-job!
-  ([job]
-   (index-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "index" job)
-     (try
-       (let [update-count (index-next-batch! conn job)]
-         (tracer/add-data! {:attributes {:update-count update-count}})
-         (cond->> job
-           (not (zero? update-count)) (add-work-completed! conn update-count)
-           (zero? update-count) (set-next-stage! conn "insert-nulls")))
-       (catch clojure.lang.ExceptionInfo e
-         (abort-index! conn job)
-         (mark-error-from-ex-info! conn e job))))))
+(defn index--update-triples [conn job]
+  (tracer/with-span! (job-span-attrs "index" job)
+    (try
+      (let [{:keys [app_id attr_id]} job
+            q {:update :triples
+               :set {:ave true}
+               :where [:in :ctid
+                       {:select :ctid
+                        :for :update
+                        :from :triples
+                        :limit batch-size
+                        :where [:and
+                                [:= :app-id app_id]
+                                [:= :attr-id attr_id]
+                                [:not :ave]]}]}
+            res (sql/do-execute! ::index-next-batch! conn (hsql/format q))
+            update-count (:next.jdbc/update-count (first res))]
+        (tracer/add-data! {:attributes {:update-count update-count}})
+        (add-work-completed! conn update-count job)
+        (when (pos? update-count)
+          [::repeat]))
+      (catch ExceptionInfo e
+        (abort-index! conn job)
+        [::exception e]))))
 
-(defn insert-nulls-batch-and-update-job!
-  ([job]
-   (insert-nulls-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "insert-nulls" job)
-     (try
-       (let [update-count (insert-nulls-next-batch! conn job)]
-         (tracer/add-data! {:attributes {:update-count update-count}})
-         (cond->> job
-           (not (zero? update-count)) (add-work-completed! conn update-count)
-           (zero? update-count) (set-next-stage! conn "update-attr-done")))
-       (catch clojure.lang.ExceptionInfo e
-         (abort-index! conn job)
-         (mark-error-from-ex-info! conn e job))))))
+(defn index--insert-nulls [conn job]
+  (tracer/with-span! (job-span-attrs "insert-nulls" job)
+    (try
+      (let [{:keys [attr_id]} job
+            q {:insert-into [[:triples triple-model/triple-cols]
+                             {:select [[:app_id :app_id]
+                                       [:entity_id :entity_id]
+                                       [attr_id :attr_id]
+                                       [[:cast "null" :jsonb] :value]
+                                       [[:inline json-null-md5] :value_md5]
+                                       [[:= :cardinality [:inline "one"]] :ea]
+                                       [[:= :value_type [:inline "ref"]] :eav]
+                                       [:is_unique :av]
+                                       [:is_indexed :ave]
+                                       [[:= :value_type [:inline "ref"]] :vae]
+                                       :checked_data_type]
+                              :from {:select [:triples.app_id
+                                              :triples.entity_id
+                                              :attrs.cardinality
+                                              :attrs.value_type
+                                              :attrs.is_unique
+                                              :attrs.is_indexed
+                                              :attrs.checked_data_type]
+                                     :from :triples
+                                     ;; The `for update` should prevent a concurrent
+                                     ;; query from deleting the entity while we're
+                                     ;; doing our insert
+                                     :for :update
+                                     :join [:attrs [:and
+                                                    [:= :triples.app_id :attrs.app_id]
+                                                    [:= :attrs.id attr_id]]]
+                                     :where (missing-null-triple-wheres conn :update job)
+                                     :limit batch-size}}]}
+            res (sql/do-execute! ::insert-nulls-next-batch! conn (hsql/format q))
+            update-count (:next.jdbc/update-count (first res))]
+        (tracer/add-data! {:attributes {:update-count update-count}})
+        (add-work-completed! conn update-count job)
+        (when (pos? update-count)
+          [::repeat]))
+      (catch ExceptionInfo e
+        (abort-index! conn job)
+        [::exception e]))))
 
-(defn run-next-index-step
-  ([job]
-   (run-next-index-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (case (:job_stage job)
-     "update-attr-start" (update-attr-for-index-start! conn job)
-     "estimate-work" (update-work-estimate! conn "update-triples" job)
-     "update-triples" (index-batch-and-update-job! conn job)
-     "insert-nulls" (insert-nulls-batch-and-update-job! conn job)
-     "update-attr-done" (update-attr-for-index-done! conn job))))
+(defn index--update-attr-done [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :is-indexed true]
+                              [:= :indexing true]]
+                      :set {:indexing false}}))
 
-(defn update-attr-for-remove-index-start!
-  ([job]
-   (update-attr-for-remove-index-start! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :set {:is-indexed false
-                                 :indexing true}})
-     (set-next-stage! conn "estimate-work" job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+(def index--stages
+  [{:stage "update-attr-start", :fn #'index--update-attr-start}
+   {:stage "estimate-work",     :fn #'update-work-estimate!}
+   {:stage "update-triples",    :fn #'index--update-triples}
+   {:stage "insert-nulls",      :fn #'index--insert-nulls}
+   {:stage "update-attr-done",  :fn #'index--update-attr-done}])
 
-(defn update-attr-for-remove-index-done!
-  ([job]
-   (update-attr-for-remove-index-done! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :where [[:= :is-indexed false]
-                                   [:= :indexing true]]
-                           :set {:indexing false}})
-     (mark-job-completed! conn job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
 
-(defn remove-index-next-batch!
-  ([job]
-   (remove-index-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [app_id attr_id job_type]}]
-   (assert (= "remove-index" job_type))
-   (let [q {:update :triples
-            :set {:ave false}
-            :where [:in :ctid
-                    {:select :ctid
-                     :for :update
-                     :from :triples
-                     :limit batch-size
-                     :where [:and
-                             [:= :app-id app_id]
-                             [:= :attr-id attr_id]
-                             :ave]}]}
-         res (sql/do-execute! ::remove-index-next-batch
-                              conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
+;; "remove-index" -------------------------------------------------------------
 
-(defn remove-index-batch-and-update-job!
-  ([job]
-   (remove-index-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "remove-index" job)
-     (let [update-count (remove-index-next-batch! conn job)]
-       (tracer/add-data! {:attributes {:update-count update-count}})
-       (cond->> job
-         (not (zero? update-count)) (add-work-completed! conn update-count)
-         (< update-count batch-size) (set-next-stage! conn "update-attr-done"))))))
+(defn remove-index--update-attr-start [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :set {:is-indexed false
+                            :indexing true}}))
 
-(defn run-next-remove-index-step
-  ([job]
-   (run-next-index-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (assert (= "remove-index" (:job_type job)))
-   (case (:job_stage job)
-     "update-attr-start" (update-attr-for-remove-index-start! conn job)
-     "estimate-work" (update-work-estimate! conn "update-triples" job)
-     "update-triples" (remove-index-batch-and-update-job! conn job)
-     "update-attr-done" (update-attr-for-remove-index-done! conn job))))
+(defn remove-index--update-triples [conn job]
+  (tracer/with-span! (job-span-attrs "remove-index" job)
+    (let [{:keys [app_id attr_id]} job
+          q {:update :triples
+             :set {:ave false}
+             :where [:in :ctid
+                     {:select :ctid
+                      :for :update
+                      :from :triples
+                      :limit batch-size
+                      :where [:and
+                              [:= :app-id app_id]
+                              [:= :attr-id attr_id]
+                              :ave]}]}
+          res (sql/do-execute! ::remove-index-next-batch
+                               conn (hsql/format q))
+          update-count (:next.jdbc/update-count (first res))]
+      (tracer/add-data! {:attributes {:update-count update-count}})
+      (add-work-completed! conn update-count job)
+      (when (<= batch-size update-count)
+        [::repeat]))))
 
-(defn update-attr-for-unique-start!
-  ([job]
-   (update-attr-for-unique-start! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :set {:is-unique true
-                                 :setting-unique true}})
-     (set-next-stage! conn "estimate-work" job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+(defn remove-index--update-attr-done [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :is-indexed false]
+                              [:= :indexing true]]
+                      :set {:indexing false}}))
 
-(defn update-attr-for-unique-done!
-  ([job]
-   (update-attr-for-unique-done! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :where [[:= :is-unique true]
-                                   [:= :setting-unique true]]
-                           :set {:setting-unique false}})
-     (mark-job-completed! conn job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+(def remove-index--stages
+  [{:stage "update-attr-start", :fn #'remove-index--update-attr-start}
+   {:stage "estimate-work",     :fn #'update-work-estimate!}
+   {:stage "update-triples",    :fn #'remove-index--update-triples}
+   {:stage "update-attr-done",  :fn #'remove-index--update-attr-done}])
 
-(defn unique-next-batch!
-  ([job]
-   (unique-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [app_id attr_id job_type]}]
-   (assert (= "unique" job_type))
-   (let [q {:update :triples
-            :set {:av true}
-            :where [:in :ctid
-                    {:select :ctid
-                     :for :update
-                     :from :triples
-                     :limit batch-size
-                     :where [:and
-                             [:= :app-id app_id]
-                             [:= :attr-id attr_id]
-                             [:not :av]]}]}
-         res (sql/do-execute! ::unique-next-batch! conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
 
-(defn abort-unique! [conn job]
+;; "unique" -------------------------------------------------------------------
+
+(defn unique--update-attr-start [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :set {:is-unique true
+                            :setting-unique true}}))
+
+(defn unique--update-triples [conn job]
+  (tracer/with-span! (job-span-attrs "unique" job)
+    (try
+      (let [{:keys [app_id attr_id]} job
+            q {:update :triples
+               :set {:av true}
+               :where [:in :ctid
+                       {:select :ctid
+                        :for :update
+                        :from :triples
+                        :limit batch-size
+                        :where [:and
+                                [:= :app-id app_id]
+                                [:= :attr-id attr_id]
+                                [:not :av]]}]}
+            res (sql/do-execute! ::unique-next-batch! conn (hsql/format q))
+            update-count (:next.jdbc/update-count (first res))]
+        (tracer/add-data! {:attributes {:update-count update-count}})
+        (add-work-completed! conn update-count job)
+        (when (<= batch-size update-count)
+          [::repeat]))
+      (catch ExceptionInfo e
+        (update-attr! conn {:app-id (:app_id job)
+                            :attr-id (:attr_id job)
+                            :where [[:= :is-unique true]
+                                    [:= :setting-unique true]]
+                            :set {:setting-unique false
+                                  :is-unique false}})
+        ;; It would be better to do this in a batch or even to
+        ;; create a new job to undo the update
+        (sql/do-execute! ::abort-unique!
+                         conn (hsql/format {:update :triples
+                                            :set {:av false}
+                                            :where [:and
+                                                    [:= :app-id (:app_id job)]
+                                                    [:= :attr-id (:attr_id job)]
+                                                    :av]}))
+        [::exception e]))))
+
+(defn unique--update-attr-done [conn job]
   (update-attr! conn {:app-id (:app_id job)
                       :attr-id (:attr_id job)
                       :where [[:= :is-unique true]
                               [:= :setting-unique true]]
-                      :set {:setting-unique false
-                            :is-unique false}})
-  ;; It would be better to do this in a batch or even to
-  ;; create a new job to undo the update
-  (sql/do-execute! ::abort-unique!
-                   conn (hsql/format {:update :triples
-                                      :set {:av false}
-                                      :where [:and
-                                              [:= :app-id (:app_id job)]
-                                              [:= :attr-id (:attr_id job)]
-                                              :av]})))
+                      :set {:setting-unique false}}))
 
-(defn unique-batch-and-update-job!
-  ([job]
-   (unique-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "unique" job)
-     (try
-       (let [update-count (unique-next-batch! conn job)]
-         (tracer/add-data! {:attributes {:update-count update-count}})
-         (cond->> job
-           (not (zero? update-count)) (add-work-completed! conn update-count)
-           (< update-count batch-size) (set-next-stage! conn "update-attr-done")))
-       (catch clojure.lang.ExceptionInfo e
-         (abort-unique! conn job)
-         (mark-error-from-ex-info! conn e job))))))
+(def unique--stages
+  [{:stage "update-attr-start", :fn #'unique--update-attr-start}
+   {:stage "estimate-work",     :fn #'update-work-estimate!}
+   {:stage "update-triples",    :fn #'unique--update-triples}
+   {:stage "update-attr-done",  :fn #'unique--update-attr-done}])
 
-(defn run-next-unique-step
-  ([job]
-   (run-next-unique-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (case (:job_stage job)
-     "update-attr-start" (update-attr-for-unique-start! conn job)
-     "estimate-work" (update-work-estimate! conn "update-triples" job)
-     "update-triples" (unique-batch-and-update-job! conn job)
-     "update-attr-done" (update-attr-for-unique-done! conn job))))
 
-(defn update-attr-for-remove-unique-start!
-  ([job]
-   (update-attr-for-remove-unique-start! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :set {:is-unique false
-                                 :setting-unique true}})
-     (set-next-stage! conn "estimate-work" job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+;; "remove-unique" ------------------------------------------------------------
 
-(defn update-attr-for-remove-unique-done!
-  ([job]
-   (update-attr-for-remove-unique-done! (aurora/conn-pool :write) job))
-  ([conn job]
-   (if (update-attr! conn {:app-id (:app_id job)
-                           :attr-id (:attr_id job)
-                           :where [[:= :is-unique false]
-                                   [:= :setting-unique true]]
-                           :set {:setting-unique false}})
-     (mark-job-completed! conn job)
-     (mark-error! conn {:error invalid-attr-state-error} job))))
+(defn remove-unique--update-attr-start [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :set {:is-unique false
+                            :setting-unique true}}))
 
-(defn remove-unique-next-batch!
-  ([job]
-   (remove-unique-next-batch! (aurora/conn-pool :write) job))
-  ([conn {:keys [app_id attr_id job_type]}]
-   (assert (= "remove-unique" job_type))
-   (let [q {:update :triples
-            :set {:av false}
-            :where [:in :ctid
-                    {:select :ctid
-                     :for :update
-                     :from :triples
-                     :limit batch-size
-                     :where [:and
-                             [:= :app-id app_id]
-                             [:= :attr-id attr_id]
-                             :av]}]}
-         res (sql/do-execute! ::remove-unique-next-batch!
-                              conn (hsql/format q))]
-     (:next.jdbc/update-count (first res)))))
+(defn remove-unique--update-triples [conn job]
+  (tracer/with-span! (job-span-attrs "remove-unique" job)
+    (let [{:keys [app_id attr_id]} job
+          q {:update :triples
+             :set {:av false}
+             :where [:in :ctid
+                     {:select :ctid
+                      :for :update
+                      :from :triples
+                      :limit batch-size
+                      :where [:and
+                              [:= :app-id app_id]
+                              [:= :attr-id attr_id]
+                              :av]}]}
+          res (sql/do-execute! ::remove-unique-next-batch!
+                               conn (hsql/format q))
+          update-count (:next.jdbc/update-count (first res))]
+      (tracer/add-data! {:attributes {:update-count update-count}})
+      (add-work-completed! conn update-count job)
+      (when (<= batch-size update-count)
+        [::repeat]))))
 
-(defn remove-unique-batch-and-update-job!
-  ([job]
-   (remove-unique-batch-and-update-job! (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "remove-unique" job)
-     (let [update-count (remove-unique-next-batch! conn job)]
-       (tracer/add-data! {:attributes {:update-count update-count}})
-       (cond->> job
-         (not (zero? update-count)) (add-work-completed! conn update-count)
-         (< update-count batch-size) (set-next-stage! conn "update-attr-done"))))))
+(defn remove-unique--update-attr-done [conn job]
+  (update-attr! conn {:app-id (:app_id job)
+                      :attr-id (:attr_id job)
+                      :where [[:= :is-unique false]
+                              [:= :setting-unique true]]
+                      :set {:setting-unique false}}))
 
-(defn run-next-remove-unique-step
-  ([job]
-   (run-next-unique-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (assert (= "remove-unique" (:job_type job)))
-   (case (:job_stage job)
-     "update-attr-start" (update-attr-for-remove-unique-start! conn job)
-     "estimate-work" (update-work-estimate! conn "update-triples" job)
-     "update-triples" (remove-unique-batch-and-update-job! conn job)
-     "update-attr-done" (update-attr-for-remove-unique-done! conn job))))
+(def remove-unique--stages
+   [{:stage "update-attr-start", :fn #'remove-unique--update-attr-start}
+    {:stage "estimate-work",     :fn #'update-work-estimate!}
+    {:stage "update-triples",    :fn #'remove-unique--update-triples}
+    {:stage "update-attr-done",  :fn #'remove-unique--update-attr-done}])
 
-(defn run-next-step
-  ([job]
-   (run-next-step (aurora/conn-pool :write) job))
-  ([conn job]
-   (tracer/with-span! (job-span-attrs "run-next-step" job)
-     (assert (= "processing" (:job_status job)) (:job_status job))
-     (case (:job_type job)
-       "check-data-type" (run-next-check-step conn job)
-       "remove-data-type" (run-next-remove-data-type-step conn job)
-       "index" (run-next-index-step conn job)
-       "remove-index" (run-next-remove-index-step conn job)
-       "unique" (run-next-unique-step conn job)
-       "remove-unique" (run-next-remove-unique-step conn job)))))
+
+;; ----------------------------------------------------------------------------
+
+(def jobs
+  {"check-data-type"  {:serial-key "data-type", :stages check-data-type--stages}
+   "remove-data-type" {:serial-key "data-type", :stages remove-data-type--stages}
+   "index"            {:serial-key "index",     :stages index--stages}
+   "remove-index"     {:serial-key "index",     :stages remove-index--stages}
+   "unique"           {:serial-key "unique",    :stages unique--stages}
+   "remove-unique"    {:serial-key "unique",    :stages remove-unique--stages}})
+
+(defn run-next-stage [conn job]
+  (tracer/with-span! (job-span-attrs "run-next-stage" job)
+    (assert (= "processing" (:job_status job)) (:job_status job))
+    (let [[stage & next-stages] (-> jobs
+                                    (get (:job_type job))
+                                    :stages
+                                    (->> (drop-while #(not= (:stage %) (:job_stage job)))))
+          _                     (when (nil? stage)
+                                  (ex/throw+ {::ex/type ::ex/param-malformed
+                                              ::ex/mesasge (str "Unexpected job stage: " (:job_stage job))
+                                              ::ex/hint {:job job}}))
+          res                   ((:fn stage) conn job)
+          [res-type res-value]  (when (vector? res) res)]
+      (cond
+        (= ::error res-type)
+        (mark-error! conn {:error res-value} job)
+
+        (= ::exception res-type)
+        (mark-error-from-ex-info! conn res-value job)
+
+        (= ::repeat res-type)
+        job
+
+        (empty? next-stages)
+        (mark-job-completed! conn job)
+
+        :else
+        (set-next-stage! conn (:stage (first next-stages)) job)))))
 
 (defn enqueue-job
   ([job]
@@ -1089,7 +834,7 @@
   ([chan job]
    (process-job (aurora/conn-pool :write) chan job))
   ([conn chan job]
-   (let [updated-job (run-next-step conn job)]
+   (let [updated-job (run-next-stage conn job)]
      (if (not= "processing" (:job_status updated-job))
        (tracer/record-info! (job-span-attrs "job-finished-processing" updated-job))
        (if-let [job (release-job! conn updated-job)]
@@ -1267,9 +1012,10 @@
     (doseq [attr attrs]
       (loop [total 0]
         (println "Starting" (str "app_id=" (:app_id attr)) (str "attr_id=" (:id attr)))
-        (let [update-count (time (insert-nulls-next-batch! {:attr_id (:id attr)
-                                                            :app_id (:app_id attr)
-                                                            :job_type "index"}))]
+        (let [update-count (time (index--insert-nulls (aurora/conn-pool :write)
+                                                      {:attr_id (:id attr)
+                                                       :app_id (:app_id attr)
+                                                       :job_type "index"}))]
           (println "Updated" (+ total update-count) "for" (str "app_id=" (:app_id attr)) (str "attr_id=" (:id attr)))
           (when (pos? update-count)
             (recur (long (+ total update-count)))))))))

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -408,32 +408,12 @@
 (defn create-indexing-jobs [app-id job-steps]
   (let [group-id (random-uuid)
         jobs (mapv (fn [[action {:keys [attr-id checked-data-type]}]]
-                     (let [job (case action
-                                 :check-data-type (indexing-jobs/create-check-data-type-job!
-                                                   {:app-id app-id
-                                                    :group-id group-id
-                                                    :attr-id attr-id
-                                                    :checked-data-type checked-data-type})
-                                 :remove-data-type (indexing-jobs/create-remove-data-type-job!
-                                                    {:app-id app-id
-                                                     :group-id group-id
-                                                     :attr-id attr-id})
-                                 :index (indexing-jobs/create-index-job!
-                                         {:app-id app-id
-                                          :group-id group-id
-                                          :attr-id attr-id})
-                                 :remove-index (indexing-jobs/create-remove-index-job!
-                                                {:app-id app-id
-                                                 :group-id group-id
-                                                 :attr-id attr-id})
-                                 :unique (indexing-jobs/create-unique-job!
-                                          {:app-id app-id
-                                           :group-id group-id
-                                           :attr-id attr-id})
-                                 :remove-unique (indexing-jobs/create-remove-unique-job!
-                                                 {:app-id app-id
-                                                  :group-id group-id
-                                                  :attr-id attr-id}))]
+                     (let [job (indexing-jobs/create-job!
+                                {:app-id            app-id
+                                 :group-id          group-id
+                                 :attr-id           attr-id
+                                 :job-type          (name action)
+                                 :checked-data-type checked-data-type})]
                        (indexing-jobs/enqueue-job job)
                        (indexing-jobs/job->client-format job)))
                    job-steps)]

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -729,16 +729,16 @@
       (testing "good error message for create + update with lookup"
         ;; We may be able to fix with merge in postgres 16
         ;; https://www.postgresql.org/docs/current/sql-merge.html
-        (= "Updates with lookups can only update the lookup attribute if an entity with the unique attribute value already exists."
-           (-> (transact-post
-                {:body {:steps [["update" "users" ["handle" "stopa"] {"handle" "stopa2"}]]}
-                 :headers {"app-id" (str app-id)
-                           "authorization" (str "Bearer " admin-token)}})
-               :body
-               :hint
-               :errors
-               first
-               :message)))
+        (is (= "Updates with lookups can only update the lookup attribute if an entity with the unique attribute value already exists."
+               (-> (transact-post
+                    {:body {:steps [["update" "users" ["handle" "stopa"] {"handle" "stopa2"}]]}
+                     :headers {"app-id" (str app-id)
+                               "authorization" (str "Bearer " admin-token)}})
+                   :body
+                   :hint
+                   :errors
+                   first
+                   :message))))
       (testing "update"
         (is (transact-ok?
              (transact-post


### PR DESCRIPTION
As a preparation for adding new job for required fields, a little refactoring on indexing_jobs.

Main motivation was to decouple scheduling/dispatching from job body itself. After this PR, job body just changes what needs to be changed, but doesn’t know what stage is next or how to handle error. This is decided outside, from data-first description instead of imperative code. Functional core, imperative shell (although our “functional” core still runs updates over SQL, I still feel like scheduling and execution should be separated)

Nothing functionally changed, just moved code around.

Also net negative on code size: 530 insertions(+), 808 deletions(-)