### PR TITLE
Bug fix for ors and and in rule-wheres

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -2054,11 +2054,13 @@
   (reduce-kv (fn [new-where k v]
                (if (or (or-where-cond? [k v])
                        (and-where-cond? [k v]))
-                 (assoc new-where k (concat (map (partial extend-where-with-rule-refs
-                                                          etype
-                                                          ctx
-                                                          rule-wheres)
-                                                 v)
+                 (assoc new-where k (concat (map
+                                             (fn [where]
+                                               (extend-where-with-rule-refs etype
+                                                                            ctx
+                                                                            rule-wheres
+                                                                            where))
+                                             v)
                                             ;; We may have added our own ands/or
                                             ;; in add-rule-wheres-to-query
                                             (get new-where k)))

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -2055,6 +2055,7 @@
                (if (or (or-where-cond? [k v])
                        (and-where-cond? [k v]))
                  (assoc new-where k (concat (map (partial extend-where-with-rule-refs
+                                                          etype
                                                           ctx
                                                           rule-wheres)
                                                  v)


### PR DESCRIPTION
Forgot to provide an argument.

Also removed the call to `partial`, since clj-kondo won't find invalid arity errors with `partial`.

Includes a test.