### PR TITLE
[db] fix home page migration

### DIFF
--- a/server/resources/migrations/63_seed_homepage_app.up.sql
+++ b/server/resources/migrations/63_seed_homepage_app.up.sql
@@ -1,22 +1,40 @@
+with u_ins as (
+  insert into
+    instant_users (id, email)
+  values
+    (
+      '6f0f64c9-207f-4b35-aec7-82739dcde58e',
+      'stopa@instantdb.com'
+    ) on conflict (email) do nothing returning id
+),
+u as (
+  select
+    id
+  from
+    u_ins
+  union
+  all
+  select
+    id
+  from
+    instant_users
+  where
+    email = 'stopa@instantdb.com'
+),
+app_ins as (
+  insert into
+    apps (id, creator_id, title)
+  select
+    'fc5a4977-910a-43d9-ac28-39c7837c1eb5',
+    id,
+    'homepage'
+  from
+    u on conflict do nothing
+)
 insert into
-  instant_users (id, email)
+  rules (app_id, code)
 values
   (
-    '6f0f64c9-207f-4b35-aec7-82739dcde58e',
-    'stopa@instantdb.com'
+    'fc5a4977-910a-43d9-ac28-39c7837c1eb5',
+    '{ "$default": { "allow": { "$default": "false" } } }'
   ) on conflict do nothing;
-
-insert into 
-  apps (id, creator_id, title) 
-values (
-  'fc5a4977-910a-43d9-ac28-39c7837c1eb5', 
-  '6f0f64c9-207f-4b35-aec7-82739dcde58e',
-  'homepage'
-) on conflict do nothing;
-
-insert into 
-  rules (app_id, code) 
-values (
-  'fc5a4977-910a-43d9-ac28-39c7837c1eb5', 
-  '{ "$default": { "allow": { "$default": "false" } } }'
-) on conflict do nothing;


### PR DESCRIPTION
I got an error running my migration locally:

error: migration failed: insert or update on table "apps" violates foreign key constraint "apps_creator_id_fkey", Key (creator_id)=(6f0f64c9-207f-4b35-aec7-82739dcde58e) is not present in table 

I think this could happen when stopa@instantdb.com is inserted, but the id is not 6f0... 

Afaik @verveguy had this issue here too https://github.com/instantdb/instant/issues/1114 

This updates the migration so we do all the transactions in one query, and get the id from the db. 

@nezaj @dwwoelfel @tonsky 