### PR TITLE
Drop old ref_values_are_uuid constraint 

### DIFF
--- a/server/resources/migrations/64_better_uuid_constraint.up.sql
+++ b/server/resources/migrations/64_better_uuid_constraint.up.sql
@@ -23,11 +23,10 @@ as $$
   end;
 $$;
 
--- We use `not valid` here to prevent a full table scan when we add the constraint
+-- We used `not valid` here to prevent a full table scan when we add the constraint
 -- We need to run validate constraint in production after adding this
 -- See note https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES
 -- TODO: run `alter table triples validate constraint valid_value_data_type;` in production
 alter table triples
   add constraint valid_ref_value
-    check (public.triples_valid_ref_value(triples))
-    not valid;
+    check (public.triples_valid_ref_value(triples));

--- a/server/resources/migrations/65_drop_old_constraint.down.sql
+++ b/server/resources/migrations/65_drop_old_constraint.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE triples
+  ADD CONSTRAINT ref_values_are_uuid
+  CHECK (
+    CASE WHEN eav OR vae THEN
+        jsonb_typeof(value) = 'string' AND
+        (value->>0)::uuid IS NOT NULL
+    ELSE TRUE
+    END
+  )
+  not valid;

--- a/server/resources/migrations/65_drop_old_constraint.up.sql
+++ b/server/resources/migrations/65_drop_old_constraint.up.sql
@@ -1,0 +1,1 @@
+alter table triples drop constraint if exists ref_values_are_uuid;

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -625,17 +625,16 @@
                        [[:= :attr-id tag-attr-id]])))))
         (testing "invalid uuids are rejected"
           (is
-           (= :invalid-text-representation
+           (= ::ex/validation-failed
               (->  (test-util/instant-ex-data
                     (tx/transact!
                      (aurora/conn-pool :write)
                      (attr-model/get-by-app-id app-id)
                      app-id
                      [[:add-triple stopa-eid tag-attr-id "Foo"]]))
-                   ::ex/hint
-                   :condition)))
+                   ::ex/type)))
           (is
-           (= "Check Violation: ref_values_are_uuid"
+           (= "Linked value must be a valid uuid."
               (-> (test-util/instant-ex-data
                    (tx/transact!
                     (aurora/conn-pool :write)

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -2041,7 +2041,6 @@
                   (attr-model/get-by-app-id (:id app))
                   (:id app)
                   [[:add-triple alex-eid bookshelf-aid ""]]))]
-        (tool/def-locals)
         (is ex)
         (is (= ::ex/validation-failed
                (::ex/type ex)))

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -2030,28 +2030,27 @@
                         [[:add-triple stopa-eid (UUID/randomUUID) "Stopa"]]))
                       ::ex/type))))))))
 
-;; Will fail until the existing contraint in the database is dropped
-#_(deftest good-error-for-invalid-ref-uuid
-    (with-zeneca-app
-      (fn [app r]
-        (let [alex-eid (resolvers/->uuid r "eid-alex")
-              bookshelf-aid (resolvers/->uuid r :users/bookshelves)
-              ex (test-util/instant-ex-data
-                   (tx/transact!
-                    (aurora/conn-pool :write)
-                    (attr-model/get-by-app-id (:id app))
-                    (:id app)
-                    [[:add-triple alex-eid bookshelf-aid ""]]))]
-          (tool/def-locals)
-          (is ex)
-          (is (= ::ex/validation-failed
-                 (::ex/type ex)))
-          (is (= "" (-> ex
-                        ::ex/hint
-                        :errors
-                        first
-                        :hint
-                        :value)))))))
+(deftest good-error-for-invalid-ref-uuid
+  (with-zeneca-app
+    (fn [app r]
+      (let [alex-eid (resolvers/->uuid r "eid-alex")
+            bookshelf-aid (resolvers/->uuid r :users/bookshelves)
+            ex (test-util/instant-ex-data
+                 (tx/transact!
+                  (aurora/conn-pool :write)
+                  (attr-model/get-by-app-id (:id app))
+                  (:id app)
+                  [[:add-triple alex-eid bookshelf-aid ""]]))]
+        (tool/def-locals)
+        (is ex)
+        (is (= ::ex/validation-failed
+               (::ex/type ex)))
+        (is (= "" (-> ex
+                      ::ex/hint
+                      :errors
+                      first
+                      :hint
+                      :value)))))))
 
 (deftest rejects-invalid-data-for-checked-attrs
   (with-empty-app


### PR DESCRIPTION
Part 2 of https://github.com/instantdb/instant/pull/1139

Shouldn't be merged until the migration from #1139  is run and the constraint is checked.