### PR TITLE
Fix /utils/fetch and /version imports with .js

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -60,7 +60,7 @@ import {
   PresenceOf,
 } from '@instantdb/core';
 
-import version from './version';
+import version from './version.js';
 
 type DebugCheckResult = {
   /** The ID of the record. */

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -20,7 +20,7 @@ import {
   insertInMutative,
 } from './utils/object';
 import { createLinkIndex } from './utils/linkIndex';
-import version from './version';
+import version from './version.js';
 import { create } from 'mutative';
 
 const STATUS = {

--- a/client/packages/core/src/StorageAPI.ts
+++ b/client/packages/core/src/StorageAPI.ts
@@ -1,4 +1,4 @@
-import { jsonFetch } from './utils/fetch';
+import { jsonFetch } from './utils/fetch.js';
 
 export type UploadFileResponse = {
   data: {

--- a/client/packages/core/src/authAPI.ts
+++ b/client/packages/core/src/authAPI.ts
@@ -1,5 +1,5 @@
 import { User } from './clientTypes';
-import { jsonFetch } from './utils/fetch';
+import { jsonFetch } from './utils/fetch.js';
 
 type SharedInput = {
   apiURI: string;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -89,7 +89,7 @@ import type {
   VerifyResponse,
 } from './authAPI';
 
-import { InstantAPIError, type InstantIssue } from './utils/fetch';
+import { InstantAPIError, type InstantIssue } from './utils/fetch.js';
 
 const defaultOpenDevtool = true;
 

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -2,7 +2,7 @@ import 'react-native-get-random-values';
 
 import Storage from './Storage';
 import NetworkListener from './NetworkListener';
-import version from './version';
+import version from './version.js';
 
 import {
   // react

--- a/client/packages/react/src/init.ts
+++ b/client/packages/react/src/init.ts
@@ -5,7 +5,7 @@ import type {
 } from '@instantdb/core';
 
 import InstantReactWebDatabase from './InstantReactWebDatabase';
-import version from './version';
+import version from './version.js';
 
 /**
  *


### PR DESCRIPTION
I was still receiving errors when starting my Tanstack Start app with vinxi. I even had to change the import from the fetch to fetch.js while it is a typescript file. This is a quick fix and will make the builds for Tanstack and Nuxt apps work again.


```
[7:59:27 PM]  ERROR  Cannot find module '/node_modules/.pnpm/@instantdb+core@0.18.6/node_modules/@instantdb/core/dist/utils/fetch' imported from /.output/server/index.mjs
Did you mean to import "/node_modules/.pnpm/@instantdb+core@0.18.6/node_modules/@instantdb/core/dist/utils/fetch.js"?
```