### PR TITLE
Fix rule-where-testing compare on errors

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -2103,8 +2103,8 @@
                              (update-in [:$ :where]
                                         (fn [where]
                                           (if where
-                                            {:and [etype-rule-where
-                                                   where]}
+                                            {:and [where
+                                                   etype-rule-where]}
                                             etype-rule-where))))))))
               {}
               o)))


### PR DESCRIPTION
Two changes:

1. Fixes a bug where I tried to call `instaql-nodes->object-tree` on an Exception
2. Puts the user's where clauses first in hopes we'll get a more efficient match.