### PR TITLE
Better error for record-not-unique errors

### DIFF
--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -152,6 +152,10 @@
   [attr]
   (str (fwd-etype attr) "." (fwd-label attr)))
 
+(defn attr-details [attr]
+  {:etype (fwd-etype attr)
+   :label (fwd-label attr)})
+
 ;; -------
 ;; caching
 
@@ -731,3 +735,11 @@
     (:id (or (seek-by-fwd-ident-name n wrapped-attrs)
              (seek-by-rev-ident-name n wrapped-attrs)))))
 
+(defn get-attr-details
+  "Used in exception to construct nicer error messages."
+  [app-id attr-id]
+  (let [attrs (get-by-app-id app-id)]
+    (some-> (seek-by-id attr-id attrs)
+            (attr-details))))
+
+(ex/define-get-attr-details get-attr-details)

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -130,14 +130,13 @@
                  (add-char c)
                  (recur (inc open-parens)
                         in-quote?))
-            \" (do
-                 (let [escaped-quote? (= (safe-char s (dec @i))
-                                         \\)]
-                   (add-char c)
-                   (recur open-parens
-                          (if escaped-quote?
-                            in-quote?
-                            (not in-quote?)))))
+            \" (let [escaped-quote? (= (safe-char s (dec @i))
+                                       \\)]
+                 (add-char c)
+                 (recur open-parens
+                        (if escaped-quote?
+                          in-quote?
+                          (not in-quote?))))
             (do (add-char c)
                 (recur open-parens
                        in-quote?))))))))
@@ -180,8 +179,8 @@
     (try
       (let [details (parse-unique-detail (:detail pg-data))
             value   (get details "json_null_to_null(value)")
-            app-id  (parse-uuid (get details "app_id"))
-            attr-id (parse-uuid (get details "attr_id"))
+            app-id  (uuid-util/coerce (get details "app_id"))
+            attr-id (uuid-util/coerce (get details "attr_id"))
             {:keys [etype label]} (get-attr-details app-id attr-id)]
         (cond (and etype label value)
               {:message (format "`%s` is a unique attribute on `%s` and an entity already exists with `%s.%s` = %s"

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -7,6 +7,7 @@
    [instant.jdbc.pgerrors :as pgerrors]
    [instant.util.json :refer [<-json]]
    [instant.util.string :refer [indexes-of safe-name]]
+   [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util])
   (:import
    (java.io IOException)
@@ -60,6 +61,21 @@
            ::message "hey!"}))
 
 ;; -------
+;; Helpers
+
+(defonce get-attr-details* (atom nil))
+
+(defn define-get-attr-details
+  "Allows us to access the function in attr.clj without
+   creating a cyclic dependency."
+  [f]
+  (reset! get-attr-details* f))
+
+(defn get-attr-details [app-id attr-id]
+  (when-let [f @get-attr-details*]
+    (f app-id attr-id)))
+
+;; -------
 ;; Records
 
 (defn throw-expiration-err! [record-type hint]
@@ -74,28 +90,128 @@
              ::hint (assoc hint :record-type record-type)}))
   record)
 
+(defn safe-char [s i]
+  (when (< i (count s))
+    (String/.charAt s i)))
+
+(defn parse-unique-detail-column!
+  "Returns the column at the given starting position.
+   Sets `i` to the start of the next column."
+  [i s]
+  (let [col (StringBuffer.)
+        advance (fn []
+                  (vswap! i inc))
+        add-char (fn [c]
+                   (.append col c)
+                   (advance))]
+    (loop [open-parens 0
+           in-quote? false]
+      (let [c (safe-char s @i)]
+        (if-not c
+          (.toString col)
+          (case c
+            \, (if in-quote?
+                 (do
+                   (add-char c)
+                   (recur open-parens
+                          in-quote?))
+                 (do
+                   (advance)
+                   ;; Consume next space
+                   (advance)
+                   (.toString col)))
+            \) (if (pos? open-parens)
+                 (do
+                   (add-char c)
+                   (recur (dec open-parens)
+                          in-quote?))
+                 (.toString col))
+            \( (do
+                 (add-char c)
+                 (recur (inc open-parens)
+                        in-quote?))
+            \" (do
+                 (let [escaped-quote? (= (safe-char s (dec @i))
+                                         \\)]
+                   (add-char c)
+                   (recur open-parens
+                          (if escaped-quote?
+                            in-quote?
+                            (not in-quote?)))))
+            (do (add-char c)
+                (recur open-parens
+                       in-quote?))))))))
+
+(defn parse-unique-detail-columns!
+  "Finds the list of columns and returns them as a vector of strings.
+   Sets `i` to the end of the columns.
+   Given \"Key (a, b, c)=(1, 2, 3) already exists\"
+   Returns [\"a\", \"b\", \"c\"] with i at the `=` char."
+  [i s]
+  (loop [columns []
+         stage :find-columns-start]
+    (let [c (safe-char s @i)]
+      (if-not c
+        columns
+        (if (= c \))
+          (do
+            (vswap! i inc)
+            columns)
+          (case stage
+            :find-columns-start (do (vswap! i inc)
+                                    (if (= \( c)
+                                      (recur columns
+                                             :get-column)
+                                      (recur columns
+                                             :find-columns-start)))
+            :get-column (recur (conj columns
+                                     (parse-unique-detail-column! i s))
+                               :get-column)))))))
+
+(defn parse-unique-detail [s]
+  (let [i (volatile! 0)
+        keys (parse-unique-detail-columns! i s)
+        values (parse-unique-detail-columns! i s)]
+    (zipmap keys values)))
+
 (defn extract-unique-triple-data [pg-data]
   (when (and (= "triples" (:table pg-data))
-             (= "av_index" (:constraint pg-data))
-             (string/starts-with? (:detail pg-data) "Key (app_id, attr_id, json_null_to_null(value))="))
-    (let [prefix "Key (app_id, attr_id, json_null_to_null(value))=(00000000-0000-0000-0000-000000000000, "
-          attr-id (-> (subs (:detail pg-data)
-                            (count prefix)
-                            (+ (count prefix) 36))
-                      uuid-util/coerce)
-          value (-> (subs (:detail pg-data)
-                          (+ (count prefix) 36 2)
-                          (string/last-index-of (:detail pg-data) ") already exists.")))]
-      {:attr-id attr-id
-       :value value})))
+             (= "av_index" (:constraint pg-data)))
+    (try
+      (let [details (parse-unique-detail (:detail pg-data))
+            value   (get details "json_null_to_null(value)")
+            app-id  (parse-uuid (get details "app_id"))
+            attr-id (parse-uuid (get details "attr_id"))
+            {:keys [etype label]} (get-attr-details app-id attr-id)]
+        (cond (and etype label value)
+              {:message (format "`%s` is a unique attribute on `%s` and an entity already exists with `%s.%s` = %s"
+                                label
+                                etype
+                                etype
+                                label
+                                value)
+               :hint {:attr-id attr-id
+                      :etype etype
+                      :label label
+                      :value value}}
+
+              attr-id
+              {:hint {:attr-id attr-id
+                      :value value}}
+
+              :else nil))
+      (catch Exception e
+        (tracer/record-exception-span! e {:name "ex/extract-unique-triple-data-error"})
+        nil))))
 
 (defn throw-record-not-unique!
   ([record-type] (throw-record-not-unique! record-type nil nil))
   ([record-type pg-data e]
    (let [extra-hint-data (extract-unique-triple-data pg-data)]
      (throw+ {::type ::record-not-unique
-              ::message (format "Record not unique: %s" (name record-type))
-              ::hint (merge {:record-type record-type} extra-hint-data)}
+              ::message (or (:message extra-hint-data)
+                            (format "Record not unique: %s" (name record-type)))
+              ::hint (merge {:record-type record-type} (:hint extra-hint-data))}
              e))))
 
 ;; -----------

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -547,14 +547,16 @@
                   app-id
                   [[:= :attr-id email-attr-id]]))))
         (testing "unicity throws"
-          (is
-           (= ::ex/record-not-unique
-              (::ex/type (test-util/instant-ex-data
-                          (tx/transact!
-                           (aurora/conn-pool :write)
-                           (attr-model/get-by-app-id app-id)
-                           app-id
-                           [[:add-triple joe-eid email-attr-id "test2@instantdb.com"]]))))))))))
+          (let [ex-data  (test-util/instant-ex-data
+                           (tx/transact!
+                            (aurora/conn-pool :write)
+                            (attr-model/get-by-app-id app-id)
+                            app-id
+                            [[:add-triple joe-eid email-attr-id "test2@instantdb.com"]]))]
+            (is (= ::ex/record-not-unique
+                   (::ex/type ex-data)))
+            (is (= "`email` is a unique attribute on `users` and an entity already exists with `users.email` = \"test2@instantdb.com\""
+                   (::ex/message ex-data)))))))))
 
 (deftest tx-ref-many-to-many
   (with-empty-app

--- a/server/test/instant/util/exception_test.clj
+++ b/server/test/instant/util/exception_test.clj
@@ -1,0 +1,14 @@
+(ns instant.util.exception-test
+  (:require [instant.util.exception :as ex]
+            [clojure.test :refer [deftest is]]))
+
+(deftest parse-unique-detail
+  (is (= (ex/parse-unique-detail "Key (app_id, attr_id, json_null_to_null(value))=(7c7625f7-6eb3-4470-b745-fd28e006cbe9, 55ac8990-86e1-4e20-98fb-ca70fe8bbaae, \"d\") already exists.")
+         {"app_id" "7c7625f7-6eb3-4470-b745-fd28e006cbe9"
+          "attr_id" "55ac8990-86e1-4e20-98fb-ca70fe8bbaae"
+          "json_null_to_null(value)" "\"d\""}))
+
+  (is (= (ex/parse-unique-detail  "Key (app_id, attr_id, json_null_to_null(value))=(7c7625f7-6eb3-4470-b745-fd28e006cbe9, 55ac8990-86e1-4e20-98fb-ca70fe8bbaae, \"{\\\"hello\\\": \\\"worl,d\\\", \\\"testing\\\": \\\"this\\\"}\") already exists.")
+         {"app_id" "7c7625f7-6eb3-4470-b745-fd28e006cbe9"
+          "attr_id" "55ac8990-86e1-4e20-98fb-ca70fe8bbaae"
+          "json_null_to_null(value)" "\"{\\\"hello\\\": \\\"worl,d\\\", \\\"testing\\\": \\\"this\\\"}\""})))


### PR DESCRIPTION
Creates a better error for `record not unique: triple`.

**Before**

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/b380ab80-7587-4142-a6b0-09515405f1c6" />

**After**

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/351beba5-78a7-4a01-8455-2dfabd5891db" />

Full error:

```json
{
    "op": "error",
    "status": 400,
    "type": "record-not-unique",
    "message": "`handle` is a unique attribute on `users` and an entity already exists with `users.handle` = \"daniel\"",
    "hint": {
        "record-type": "triple",
        "attr-id": "d985fdee-8848-46d5-98fa-580625c43c3e",
        "etype": "users",
        "label": "handle",
        "value": "\"daniel\""
    }
}
```