### PR TITLE
Add trace ids to user-visible errors

### DIFF
--- a/client/www/lib/config.ts
+++ b/client/www/lib/config.ts
@@ -75,3 +75,5 @@ export const discordInviteUrl = 'https://discord.com/invite/VU53p7uQcE';
 
 export const discordOAuthAppsFeedbackInviteUrl =
   'https://discord.gg/2rnGtfFQup';
+
+export const bugsAndQuestionsInviteUrl = 'https://discord.gg/unA5vyV6mP';

--- a/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
+++ b/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
@@ -62,8 +62,6 @@ function Page() {
     }
   }, []);
 
-  console.log('adminInfo', adminInfo);
-
   return (
     <div className="mx-auto flex max-w-5xl flex-col px-4 py-12 flex flex-col items-center justify-center gap-4 p-8">
       <div className="text-4xl">🐞</div>

--- a/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
+++ b/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
@@ -1,0 +1,102 @@
+import { asClientOnlyPage, useReadyRouter } from '@/components/clientOnlyPage';
+import { Button, Content, Copyable, SectionHeading } from '@/components/ui';
+import { useAuthToken } from '@/lib/auth';
+import config, { bugsAndQuestionsInviteUrl } from '@/lib/config';
+import { jsonFetch } from '@/lib/fetch';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+function fetchDebugUriInfo(
+  { traceId, spanId }: { traceId: string; spanId: string },
+  token: string | undefined,
+) {
+  return jsonFetch(
+    `${config.apiURI}/dash/admin-debug-uri?trace-id=${traceId}&span-id=${spanId}`,
+    {
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+    },
+  );
+}
+
+function AdminInfo({ urls }: { urls: { label: string; url: string }[] }) {
+  return (
+    <div className="flex flex-col gap-4 items-center">
+      <div>Admin URLs</div>
+      {urls.map((u) => (
+        <a
+          key={u.url}
+          target="_blank"
+          href={u.url}
+          rel="noopener noreferrer"
+          className="text-blue-600 underline hover:text-blue-800"
+        >
+          {u.label}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function Page() {
+  const router = useReadyRouter();
+
+  const token = useAuthToken();
+
+  const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [adminInfo, setAdminInfo] = useState<any | null>(null);
+  useEffect(() => {
+    setCurrentUrl(window.location.href);
+    const spanId = router.query['span-id'] as string;
+    const traceId = router.query['trace-id'] as string;
+    if (token) {
+      fetchDebugUriInfo({ traceId, spanId }, token).then(
+        (res) => setAdminInfo(res),
+        (_err) => {
+          console.log('No extra info.');
+        },
+      );
+    }
+  }, []);
+
+  console.log('adminInfo', adminInfo);
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col px-4 py-12 flex flex-col items-center justify-center gap-4 p-8">
+      <div className="text-4xl">🐞</div>
+      {adminInfo ? (
+        <AdminInfo urls={adminInfo.urls} />
+      ) : (
+        <p>We don't have any additional information about this error.</p>
+      )}
+      <p>
+        Ping us with this url in{' '}
+        <a
+          className="text-blue-600 underline hover:text-blue-800"
+          rel="noopener noreferrer"
+          href={bugsAndQuestionsInviteUrl}
+        >
+          #bug-and-questions on Discord
+        </a>{' '}
+        for help.
+      </p>
+
+      {currentUrl ? (
+        <div className="w-96">
+          <Copyable label="URL" value={currentUrl} />
+        </div>
+      ) : null}
+
+      <Button type="link" href="/dash">
+        Back to the dash
+      </Button>
+    </div>
+  );
+}
+
+const ClientPage = asClientOnlyPage(Page);
+
+export default ClientPage;

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -247,7 +247,6 @@
              span-id))))
 
 (defn honeycomb-uri [{:keys [trace-id span-id]}]
-  (tool/def-locals)
   (format "https://ui.honeycomb.io/%s/environments/%s/datasets/%s/trace?trace_id=%s&span=%s"
           team-name
           (get-env-name)

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -224,22 +224,6 @@
 
 (def dataset-name "instant-server")
 
-(defn span-uri
-  ([]
-   (when *span*
-     (span-uri *span*)))
-  ([^Span span]
-   (let [ctx (.getSpanContext span)
-         trace-id (.getTraceId ctx)
-         span-id (.getSpanId ctx)]
-     (format
-      "https://ui.honeycomb.io/%s/environments/%s/datasets/%s/trace?trace_id=%s&span=%s"
-      team-name
-      (get-env-name)
-      dataset-name
-      trace-id
-      span-id))))
-
 (defn current-span-ids []
   (when-let [^Span span *span*]
     {:span-id (-> span
@@ -248,3 +232,30 @@
      :trace-id (-> span
                    (.getSpanContext)
                    (.getTraceId))}))
+
+(defn span-uri
+  ([]
+   (when *span*
+     (span-uri *span*)))
+  ([^Span span]
+   (let [ctx (.getSpanContext span)
+         trace-id (.getTraceId ctx)
+         span-id (.getSpanId ctx)]
+     (format "%s/debug-uri/%s/%s"
+             (config/dashboard-origin)
+             trace-id
+             span-id))))
+
+(defn honeycomb-uri [{:keys [trace-id span-id]}]
+  (tool/def-locals)
+  (format "https://ui.honeycomb.io/%s/environments/%s/datasets/%s/trace?trace_id=%s&span=%s"
+          team-name
+          (get-env-name)
+          dataset-name
+          trace-id
+          span-id))
+
+(defn cloudwatch-uri [{:keys [trace-id span-id]}]
+  (format "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-43200~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*27%s*2f%s*27*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2010000~queryId~'974cdbee-1e72-4492-9aef-c79ac11afe79~source~(~'*2faws*2felasticbeanstalk*2fInstant-docker-prod-env-2*2fvar*2flog*2feb-docker*2fcontainers*2feb-current-app*2fstdouterr.log)~lang~'CWLI)"
+          trace-id
+          span-id))

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -2074,11 +2074,12 @@
                                                       :checked-data-type "string",
                                                       :attr-id (str email-attr-id)
                                                       :entity-id (str eid)}}]}}
-                   (test-util/instant-ex-data
-                    (tx/transact! (aurora/conn-pool :write)
-                                  (attr-model/get-by-app-id app-id)
-                                  app-id
-                                  [[:add-triple eid email-attr-id 10]]))))))))))
+                   (dissoc (test-util/instant-ex-data
+                             (tx/transact! (aurora/conn-pool :write)
+                                           (attr-model/get-by-app-id app-id)
+                                           app-id
+                                           [[:add-triple eid email-attr-id 10]]))
+                           ::ex/trace-id)))))))))
 
 (deftest rejects-large-values-for-indexed-data
   (with-empty-app
@@ -2123,11 +2124,12 @@
                                                       :attr-id (str email-attr-id)
                                                       :entity-id (str eid)
                                                       :value-too-large? true}}]}}
-                   (test-util/instant-ex-data
-                    (tx/transact! (aurora/conn-pool :write)
-                                  (attr-model/get-by-app-id app-id)
-                                  app-id
-                                  [[:add-triple eid email-attr-id (apply str (repeat 1000000 "a"))]]))))))
+                   (dissoc (test-util/instant-ex-data
+                             (tx/transact! (aurora/conn-pool :write)
+                                           (attr-model/get-by-app-id app-id)
+                                           app-id
+                                           [[:add-triple eid email-attr-id (apply str (repeat 1000000 "a"))]]))
+                           ::ex/trace-id)))))
         (testing "returns a friendly error message for unique data"
           (let [eid (random-uuid)]
             (is (= #:instant.util.exception{:type
@@ -2143,11 +2145,13 @@
                                                       :attr-id (str unique-attr-id)
                                                       :entity-id (str eid)
                                                       :value-too-large? true}}]}}
-                   (test-util/instant-ex-data
-                    (tx/transact! (aurora/conn-pool :write)
-                                  (attr-model/get-by-app-id app-id)
-                                  app-id
-                                  [[:add-triple eid unique-attr-id (apply str (repeat 1000000 "a"))]]))))))))))
+                   (dissoc
+                    (test-util/instant-ex-data
+                      (tx/transact! (aurora/conn-pool :write)
+                                    (attr-model/get-by-app-id app-id)
+                                    app-id
+                                    [[:add-triple eid unique-attr-id (apply str (repeat 1000000 "a"))]]))
+                    ::ex/trace-id)))))))))
 
 (deftest deep-merge-existing-object
   (with-empty-app


### PR DESCRIPTION
This adds a trace id to instant exceptions to make it easier for us to find those errors when users report them:

A regular error looks like this:

```
{
  "name": "InstantAPIError",
  "status": 400,
  "body": {
    "type": "validation-failed",
    "message": "Validation failed for coerced-query",
    "hint": {
      "data-type": "coerced-query",
    },
    "trace-id": "266763b27b2acbff8b4953a7cdb91425"
  }
}
```

An unexpected error looks like this:

```
{
  "name": "InstantAPIError",
  "status": 500,
  "body": {
    "type": "unknown",
    "message": "Something went wrong. Please ping `debug-uri` in #bug-and-questions, and we'll take a look. Sorry about this!",
    "hint": {
      "debug-uri": "http://localhost:3000/debug-uri/05dc1329925857cc117647024098089c/e261a08df3772884"
    }
  }
}
```

The debug-uri goes to a custom page. It looks like this when a user goes there:

<img width="837" alt="Screenshot 2025-04-17 at 3 24 49 PM" src="https://github.com/user-attachments/assets/2405bd27-3738-4c51-9dea-b4df99251950" />



It has urls to honeycomb and cloudwatch when we go there:

<img width="918" alt="Screenshot 2025-04-17 at 3 27 29 PM" src="https://github.com/user-attachments/assets/7d29ace6-464c-472a-b86f-5a5d8f784237" />

