### PR TITLE
Fixes :dev alias and remove reflection warnings

### DIFF
--- a/server/build.clj
+++ b/server/build.clj
@@ -17,7 +17,7 @@
   (compile-java nil)
   (b/process
    (b/java-command {:basis (b/create-basis {:project "deps.edn"
-                                            :aliases ["dev"]})
+                                            :aliases [:dev]})
                     :main 'clojure.main
                     :main-args ["-m" "instant.core"]})))
 


### PR DESCRIPTION
Fixes a couple of dev-time annoyances introduced in https://github.com/instantdb/instant/pull/1112

1. Uses the correct alias to pull in the dev deps (`:dev` instead of "dev")
2. Fixes reflection warnings in logging_exporter.clj