### PR TITLE
Single exception log and java in src

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -96,6 +96,10 @@ jobs:
       working-directory: server
       run: clojure -P
 
+    - name: Compile java src files
+      working-directory: server
+      run: clojure -T:build compile-java
+
     - name: Run Clojure tests
       working-directory: server
       env:

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -33,6 +33,9 @@ jobs:
             echo "did_change=True" >> $GITHUB_OUTPUT
             break
           fi
+          if echo $file | grep -E '.github/workflows/clojure.yml'; then
+            echo "did_change=True" >> $GITHUB_OUTPUT
+          break
         done
 
   clj-check:

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -35,7 +35,8 @@ jobs:
           fi
           if echo $file | grep -E '.github/workflows/clojure.yml'; then
             echo "did_change=True" >> $GITHUB_OUTPUT
-          break
+            break
+          fi
         done
 
   clj-check:

--- a/server/Makefile
+++ b/server/Makefile
@@ -30,6 +30,9 @@ dev-down:
 	@echo "Migrating dev db up down by 1"
 	migrate -database "postgresql://localhost:5432/instant?sslmode=disable" -path resources/migrations down 1
 
+compile-java:
+	clojure -T:build compile-java
+
 test:
 	TEST=true clojure -M:test
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -4,7 +4,7 @@ DC = $(shell command -v docker-compose >/dev/null 2>&1 && echo "docker-compose" 
 
 dev:
 	@echo "Booting up backend w/ local db..."
-	clojure -M:dev:run
+	clojure -T:build dev
 
 bootstrap-oss:
 	clojure -X:dev:oss-bootstrap
@@ -13,7 +13,7 @@ dev-oss:
 	@echo "Booting up backend w/ local db..."
 	clojure -X:dev:oss-bootstrap
 	@echo "Starting server..."
-	clojure -M:dev:run
+	clojure -T:build dev
 
 install-hooks:
 	@echo "Installing .git/hooks/pre-commit..."
@@ -29,13 +29,6 @@ dev-up:
 dev-down:
 	@echo "Migrating dev db up down by 1"
 	migrate -database "postgresql://localhost:5432/instant?sslmode=disable" -path resources/migrations down 1
-
-dev-storm:
-	@echo "Booting up dev with storm debugger..."
-	@echo "Usage:"
-	@echo " user> (require '[flow-storm.api :as fs-api])"
-	@echo " user> (fs-api/local-connect)"
-	clojure -M:dev:storm:run
 
 test:
 	TEST=true clojure -M:test
@@ -59,7 +52,7 @@ restart:
 dev-with-prod-db:
 	@DATABASE_URL=$$(./scripts/prod_connection_string.sh); \
 	echo "[IMPORTANT] Booting up backend w/ prod db..." && \
-	DATABASE_URL="$${DATABASE_URL}" clj -M:dev:run
+	DATABASE_URL="$${DATABASE_URL}" clj -T:build dev
 
 prod-ssh:
 	./scripts/prod_ssh.sh

--- a/server/README.md
+++ b/server/README.md
@@ -57,6 +57,7 @@ The instant server will run at [localhost:8888](http://localhost:8888) and you c
 To run tests:
 
 ```sh
+make compile-java
 make test
 ```
 

--- a/server/build.clj
+++ b/server/build.clj
@@ -7,11 +7,34 @@
 ;; delay to defer side effects (artifact downloads)
 (def basis (delay (b/create-basis {:project "deps.edn"})))
 
+(defn compile-java [_]
+  (println "COMPILE JAVA")
+  (b/javac {:src-dirs ["src/java"]
+            :class-dir "target/classes"
+            :basis @basis
+            :javac-opts ["-proc:none"]}))
+
+(defn dev [_]
+  (compile-java nil)
+  (b/process
+   (b/java-command {:basis (b/create-basis {:project "deps.edn"
+                                            :aliases ["dev"]})
+                    :main 'clojure.main
+                    :main-args ["-m" "instant.core"]})))
+
+(defn run [_]
+  (compile-java nil)
+  (b/process
+   (b/java-command {:basis (b/create-basis {:project "deps.edn"})
+                    :main 'clojure.main
+                    :main-args ["-m" "instant.core"]})))
+
 (defn clean [_]
   (b/delete {:path "target"}))
 
 (defn uber [_]
   (clean nil)
+  (compile-java)
   (b/copy-dir {:src-dirs ["src" "resources" "data"]
                :target-dir class-dir})
   (b/compile-clj {:basis @basis

--- a/server/build.clj
+++ b/server/build.clj
@@ -34,7 +34,7 @@
 
 (defn uber [_]
   (clean nil)
-  (compile-java)
+  (compile-java nil)
   (b/copy-dir {:src-dirs ["src" "resources" "data"]
                :target-dir class-dir})
   (b/compile-clj {:basis @basis

--- a/server/build.clj
+++ b/server/build.clj
@@ -8,7 +8,6 @@
 (def basis (delay (b/create-basis {:project "deps.edn"})))
 
 (defn compile-java [_]
-  (println "COMPILE JAVA")
   (b/javac {:src-dirs ["src/java"]
             :class-dir "target/classes"
             :basis @basis

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources" "data"]
+{:paths ["src" "resources" "data" "target/classes"]
  :deps {cheshire/cheshire {:mvn/version "5.10.0"}
         clj-http/clj-http {:mvn/version "3.12.3"}
 
@@ -118,14 +118,8 @@
 
                             ;; headless charts 
                             "-Djava.awt.headless=true"]}
-           :storm {:extra-deps {com.github.flow-storm/clojure {:mvn/version "1.11.2-4"}
-                                com.github.flow-storm/flow-storm-dbg {:mvn/version "3.14.0"}}
-                   :override-deps {org.clojure/clojure nil}
-                   :jvm-opts ["-Dclojure.storm.instrumentEnable=true"
-                              "-Dclojure.storm.instrumentOnlyPrefixes=instant."]}
-           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.3" :git/sha "15ead66"}}
+           :build {:extra-deps {io.github.clojure/tools.build {:git/tag "v0.10.3" :git/sha "15ead66"}}
                    :ns-default build}
-           :run {:main-opts ["-m" "instant.core"]}
            :test {:extra-paths ["test" "dev-resources"]
                   :extra-deps {io.github.tonsky/clj-reload {:mvn/version "0.9.4"}
                                zprint/zprint               {:mvn/version "1.2.9"}}

--- a/server/src/java/instant/SpanTrackException.java
+++ b/server/src/java/instant/SpanTrackException.java
@@ -1,0 +1,8 @@
+package instant;
+
+// Creates an exception without a stack trace
+public class SpanTrackException extends Throwable {
+    public SpanTrackException(String spanId) {
+        super(spanId, null, true, false);
+    }
+}


### PR DESCRIPTION
This does two things:

1. It sets us up to be able to include java code in our codebase. There have been a few times where it would be easier to just write something in Java, but it was too much effort to get clojure to consume the java file. Now we can easily add new java files in src/java. You still have to restart if you make changes to the java file, though, so it's not super easy (but maybe somebody knows how to set up a reload workflow?). 

2. It only logs a single exception in a set of nested spans.
  Right now, we'll log the exception in every single span, since each span will catch the exception, log it, then rethrow the exception.
  We accomplish this by adding some data to the throwable. You can add a "suppressed" exception to any throwable, so we add a custom `SpanTrackException` that puts the spanid in the message. We want the `SpanTrackException` to be as cheap as possible, so I created an exception that doesn't attach a stack trace (hence the java changes).
  
```clojure
(tracer/with-span! {:name "a"}       
  (tracer/with-span! {:name "b"}     
    (tracer/with-span! {:name "c"}   
      (throw (Exception. "oops"))))) 
```

**After**:

```
[4a8d] 1ms [c] clojure.error.class=java.lang.Exception exception.type=java.lang.Exception exception.message=oops clojure.error.phase=:execution exception.stacktrace=java.lang.Exception: oops
	at instant.db.instaql$eval77986.invokeStatic(NO_SOURCE_FILE:1936)
	at instant.db.instaql$eval77986.invoke(NO_SOURCE_FILE:1934)
	at clojure.lang.Compiler.eval(Compiler.java:7700)
	at clojure.lang.Compiler.eval(Compiler.java:7655)
	...
        Suppressed: instant.SpanTrackException: d4c6875f93a31567
 clojure.error.line=1936 clojure.error.symbol=instant.db.instaql/eval77986 exception.escaped=true clojure.error.cause=oops 
[4a8d] 2ms [b] child-threw-exception=true 
[4a8d] 3ms [a] child-threw-exception=true 
```

**Before**:

```
[ae32] 0ms [c] clojure.error.class=java.lang.Exception exception.type=java.lang.Exception exception.message=oops clojure.error.phase=:execution exception.stacktrace=java.lang.Exception: oops
	at instant.db.instaql$eval78087.invokeStatic(NO_SOURCE_FILE:1942)
	at instant.db.instaql$eval78087.invoke(NO_SOURCE_FILE:1940)
	at clojure.lang.Compiler.eval(Compiler.java:7700)
	...
 clojure.error.line=1942 clojure.error.symbol=instant.db.instaql/eval78087 exception.escaped=true clojure.error.cause=oops 
[ae32] 2ms [b] clojure.error.class=java.lang.Exception exception.type=java.lang.Exception exception.message=oops clojure.error.phase=:execution exception.stacktrace=java.lang.Exception: oops
	at instant.db.instaql$eval78087.invokeStatic(NO_SOURCE_FILE:1942)
	at instant.db.instaql$eval78087.invoke(NO_SOURCE_FILE:1940)
	at clojure.lang.Compiler.eval(Compiler.java:7700)
	at clojure.lang.Compiler.eval(Compiler.java:7655)
	...
 clojure.error.line=1942 clojure.error.symbol=instant.db.instaql/eval78087 exception.escaped=true clojure.error.cause=oops 
[ae32] 2ms [a] clojure.error.class=java.lang.Exception exception.type=java.lang.Exception exception.message=oops clojure.error.phase=:execution exception.stacktrace=java.lang.Exception: oops
	at instant.db.instaql$eval78087.invokeStatic(NO_SOURCE_FILE:1942)
	at instant.db.instaql$eval78087.invoke(NO_SOURCE_FILE:1940)
	at clojure.lang.Compiler.eval(Compiler.java:7700)
	...
 clojure.error.line=1942 clojure.error.symbol=instant.db.instaql/eval78087 exception.escaped=true clojure.error.cause=oops 
[e445] 1ms [sql/select] idle_connections=20 active_connections=0 pending_threads=0 
```