### PR TITLE
Better error when you transact an invalid ref value

### DIFF
--- a/server/resources/migrations/64_better_uuid_constraint.down.sql
+++ b/server/resources/migrations/64_better_uuid_constraint.down.sql
@@ -1,0 +1,5 @@
+alter table triples drop constraint valid_ref_value;
+
+drop function public.triples_extract_uuid_value(value jsonb);
+
+drop function public.triples_valid_ref_value(t public.triples);

--- a/server/resources/migrations/64_better_uuid_constraint.up.sql
+++ b/server/resources/migrations/64_better_uuid_constraint.up.sql
@@ -1,0 +1,33 @@
+create or replace function public.triples_extract_uuid_value(value jsonb)
+ returns uuid
+ language sql
+ immutable
+as $$
+  select case
+    when jsonb_typeof(value) = 'string'
+     and pg_input_is_valid(value #>> '{}', 'uuid')
+    then (value #>> '{}')::uuid
+    else null
+  end;
+$$;
+
+create or replace function public.triples_valid_ref_value(t public.triples)
+ returns boolean
+ language sql
+ immutable
+as $$
+  select case
+    when t.eav or t.vae
+      then public.triples_extract_uuid_value(t.value) is not null
+    else true
+  end;
+$$;
+
+-- We use `not valid` here to prevent a full table scan when we add the constraint
+-- We need to run validate constraint in production after adding this
+-- See note https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES
+-- TODO: run `alter table triples validate constraint valid_value_data_type;` in production
+alter table triples
+  add constraint valid_ref_value
+    check (public.triples_valid_ref_value(triples))
+    not valid;

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -450,6 +450,7 @@
                         (if (= "t" (:av triple))
                           "Value is too large for a unique attribute."
                           "Value is too large for an indexed attribute.")
+                        "valid_ref_value" "Linked value must be a valid uuid."
 
                         (format "Check Violation: %s" (name (:constraint data))))
              :hint (merge


### PR DESCRIPTION
Right now if you transact an empty string as a linked uuid, you'll get an unhelpful "invalid-text-representation" error.

Example:
```js
db.transact(tx['with-number'][id()].update({}).link({'ref-ns': ''}))
```

<img width="430" alt="image" src="https://github.com/user-attachments/assets/4b302473-8ef0-4507-85b2-3737a7548e89" />


#### Cause
This happens because we throw in the constraint on the triples table when we encounter an invalid uuid (in `(value ->>0)::uuid)`:

```sql
CONSTRAINT ref_values_are_uuid CHECK (
CASE
    WHEN eav OR vae THEN jsonb_typeof(value) = 'string'::text AND ((value ->> 0)::uuid) IS NOT NULL
    ELSE true
END)
```

#### Fix
Now that we're on postgres 16, we can use the handy `pg_input_is_valid` function to check that the value is valid.

Now the error looks like this:

<img width="443" alt="image" src="https://github.com/user-attachments/assets/c026174b-9aed-4dba-9b0e-6298f6d9398f" />


#### Deployment plan
- [ ] Run the migration
- [ ] Run `alter table triples validate constraint valid_value_data_type;` (prevents locking table during up migration, same as we did on https://github.com/instantdb/instant/pull/448)
- [ ] Push up a new migration that drops the old constraint

