### PR TITLE
Make it easier to create play pages with ephemeral apps

### DIFF
--- a/client/sandbox/react-nextjs/components/EphemeralAppPage.tsx
+++ b/client/sandbox/react-nextjs/components/EphemeralAppPage.tsx
@@ -1,0 +1,206 @@
+import { useRouter } from 'next/router';
+import config from '../config';
+import {
+  EntitiesDef,
+  init,
+  InstantReactAbstractDatabase,
+  InstantSchemaDef,
+  LinksDef,
+} from '@instantdb/react';
+import { useEffect, useState } from 'react';
+import { RoomsDef, TransactionChunk } from '../../../packages/core/dist/module';
+import { IContainEntitiesAndLinks } from '../../../packages/core/dist/module/schemaTypes';
+
+async function provisionEphemeralApp({
+  perms,
+  schema,
+  onCreateApp,
+}: {
+  perms?: any;
+  schema?: InstantSchemaDef<any, any, any>;
+  onCreateApp?: (
+    db: InstantReactAbstractDatabase<InstantSchemaDef<any, any, any>>,
+  ) => Promise<void>;
+}) {
+  const body: any = { title: 'Example app' };
+  if (perms) {
+    body.rules = { code: perms };
+  }
+  if (schema) {
+    body.schema = schema;
+  }
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const res = await r.json();
+
+  if (res.app && onCreateApp) {
+    const db = init({ ...config, appId: res.app.id, schema: schema });
+    onCreateApp(db);
+  }
+
+  return res;
+}
+
+async function verifyEphemeralApp({ appId }: { appId: string }) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return r.json();
+}
+
+function AppPage<
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  Rooms extends RoomsDef,
+>({
+  urlAppId,
+  schema,
+  perms,
+  onCreateApp,
+  Component,
+}: {
+  urlAppId: string | undefined;
+  schema?: InstantSchemaDef<Entities, Links, Rooms>;
+  perms?: any;
+  onCreateApp?: (
+    db: InstantReactAbstractDatabase<InstantSchemaDef<Entities, Links, Rooms>>,
+  ) => Promise<void>;
+  txChunks?: TransactionChunk<
+    IContainEntitiesAndLinks<Entities, Links>,
+    keyof Entities
+  >[];
+  Component: React.ComponentType<{
+    db: InstantReactAbstractDatabase<InstantSchemaDef<Entities, Links, Rooms>>;
+    appId: string;
+  }>;
+}) {
+  const router = useRouter();
+  const [appId, setAppId] = useState();
+  const [error, setError] = useState<string | null>(null);
+
+  const provisionApp = async () => {
+    try {
+      const res = await provisionEphemeralApp({ schema, perms, onCreateApp });
+
+      if (res.app) {
+        router.replace({
+          pathname: router.pathname,
+          query: { ...router.query, app: res.app.id },
+        });
+
+        setAppId(res.app.id);
+      } else {
+        console.log(res);
+        setError('Could not create app.');
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    if (urlAppId) {
+      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
+        if (res.app) {
+          setAppId(res.app.id);
+        } else {
+          provisionApp();
+        }
+      });
+    } else {
+      provisionApp();
+    }
+  }, [urlAppId]);
+
+  if (error) {
+    return (
+      <div>
+        <p>There was an error</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!appId) {
+    return <div>Loading...</div>;
+  }
+
+  const db = init({ ...config, schema, appId });
+
+  console.log(Component);
+
+  return <Component key={appId} db={db} appId={appId} />;
+}
+
+function Page<
+  Entities extends EntitiesDef,
+  Links extends LinksDef<Entities>,
+  Rooms extends RoomsDef,
+>({
+  schema,
+  perms,
+  onCreateApp,
+  Component,
+}: {
+  schema?: InstantSchemaDef<Entities, Links, Rooms>;
+  perms?: any;
+  onCreateApp?: (
+    db: InstantReactAbstractDatabase<InstantSchemaDef<Entities, Links, Rooms>>,
+  ) => Promise<void>;
+  Component: React.ComponentType<{
+    db: InstantReactAbstractDatabase<InstantSchemaDef<Entities, Links, Rooms>>;
+    appId: string;
+  }>;
+}) {
+  const router = useRouter();
+  if (router.isReady) {
+    return (
+      <AppPage
+        schema={schema}
+        perms={perms}
+        onCreateApp={onCreateApp}
+        Component={Component}
+        urlAppId={router.query.app as string}
+      />
+    );
+  } else {
+    return <div>Loading...</div>;
+  }
+}
+
+export default Page;
+
+export function ResetButton({
+  className,
+  label,
+}: {
+  className?: string;
+  label?: string;
+}) {
+  const router = useRouter();
+  if (!router.isReady) {
+    return null;
+  }
+  return (
+    <button
+      className={className}
+      onClick={() => {
+        router.push({
+          ...router,
+          query: { ...router.query, app: undefined },
+        });
+      }}
+    >
+      {label || 'Start over'}
+    </button>
+  );
+}

--- a/client/sandbox/react-nextjs/pages/play/ephemeral-demo.tsx
+++ b/client/sandbox/react-nextjs/pages/play/ephemeral-demo.tsx
@@ -1,0 +1,59 @@
+import { i, id, InstantReactAbstractDatabase, tx } from '@instantdb/react';
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
+
+const schema = i.schema({
+  entities: {
+    docs: i.entity({
+      title: i.string(),
+    }),
+  },
+});
+
+const perms = {
+  docs: {
+    allow: {
+      view: 'true',
+    },
+  },
+};
+
+function App({ db }: { db: InstantReactAbstractDatabase<typeof schema> }) {
+  const { isLoading, error, data } = db.useQuery({ docs: {} });
+
+  if (isLoading) {
+    return <div>Loading</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <ResetButton className="bg-black text-white m-2 p-2" />
+      <pre>{JSON.stringify(data, null, 2)}</pre>;
+      <button
+        className="bg-black text-white m-2 p-2"
+        onClick={() =>
+          db.transact(db.tx.docs[id()].update({ title: 'New doc' }))
+        }
+      >
+        Add doc
+      </button>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <div className="max-w-lg flex flex-col mt-20 mx-auto">
+      <div>
+        This is a demo of how to create a play page with an ephemeral app. Look
+        at `ephemeral-demo.tsx` to create your own.
+      </div>
+      <EphemeralAppPage schema={schema} perms={perms} Component={App} />
+    </div>
+  );
+}

--- a/client/sandbox/react-nextjs/pages/play/fields.tsx
+++ b/client/sandbox/react-nextjs/pages/play/fields.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useState } from 'react';
-import config from '../../config';
-import { init, tx, id, i } from '@instantdb/react';
-import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+import { id, i, InstantReactAbstractDatabase } from '@instantdb/react';
+
 import { InstaQLFields } from '../../../../packages/core/dist/module';
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
 
 const _schema = i.schema({
   entities: {
@@ -32,11 +35,7 @@ const defaultFields: InstaQLFields<AppSchema, 'characters'> = [
   'rating',
 ];
 
-function Example({ appId }: { appId: string }) {
-  const router = useRouter();
-  const myConfig = { ...config, appId, schema };
-  const db = init(myConfig);
-
+function Example({ db }: { db: InstantReactAbstractDatabase<typeof _schema> }) {
   const [fields, setFields] =
     useState<InstaQLFields<AppSchema, 'characters'>>(defaultFields);
   const [noFields, setNoFields] = useState(false);
@@ -74,14 +73,10 @@ function Example({ appId }: { appId: string }) {
   return (
     <div>
       <div>
-        <button
+        <ResetButton
           className="bg-black text-white m-2 p-2"
-          onClick={() => {
-            window.location.href = router.pathname;
-          }}
-        >
-          Start over
-        </button>
+          label="Start over"
+        />
       </div>
       <div>
         {defaultFields.map((field) => {
@@ -293,106 +288,18 @@ const characters = [
   },
 ];
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Comparisons example',
-    }),
-  });
-
-  const res = await r.json();
-  if (res.app) {
-    const db = init({ ...config, appId: res.app.id, schema: schema });
-    db.transact(
-      characters.map((character) => db.tx.characters[id()].update(character)),
-    );
-  }
-  return res;
+export default function Page() {
+  return (
+    <EphemeralAppPage
+      schema={schema}
+      onCreateApp={async (db) => {
+        await db.transact(
+          characters.map((character) =>
+            db.tx.characters[id()].update(character),
+          ),
+        );
+      }}
+      Component={Example}
+    />
+  );
 }
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({ urlAppId }: { urlAppId: string | undefined }) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-  return <Example appId={appId} />;
-}
-
-function Page() {
-  const router = useRouter();
-  if (router.isReady) {
-    return <App urlAppId={router.query.app as string} />;
-  } else {
-    return <div>Loading...</div>;
-  }
-}
-
-export default Page;

--- a/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
+++ b/client/sandbox/react-nextjs/pages/play/missing-attrs.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import config from '../../config';
 import { init, tx, id, i } from '@instantdb/react';
 import { useRouter } from 'next/router';
+import EphemeralAppPage from '../../components/EphemeralAppPage';
 
 const schema = i.schema({
   entities: {
@@ -28,7 +29,10 @@ const schema = i.schema({
   },
 });
 
-function Example({ appId, useSchema }: { appId: string; useSchema: boolean }) {
+function Example({ appId }: { appId: string }) {
+  const router = useRouter();
+  const useSchema = router.query.schema === 'true';
+
   const myConfig = { ...config, appId };
   const db = useSchema
     ? init({ ...myConfig, schema })
@@ -83,123 +87,19 @@ function Example({ appId, useSchema }: { appId: string; useSchema: boolean }) {
   );
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Pagination example',
-      // Uncomment and start a new app to test rules
-      /* rules: {
-        code: {
-          goals: {
-            allow: {
-              // data.number % 2 == 0 gives me a typecasting error
-              // so does int(data.number) % 2 == 0
-              view: "data.number == 2 || data.number == 4 || data.number == 6 || data.number == 8 || data.number == 10",
-            },
-          },
-        },
-      }, */
-    }),
-  });
-
-  return r.json();
-}
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({
-  urlAppId,
-  useSchema,
-}: {
-  urlAppId: string | undefined;
-  useSchema: boolean;
-}) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-
-  return <Example appId={appId} useSchema={useSchema} />;
-}
-
 function Page() {
   const router = useRouter();
-  if (router.isReady) {
-    return (
-      <App
-        urlAppId={router.query.app as string}
-        useSchema={router.query.schema === 'true'}
-      />
-    );
-  } else {
+
+  if (!router.isReady) {
     return <div>Loading...</div>;
   }
+  const useSchema = router.query.schema === 'true';
+
+  return useSchema ? (
+    <EphemeralAppPage Component={Example} schema={schema} />
+  ) : (
+    <EphemeralAppPage Component={Example} />
+  );
 }
 
 export default Page;

--- a/client/sandbox/react-nextjs/pages/play/notandnil.tsx
+++ b/client/sandbox/react-nextjs/pages/play/notandnil.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
 import config from '../../config';
 import { init, tx, id } from '@instantdb/react';
-import { useRouter } from 'next/router';
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
 
 function Example({ appId }: { appId: string }) {
-  const router = useRouter();
   const myConfig = { ...config, appId };
   const db = init(myConfig);
 
@@ -81,14 +81,10 @@ function Example({ appId }: { appId: string }) {
         >
           Create link with val = "a"
         </button>
-        <button
+        <ResetButton
           className="bg-black text-white m-2 p-2"
-          onClick={() => {
-            window.location.href = router.pathname;
-          }}
-        >
-          Start over
-        </button>
+          label="Start over"
+        />
       </div>
       <div className="p-2"></div>
       <div className="flex">
@@ -208,111 +204,8 @@ function Example({ appId }: { appId: string }) {
   );
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Pagination example',
-      // Uncomment and start a new app to test rules
-      /* rules: {
-        code: {
-          goals: {
-            allow: {
-              // data.number % 2 == 0 gives me a typecasting error
-              // so does int(data.number) % 2 == 0
-              view: "data.number == 2 || data.number == 4 || data.number == 6 || data.number == 8 || data.number == 10",
-            },
-          },
-        },
-      }, */
-    }),
-  });
-
-  return r.json();
-}
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({ urlAppId }: { urlAppId: string | undefined }) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-  return <Example appId={appId} />;
-}
-
 function Page() {
-  const router = useRouter();
-  if (router.isReady) {
-    return <App urlAppId={router.query.app as string} />;
-  } else {
-    return <div>Loading...</div>;
-  }
+  return <EphemeralAppPage Component={Example} />;
 }
 
 export default Page;

--- a/client/sandbox/react-nextjs/pages/play/operators.tsx
+++ b/client/sandbox/react-nextjs/pages/play/operators.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
-import config from '../../config';
-import { init, tx, id, i } from '@instantdb/react';
-import { useRouter } from 'next/router';
+import { tx, id, i, InstantReactAbstractDatabase } from '@instantdb/react';
+
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
 
 const schema = i.schema({
   entities: {
@@ -38,11 +39,7 @@ function randInt(max: number) {
 
 const d = new Date();
 
-function Example({ appId }: { appId: string }) {
-  const router = useRouter();
-  const myConfig = { ...config, appId, schema };
-  const db = init(myConfig);
-
+function Example({ db }: { db: InstantReactAbstractDatabase<typeof schema> }) {
   const { data } = db.useQuery({
     comments: {
       $: { where: { order: { $gt: 50 } } },
@@ -79,14 +76,10 @@ function Example({ appId }: { appId: string }) {
         >
           Add order = 50
         </button>
-        <button
+        <ResetButton
           className="bg-black text-white m-2 p-2"
-          onClick={() => {
-            window.location.href = router.pathname;
-          }}
-        >
-          Start over
-        </button>
+          label="Start over"
+        />
       </div>
       <div className="p-2"></div>
       <div className="flex">
@@ -113,99 +106,8 @@ function Example({ appId }: { appId: string }) {
   );
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Comparisons example',
-    }),
-  });
-
-  return r.json();
-}
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({ urlAppId }: { urlAppId: string | undefined }) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-  return <Example appId={appId} />;
-}
-
 function Page() {
-  const router = useRouter();
-  if (router.isReady) {
-    return <App urlAppId={router.query.app as string} />;
-  } else {
-    return <div>Loading...</div>;
-  }
+  return <EphemeralAppPage schema={schema} Component={Example} />;
 }
 
 export default Page;

--- a/client/sandbox/react-nextjs/pages/play/pagination.tsx
+++ b/client/sandbox/react-nextjs/pages/play/pagination.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useState } from 'react';
-import config from '../../config';
-import { init, tx, id, i } from '@instantdb/react';
-import { useRouter } from 'next/router';
+import { useState } from 'react';
 
-const schema = i.graph(
-  {
+import { tx, id, i, InstantReactAbstractDatabase } from '@instantdb/react';
+
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
+
+const schema = i.schema({
+  entities: {
     goals: i.entity({
       number: i.number().indexed(),
       date: i.date().indexed(),
@@ -19,14 +22,9 @@ const schema = i.graph(
       email: i.string().unique().indexed(),
     }),
   },
-  {},
-);
+});
 
-function Example({ appId }: { appId: string }) {
-  const router = useRouter();
-  const myConfig = { ...config, appId, schema };
-  const db = init(myConfig);
-
+function Example({ db }: { db: InstantReactAbstractDatabase<typeof schema> }) {
   const { data } = db.useQuery({ goals: {} });
 
   const [direction, setDirection] = useState<'asc' | 'desc'>('asc');
@@ -142,17 +140,10 @@ function Example({ appId }: { appId: string }) {
         >
           Delete all
         </button>
-        <button
+        <ResetButton
+          label="Start over"
           className="bg-black text-white m-2 p-2"
-          onClick={() =>
-            router.push({
-              ...router,
-              query: {},
-            })
-          }
-        >
-          Start over
-        </button>
+        />
       </div>
       <div className="p-2">
         <select
@@ -282,111 +273,6 @@ function Example({ appId }: { appId: string }) {
   );
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Pagination example',
-      // Uncomment and start a new app to test rules
-      /* rules: {
-        code: {
-          goals: {
-            allow: {
-              // data.number % 2 == 0 gives me a typecasting error
-              // so does int(data.number) % 2 == 0
-              view: "data.number == 2 || data.number == 4 || data.number == 6 || data.number == 8 || data.number == 10",
-            },
-          },
-        },
-      }, */
-    }),
-  });
-
-  return r.json();
+export default function Page() {
+  return <EphemeralAppPage schema={schema} Component={Example} />;
 }
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({ urlAppId }: { urlAppId: string | undefined }) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-  return <Example appId={appId} />;
-}
-
-function Page() {
-  const router = useRouter();
-  if (router.isReady) {
-    return <App urlAppId={router.query.app as string} />;
-  } else {
-    return <div>Loading...</div>;
-  }
-}
-
-export default Page;

--- a/client/sandbox/react-nextjs/pages/play/query-like.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-like.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
-import config from '../../config';
-import { init, tx, id, i } from '@instantdb/react';
-import { useRouter } from 'next/router';
+import { tx, id, i, InstantReactAbstractDatabase } from '@instantdb/react';
+
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
 
 const schema = i.schema({
   entities: {
@@ -28,11 +29,7 @@ const schema = i.schema({
   },
 });
 
-function Example({ appId }: { appId: string }) {
-  const router = useRouter();
-  const myConfig = { ...config, appId, schema };
-  const db = init(myConfig);
-
+function Example({ db }: { db: InstantReactAbstractDatabase<typeof schema> }) {
   const { data } = db.useQuery({ items: {} });
 
   const { data: isEquality } = db.useQuery({
@@ -110,14 +107,10 @@ function Example({ appId }: { appId: string }) {
         >
           Create link with val = "womp"
         </button>
-        <button
+        <ResetButton
           className="bg-black text-white m-2 p-2"
-          onClick={() => {
-            window.location.href = router.pathname;
-          }}
-        >
-          Start over
-        </button>
+          label="Start over"
+        />
       </div>
       <div className="p-2"></div>
       <div className="flex">
@@ -239,99 +232,8 @@ function Example({ appId }: { appId: string }) {
   );
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Query Like Sandbox',
-    }),
-  });
-
-  return r.json();
-}
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({ urlAppId }: { urlAppId: string | undefined }) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-  return <Example appId={appId} />;
-}
-
 function Page() {
-  const router = useRouter();
-  if (router.isReady) {
-    return <App urlAppId={router.query.app as string} />;
-  } else {
-    return <div>Loading...</div>;
-  }
+  return <EphemeralAppPage Component={Example} schema={schema} />;
 }
 
 export default Page;

--- a/client/sandbox/react-nextjs/pages/play/stress.tsx
+++ b/client/sandbox/react-nextjs/pages/play/stress.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import config from '../../config';
 import { init, tx, id } from '@instantdb/react';
 import { useRouter } from 'next/router';
+import EphemeralAppPage from '../../components/EphemeralAppPage';
 
 function Example({ appId }: { appId: string }) {
   const router = useRouter();
@@ -120,111 +121,8 @@ function Example({ appId }: { appId: string }) {
   );
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: 'Pagination example',
-      // Uncomment and start a new app to test rules
-      /* rules: {
-        code: {
-          goals: {
-            allow: {
-              // data.number % 2 == 0 gives me a typecasting error
-              // so does int(data.number) % 2 == 0
-              view: "data.number == 2 || data.number == 4 || data.number == 6 || data.number == 8 || data.number == 10",
-            },
-          },
-        },
-      }, */
-    }),
-  });
-
-  return r.json();
-}
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  return r.json();
-}
-
-function App({ urlAppId }: { urlAppId: string | undefined }) {
-  const router = useRouter();
-  const [appId, setAppId] = useState();
-
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (appId) {
-      return;
-    }
-    if (urlAppId) {
-      verifyEphemeralApp({ appId: urlAppId }).then((res): any => {
-        if (res.app) {
-          setAppId(res.app.id);
-        } else {
-          provisionEphemeralApp().then((res) => {
-            if (res.app) {
-              router.replace({
-                pathname: router.pathname,
-                query: { ...router.query, app: res.app.id },
-              });
-
-              setAppId(res.app.id);
-            } else {
-              console.log(res);
-              setError('Could not create app.');
-            }
-          });
-        }
-      });
-    } else {
-      provisionEphemeralApp().then((res) => {
-        if (res.app) {
-          router.replace({
-            pathname: router.pathname,
-            query: { ...router.query, app: res.app.id },
-          });
-
-          setAppId(res.app.id);
-        } else {
-          console.log(res);
-          setError('Could not create app.');
-        }
-      });
-    }
-  }, []);
-
-  if (error) {
-    return (
-      <div>
-        <p>There was an error</p>
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!appId) {
-    return <div>Loading...</div>;
-  }
-  return <Example appId={appId} />;
-}
-
 function Page() {
-  const router = useRouter();
-  if (router.isReady) {
-    return <App urlAppId={router.query.app as string} />;
-  } else {
-    return <div>Loading...</div>;
-  }
+  return <EphemeralAppPage Component={Example} />;
 }
 
 export default Page;


### PR DESCRIPTION
Creates a new `EphemeralAppPage` component that takes optional `schema` and `perms` props. You can use it to quickly create ephemeral apps for your play page. 

Also updates the ephemeral app endpoint to accept a schema.

You can even seed it with data using the `onCreateApp` prop.

Hopefully this will make it easier to quickly create new play pages. And if you forget how it works, there's a play page for that at http://localhost:4000/play/ephemeral-demo

Here's what the code for a page looks like:

```jsx
import { i, id, InstantReactAbstractDatabase, tx } from '@instantdb/react';
import EphemeralAppPage, {
  ResetButton,
} from '../../components/EphemeralAppPage';

const schema = i.schema({
  entities: {
    docs: i.entity({
      title: i.string(),
    }),
  },
});

const perms = {
  docs: {
    allow: {
      view: 'true',
    },
  },
};

function App({ db }: { db: InstantReactAbstractDatabase<typeof schema> }) {
  const { isLoading, error, data } = db.useQuery({ docs: {} });

  if (isLoading) {
    return <div>Loading</div>;
  }

  if (error) {
    return <div>Error: {error.message}</div>;
  }

  return (
    <div>
      <ResetButton className="bg-black text-white m-2 p-2" />
      <pre>{JSON.stringify(data, null, 2)}</pre>;
      <button
        className="bg-black text-white m-2 p-2"
        onClick={() =>
          db.transact(db.tx.docs[id()].update({ title: 'New doc' }))
        }
      >
        Add doc
      </button>
    </div>
  );
}

export default function Page() {
  return <EphemeralAppPage schema={schema} perms={perms} Component={App} />
}
```
