### PR TITLE
Autocomplete users in the sandbox

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -600,7 +600,6 @@ function EmailInput({
         value={email}
         onChange={(e) => {
           setEmail(e.target.value);
-          //searchDebounce(e.target.value);
         }}
         onKeyDown={(e) => {
           if (e.metaKey && e.key === 'Enter') {
@@ -614,6 +613,16 @@ function EmailInput({
         modal={false}
         className="mt-1 w-[var(--input-width)] overflow-auto bg-white shadow-lg z-10 border border-gray-300 divide-y"
       >
+        {!email ? (
+          <ComboboxOption
+            key="none"
+            value=""
+            className={clsx('text-xs px-2 py-0.5 data-[focus]:bg-blue-100', {})}
+          >
+            <span>{'<none>'}</span>
+          </ComboboxOption>
+        ) : null}
+
         {comboOptions.map((user, i) => (
           <ComboboxOption
             key={user.id}

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -341,7 +341,7 @@ function DevtoolWithData({
             <Explorer db={connection.db} appId={appId} />
           ) : tab === 'sandbox' ? (
             <div className="min-w-[960px] w-full">
-              <Sandbox app={app} />
+              <Sandbox app={app} db={connection.db} />
             </div>
           ) : tab === 'admin' ? (
             <div className="min-w-[960px] w-full p-4">

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -509,7 +509,7 @@ function Dashboard() {
                     db={connection.db}
                   />
                 ) : tab === 'sandbox' ? (
-                  <Sandbox key={appId} app={app} />
+                  <Sandbox key={appId} app={app} db={connection.db} />
                 ) : tab === 'perms' ? (
                   <Perms app={app} dashResponse={dashResponse} />
                 ) : tab === 'auth' ? (


### PR DESCRIPTION
Adds a combobox to the auth.email field in the sandbox that pulls data from the `$users` table. 

You can still enter a email that's not in the $users table and there's a special `<none>` option for selecting no user.

We'll also keep the last user that you selected in localstorage so you can navigate in the dashboard without losing your place.

I moved it to the middle of the sandbox to give a place for the autocomplete to go and to make it easier to see what user was set.

<img width="499" alt="image" src="https://github.com/user-attachments/assets/dd389079-6ed9-4251-8718-64acd9c55f38" />
