### PR TITLE
[Dash] Reverse parent <-> children self-link

### DIFF
--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -266,10 +266,10 @@ function AddAttrForm({
     if (!reverseNamespace) return;
 
     const isSelfLink = reverseNamespace.name === namespace.name;
-    setAttrName(isSelfLink ? 'children' : reverseNamespace.name);
-    setReverseAttrName(isSelfLink ? 'parent' : namespace.name);
+    setAttrName(isSelfLink ? 'parent' : reverseNamespace.name);
+    setReverseAttrName(isSelfLink ? 'children' : namespace.name);
     if (isSelfLink) {
-      setRelationship('many-one');
+      setRelationship('one-many');
     }
   }, [attrType, reverseNamespace]);
 


### PR DESCRIPTION
A user pointed out that the default had this reversed. Likely folks will want `parent` in the forward direction