### PR TITLE
[docs] add to tailwind detection

### DIFF
--- a/client/www/tailwind.config.js
+++ b/client/www/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
   darkMode: 'class',
   content: [
     './lib/**/*.{js,ts,jsx,tsx}',
-    './pages/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx,md}',
     './components/**/*.{js,ts,jsx,tsx}',
     './utils/**/*.{js,ts,jsx,tsx}',
   ],


### PR DESCRIPTION
I added some custom divs in our docs: 

https://github.com/instantdb/instant/blob/main/client/www/pages/docs/auth/google-oauth.md?plain=1#L12-L47

**You may be wondering: why not just use a custom tag?** 

I needed to lay out the buttons as a 2 x 2 matrix with titles. When read in mobile, I had to make sure that the title covered the right buttons. 

In order to do this, I had to write a grid layout, and the number of `nav-items` really matters. I thought about using a custom tag, but didn't see an abstraction that was useful. 

So...I went with a `div` abstraction, and just wrote the markup in the markdown. This means though that we need tailwind to pick up those classes. 

@nezaj @dwwoelfel @tonsky 