### PR TITLE
Fix wal shutdown

### DIFF
--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -327,7 +327,7 @@
              shutdown-fn))))
 
 (defn closed? [o]
-  (case (class o)
+  (condp instance? o
     Connection (Connection/.isClosed o)
     PGReplicationStream (PGReplicationStream/.isClosed o)))
 


### PR DESCRIPTION
We are getting this on app shutdown now:

```
[1761] 1ms [wal-worker/shutdown!] slot_name=dev_768cfcd2597ab83d_0b0067c0cab6f683 exception.message=No matching clause: class org.postgresql.core.v3.replication.V3PGReplicationStream clojure.error.source=wal.clj exception.type=java.lang.IllegalArgumentException exception.escaped=true clojure.error.class=java.lang.IllegalArgumentException clojure.error.cause=No matching clause: class org.postgresql.core.v3.replication.V3PGReplicationStream exception.stacktrace=java.lang.IllegalArgumentException: No matching clause: class org.postgresql.core.v3.replication.V3PGReplicationStream
        at instant.jdbc.wal$closed_QMARK_.invokeStatic(wal.clj:330)
        at instant.jdbc.wal$closed_QMARK_.invoke(wal.clj:329)
        at instant.jdbc.wal$close_nicely.invokeStatic(wal.clj:335)
        at instant.jdbc.wal$close_nicely.invoke(wal.clj:334)
        at instant.jdbc.wal$start_worker$fn__66421.invoke(wal.clj:405)
        at instant.jdbc.wal$shutdown_BANG_.invokeStatic(wal.clj:441)
        at instant.jdbc.wal$shutdown_BANG_.invoke(wal.clj:437)
        at instant.reactive.invalidator$stop$fn__74826.invoke(invalidator.clj:505)
        at clojure.core$binding_conveyor_fn$fn__5842.invoke(core.clj:2047)
        at clojure.lang.AFn.call(AFn.java:18)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1570)
        Suppressed: instant.SpanTrackException: b5a7cfe938224b27
 clojure.error.symbol=instant.jdbc.wal/closed? clojure.error.line=330 clojure.error.phase=:execution
 ```