### PR TITLE
Narek/error type fix

### DIFF
--- a/client/packages/core/src/utils/fetch.ts
+++ b/client/packages/core/src/utils/fetch.ts
@@ -21,6 +21,11 @@ type InstantIssueBody =
       message: string;
       hint: { 'record-type': string };
     }
+  | {
+      type: 'permission-denied';
+      message: string;
+      hint: { input: any; expected: string };
+    }
   | { type: undefined; [k: string]: any }
   | undefined;
 

--- a/client/packages/core/src/utils/fetch.ts
+++ b/client/packages/core/src/utils/fetch.ts
@@ -22,13 +22,54 @@ type InstantIssueBody =
       hint: { 'record-type': string };
     }
   | {
+      type: 'record-foreign-key-invalid';
+      message: string;
+      hint: { table?: string; condition?: string; constraint?: string };
+    }
+  | {
+      type: 'record-check-violation';
+      message: string;
+      hint: { table?: string; condition?: string; constraint?: string };
+    }
+  | {
       type: 'permission-denied';
       message: string;
       hint: { input: any; expected: string };
     }
+  | {
+      type: 'permission-evaluation-failed';
+      message: string;
+      hint: {
+        rule: [string, string];
+        error?: { type: string; message: string; hint: any };
+      };
+    }
+  | {
+      type: 'sql-raise';
+      message: string;
+      hint: { table?: string; condition?: string; constraint?: string };
+    }
+  | {
+      type: 'sql-exception';
+      message: string;
+      hint: { table?: string; condition?: string; constraint?: string };
+    }
+  | {
+      type: 'rate-limited';
+      message: string;
+    }
+  | {
+      type: 'session-missing';
+      message: string;
+      hint: { 'sess-id': string };
+    }
+  | {
+      type: 'socket-missing';
+      message: string;
+      hint: { 'sess-id': string; 'exception-message'?: string };
+    }
   | { type: undefined; [k: string]: any }
   | undefined;
-
 // Note that InstantIssueBody is not exported and is only necessary for making InstantAPIError
 // below to have all the members and typecheck as InstantIssue
 export type InstantIssue = {

--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -11,7 +11,7 @@ import {
 import config, { isDev } from '@/lib/config';
 import googleIconSvg from '../../public/img/google_g.svg';
 import Image from 'next/image';
-import { InstantError } from '@/lib/types';
+import { InstantIssue } from '@/lib/types';
 import { url } from '@/lib/url';
 import { useRouter } from 'next/router';
 
@@ -244,7 +244,7 @@ export default function Auth(props: {
   );
 }
 
-function errorFromVerifyMagicCode(res: InstantError): string {
+function errorFromVerifyMagicCode(res: InstantIssue): string {
   const errorType = res.body?.type;
   switch (errorType) {
     case 'param-missing':
@@ -260,7 +260,7 @@ function errorFromVerifyMagicCode(res: InstantError): string {
   }
 }
 
-function errorFromSendMagicCode(res: InstantError): string {
+function errorFromSendMagicCode(res: InstantIssue): string {
   const errorType = res.body?.type;
   const defaultMsg =
     'Uh oh, something went wrong sending you a magic code, please ping us!';

--- a/client/www/components/dash/Billing.tsx
+++ b/client/www/components/dash/Billing.tsx
@@ -4,7 +4,7 @@ import { messageFromInstantError } from '@/lib/errors';
 import config, { stripeKey } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
-import { AppsSubscriptionResponse, InstantError } from '@/lib/types';
+import { AppsSubscriptionResponse, InstantIssue } from '@/lib/types';
 import { loadStripe } from '@stripe/stripe-js';
 import { useContext, useRef } from 'react';
 import { Loading, ErrorMessage } from '@/components/dash/shared';
@@ -47,7 +47,7 @@ async function createCheckoutSession(appId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantError) ||
+        messageFromInstantError(err as InstantIssue) ||
         'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
@@ -75,7 +75,7 @@ async function createPortalSession(appId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantError) ||
+        messageFromInstantError(err as InstantIssue) ||
         'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);

--- a/client/www/components/dash/OAuthApps.tsx
+++ b/client/www/components/dash/OAuthApps.tsx
@@ -15,7 +15,7 @@ import { messageFromInstantError } from '@/lib/errors';
 import config, { discordOAuthAppsFeedbackInviteUrl } from '@/lib/config';
 import { jsonFetch } from '@/lib/fetch';
 import {
-  InstantError,
+  InstantIssue,
   OAuthApp,
   OAuthAppClient,
   OAuthAppClientSecret,
@@ -317,7 +317,7 @@ interface OAuthAppContext {
 const OAuthAppContext = createContext<OAuthAppContext | null>(null);
 
 function exceptionToast(e: unknown, backupMsg: string) {
-  const msg = messageFromInstantError(e as InstantError) || backupMsg;
+  const msg = messageFromInstantError(e as InstantIssue) || backupMsg;
   errorToast(msg, { autoClose: 60000 });
 }
 

--- a/client/www/components/dash/auth/Apple.tsx
+++ b/client/www/components/dash/auth/Apple.tsx
@@ -25,7 +25,7 @@ import { addProvider, addClient, deleteClient, findName } from './shared';
 import {
   AppsAuthResponse,
   InstantApp,
-  InstantError,
+  InstantIssue,
   OAuthClient,
   OAuthServiceProvider,
 } from '@/lib/types';
@@ -59,7 +59,7 @@ export function AppleClient({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error deleting client.';
+        messageFromInstantError(e as InstantIssue) || 'Error deleting client.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);
@@ -230,7 +230,7 @@ export function AddClientExpanded({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error creating client.';
+        messageFromInstantError(e as InstantIssue) || 'Error creating client.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -26,7 +26,7 @@ import { messageFromInstantError } from '@/lib/errors';
 import { addProvider, addClient, deleteClient, findName } from './shared';
 import {
   InstantApp,
-  InstantError,
+  InstantIssue,
   OAuthClient,
   OAuthServiceProvider,
 } from '@/lib/types';
@@ -52,7 +52,7 @@ export function AddClerkProviderForm({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) ||
+        messageFromInstantError(e as InstantIssue) ||
         'There was an error setting up Clerk.';
       errorToast(msg, { autoClose: 5000 });
       // report error
@@ -227,7 +227,7 @@ export function ClerkClient({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error deleting client.';
+        messageFromInstantError(e as InstantIssue) || 'Error deleting client.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);
@@ -416,7 +416,7 @@ export function AddClerkClientForm({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error creating client.';
+        messageFromInstantError(e as InstantIssue) || 'Error creating client.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);

--- a/client/www/components/dash/auth/Google.tsx
+++ b/client/www/components/dash/auth/Google.tsx
@@ -3,7 +3,7 @@ import { errorToast } from '@/lib/toast';
 import { TokenContext } from '@/lib/contexts';
 import {
   InstantApp,
-  InstantError,
+  InstantIssue,
   OAuthClient,
   OAuthServiceProvider,
 } from '@/lib/types';
@@ -123,7 +123,7 @@ export function AddClientForm({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error creating client.';
+        messageFromInstantError(e as InstantIssue) || 'Error creating client.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);
@@ -270,7 +270,7 @@ export function AddGoogleProviderForm({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) ||
+        messageFromInstantError(e as InstantIssue) ||
         'There was an error setting up Google.';
       errorToast(msg, { autoClose: 5000 });
       // report error
@@ -335,7 +335,7 @@ export function Client({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error deleting client.';
+        messageFromInstantError(e as InstantIssue) || 'Error deleting client.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);

--- a/client/www/components/dash/auth/Origins.tsx
+++ b/client/www/components/dash/auth/Origins.tsx
@@ -5,7 +5,7 @@ import {
   AuthorizedOrigin,
   AuthorizedOriginService,
   InstantApp,
-  InstantError,
+  InstantIssue,
   OAuthClient,
   OAuthServiceProvider,
 } from '@/lib/types';
@@ -168,7 +168,7 @@ export function AuthorizedOriginsForm({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error creating origin.';
+        messageFromInstantError(e as InstantIssue) || 'Error creating origin.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);
@@ -335,7 +335,7 @@ export function AuthorizedOriginRow({
     } catch (e) {
       console.error(e);
       const msg =
-        messageFromInstantError(e as InstantError) || 'Error removing origin.';
+        messageFromInstantError(e as InstantIssue) || 'Error removing origin.';
       errorToast(msg, { autoClose: 5000 });
     } finally {
       setIsLoading(false);

--- a/client/www/lib/errors.ts
+++ b/client/www/lib/errors.ts
@@ -1,6 +1,6 @@
 import { capitalize } from 'lodash';
 
-import { InstantError } from './types';
+import { InstantIssue } from './types';
 
 const friendlyName = (s: string) => {
   return s.replaceAll(/[_-]/g, ' ');
@@ -12,7 +12,7 @@ const friendlyNameFromIn = (inArr: string[]) => {
 
 /* Standardize error messages from Instant */
 export const messageFromInstantError = (
-  e: InstantError,
+  e: InstantIssue,
 ): string | undefined => {
   const body = e.body;
   if (!body) return;

--- a/client/www/lib/hooks/useTotalSessionsCount.tsx
+++ b/client/www/lib/hooks/useTotalSessionsCount.tsx
@@ -4,7 +4,7 @@ import useCurrentDate from './useCurrentDate';
 import config from '@/lib/config';
 import { jsonFetch } from '../fetch';
 import { messageFromInstantError } from '@/lib/errors';
-import { InstantError } from '../types';
+import { InstantIssue } from '../types';
 
 async function fetchTotalSessionsCount() {
   return jsonFetch(`${config.apiURI}/dash/stats/active_sessions`, {
@@ -42,7 +42,7 @@ export default function useTotalSessionsCount({
       } catch (error) {
         if (cancel) return;
         const message =
-          messageFromInstantError(error as InstantError) ||
+          messageFromInstantError(error as InstantIssue) ||
           'Failed to fetch total sessions count';
         setState({ data: undefined, error: { message }, isLoading: false });
       }

--- a/client/www/lib/types.ts
+++ b/client/www/lib/types.ts
@@ -1,3 +1,5 @@
+import { InstantIssue } from '@instantdb/core';
+
 export type InstantApp = {
   id: string;
   pro: boolean;
@@ -242,31 +244,5 @@ export type OAuthAppsResponse = {
   apps: OAuthApp[];
 };
 
-export type InstantIssue = {
-  body:
-    | { type: 'param-missing'; message: string; hint: { in: string[] } }
-    | { type: 'param-malformed'; message: string; hint: { in: string[] } }
-    | {
-        type: 'record-not-found';
-        message: string;
-        hint: { 'record-type': string };
-      }
-    | {
-        type: 'record-not-unique';
-        message: string;
-        hint: { 'record-type': string };
-      }
-    | {
-        type: 'validation-failed';
-        message: string;
-        hint: { 'data-type': 'string'; errors: any[] };
-      }
-    | {
-        type: 'record-expired';
-        message: string;
-        hint: { 'record-type': string };
-      }
-    | { type: undefined; [k: string]: any }
-    | undefined;
-  status: number;
-};
+// re-export InstantIssue from the core library
+export { type InstantIssue };

--- a/client/www/lib/types.ts
+++ b/client/www/lib/types.ts
@@ -242,7 +242,7 @@ export type OAuthAppsResponse = {
   apps: OAuthApp[];
 };
 
-export type InstantError = {
+export type InstantIssue = {
   body:
     | { type: 'param-missing'; message: string; hint: { in: string[] } }
     | { type: 'param-malformed'; message: string; hint: { in: string[] } }

--- a/client/www/pages/dash/oauth/callback.tsx
+++ b/client/www/pages/dash/oauth/callback.tsx
@@ -6,7 +6,7 @@ import { Button, Content, ScreenHeading } from '@/components/ui';
 import { exchangeOAuthCodeForToken } from '@/lib/auth';
 import { messageFromInstantError } from '@/lib/errors';
 import config, { cliOauthParamName } from '@/lib/config';
-import { InstantError } from '@/lib/types';
+import { InstantIssue } from '@/lib/types';
 
 type CallbackState =
   | { type: 'router-loading' }
@@ -127,7 +127,7 @@ export default function OAuthCallback() {
             router.push(finalPath);
           })
           .catch((res) => {
-            const error = messageFromInstantError(res as InstantError);
+            const error = messageFromInstantError(res as InstantIssue);
 
             setState({
               type: 'error',

--- a/client/www/pages/platform/oauth/start.tsx
+++ b/client/www/pages/platform/oauth/start.tsx
@@ -5,7 +5,7 @@ import { useAuthToken } from '@/lib/auth';
 import config, { discordInviteUrl } from '@/lib/config';
 import { messageFromInstantError } from '@/lib/errors';
 import { jsonFetch } from '@/lib/fetch';
-import { InstantError } from '@/lib/types';
+import { InstantIssue } from '@/lib/types';
 import { useEffect, useRef, useState } from 'react';
 
 /*
@@ -21,7 +21,7 @@ function InvalidRedirect({
   error?: unknown;
 }) {
   const instantError = error
-    ? messageFromInstantError(error as InstantError)
+    ? messageFromInstantError(error as InstantIssue)
     : null;
   return (
     <div className="flex h-full items-center justify-center p-4">


### PR DESCRIPTION
A few changes missed in #1115 

1.  Add 'permission-denied' subtype to the API error type (needed and used in our tests)
2. Add a bunch of other subtypes to the error type LLM-extracted from [`exceptions.clj`](https://github.com/instantdb/instant/blob/d79ff56d2abe2ede82fb20bdf702167025a9299f/server/src/instant/util/exception.clj) (not used by us, happy to change or revert)
3. Use the created `InstantIssue` type from core in `client/www` in stead of redefining a similar type (happy to revert)
