### PR TITLE
Faster aurora failover

### DIFF
--- a/server/scripts/prod_connection_string.sh
+++ b/server/scripts/prod_connection_string.sh
@@ -4,15 +4,16 @@ set -euo pipefail
 
 output="text"
 
+cluster_id='instant-aurora-8'
+
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --output) output="$2"; shift ;;
+    --cluster-id) cluster_id="$2"; shift ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
 done
-
-cluster_id='instant-aurora-8'
 
 cluster_info=$(aws rds describe-db-clusters --db-cluster-identifier $cluster_id --query 'DBClusters[0].{host: Endpoint, port: Port, secretArn: MasterUserSecret.SecretArn, dbname: DatabaseName}')
 

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -1,6 +1,6 @@
 (ns instant.jdbc.aurora
   (:require
-   [instant.aurora-config :refer [secret-arn->db-creds]]
+   [instant.aurora-config :refer [rds-cluster-id->db-config secret-arn->db-creds]]
    [instant.config :as config]
    [instant.util.lang :as lang]
    [instant.util.tracer :as tracer]
@@ -8,7 +8,14 @@
    [next.jdbc.connection :as connection])
   (:import
    (com.zaxxer.hikari HikariConfig HikariDataSource)
-   (javax.sql DataSource)))
+   (com.zaxxer.hikari.pool HikariPool)
+   (java.sql Connection
+             SQLException
+             SQLFeatureNotSupportedException)
+   (java.util WeakHashMap)
+   (java.util.function BiConsumer)
+   (javax.sql DataSource)
+   (org.postgresql PGConnection)))
 
 (set! *warn-on-reflection* true)
 
@@ -35,7 +42,9 @@
     (isWrapperFor [iface]
       (.isWrapperFor pool iface))
     (getHikariPoolMXBean []
-      (.getHikariPoolMXBean pool))))
+      (.getHikariPoolMXBean pool))
+    (evictConnection [c]
+      (.evictConnection pool c))))
 
 (defn memoized-read-only-wrapper [^HikariDataSource pool]
   (if-let [wrapper (when-let [[memo-pool wrapper] @read-only-memoize]
@@ -45,6 +54,33 @@
     (let [wrapper (read-only-wrapper pool)]
       (reset! read-only-memoize [pool wrapper])
       wrapper)))
+
+(defn filter-closed-connections-wrapper
+  "Evicts the connections we closed on aurora failover from the pool."
+  [on-close ^HikariDataSource pool]
+  (proxy [HikariDataSource] []
+    (getConnection
+      ([]
+       (loop [conn (.getConnection pool)]
+         (if (.isClosed ^Connection (.unwrap conn PGConnection))
+           (do
+             (.evictConnection pool conn)
+             (recur (.getConnection pool)))
+           conn)))
+      ([user pass]
+       ;; Hikari doesn't support this
+       (throw (SQLFeatureNotSupportedException.))))
+    (unwrap [iface]
+      (.unwrap pool iface))
+    (isWrapperFor [iface]
+      (.isWrapperFor pool iface))
+    (getHikariPoolMXBean []
+      (.getHikariPoolMXBean pool))
+    (evictConnection [c]
+      (.evictConnection pool c))
+    (close []
+      (.close pool)
+      (on-close))))
 
 (defn creds-provider
   "Given the secretsmanager secret arn, will create a function that acts like a delay,
@@ -99,10 +135,60 @@
           creds
           (recur (inc attempt)))))))
 
-(defn datasource-with-secretsmanager
-  "Creates a datasource that is resilent to password rotations in aurora"
-  [secret-arn aurora-config]
-  (let [get-creds (creds-provider secret-arn)
+(defn- safe-close [^Connection conn]
+  (when (try (not (.isClosed conn)) (catch SQLException _ false))
+    (try (.close conn) (catch SQLException _
+                         nil))))
+
+(defn make-failover-watcher
+  "Polls the RDS api for changes to the primary instance.
+   Updates the aurora-config and closes all of the connections
+   to the old instance when we detect a new primary.
+
+   The pool needs to be wrapped with `filter-closed-connections-wrapper`
+   to remove the closed connections before we try to query against them."
+  [weak-conn-tracker aurora-config]
+  (let [cluster-id (:cluster-id aurora-config)
+        current-config (atom aurora-config)
+        shutdown? (atom false)
+        default-sleep-ms 1000
+        config-watcher (future
+                         (loop [last-config aurora-config
+                                sleep-ms default-sleep-ms]
+                           (when-not @shutdown?
+                             (Thread/sleep sleep-ms)
+                             (let [next-config (try (merge aurora-config
+                                                           (rds-cluster-id->db-config cluster-id))
+                                                    (catch Exception e
+                                                      (tracer/record-exception-span! e {:name "failover-watcher-error"})
+                                                      last-config))]
+
+                               (when (and (not= (:instance-id next-config)
+                                                (:instance-id last-config))
+                                          (:instance-id next-config))
+                                 (tracer/with-span! {:name "aurora/handle-failover"
+                                                     :attributes {:from-instance-id (:instance-id last-config)
+                                                                  :to-instance-id (:instance-id next-config)
+                                                                  :cluster-status (:cluster-status next-config)}}
+                                   (reset! current-config next-config)
+                                   (when-let [^WeakHashMap m (get @weak-conn-tracker (:instance-id last-config))]
+                                     (.forEach m (reify BiConsumer
+                                                   (accept [_ k _v]
+                                                     (safe-close k)))))))
+                               (recur next-config
+                                      (if (not= "available" (:cluster-status next-config))
+                                        100
+                                        default-sleep-ms))))))]
+    {:shutdown (fn []
+                 (reset! shutdown? true)
+                 @config-watcher)
+     :get-config (fn [] @current-config)}))
+
+(defn aurora-cluster-datasource
+  "Creates a datasource that is resilent to password rotations and failover in aurora"
+  [add-conn-to-tracker get-config]
+  (let [secret-arn (:secret-arn (get-config))
+        get-creds (creds-provider secret-arn)
         login-timeout (atom nil)]
     (reify DataSource
       (getConnection [_]
@@ -112,7 +198,8 @@
             (let [{:keys [user password] :as creds}
                   (get-creds {:failed-credentials failed-credentials
                               :attempts 3})
-                  conn (try (next-jdbc/get-connection aurora-config user password)
+                  config (get-config)
+                  conn (try (next-jdbc/get-connection config user password)
                             (catch Exception e
                               (let [throwing? (>= attempt 3)]
                                 (tracer/record-info! {:name "aurora/get-conn-error"
@@ -121,19 +208,19 @@
                                                                    :err (.getMessage e)}})
                                 (when throwing?
                                   (throw e)))))]
+              (add-conn-to-tracker (:instance-id config) conn)
               (if conn
                 conn
                 ;; If we fail with these credentials, try to fetch new ones
                 (recur (inc attempt)
                        creds))))))
       (getConnection [_ user pass]
-        (next-jdbc/get-connection aurora-config user pass))
+        (next-jdbc/get-connection (get-config) user pass))
       (getLoginTimeout [_] (or @login-timeout 0))
       (setLoginTimeout [_ seconds] (reset! login-timeout seconds))
-      (toString [_] (connection/jdbc-url aurora-config)))))
+      (toString [_] (connection/jdbc-url (get-config))))))
 
-(defonce -conn-pool
-  nil)
+(defonce -conn-pool nil)
 
 (defn conn-pool
   "Takes a single argument that should be either :read for a read-only connection
@@ -154,7 +241,6 @@
   ;; then it can try again on another connection.
   (System/setProperty "com.zaxxer.hikari.aliveBypassWindowMs" "60000"))
 
-
 (defn start-pool ^HikariDataSource [pool-size aurora-config]
   (patch-hikari)
   (tracer/record-info! {:name "aurora/start-conn-pool"
@@ -164,28 +250,42 @@
         hikari-config (doto (HikariConfig.)
                         (.setMaxLifetime (* 10 60 1000))
                         (.setMaximumPoolSize pool-size))
-        _ (if-let [secret-arn (:secret-arn aurora-config)]
-            (.setDataSource hikari-config (datasource-with-secretsmanager secret-arn config))
-            (doto hikari-config
-              (.setUsername (:user config))
-              (.setPassword (:password config))
-              (.setJdbcUrl (connection/jdbc-url (dissoc config
-                                                        :user :password)))))
-
-        pool (HikariDataSource. hikari-config)]
+        pool (if (:cluster-id config)
+               (let [weak-conn-tracker (atom {})
+                     track-conn-lock (Object.)
+                     add-conn-to-tracker (fn [instance-id conn]
+                                           (locking track-conn-lock
+                                             (swap! weak-conn-tracker
+                                                    update
+                                                    instance-id
+                                                    (fn [m]
+                                                      (let [^WeakHashMap m (or m (WeakHashMap.))]
+                                                        (.put m conn true)
+                                                        m)))))
+                     {:keys [shutdown get-config]} (make-failover-watcher weak-conn-tracker config)
+                     ds (aurora-cluster-datasource add-conn-to-tracker get-config)
+                     pool (HikariDataSource. (doto hikari-config
+                                               (.setDataSource ds)))]
+                 (filter-closed-connections-wrapper shutdown pool))
+               (HikariDataSource.
+                (doto hikari-config
+                  (.setUsername (:user config))
+                  (.setPassword (:password config))
+                  (.setJdbcUrl (connection/jdbc-url (dissoc config
+                                                            :user :password))))))]
     ;; Check that the pool is working
     (.close (next-jdbc/get-connection pool))
     pool))
 
 (defn start []
   (let [conn-pool-size (config/get-connection-pool-size)]
-    (tracer/record-info!
-     {:name "aurora/start-conn-pool" :attributes {:size conn-pool-size}})
     (lang/set-var! -conn-pool
       (start-pool conn-pool-size (config/get-aurora-config)))))
 
 (defn stop []
-  (lang/clear-var! -conn-pool HikariDataSource/.close))
+  (lang/clear-var! -conn-pool (fn [^HikariDataSource d]
+                                (.close d)
+                                (.shutdown ^HikariPool (.getHikariPoolMXBean d)))))
 
 (defn restart []
   (stop)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -477,12 +477,13 @@
          wal-opts (wal/make-wal-opts {:wal-chan wal-chan
                                       :close-signal-chan close-signal-chan
                                       :ex-handler wal-ex-handler
-                                      :conn-config (or (config/get-next-aurora-config)
-                                                       ;; Use the next db so that we don't
-                                                       ;; have to worry about restarting the
-                                                       ;; invalidator when failing over to a
-                                                       ;; new blue/green deployment
-                                                       (config/get-aurora-config))
+                                      :get-conn-config (fn []
+                                                         (or (config/get-next-aurora-config)
+                                                             ;; Use the next db so that we don't
+                                                             ;; have to worry about restarting the
+                                                             ;; invalidator when failing over to a
+                                                             ;; new blue/green deployment
+                                                             (config/get-aurora-config)))
                                       :slot-name process-id})]
      (ua/fut-bg
       (wal/start-worker wal-opts))


### PR DESCRIPTION
This PR makes us recover from aurora failover faster.

Instead of connecting to the cluster, which routes us to the writer via DNS, we look up the writer from the RDS API and connect to it directly. There's a process running in the background that will poll the RDS API for changes to the writer. When it notices that the writer changes, it will close all open connections to the old instance and update the config.

In my testing, it took about 15-20 seconds for the failover to succeed.