### PR TITLE
[docs] ownedTodos fix

### DIFF
--- a/client/www/pages/docs/patterns.md
+++ b/client/www/pages/docs/patterns.md
@@ -116,7 +116,7 @@ import type { InstantRules } from '@instantdb/react';
 const rules = {
   todos: {
     allow: {
-      create: "size(data.ref('owner.todos.id')) <= 2",
+      create: "size(data.ref('owner.ownedTodos.id')) <= 2",
     },
   },
 } satisfies InstantRules;


### PR DESCRIPTION
Narek pointed out a typo in one of our permission examples. Based on the schema, it should be `owner.ownedTodos`

@nezaj @tonsky 