### PR TITLE
Use custom `Error` instances in `Promise.reject` for improved stack traces

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -6,6 +6,8 @@ import {
   id,
   txInit,
   version as coreVersion,
+  InstantAPIError,
+  type InstantIssue,
   type TransactionChunk,
   type AuthToken,
   type Exactly,
@@ -177,7 +179,7 @@ async function jsonFetch(
   const json = await res.json();
   return res.status === 200
     ? Promise.resolve(json)
-    : Promise.reject({ status: res.status, body: json });
+    : Promise.reject(new InstantAPIError({ status: res.status, body: json }));
 }
 
 /**

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -838,6 +838,9 @@ export {
   lookup,
   i,
 
+  // error
+  InstantAPIError,
+
   // types
   type Config,
   type ImpersonationOpts,
@@ -888,4 +891,7 @@ export {
   type UploadFileResponse,
   type DeleteFileResponse,
   type DeleteManyFileResponse,
+
+  // error types
+  type InstantIssue,
 };

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -89,6 +89,8 @@ import type {
   VerifyResponse,
 } from './authAPI';
 
+import { InstantAPIError, type InstantIssue } from './utils/fetch';
+
 const defaultOpenDevtool = true;
 
 // types
@@ -763,6 +765,9 @@ export {
   txInit,
   lookup,
 
+  // error
+  InstantAPIError,
+
   // cli
   i,
 
@@ -853,4 +858,7 @@ export {
   type FileOpts,
   type UploadFileResponse,
   type DeleteFileResponse,
+
+  // error types
+  type InstantIssue,
 };

--- a/client/packages/core/src/utils/fetch.ts
+++ b/client/packages/core/src/utils/fetch.ts
@@ -1,3 +1,65 @@
+type InstantIssueBody =
+  | { type: 'param-missing'; message: string; hint: { in: string[] } }
+  | { type: 'param-malformed'; message: string; hint: { in: string[] } }
+  | {
+      type: 'record-not-found';
+      message: string;
+      hint: { 'record-type': string };
+    }
+  | {
+      type: 'record-not-unique';
+      message: string;
+      hint: { 'record-type': string };
+    }
+  | {
+      type: 'validation-failed';
+      message: string;
+      hint: { 'data-type': 'string'; errors: any[] };
+    }
+  | {
+      type: 'record-expired';
+      message: string;
+      hint: { 'record-type': string };
+    }
+  | { type: undefined; [k: string]: any }
+  | undefined;
+
+// Note that InstantIssueBody is not exported and is only necessary for making InstantAPIError
+// below to have all the members and typecheck as InstantIssue
+export type InstantIssue = {
+  body: InstantIssueBody;
+  status: number;
+};
+
+export class InstantAPIError extends Error {
+  body: InstantIssueBody;
+  status: number;
+
+  constructor(error: InstantIssue) {
+    // Create a descriptive message based on the error
+    const message = error.body?.message || `API Error (${error.status})`;
+    super(message);
+
+    const actualProto = new.target.prototype;
+    if (Object.setPrototypeOf) {
+      Object.setPrototypeOf(this, actualProto);
+    }
+
+    // Maintain proper stack trace for where our error was thrown
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InstantAPIError);
+    }
+
+    this.name = 'InstantAPIError';
+    this.status = error.status;
+    this.body = error.body;
+  }
+
+  get [Symbol.toStringTag]() {
+    return 'InstantAPIError';
+  }
+}
+
 export async function jsonFetch(
   input: RequestInfo,
   init: RequestInit | undefined,
@@ -6,5 +68,5 @@ export async function jsonFetch(
   const json = await res.json();
   return res.status === 200
     ? Promise.resolve(json)
-    : Promise.reject({ status: res.status, body: json });
+    : Promise.reject(new InstantAPIError({ status: res.status, body: json }));
 }


### PR DESCRIPTION
Previously, promise rejections used plain objects, losing debugging context. Now, using a custom `Error` instance ensures proper (though possibly truncated [^1] ) stack traces, enhancing clarity when debugging failed `await db.transact` calls.

Using `Error` instances in promise rejections is considered a best practice: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject

[^1]: (My understanding is), to get full stack traces in npm-installed version, [current compile target](https://github.com/instantdb/instant/blob/main/client/tsconfig.base.json#L8) has to be changed from `es2015` to `es2017`

## Example

When an InstantDB transaction such as:

```typescript
const p = await db.transact(memberTxs);
```
fails during development, the error output currently lacks a proper stack trace:


Before this PR:
<div>
<img width="503" alt="current non-Error object" src="https://github.com/user-attachments/assets/be849461-2df9-4bdb-b1b2-4b73cd5fa281" />
</div>

With the updated version of the library (this PR), errors become instances of a custom Error, providing clearer debugging information:

After this PR (compiled with target=es2015):
<div>
<img width="269" alt="Custom Error object with es2015" src="https://github.com/user-attachments/assets/66fc2dcb-05bc-421f-bc58-1bda65affcb3" />
</div>


After this PR (compiled with target=es2017):
<div>
<img width="326" alt="Custom Error object with es2017" src="https://github.com/user-attachments/assets/0cdace2a-bb7d-49b6-831b-ff0ac01ca30b" />
</div>


## Note

The type definition of `InstantIssueBody` may be incomplete or incorrect. I just noticed that it is missing e.g. "permission-denied" option for `body.type`. I copied the current definition from [here](https://github.com/instantdb/instant/blob/b16b8d1ba2a3c1945e9bb1e41b363cb0dcd56152/client/www/lib/types.ts#L245-L272)


