### PR TITLE
CLI import and export

### DIFF
--- a/client/packages/cli/package.json
+++ b/client/packages/cli/package.json
@@ -27,7 +27,9 @@
     "test": "vitest",
     "build": "rm -rf dist; tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w --skipLibCheck --preserveWatchOutput",
-    "publish-package": "pnpm publish --access public --no-git-checks"
+    "publish-package": "pnpm publish --access public --no-git-checks",
+    "link": "pnpm build && npm link",
+    "unlink": "npm unlink -g instant-cli"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/client/packages/cli/src/export.ts
+++ b/client/packages/cli/src/export.ts
@@ -1,0 +1,744 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import chalk from 'chalk';
+import ora from 'ora';
+
+/**
+ * Sleep for the specified number of milliseconds
+ * @param ms - Milliseconds to sleep
+ * @returns Promise that resolves after the specified delay
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Console output styling helper
+ */
+const log = {
+  header: (message: string) => console.log('\n' + chalk.bold.blue('▶︎ ' + message)),
+  step: (step: number, totalSteps: number, message: string) => console.log(chalk.bold.cyan(`[${step}/${totalSteps}] ${message}`)),
+  success: (message: string) => console.log(chalk.green('✓ ') + message),
+  warning: (message: string) => console.log(chalk.yellow('⚠ ') + message),
+  error: (message: string) => console.log(chalk.red('✗ ') + message),
+  info: (message: string) => console.log(chalk.dim('• ') + message)
+};
+
+/**
+ * Generate a timestamp string suitable for directory naming
+ * Format: YYYY-MM-DD_HH-MM-SS
+ */
+function generateTimestampDirName(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  
+  return `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+}
+
+/**
+ * Format link info text based on link count
+ */
+function formatLinkInfo(linkCount: number): string {
+  if (linkCount === 0) return '';
+  return ` with ${linkCount} linked relationship${linkCount !== 1 ? 's' : ''}`;
+}
+
+interface PackageAndAuthInfo {
+  pkgDir: string;
+  authToken: string;
+  instantModuleName?: string;
+}
+
+interface ExportOptions {
+  output?: string;
+  limit?: string | number;
+  dryRun?: boolean;
+  batchSize?: number;
+  sleep?: number;     // Add sleep option for rate limiting
+  verbose?: boolean;
+}
+
+/**
+ * Export schema and data from an Instant app to local JSON files
+ * @param appId - The app ID to export from
+ * @param pkgAndAuthInfo - Authentication info
+ * @param opts - Export options
+ * @returns Object indicating success or failure
+ */
+export async function exportData(
+  appId: string, 
+  pkgAndAuthInfo: PackageAndAuthInfo, 
+  opts: ExportOptions
+): Promise<{ ok: boolean }> {
+  const { authToken } = pkgAndAuthInfo;
+  const dryRun = opts.dryRun || false;
+  
+  // Define the total steps in the export process
+  const TOTAL_STEPS = 6;
+  
+  // Record start time
+  const startTime = new Date();
+  const startTimeFormatted = startTime.toLocaleString(undefined, { timeZoneName: 'short' });
+  
+  // Create a timestamped directory for this export using the start time
+  const timestamp = generateTimestampDirName(startTime);
+  const baseDir = opts.output || 'instant-export';
+  const exportPath = join(process.cwd(), baseDir, timestamp);
+  const namespacesPath = join(exportPath, 'namespaces');
+  
+  log.header(dryRun ? "EXPORT PREVIEW (DRY RUN)" : "STARTING EXPORT");
+  
+  // Metadata to collect
+  const metadata: {
+    appId: string;
+    appName: string;
+    startTimestamp: string;
+    endTimestamp: string;
+    summary: {
+      namespaces: {
+        name: string;
+        entityCount: number;
+        linkCount: number;
+      }[];
+    };
+  } = {
+    appId,
+    appName: '', // Will be filled in after fetching app information
+    startTimestamp: startTimeFormatted,
+    endTimestamp: '',
+    summary: {
+      namespaces: []
+    }
+  };
+  
+  // Parse limit options
+  const limit = opts.limit === 'none' ? null : 
+    typeof opts.limit === 'string' ? parseInt(opts.limit, 10) : opts.limit;
+    
+  if (opts.limit !== 'none' && typeof limit === 'number' && isNaN(limit)) {
+    log.error(`Invalid limit value: ${opts.limit}. Use a number or "none".`);
+    return { ok: false };
+  }
+
+  // Set a batch size for pagination to avoid hitting API limits
+  const batchSize = opts.batchSize || 100;
+  
+  // Set sleep time between batches for rate limiting
+  // Default to 100ms if not specified
+  const sleepTime = opts.sleep !== undefined ? opts.sleep : 100;
+  
+  // Log basic configuration
+  log.info(`Batch size: ${batchSize} entities per batch`);
+  log.info(`Sleep between batches: ${sleepTime}ms`);
+  log.info(`Entity limit: ${limit === null ? 'none' : limit} per namespace`);
+
+  // ---------------
+  // STEP 1: Create export directories
+  // ---------------
+  log.step(1, TOTAL_STEPS, "Creating export directories");
+  
+  // Create export directories if they don't exist (unless in dry run mode)
+  if (!dryRun) {
+    try {
+      await mkdir(exportPath, { recursive: true });
+      await mkdir(namespacesPath, { recursive: true });
+      log.success(`Created directories at ${chalk.dim(exportPath)}`);
+    } catch (err) {
+      log.error(`Failed to create export directories: ${(err as Error).message}`);
+      return { ok: false };
+    }
+  } else {
+    log.info(`Would create directories at ${chalk.dim(exportPath)}`);
+  }
+
+  // ---------------
+  // STEP 2: Fetch app info and authentication
+  // ---------------
+  log.step(2, TOTAL_STEPS, "Fetching app information");
+  
+  const apiURI = process.env.INSTANT_CLI_API_URI || 
+    (process.env.INSTANT_CLI_DEV ? 'http://localhost:8888' : 'https://api.instantdb.com');
+  
+  try {
+    // First fetch the app info from the /dash endpoint to get the admin token
+    const appInfoSpinner = ora('Retrieving app credentials...').start();
+    
+    const appInfoResponse = await fetch(`${apiURI}/dash`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      }
+    });
+    
+    if (!appInfoResponse.ok) {
+      appInfoSpinner.fail();
+      log.error(`Failed to fetch app information: ${appInfoResponse.status} ${appInfoResponse.statusText}`);
+      return { ok: false };
+    }
+    
+    const dashData = await appInfoResponse.json();
+    const app = dashData.apps.find((a: any) => a.id === appId);
+    
+    if (!app) {
+      appInfoSpinner.fail();
+      log.error(`Could not find app with ID ${appId} in your account.`);
+      return { ok: false };
+    }
+    
+    const adminToken = app.admin_token;
+    
+    if (!adminToken) {
+      appInfoSpinner.fail();
+      log.error('Could not retrieve admin token for the app.');
+      return { ok: false };
+    }
+    
+    // Store app title in metadata
+    metadata.appName = app.title;
+    
+    appInfoSpinner.succeed(`Found app: ${chalk.bold(app.title)}`);
+    
+    // ---------------
+    // STEP 3: Fetch schema
+    // ---------------
+    log.step(3, TOTAL_STEPS, "Fetching schema and permissions");
+    
+    // Function to make authenticated requests using the admin token
+    async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+      const url = `${apiURI}${path}`;
+      const headers = {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${adminToken}`,
+        'App-Id': appId
+      };
+      
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          ...headers,
+          ...(options.headers || {}),
+        },
+      });
+      
+      try {
+        const responseText = await response.text();
+        
+        if (!response.ok) {
+          throw new Error(`API request failed: ${responseText || 'Unknown error'}`);
+        }
+        
+        return JSON.parse(responseText);
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          throw new Error('API response was not valid JSON');
+        }
+        throw err;
+      }
+    }
+    
+    const client = {
+      query: async <T extends Record<string, any>>(query: T): Promise<any> => {
+        const requestBody = JSON.stringify({
+          query: query,
+          'inference?': false,
+        });
+        
+        return request('/admin/query', {
+          method: 'POST',
+          body: requestBody,
+        });
+      }
+    };
+
+    // Fetch schema
+    const schemaSpinner = ora('Fetching schema...').start();
+    
+    try {
+      // Try to get schema using admin/schema endpoint, fall back to query if needed
+      let schema;
+      
+      try {
+        const schemaResult = await request<{schema: any}>('/admin/schema', { method: 'GET' });
+        schema = schemaResult.schema;
+      } catch (schemaErr) {
+        schemaSpinner.text = 'Falling back to alternate schema method...';
+        const result = await client.query({ __schema: { entities: {}, links: {} } });
+        schema = result.__schema;
+      }
+      
+      if (!schema) {
+        throw new Error('Could not retrieve schema information');
+      }
+      
+      // Save schema to file if not in dry run mode
+      if (!dryRun) {
+        await writeFile(
+          join(exportPath, 'schema.json'),
+          JSON.stringify(schema, null, 2),
+          'utf-8'
+        );
+        schemaSpinner.succeed('Schema exported successfully');
+      } else {
+        schemaSpinner.succeed('Schema retrieved successfully');
+      }
+
+      // ---------------
+      // STEP 4: Export permissions rules
+      // ---------------
+      const permsSpinner = ora('Fetching permissions...').start();
+      
+      try {
+        // Create a special fetch for permissions using the user auth token, not admin token
+        const fetchPerms = async () => {
+          const url = `${apiURI}/dash/apps/${appId}/perms/pull`;
+          const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${authToken}`, // Use the user token, not admin token
+            },
+          });
+          
+          const responseText = await response.text();
+          
+          if (!response.ok) {
+            throw new Error(`API request failed: ${responseText || 'Unknown error'}`);
+          }
+          
+          return JSON.parse(responseText);
+        };
+        
+        // Fetch permissions using the user token
+        const permsResult = await fetchPerms();
+        const permsData = permsResult.perms || {};
+        
+        // Save permissions to file if not in dry run mode
+        if (!dryRun) {
+          await writeFile(
+            join(exportPath, 'permissions.json'),
+            JSON.stringify(permsData, null, 2),
+            'utf-8'
+          );
+          permsSpinner.succeed('Permissions exported successfully');
+        } else {
+          permsSpinner.succeed('Permissions retrieved successfully');
+        }
+
+        // Extract and sort namespaces from schema
+        const namespaces = extractNamespacesFromSchema(schema);
+        
+        if (namespaces.length === 0) {
+          log.info('No namespaces found in schema. Export complete.');
+          
+          // Write metadata even if no namespaces
+          if (!dryRun) {
+            metadata.endTimestamp = new Date().toLocaleString(undefined, { timeZoneName: 'short' });
+            await writeFile(
+              join(exportPath, 'metadata.json'),
+              JSON.stringify(metadata, null, 2),
+              'utf-8'
+            );
+            log.success(`Metadata exported successfully`);
+          } else {
+            log.info(`Would export metadata information`);
+          }
+          
+          return { ok: true };
+        }
+
+        namespaces.sort();
+        
+        // ---------------
+        // STEP 5: Analyze namespaces
+        // ---------------
+        log.step(5, TOTAL_STEPS, "Analyzing namespaces");
+        
+        log.info(`Found ${namespaces.length} namespaces: ${chalk.cyan(namespaces.join(', '))}`);
+        
+        // ---------------
+        // STEP 6: Export each namespace
+        // ---------------
+        log.step(6, TOTAL_STEPS, "Exporting namespace data");
+        
+        // For each namespace, export data
+        for (const namespace of namespaces) {
+          // Get link information for this namespace
+          const namespaceLinks = getNamespaceLinks(schema, namespace);
+          const linkCount = Object.keys(namespaceLinks).length;
+          const linkInfo = formatLinkInfo(linkCount);
+          
+          // Handle dry run
+          if (dryRun) {
+            log.info(`Would export namespace: ${chalk.cyan(namespace)}${linkInfo}`);
+            
+            metadata.summary.namespaces.push({
+              name: namespace,
+              entityCount: 0, // Placeholder for dry run
+              linkCount: linkCount
+            });
+            continue;
+          }
+          
+          // Export namespace data
+          const spinner = ora(`Exporting ${namespace}`).start();
+          
+          try {
+            // Query entities with batching
+            let entities: any[] = [];
+            let cursor: { after?: string; before?: string; offset?: number; } | undefined = undefined;
+            let hasMore = true;
+            let totalEntities = 0;
+            let batchCount = 0;
+            
+            // Determine the query batch size
+            const queryBatchSize = limit && limit < batchSize ? limit : batchSize;
+            
+            // Sleep before starting the first batch
+            if (sleepTime > 0 && batchCount === 0) {
+              spinner.text = `Preparing to export ${chalk.cyan(namespace)}...`;
+              await sleep(sleepTime);
+            }
+            
+            // Flag to indicate if we should stop fetching more batches
+            let shouldStopAfterBatch = false;
+            
+            while (hasMore && !shouldStopAfterBatch) {
+              batchCount++;
+              spinner.text = `Exporting ${chalk.cyan(namespace)} - batch ${batchCount}`;
+              
+              // For subsequent batches, calculate remaining items
+              const remainingItems = limit ? limit - totalEntities : null;
+              const currentBatchSize = remainingItems && remainingItems < queryBatchSize 
+                ? remainingItems 
+                : queryBatchSize;
+              
+              // Build query for this namespace with expanded links and cursor
+              const namespaceQuery = buildQueryWithLinks(namespace, namespaceLinks, currentBatchSize, cursor);
+              
+              if (opts.verbose) {
+                log.info(`\nQuery details for batch ${batchCount}:`);
+                log.info(`- Batch size: ${currentBatchSize}`);
+                log.info(`- Cursor: ${JSON.stringify(cursor)}`);
+                log.info(`- Total so far: ${totalEntities}`);
+              }
+              
+              const query = { [namespace]: namespaceQuery };
+              const data = await client.query(query);
+              const batchEntities = data[namespace] || [];
+              
+              // Parse pageInfo - this could be in different locations depending on API version
+              const pageInfo = data?.pageInfo && data?.pageInfo[namespace] ? 
+                              data?.pageInfo[namespace] : 
+                              data?.__pageInfo && data?.__pageInfo[namespace] ? 
+                              data?.__pageInfo[namespace] : null;
+              
+              const endCursor = pageInfo?.endCursor;
+              
+              // Add entities to our accumulated list
+              entities = entities.concat(batchEntities);
+              totalEntities += batchEntities.length;
+              
+              // Update spinner text to show progress
+              spinner.text = `Exporting ${chalk.cyan(namespace)} - ${totalEntities}/${limit || '∞'} entities (batch ${batchCount})`;
+              
+              // Continue fetching if:
+              // 1. We have an endCursor AND
+              // 2. Either we have no limit OR we haven't reached the limit yet AND
+              // 3. We received some entities in this batch (items remain)
+              hasMore = Boolean(endCursor) && 
+                       (limit === null || totalEntities < limit) && 
+                       batchEntities.length > 0;
+              
+              // Fallback: if we don't have pageInfo but received a full batch
+              // and haven't reached our limit, assume there's more data
+              if (!pageInfo && batchEntities.length === currentBatchSize &&
+                  (limit === null || totalEntities < limit)) {
+                hasMore = true;
+                
+                // Since we don't have a cursor, use count-based pagination
+                cursor = { offset: totalEntities };
+              } else if (hasMore) {
+                // We have a cursor, use it
+                cursor = { after: endCursor };
+              }
+              
+              // Sleep between batches if specified
+              if (hasMore && sleepTime > 0) {
+                spinner.text = `Waiting ${sleepTime}ms before next batch...`;
+                await sleep(sleepTime);
+              }
+              
+              // Check if we've reached the specified limit
+              if (limit && totalEntities >= limit) {
+                shouldStopAfterBatch = true;
+                // Truncate entities if we got more than the limit
+                if (totalEntities > limit) {
+                  entities = entities.slice(0, limit);
+                  totalEntities = limit;
+                }
+              }
+            }
+            
+            // Add to metadata summary
+            metadata.summary.namespaces.push({
+              name: namespace,
+              entityCount: totalEntities,
+              linkCount: linkCount
+            });
+            
+            // Write to file
+            await writeFile(
+              join(namespacesPath, `${namespace}.json`),
+              JSON.stringify(entities, null, 2),
+              'utf-8'
+            );
+            
+            spinner.succeed(`Exported ${chalk.bold(totalEntities)} ${chalk.cyan(namespace)} entities${linkInfo}`);
+          } catch (err) {
+            spinner.fail(`Error exporting ${chalk.cyan(namespace)}`);
+            log.error((err as Error).message);
+          }
+        }
+        
+        // Write metadata and complete
+        if (!dryRun) {
+          metadata.endTimestamp = new Date().toLocaleString(undefined, { timeZoneName: 'short' });
+          await writeFile(
+            join(exportPath, 'metadata.json'),
+            JSON.stringify(metadata, null, 2),
+            'utf-8'
+          );
+          
+          log.header("EXPORT SUMMARY");
+          
+          // Count total entities and namespaces for summary
+          const totalEntities = metadata.summary.namespaces.reduce((sum, ns) => sum + ns.entityCount, 0);
+          const totalNamespaces = metadata.summary.namespaces.length;
+          
+          log.success(`Exported ${chalk.bold(totalEntities)} entities across ${chalk.bold(totalNamespaces)} namespaces`);
+          log.info(`Export completed at ${chalk.dim(metadata.endTimestamp)}`);
+          log.info(`Files saved to ${chalk.dim(exportPath)}`);
+        } else {
+          log.header("DRY RUN COMPLETE");
+          log.info(`No files were written. Use without --dry-run to perform the actual export.`);
+        }
+        
+        return { ok: true };
+        
+      } catch (err) {
+        permsSpinner.fail();
+        log.error(`Failed to export permissions: ${(err as Error).message}`);
+        return { ok: false };
+      }
+      
+    } catch (err) {
+      schemaSpinner.fail();
+      log.error(`Failed to export schema: ${(err as Error).message}`);
+      return { ok: false };
+    }
+  } catch (err) {
+    log.error(`Failed to fetch app information: ${(err as Error).message}`);
+    return { ok: false };
+  }
+}
+
+/**
+ * Extract namespaces from schema
+ * @param schema - The schema object
+ * @returns Array of namespace names
+ */
+function extractNamespacesFromSchema(schema: {
+  entities?: Record<string, any>;
+  links?: Record<string, any>;
+  refs?: Record<string, any>;
+  blobs?: Record<string, any>;
+}): string[] {
+  const namespaces = new Set<string>();
+  
+  // Always include special namespaces
+  namespaces.add('$users');
+  namespaces.add('$files');
+  
+  // Extract from entities if they exist
+  if (schema.entities) {
+    Object.keys(schema.entities).forEach(namespace => {
+      namespaces.add(namespace);
+    });
+  }
+  
+  // Extract from refs which contain relationships between entities
+  if (schema.refs) {
+    Object.entries(schema.refs).forEach(([refKey, ref]) => {
+      // Extract namespaces from ref keys (usually in format "entity1-entity2")
+      const parts = refKey.split('-');
+      if (parts.length >= 2) {
+        // First and last parts are typically entity types
+        namespaces.add(parts[0]);
+        namespaces.add(parts[parts.length - 1]);
+      }
+      
+      // Also extract from forward/reverse identity
+      if (ref['forward-identity'] && ref['forward-identity'][1]) {
+        namespaces.add(ref['forward-identity'][1]);
+      }
+      if (ref['reverse-identity'] && ref['reverse-identity'][1]) {
+        namespaces.add(ref['reverse-identity'][1]);
+      }
+    });
+  }
+  
+  // Extract from blobs which define entity attributes
+  if (schema.blobs) {
+    Object.keys(schema.blobs).forEach(blobKey => {
+      // Include all entity types including special namespaces $users and $files
+      namespaces.add(blobKey);
+    });
+  }
+  
+  // Extract from links if they exist (original logic)
+  if (schema.links) {
+    // Add link sources and targets from either format
+    Object.entries(schema.links).forEach(([linkKey, link]) => {
+      // Handle forward/reverse format
+      if (link.forward?.on) {
+        namespaces.add(link.forward.on);
+      }
+      if (link.reverse?.on) {
+        namespaces.add(link.reverse.on);
+      }
+      
+      // Handle forward-identity/reverse-identity format
+      if (link['forward-identity'] && link['forward-identity'][1]) {
+        namespaces.add(link['forward-identity'][1]);
+      }
+      if (link['reverse-identity'] && link['reverse-identity'][1]) {
+        namespaces.add(link['reverse-identity'][1]);
+      }
+    });
+  }
+  
+  return Array.from(namespaces);
+}
+
+/**
+ * Get all link labels for a given namespace
+ * @param schema - The schema object
+ * @param namespace - The namespace to find links for
+ * @returns Object with link labels mapped to target namespaces
+ */
+function getNamespaceLinks(schema: {
+  links?: Record<string, any>;
+  refs?: Record<string, any>;
+}, namespace: string): Record<string, string> {
+  const links: Record<string, string> = {};
+  
+  if (!schema.refs) {
+    return links;
+  }
+  
+  // Process each ref
+  Object.entries(schema.refs).forEach(([refKey, ref]) => {
+    // Skip if missing identity information
+    if (!ref['forward-identity'] || !ref['reverse-identity']) return;
+    
+    // Get forward identity information
+    const fwdIdentity = ref['forward-identity'];
+    if (!Array.isArray(fwdIdentity) || fwdIdentity.length < 3) return;
+    
+    // Get reverse identity information
+    const revIdentity = ref['reverse-identity'];
+    if (!Array.isArray(revIdentity) || revIdentity.length < 3) return;
+    
+    const fwdEntity = String(fwdIdentity[1]);
+    const fwdAttribute = String(fwdIdentity[2]);
+    const revEntity = String(revIdentity[1]);
+    const revAttribute = String(revIdentity[2]);
+    
+    // If this namespace is the forward entity
+    if (fwdEntity === namespace) {
+      links[fwdAttribute] = revEntity;
+    }
+    
+    // If this namespace is the reverse entity
+    if (revEntity === namespace) {
+      links[revAttribute] = fwdEntity;
+    }
+  });
+  
+  return links;
+}
+
+/**
+ * Build a query object with expanded links
+ * @param namespace - The namespace to query
+ * @param links - Links information from the schema
+ * @param limit - Main query limit
+ * @param cursor - Pagination cursor (after/before)
+ * @returns Query object with expanded links
+ */
+function buildQueryWithLinks(
+  namespace: string,
+  links: Record<string, string>,
+  limit: number | null,
+  cursor?: { after?: string; before?: string; offset?: number; }
+): Record<string, any> {
+  const query: Record<string, any> = {};
+  
+  // Add main namespace query with pagination options in the $ object
+  query.$ = {
+    // Always use orderBy for consistency
+    order: {
+      serverCreatedAt: 'desc',
+    }
+  };
+
+  // Add pagination parameters based on cursor type
+  if (cursor?.after) {
+    // When paginating forward with "after" cursor
+    query.$.after = cursor.after;
+    if (limit) {
+      // For cursor-based pagination, use first instead of limit
+      query.$.first = limit;
+    }
+  } else if (cursor?.before) {
+    // When paginating backward with "before" cursor
+    query.$.before = cursor.before;
+    if (limit) {
+      // For backward pagination, use last instead of first
+      query.$.last = limit;
+    }
+  } else if (cursor?.offset !== undefined) {
+    // When using offset-based pagination
+    query.$.offset = cursor.offset;
+    if (limit) {
+      // For offset-based pagination, use limit
+      query.$.limit = limit;
+    }
+  } else {
+    // Initial query with no cursor - use limit for first query
+    if (limit) {
+      query.$.limit = limit;
+    }
+  }
+  
+  // Get links sorted alphabetically by attribute name
+  const sortedLinks = Object.entries(links).sort(([attr1], [attr2]) => attr1.localeCompare(attr2));
+  
+  // Add links to the query with field selection in alphabetical order
+  sortedLinks.forEach(([attribute, targetNamespace]) => {
+    // Add the link attribute to the query, only selecting the ID field
+    query[attribute] = {
+      $: {
+        fields: ['id']
+      }
+    };
+  });
+  
+  return query;
+} 

--- a/client/packages/cli/src/import.ts
+++ b/client/packages/cli/src/import.ts
@@ -1,0 +1,1488 @@
+import { mkdir, writeFile, readFile, readdir } from 'fs/promises';
+import { join, dirname } from 'path';
+import chalk from 'chalk';
+import ora from 'ora';
+import inquirer from 'inquirer';
+import { exportData as exportAppData } from './export.js';
+
+/**
+ * Sleep for the specified number of milliseconds
+ * @param ms - Milliseconds to sleep
+ * @returns Promise that resolves after the specified delay
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Console output styling helper
+ */
+const log = {
+  header: (message: string) => console.log('\n' + chalk.bold.blue('▶︎ ' + message)),
+  step: (step: number, totalSteps: number, message: string) => console.log(chalk.bold.cyan(`[${step}/${totalSteps}] ${message}`)),
+  success: (message: string) => console.log(chalk.green('✓ ') + message),
+  warning: (message: string) => console.log(chalk.yellow('⚠ ') + message),
+  error: (message: string) => console.log(chalk.red('✗ ') + message),
+  info: (message: string) => console.log(chalk.dim('• ') + message)
+};
+
+/**
+ * Generate a timestamp string suitable for directory naming
+ * Format: YYYY-MM-DD_HH-MM-SS
+ */
+function generateTimestampDirName(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  
+  return `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+}
+
+/**
+ * Find all available exports by reading metadata.json files
+ * @returns Array of export options sorted by timestamp (newest first)
+ */
+async function findExports(): Promise<Array<{
+  path: string;
+  timestamp: string;
+  appName: string;
+  entities: number;
+  exportedAt: string;
+}>> {
+  const baseDir = 'instant-export';
+  try {
+    // Check if export directory exists using stat instead of readFile
+    try {
+      const { stat } = await import('fs/promises');
+      const stats = await stat(baseDir);
+      if (!stats.isDirectory()) {
+        return [];
+      }
+    } catch {
+      return [];
+    }
+    
+    // List all directories in the export folder
+    const dirs = await readdir(baseDir);
+    const exportOptions = [];
+    
+    for (const dir of dirs) {
+      const metadataPath = join(baseDir, dir, 'metadata.json');
+      try {
+        const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'));
+        exportOptions.push({
+          path: join(baseDir, dir),
+          timestamp: dir,
+          appName: metadata.appName || 'Unknown app',
+          entities: metadata.summary.namespaces.reduce((sum, ns) => sum + ns.entityCount, 0),
+          exportedAt: metadata.endTimestamp || 'Unknown date'
+        });
+      } catch (err) {
+        // Skip directories without valid metadata.json
+      }
+    }
+    
+    // Sort by timestamp (newest first)
+    return exportOptions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  } catch (err) {
+    return [];
+  }
+}
+
+interface PackageAndAuthInfo {
+  pkgDir: string;
+  authToken: string;
+  instantModuleName?: string;
+}
+
+interface ImportOptions {
+  input?: string;
+  dryRun?: boolean;
+  batchSize?: number;
+  sleep?: number;
+  verbose?: boolean;
+  force?: boolean;
+}
+
+/**
+ * Import schema, permissions, and data from exported JSON files to an Instant app
+ * @param appId - The app ID to import to
+ * @param pkgAndAuthInfo - Authentication info
+ * @param opts - Import options
+ * @returns Object indicating success or failure
+ */
+export async function importData(
+  appId: string,
+  pkgAndAuthInfo: PackageAndAuthInfo,
+  opts: ImportOptions
+): Promise<{ ok: boolean }> {
+  const { authToken } = pkgAndAuthInfo;
+  const dryRun = opts.dryRun || false;
+  
+  // Record start time
+  const startTime = new Date();
+  const startTimeFormatted = startTime.toLocaleString(undefined, { timeZoneName: 'short' });
+  
+  // Set a batch size for pagination to avoid hitting API limits
+  const batchSize = opts.batchSize || 100;
+  
+  // Set sleep time between batches for rate limiting
+  // Default to 100ms if not specified
+  const sleepTime = opts.sleep !== undefined ? opts.sleep : 100;
+  
+  // Total steps in the import process
+  const TOTAL_STEPS = 10;
+  
+  // Create import metadata object
+  const importMetadata: {
+    sourceAppName: string;
+    sourceAppId: string;
+    sourceExportDate: string;
+    destinationAppId: string;
+    destinationAppName: string;
+    importStarted: string;
+    importCompleted: string;
+    dryRun: boolean;
+    summary: {
+      totalEntitiesImported: number;
+      totalRelationshipsImported: number;
+      userMappingsCreated: number;
+      entityTypeCount: number;
+      entityTypes: {
+        name: string;
+        entitiesImported: number;
+        relationshipsImported: number;
+      }[];
+    };
+  } = {
+    sourceAppName: 'Unknown',
+    sourceAppId: 'Unknown',
+    sourceExportDate: 'Unknown',
+    destinationAppId: appId,
+    destinationAppName: 'Unknown',
+    importStarted: startTimeFormatted,
+    importCompleted: '',
+    dryRun,
+    summary: {
+      totalEntitiesImported: 0,
+      totalRelationshipsImported: 0,
+      userMappingsCreated: 0,
+      entityTypeCount: 0,
+      entityTypes: []
+    }
+  };
+  
+  log.header(dryRun ? "IMPORT PREVIEW (DRY RUN)" : "STARTING IMPORT");
+  log.info(`Batch size: ${batchSize} entities per batch`);
+  log.info(`Sleep between batches: ${sleepTime}ms`);
+
+  // Resolve input path - either use specified input or prompt user to select from available exports
+  let inputPath = opts.input;
+  
+  if (!inputPath) {
+    const exports = await findExports();
+    if (exports.length > 0) {
+      // If there are available exports, present them to the user
+      const { selectedExport } = await inquirer.prompt([{
+        type: 'list',
+        name: 'selectedExport',
+        message: 'Select an export to import:',
+        choices: exports.map(exp => ({
+          name: `${chalk.bold(exp.appName)} (${exp.entities} entities) - ${chalk.dim(exp.timestamp)}`,
+          value: exp.path
+        }))
+      }]);
+      
+      // Use the selected export path
+      inputPath = selectedExport;
+    } else {
+      // Default to 'instant-export' if no specific exports found
+      inputPath = 'instant-export';
+    }
+  }
+  
+  if (!await pathExists(inputPath)) {
+    log.error(`Import directory not found: ${inputPath}`);
+    return { ok: false };
+  }
+
+  // Create timestamped directory for this import
+  const timestamp = generateTimestampDirName();
+  const baseDir = 'instant-import';
+  const importPath = join(process.cwd(), baseDir, timestamp);
+  
+  // Create directories
+  const namespacesPath = join(importPath, 'namespaces');
+  const txFilesPath = join(importPath, 'transactions');
+  
+  try {
+    await mkdir(importPath, { recursive: true });
+    await mkdir(namespacesPath, { recursive: true });
+    await mkdir(txFilesPath, { recursive: true });
+    log.success(`Created import workspace at ${chalk.dim(importPath)}`);
+  } catch (err) {
+    log.error(`Failed to create required directories: ${(err as Error).message}`);
+    return { ok: false };
+  }
+
+  // ---------------
+  // STEP 1: First fetch app info using the user token to get the admin token
+  // ---------------
+  log.step(1, TOTAL_STEPS, "Fetching app information");
+  
+  const apiURI = process.env.INSTANT_CLI_API_URI || 
+    (process.env.INSTANT_CLI_DEV ? 'http://localhost:8888' : 'https://api.instantdb.com');
+  
+  try {
+    // First fetch the app info from the /dash endpoint to get the admin token
+    const appInfoResponse = await fetch(`${apiURI}/dash`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      }
+    });
+    
+    if (!appInfoResponse.ok) {
+      log.error(`Failed to fetch app information: ${appInfoResponse.status} ${appInfoResponse.statusText}`);
+      return { ok: false };
+    }
+    
+    const dashData = await appInfoResponse.json();
+    const app = dashData.apps.find((a: any) => a.id === appId);
+    
+    if (!app) {
+      log.error(`Could not find app with ID ${appId} in your account.`);
+      return { ok: false };
+    }
+    
+    const adminToken = app.admin_token;
+    
+    if (!adminToken) {
+      log.error('Could not retrieve admin token for the app.');
+      return { ok: false };
+    }
+    
+    const appName = app.title;
+    log.success(`Found app: ${chalk.bold(appName)}`);
+    
+    // Set destination app name in metadata
+    importMetadata.destinationAppName = appName;
+    
+    // ---------------
+    // STEP 2: Copy and prepare files
+    // ---------------
+    log.step(2, TOTAL_STEPS, "Preparing import files");
+    
+    const copySpinner = ora(`Copying files from ${chalk.dim(inputPath)}`).start();
+    
+    // Locate source files
+    const srcSchemaPath = join(inputPath, 'schema.json');
+    const srcPermissionsPath = join(inputPath, 'permissions.json');
+    const srcNamespacesPath = join(inputPath, 'namespaces');
+    const srcMetadataPath = join(inputPath, 'metadata.json');
+    
+    if (!await pathExists(srcSchemaPath)) {
+      copySpinner.fail();
+      log.error(`Schema file not found: ${srcSchemaPath}`);
+      return { ok: false };
+    }
+    
+    if (!await pathExists(srcNamespacesPath)) {
+      copySpinner.fail();
+      log.error(`Namespaces directory not found: ${srcNamespacesPath}`);
+      return { ok: false };
+    }
+    
+    // Load and copy files to the working directory
+    let schema: any = {};
+    let permissions: any = {};
+    let sourceMetadata: any = {};
+    
+    try {
+      // Copy schema
+      schema = JSON.parse(await readFile(srcSchemaPath, 'utf-8'));
+      await writeFile(join(importPath, 'schema.json'), JSON.stringify(schema, null, 2));
+      
+      // Copy permissions if they exist
+      if (await pathExists(srcPermissionsPath)) {
+        permissions = JSON.parse(await readFile(srcPermissionsPath, 'utf-8'));
+        await writeFile(join(importPath, 'permissions.json'), JSON.stringify(permissions, null, 2));
+      }
+      
+      // Read source metadata if it exists
+      if (await pathExists(srcMetadataPath)) {
+        sourceMetadata = JSON.parse(await readFile(srcMetadataPath, 'utf-8'));
+        
+        // Update our import metadata with source info
+        if (sourceMetadata.appName) importMetadata.sourceAppName = sourceMetadata.appName;
+        if (sourceMetadata.appId) importMetadata.sourceAppId = sourceMetadata.appId;
+        if (sourceMetadata.endTimestamp) importMetadata.sourceExportDate = sourceMetadata.endTimestamp;
+        
+        copySpinner.text = `Preparing to import data from app: ${chalk.bold(sourceMetadata.appName || 'Unknown')}`;
+        
+        // Save original export metadata for reference
+        await writeFile(join(importPath, 'source_metadata.json'), JSON.stringify(sourceMetadata, null, 2));
+      }
+      
+      // Copy namespace files
+      const namespaceFiles = await readdir(srcNamespacesPath);
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        
+        const content = await readFile(join(srcNamespacesPath, file), 'utf-8');
+        await writeFile(join(namespacesPath, file), content);
+      }
+      
+      copySpinner.succeed('Files prepared successfully');
+    } catch (err) {
+      copySpinner.fail();
+      log.error(`Failed to prepare files: ${(err as Error).message}`);
+      return { ok: false };
+    }
+    
+    // ---------------
+    // STEP 3: Confirmation and backup
+    // ---------------
+    log.step(3, TOTAL_STEPS, "Confirmation and backup");
+    console.log(chalk.bgRed.white.bold(' WARNING ') + chalk.red.bold(' This operation will DELETE ALL DATA in your app and replace it with imported data.'));
+    console.log(chalk.red('         This action cannot be undone.\n'));
+    
+    if (!opts.force && !dryRun) {
+      await inquirer.prompt([{
+        type: 'input',
+        name: 'confirmAppName',
+        message: `Type the app name "${appName}" to confirm:`,
+        validate: (input: string) => input === appName || 'App name does not match. Operation cancelled.'
+      }]);
+      
+      // Offer to create a backup
+      const { createBackup } = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'createBackup',
+        message: 'Create a backup of the existing app before importing?',
+        default: true
+      }]);
+      
+      if (createBackup) {
+        const backupSpinner = ora('Creating backup...').start();
+        try {
+          // Call the export function
+          const exportResult = await exportAppData(appId, pkgAndAuthInfo, {
+            limit: 'none', // Export everything
+            batchSize: opts.batchSize || 100,
+            sleep: opts.sleep || 100,
+            verbose: opts.verbose || false
+          });
+          
+          if (!exportResult.ok) {
+            backupSpinner.fail('Backup failed');
+            log.error('Import operation canceled for safety.');
+            return { ok: false };
+          } else {
+            backupSpinner.succeed(`Backup created successfully`);
+          }
+        } catch (err) {
+          backupSpinner.fail('Backup failed');
+          log.error(`Error: ${(err as Error).message}`);
+          log.error('Import operation canceled for safety.');
+          return { ok: false };
+        }
+      }
+    }
+    
+    // ---------------
+    // STEP 4: Initialize API client
+    // ---------------
+    log.step(4, TOTAL_STEPS, "Initializing API client");
+    
+    // Transaction arrays to record all operations
+    const userTxs: any[] = [];
+    const createTxs: any[] = [];
+    const linkTxs: any[] = [];
+    
+    // Function to make authenticated requests using the admin token
+    async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+      const url = `${apiURI}${path}`;
+      const headers = {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${adminToken}`,
+        'App-Id': appId
+      };
+      
+      // Capture transaction data for /admin/transact endpoint
+      if (path === '/admin/transact' && options.body) {
+        try {
+          const body = JSON.parse(options.body as string);
+          const steps = body.steps;
+          
+          // Sort transactions into appropriate arrays
+          for (const step of steps) {
+            const operation = step[0];
+            
+            if (operation === 'link') {
+              const sourceNamespace = step[1];
+              const sourceId = step[2]; 
+              const linkData = step[3];
+              
+              // For each attribute in the link data
+              for (const [attr, targetId] of Object.entries(linkData)) {
+                linkTxs.push({
+                  type: 'link',
+                  entity: sourceNamespace,
+                  id: sourceId,
+                  attr: attr,
+                  target: {
+                    entity: attr,
+                    id: targetId as string
+                  }
+                });
+              }
+            } else if (operation === 'update') {
+              createTxs.push({
+                type: 'create',
+                entity: step[1],
+                id: step[2],
+                data: step[3]
+              });
+            }
+          }
+          
+          // Log first transaction for debugging
+          if (!request.firstRequestLogged && !dryRun) {
+            request.firstRequestLogged = true;
+            await writeFile(
+              join(txFilesPath, 'first_request_debug.json'),
+              JSON.stringify({
+                url,
+                method: options.method,
+                headers,
+                body: JSON.stringify(body, null, 2).substring(0, 500) + (JSON.stringify(body).length > 500 ? '...' : '')
+              }, null, 2)
+            );
+          }
+        } catch (err) {
+          console.error('Error parsing transaction:', err);
+        }
+      }
+      
+      // Skip actual API calls in dry run mode
+      if (dryRun) {
+        return { success: true } as unknown as T;
+      }
+      
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          ...headers,
+          ...(options.headers || {}),
+        },
+      });
+      
+      try {
+        const responseText = await response.text();
+        
+        // Log first error for diagnostics
+        if (!response.ok && !request.firstErrorLogged) {
+          request.firstErrorLogged = true;
+          await writeFile(
+            join(txFilesPath, 'first_error_response.json'),
+            JSON.stringify({
+              url,
+              status: response.status,
+              statusText: response.statusText,
+              headers: Object.fromEntries(response.headers.entries()),
+              body: responseText.substring(0, 1000) + (responseText.length > 1000 ? '...' : '')
+            }, null, 2)
+          );
+        }
+        
+        if (!response.ok) {
+          throw new Error(`API request failed: ${responseText || 'Unknown error'}`);
+        }
+        
+        return JSON.parse(responseText);
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          throw new Error('API response was not valid JSON');
+        }
+        throw err;
+      }
+    }
+    
+    // Add properties to the request function for state tracking
+    request.firstRequestLogged = false;
+    request.firstErrorLogged = false;
+    
+    const client = {
+      query: async <T extends Record<string, any>>(query: T): Promise<any> => {
+        return request('/admin/query', {
+          method: 'POST',
+          body: JSON.stringify({
+            query: query,
+            'inference?': false,
+          }),
+        });
+      },
+      transact: async (tx: any[]): Promise<any> => {
+        // Convert tx to steps array format if needed
+        const steps = Array.isArray(tx[0]) ? tx : tx.map(operation => {
+          if (operation.type === 'create' || operation.type === 'update') {
+            // Clean data by removing ID
+            const data = { ...operation.data };
+            delete data.id;
+            return ["update", operation.entity, operation.id, data];
+          } else if (operation.type === 'link') {
+            const linkData = {};
+            linkData[operation.attr] = operation.target.id;
+            return ["link", operation.entity, operation.id, linkData];
+          } else if (operation.type === 'delete') {
+            return ["delete", operation.entity, operation.id];
+          }
+          return operation;
+        });
+        
+        return request('/admin/transact', {
+          method: 'POST',
+          body: JSON.stringify({ steps }),
+        });
+      }
+    };
+    
+    log.success('API client initialized');
+
+    // ---------------
+    // STEP 5: Process users
+    // ---------------
+    log.step(5, TOTAL_STEPS, "Processing users");
+
+    const userMappings = new Map<string, string>();
+    const usersPath = join(namespacesPath, '$users.json');
+    
+    if (await pathExists(usersPath)) {
+      const usersSpinner = ora('Processing users...').start();
+      
+      try {
+        const users = JSON.parse(await readFile(usersPath, 'utf-8'));
+        
+        if (dryRun) {
+          usersSpinner.text = `Would process ${users.length} users`;
+          
+          // Create user transactions for dry run
+          for (const user of users) {
+            if (!user.email) {
+              continue; // Skip users without email
+            }
+            
+            userTxs.push({
+              type: 'create',
+              entity: '$users',
+              id: user.id,
+              data: {
+                email: user.email
+              }
+            });
+            
+            // For dry run, just map the ID to itself
+            userMappings.set(user.id, user.id);
+          }
+          
+          usersSpinner.succeed(`Would process ${users.length} users (dry run)`);
+        } else {
+          let processedCount = 0;
+          let skipCount = 0;
+          
+          // Process each user directly with the refresh_tokens endpoint
+          for (const user of users) {
+            try {
+              if (!user.email) {
+                skipCount++;
+                continue;
+              }
+              
+              // Create or get user with refresh token
+              const createUserResponse = await fetch(`${apiURI}/admin/refresh_tokens`, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${adminToken}`,
+                  'App-Id': appId
+                },
+                body: JSON.stringify({
+                  email: user.email
+                })
+              });
+              
+              if (!createUserResponse.ok) {
+                skipCount++;
+                continue;
+              }
+              
+              const newUser = await createUserResponse.json();
+              
+              // Record the user transaction
+              userTxs.push({
+                type: 'create',
+                entity: '$users',
+                id: newUser.user.id,
+                data: {
+                  email: user.email
+                }
+              });
+              
+              // Map old ID to new ID
+              userMappings.set(user.id, newUser.user.id);
+              processedCount++;
+              
+              usersSpinner.text = `Processing users... ${processedCount}/${users.length}`;
+              
+              // Sleep to avoid rate limits
+              await sleep(sleepTime);
+            } catch (err) {
+              skipCount++;
+            }
+          }
+          
+          if (skipCount > 0) {
+            usersSpinner.succeed(`Processed ${processedCount} users (${skipCount} skipped)`);
+          } else {
+            usersSpinner.succeed(`Processed ${processedCount} users`);
+          }
+          
+          // Update metadata with user mapping information
+          importMetadata.summary.userMappingsCreated = userMappings.size;
+        }
+        
+        // Write user transactions to file immediately
+        await writeFile(
+          join(txFilesPath, '0_user_txs.json'),
+          JSON.stringify(userTxs, null, 2)
+        );
+        log.info(`Saved user transactions to transaction logs`);
+        
+      } catch (err) {
+        usersSpinner.fail(`Error processing users`);
+        log.error((err as Error).message);
+      }
+    } else {
+      log.info('No users found in export. Skipping user import.');
+    }
+    
+    // ---------------
+    // STEP 6: Update entity references
+    // ---------------
+    log.step(6, TOTAL_STEPS, "Updating entity references");
+    
+    const processSpinner = ora('Updating user references in entities...').start();
+    
+    try {
+      const namespaceFiles = await readdir(namespacesPath);
+      let processed = 0;
+      const totalFiles = namespaceFiles.filter(f => f.endsWith('.json') && 
+                                                f !== '$users.json' && 
+                                                f !== '$files.json').length;
+      
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        
+        // Skip $users (already processed) and $files (not supported yet)
+        const namespaceName = file.replace('.json', '');
+        if (namespaceName === '$users' || namespaceName === '$files') continue;
+        
+        // Read entity file
+        const entityPath = join(namespacesPath, file);
+        let entities = JSON.parse(await readFile(entityPath, 'utf-8'));
+        
+        // Process each entity to replace user IDs
+        entities = replaceUserIds(entities, userMappings);
+        
+        // Write back to the same file with updated user IDs
+        await writeFile(entityPath, JSON.stringify(entities, null, 2));
+        
+        processed++;
+        processSpinner.text = `Updating user references... ${processed}/${totalFiles}`;
+      }
+      
+      processSpinner.succeed(`Updated ${processed} entity types`);
+    } catch (err) {
+      processSpinner.fail(`Error updating entity references`);
+      log.error((err as Error).message);
+      return { ok: false };
+    }
+    
+    if (!dryRun) {
+      // ---------------
+      // STEP 7: Clear existing app data
+      // ---------------
+      log.step(7, TOTAL_STEPS, "Clearing existing app data");
+      
+      const clearAppSpinner = ora('Clearing existing app data...').start();
+      
+      try {
+        // Use the user token for app clearing
+        const clearResponse = await fetch(`${apiURI}/dash/apps/${appId}/clear`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${authToken}`,
+          }
+        });
+        
+        if (!clearResponse.ok) {
+          const errorText = await clearResponse.text();
+          clearAppSpinner.fail();
+          log.error(`Failed to clear app: ${errorText}`);
+          return { ok: false };
+        }
+        
+        clearAppSpinner.succeed('App data cleared');
+        
+        // Small delay to ensure the clear operation completes on the server side
+        await sleep(500);
+      } catch (err) {
+        clearAppSpinner.fail();
+        log.error(`Error clearing app: ${(err as Error).message}`);
+        return { ok: false };
+      }
+      
+      // ---------------
+      // STEP 8: Push schema and permissions
+      // ---------------
+      log.step(8, TOTAL_STEPS, "Pushing schema and permissions");
+      
+      const schemaSpinner = ora('Pushing schema...').start();
+      
+      try {
+        const schemaResponse = await fetch(`${apiURI}/admin/schema`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${adminToken}`,
+            'App-Id': appId
+          },
+          body: JSON.stringify({ schema })
+        });
+        
+        if (!schemaResponse.ok) {
+          const errorText = await schemaResponse.text();
+          schemaSpinner.fail();
+          log.error(`Failed to push schema: ${errorText}`);
+          return { ok: false };
+        }
+        
+        schemaSpinner.succeed('Schema pushed successfully');
+        
+        // Verify schema was applied correctly
+        const schemaVerifySpinner = ora('Verifying schema was applied...').start();
+        try {
+          const verifyResult = await fetch(`${apiURI}/admin/schema`, {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${adminToken}`,
+              'App-Id': appId
+            }
+          });
+          
+          if (!verifyResult.ok) {
+            schemaVerifySpinner.warn('Could not verify schema - continuing but there may be issues');
+          } else {
+            const currentSchema = await verifyResult.json();
+            
+            // Write current schema to file for comparison
+            await writeFile(
+              join(importPath, 'applied_schema.json'),
+              JSON.stringify(currentSchema.schema, null, 2)
+            );
+            
+            schemaVerifySpinner.succeed('Schema verified');
+          }
+        } catch (err) {
+          schemaVerifySpinner.warn('Could not verify schema - continuing but there may be issues');
+        }
+      } catch (err) {
+        schemaSpinner.fail();
+        log.error(`Error pushing schema: ${(err as Error).message}`);
+        return { ok: false };
+      }
+      
+      // Push permissions
+      if (Object.keys(permissions).length > 0) {
+        const permsSpinner = ora('Pushing permissions...').start();
+        
+        try {
+          const permsResponse = await fetch(`${apiURI}/dash/apps/${appId}/perms/push`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${authToken}` // Use user token for permissions
+            },
+            body: JSON.stringify({ perms: permissions })
+          });
+          
+          if (!permsResponse.ok) {
+            permsSpinner.warn('Failed to push permissions, continuing anyway');
+          } else {
+            permsSpinner.succeed('Permissions pushed successfully');
+          }
+        } catch (err) {
+          permsSpinner.warn('Failed to push permissions, continuing anyway');
+        }
+      }
+    } else {
+      // ---------------
+      // STEP 7: Preview actions (dry run)
+      // ---------------
+      log.step(7, TOTAL_STEPS, "Preview actions (dry run)");
+      log.info('Would clear existing app data');
+      log.info('Would push schema');
+      
+      if (Object.keys(permissions).length > 0) {
+        log.info('Would push permissions');
+      }
+    }
+    
+    // ---------------
+    // STEP 9: Prepare import
+    // ---------------
+    log.step(9, TOTAL_STEPS, dryRun ? "Analyzing import data" : "Preparing import data");
+    
+    // Create a summary of what will be imported
+    let entityTypesCount = 0;
+    let totalEntitiesCount = 0;
+    let totalRelationshipsCount = 0;
+    
+    try {
+      const namespaceFiles = await readdir(namespacesPath);
+      entityTypesCount = namespaceFiles.filter(f => f.endsWith('.json') && 
+                                               f !== '$files.json').length;
+      
+      // Count total entities
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        if (file === '$files.json') continue;
+        
+        const namespaceName = file.replace('.json', '');
+        const entities = JSON.parse(await readFile(join(namespacesPath, file), 'utf-8'));
+        totalEntitiesCount += entities.length;
+        
+        // Add to import metadata
+        const entityTypeSummary = {
+          name: namespaceName,
+          entitiesImported: entities.length,
+          relationshipsImported: 0
+        };
+        
+        // Get link information to estimate relationship count
+        const namespaceLinks = getAllLinkFields(schema, namespaceName);
+        
+        if (namespaceLinks.length > 0) {
+          let namespaceRelationships = 0;
+          
+          for (const entity of entities) {
+            for (const linkAttr of namespaceLinks) {
+              const linkedEntities = entity[linkAttr];
+              
+              if (!linkedEntities) continue;
+              
+              // Skip if attempting to create a forward link from $users or $files
+              if ((namespaceName === '$users' || namespaceName === '$files') && 
+                  linkedEntities.length > 0 && linkedEntities[0].id) {
+                continue;
+              }
+              
+              if (Array.isArray(linkedEntities)) {
+                namespaceRelationships += linkedEntities.length;
+                totalRelationshipsCount += linkedEntities.length;
+              } else if (linkedEntities && linkedEntities.id) {
+                namespaceRelationships += 1;
+                totalRelationshipsCount += 1;
+              }
+            }
+          }
+          
+          entityTypeSummary.relationshipsImported = namespaceRelationships;
+        }
+        
+        importMetadata.summary.entityTypes.push(entityTypeSummary);
+      }
+      
+      // Update totals in metadata
+      importMetadata.summary.totalEntitiesImported = totalEntitiesCount;
+      importMetadata.summary.totalRelationshipsImported = totalRelationshipsCount;
+      importMetadata.summary.entityTypeCount = importMetadata.summary.entityTypes.length;
+      
+      if (dryRun) {
+        log.success(`Found ${entityTypesCount} entity types with ${totalEntitiesCount} entities and approximately ${totalRelationshipsCount} relationships`);
+      } else {
+        log.success(`Ready to import ${entityTypesCount} entity types with ${totalEntitiesCount} entities and approximately ${totalRelationshipsCount} relationships`);
+      }
+    } catch (err) {
+      log.warning(`Could not generate complete import summary: ${(err as Error).message}`);
+    }
+    
+    // ---------------
+    // STEP 10: Import data
+    // ---------------
+    log.step(10, TOTAL_STEPS, dryRun ? "Previewing entity import" : "Importing entities");
+    
+    try {
+      const namespaceFiles = await readdir(namespacesPath);
+      const totalNamespaces = namespaceFiles.filter(f => f.endsWith('.json') && 
+                                                  f !== '$users.json' && 
+                                                  f !== '$files.json').length;
+      let namespaceCounter = 0;
+      
+      // First pass: process entities without links
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        
+        const namespaceName = file.replace('.json', '');
+        // Skip system namespaces which are handled separately
+        if (namespaceName === '$files' || namespaceName === '$users') continue;
+        
+        namespaceCounter++;
+        const action = dryRun ? 'Analyzing' : 'Importing';
+        const entitiesSpinner = ora(`${action} ${namespaceName} entities (${namespaceCounter}/${totalNamespaces})...`).start();
+        
+        try {
+          const entities = JSON.parse(await readFile(join(namespacesPath, file), 'utf-8'));
+          
+          // Get link information for this namespace
+          const namespaceLinks = getAllLinkFields(schema, namespaceName);
+          
+          // Create a temporary array for this namespace's transactions
+          const namespaceCreateTxs: any[] = [];
+          
+          // Import in batches
+          let imported = 0;
+          let failed = 0;
+          
+          for (let i = 0; i < entities.length; i += batchSize) {
+            const batch = entities.slice(i, i + batchSize);
+            const tx = [];
+            
+            for (const entity of batch) {
+              // Extract entity without links
+              const { entityWithoutLinks } = extractSchemaLinks(entity, schema, namespaceName);
+              
+              // Remove id from data since it's already in the transaction object
+              const entityData = { ...entityWithoutLinks };
+              delete entityData.id;
+              
+              // Generate transaction format that matches InstantDB unofficial API
+              tx.push(["update", namespaceName, entity.id, entityData]);
+              
+              // Also generate a create transaction for our transaction files
+              const createTx = {
+                type: 'create',
+                entity: namespaceName,
+                id: entity.id,
+                data: entityWithoutLinks
+              };
+              
+              namespaceCreateTxs.push(createTx);
+              createTxs.push(createTx);
+            }
+            
+            // Create entities without links (skipped in dry run mode because client.transact handles it)
+            try {
+              // Try with retries for resilience
+              const maxRetries = 3;
+              let retryCount = 0;
+              let success = false;
+              
+              while (!success && retryCount < maxRetries) {
+                try {
+                  await client.transact(tx);
+                  success = true;
+                } catch (retryErr) {
+                  retryCount++;
+                  
+                  // Log the first error for better diagnostics
+                  if (retryCount === 1) {
+                    console.error(`Error importing ${namespaceName}:`, retryErr);
+                    
+                    // Log the sample transaction data on error
+                    console.log("Sample problematic transaction:", JSON.stringify(tx.slice(0, 1), null, 2));
+                    
+                    try {
+                      const errorLogPath = join(txFilesPath, `entity_error_${namespaceName}.json`);
+                      await writeFile(
+                        errorLogPath,
+                        JSON.stringify({
+                          error: retryErr.message,
+                          sampleData: tx.slice(0, 1)
+                        }, null, 2)
+                      );
+                    } catch (e) {
+                      // Ignore errors saving error logs
+                    }
+                  }
+                  
+                  if (retryCount >= maxRetries) {
+                    failed += batch.length;
+                    break; // Give up after max retries
+                  }
+                  
+                  // Wait longer between each retry attempt
+                  const retryDelay = sleepTime * Math.pow(2, retryCount);
+                  entitiesSpinner.text = `${action} ${namespaceName}... Retry ${retryCount}/${maxRetries} (waiting ${retryDelay}ms)`;
+                  await sleep(retryDelay);
+                }
+              }
+              
+              imported += batch.length;
+            } catch (err) {
+              // Stop execution at the first error and display full details
+              entitiesSpinner.fail(`Error importing ${namespaceName} entities`);
+              
+              // Format error message for clear display
+              console.log('\n');
+              console.log(chalk.red('═════════════════════════════════════════'));
+              console.log(chalk.red.bold('IMPORT ERROR DETAILS'));
+              console.log(chalk.red('═════════════════════════════════════════'));
+              console.log(`Namespace: ${chalk.yellow(namespaceName)}`);
+              console.log(`Error: ${chalk.red((err as Error).message)}`);
+              
+              // Show sample of the data that failed
+              if (tx && tx.length > 0) {
+                console.log('\nSample of problematic entity:');
+                try {
+                  console.log(JSON.stringify(tx[0], null, 2).substring(0, 500));
+                  if (JSON.stringify(tx[0]).length > 500) {
+                    console.log('... (truncated)');
+                  }
+                } catch (e) {
+                  console.log('Unable to display entity sample');
+                }
+              }
+              
+              console.log(chalk.red('═════════════════════════════════════════'));
+              console.log('Import operation aborted due to error.');
+              
+              // Write detailed error info to a log file
+              try {
+                const errorLog = {
+                  namespace: namespaceName,
+                  error: (err as Error).message,
+                  errorObject: err,
+                  batch: tx.slice(0, 2), // Include just a couple of examples
+                  time: new Date().toISOString()
+                };
+                
+                const errorLogPath = join(txFilesPath, `error_log_${namespaceName}.json`);
+                await writeFile(
+                  errorLogPath,
+                  JSON.stringify(errorLog, null, 2)
+                );
+                console.log(`Full error details saved to: ${chalk.cyan(errorLogPath)}`);
+              } catch (logErr) {
+                console.log('Could not write error log file');
+              }
+              
+              // Exit the function with error
+              return { ok: false };
+            }
+            
+            entitiesSpinner.text = `${action} ${namespaceName}... ${imported}/${entities.length}`;
+            
+            // Sleep between batches
+            if (!dryRun) {
+              await sleep(sleepTime);
+            }
+          }
+          
+          // Write create transactions for this namespace immediately
+          await writeFile(
+            join(txFilesPath, `1_create_txs_${namespaceName}.json`),
+            JSON.stringify(namespaceCreateTxs, null, 2)
+          );
+          
+          if (dryRun) {
+            entitiesSpinner.succeed(`Would import ${entities.length} ${namespaceName} entities`);
+          } else if (failed > 0) {
+            entitiesSpinner.warn(`Imported ${imported} ${namespaceName} entities (${failed} failed)`);
+          } else {
+            entitiesSpinner.succeed(`Imported ${imported} ${namespaceName} entities`);
+          }
+        } catch (err) {
+          entitiesSpinner.fail(`Error processing ${namespaceName}`);
+        }
+      }
+      
+      // Write the combined create transactions file
+      await writeFile(
+        join(txFilesPath, '1_create_txs.json'),
+        JSON.stringify(createTxs, null, 2)
+      );
+      
+      // Second pass: process all links
+      const linkAction = dryRun ? 'Analyzing' : 'Creating';
+      log.header("Processing entity relationships");
+      
+      namespaceCounter = 0;
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        
+        const namespaceName = file.replace('.json', '');
+        // Skip system namespaces which are handled separately 
+        if (namespaceName === '$files' || namespaceName === '$users') continue;
+        
+        namespaceCounter++;
+        const linksSpinner = ora(`${linkAction} links for ${namespaceName} (${namespaceCounter}/${totalNamespaces})...`).start();
+        
+        try {
+          const entities = JSON.parse(await readFile(join(namespacesPath, file), 'utf-8'));
+          
+          // Get link information for this namespace
+          const namespaceLinks = getAllLinkFields(schema, namespaceName);
+          
+          if (namespaceLinks.length === 0) {
+            linksSpinner.succeed(`No links for ${namespaceName}`);
+            continue;
+          }
+          
+          // Create a temporary array for this namespace's link transactions
+          const namespaceLinkTxs: any[] = [];
+          
+          // Process entities in batches
+          let processed = 0;
+          let failed = 0;
+          let allLinkTransactions: any[] = [];
+          
+          // First gather all link transactions
+          for (const entity of entities) {
+            // Extract links only
+            const { links } = extractSchemaLinks(entity, schema, namespaceName);
+            
+            // Process links from schema
+            for (const linkAttr of namespaceLinks) {
+              const linkedEntities = links[linkAttr];
+              
+              if (!linkedEntities) continue;
+              
+              // Skip if attempting to create a forward link from $users or $files
+              // These system namespaces can only have reverse links
+              if ((namespaceName === '$users' || namespaceName === '$files') && 
+                  linkedEntities.length > 0 && linkedEntities[0].id) {
+                continue;
+              }
+              
+              // Create link transactions
+              processLinkEntities(entity.id, namespaceName, linkAttr, linkedEntities, 
+                               allLinkTransactions, namespaceLinkTxs, linkTxs);
+            }
+          }
+          
+          if (allLinkTransactions.length === 0) {
+            linksSpinner.succeed(`No links for ${namespaceName}`);
+            continue;
+          }
+          
+          // Now process the link transactions in batches
+          if (!dryRun) {
+            // Process link transactions in batches to avoid oversized transactions
+            for (let i = 0; i < allLinkTransactions.length; i += batchSize) {
+              const linkBatch = allLinkTransactions.slice(i, i + batchSize);
+              
+              try {
+                // Try with retries for resilience
+                const maxRetries = 3;
+                let retryCount = 0;
+                let success = false;
+                
+                while (!success && retryCount < maxRetries) {
+                  try {
+                    await client.transact(linkBatch);
+                    success = true;
+                    processed += linkBatch.length;
+                  } catch (retryErr) {
+                    retryCount++;
+                    
+                    // On first error, log more details
+                    if (retryCount === 1) {
+                      console.error(`Link error for ${namespaceName}:`, retryErr);
+                      
+                      // Log sample transaction data on error
+                      console.log("Sample problematic link transaction:", 
+                        JSON.stringify(linkBatch.slice(0, 1), null, 2));
+                      
+                      // Save error info for debugging
+                      try {
+                        const errorLogPath = join(txFilesPath, `link_error_${namespaceName}.json`);
+                        await writeFile(
+                          errorLogPath,
+                          JSON.stringify({
+                            error: retryErr.message,
+                            sampleData: linkBatch.slice(0, 2)
+                          }, null, 2)
+                        );
+                      } catch (e) {
+                        // Ignore error logging failures
+                      }
+                    }
+                    
+                    if (retryCount >= maxRetries) {
+                      failed += linkBatch.length;
+                      break; // Give up after max retries
+                    }
+                    
+                    // Wait longer between each retry attempt
+                    const retryDelay = sleepTime * Math.pow(2, retryCount);
+                    linksSpinner.text = `Creating links for ${namespaceName}... ${processed}/${allLinkTransactions.length} (Retry ${retryCount}/${maxRetries}, waiting ${retryDelay}ms)`;
+                    await sleep(retryDelay);
+                  }
+                }
+              } catch (err) {
+                failed += linkBatch.length;
+                console.error(`Link error for ${namespaceName}:`, err);
+              }
+              
+              linksSpinner.text = `Creating links for ${namespaceName}... ${processed}/${allLinkTransactions.length}`;
+              
+              // Sleep between batches
+              await sleep(sleepTime);
+            }
+          } else {
+            processed = allLinkTransactions.length;
+            linksSpinner.text = `Would create ${processed} links for ${namespaceName}`;
+          }
+          
+          // Write link transactions for this namespace immediately 
+          if (namespaceLinkTxs.length > 0) {
+            await writeFile(
+              join(txFilesPath, `2_link_txs_${namespaceName}.json`),
+              JSON.stringify(namespaceLinkTxs, null, 2)
+            );
+          }
+          
+          if (dryRun) {
+            linksSpinner.succeed(`Would create ${processed} links for ${namespaceName}`);
+          } else if (failed > 0) {
+            linksSpinner.warn(`Created ${processed} links for ${namespaceName} (${failed} failed)`);
+          } else if (processed > 0) {
+            linksSpinner.succeed(`Created ${processed} links for ${namespaceName}`);
+          } else {
+            linksSpinner.info(`No links created for ${namespaceName}`);
+          }
+        } catch (err) {
+          linksSpinner.fail(`Error processing links for ${namespaceName}`);
+        }
+      }
+      
+      // Write all link transactions 
+      await writeFile(
+        join(txFilesPath, '2_link_txs.json'),
+        JSON.stringify(linkTxs, null, 2)
+      );
+      
+      // Write import metadata with completion timestamp
+      importMetadata.importCompleted = new Date().toLocaleString(undefined, { timeZoneName: 'short' });
+      await writeFile(
+        join(importPath, 'import_metadata.json'),
+        JSON.stringify(importMetadata, null, 2)
+      );
+      
+      log.header("IMPORT SUMMARY");
+      if (dryRun) {
+        console.log(chalk.yellow('🔍 DRY RUN COMPLETED - No changes were made to your app'));
+        console.log(`   Would import: ${createTxs.length} entities with ${linkTxs.length} relationships`);
+      } else {
+        console.log(chalk.green('✅ IMPORT COMPLETED SUCCESSFULLY'));
+        console.log(`   Imported: ${createTxs.length} entities with ${linkTxs.length} relationships`);
+      }
+      
+      log.info(`All import logs saved to: ${chalk.dim(importPath)}`);
+      
+      return { ok: true };
+    } catch (err) {
+      log.error(`Import failed: ${(err as Error).message}`);
+      return { ok: false };
+    }
+  } catch (err) {
+    log.error(`Failed to fetch app information: ${(err as Error).message}`);
+    return { ok: false };
+  }
+}
+
+/**
+ * Check if a path exists
+ */
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    const { stat } = await import('fs/promises');
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Helper function to recursively replace user IDs in an object or array
+ */
+function replaceUserIds(data: any, userMappings: Map<string, string>): any {
+  if (data === null || data === undefined) {
+    return data;
+  }
+  
+  if (typeof data === 'string') {
+    // Check if the string is a UUID that needs to be replaced
+    return userMappings.has(data) ? userMappings.get(data) : data;
+  }
+  
+  if (Array.isArray(data)) {
+    return data.map(item => 
+      typeof item === 'string' 
+        ? (userMappings.has(item) ? userMappings.get(item) : item)
+        : replaceUserIds(item, userMappings)
+    );
+  }
+  
+  if (typeof data === 'object') {
+    const result = { ...data };
+    
+    for (const [key, value] of Object.entries(result)) {
+      if (typeof value === 'string') {
+        result[key] = userMappings.has(value) ? userMappings.get(value) : value;
+      } else {
+        result[key] = replaceUserIds(value, userMappings);
+      }
+    }
+    
+    return result;
+  }
+  
+  return data;
+}
+
+/**
+ * Get all link fields for a given namespace by parsing the schema
+ */
+function getAllLinkFields(schema: any, namespace: string): string[] {
+  if (!schema?.refs) return [];
+  
+  const linkFields = new Set<string>();
+  
+  // Process each ref to find both forward and reverse links
+  Object.values(schema.refs).forEach(ref => {
+    const fwdIdentity = ref['forward-identity'];
+    const revIdentity = ref['reverse-identity'];
+    
+    // Add forward links
+    if (Array.isArray(fwdIdentity) && fwdIdentity.length >= 3 && String(fwdIdentity[1]) === namespace) {
+      linkFields.add(String(fwdIdentity[2]));
+    }
+    
+    // Add reverse links
+    if (Array.isArray(revIdentity) && revIdentity.length >= 3 && String(revIdentity[1]) === namespace) {
+      linkFields.add(String(revIdentity[2]));
+    }
+  });
+  
+  return Array.from(linkFields);
+}
+
+/**
+ * Extract all link and non-link fields from an entity using comprehensive schema parsing
+ */
+function extractSchemaLinks(entity: any, schema: any, namespace: string): {
+  entityWithoutLinks: any;
+  links: Record<string, any>;
+} {
+  const entityWithoutLinks = { ...entity };
+  const links: Record<string, any> = {};
+  
+  // Get all link fields from schema
+  const linkFields = getAllLinkFields(schema, namespace);
+  
+  // Process all known link fields from schema
+  linkFields.forEach(field => {
+    if (field in entity) {
+      links[field] = entity[field];
+      delete entityWithoutLinks[field];
+    }
+  });
+  
+  // Also detect and remove any fields that look like links but weren't in schema
+  Object.keys(entityWithoutLinks).forEach(key => {
+    const value = entityWithoutLinks[key];
+    
+    // Check if it's an array containing objects with IDs or has special link naming patterns
+    if ((Array.isArray(value) && value.length > 0 && 
+         typeof value[0] === 'object' && value[0] !== null && 'id' in value[0]) ||
+        key.includes('__in__') || key.startsWith('list_item__')) {
+      // This looks like a link that wasn't explicitly in the schema
+      links[key] = value;
+      delete entityWithoutLinks[key];
+    }
+  });
+  
+  return { entityWithoutLinks, links };
+}
+
+/**
+ * Helper function to process link entities and create transactions
+ */
+function processLinkEntities(
+  entityId: string,
+  sourceNamespace: string,
+  linkAttr: string,
+  linkedEntities: any,
+  batchTransactions: any[],
+  namespaceTxs: any[],
+  allTxs: any[]
+): void {
+  // Determine target namespace from the attribute name if possible
+  let targetNamespace = linkAttr;
+  
+  // If the attribute has a format like "list_item__asset__in__category"
+  // Then the target is likely "category"
+  if (linkAttr.includes('__in__')) {
+    const parts = linkAttr.split('__in__');
+    if (parts.length > 1) {
+      targetNamespace = parts[parts.length - 1];
+    }
+  }
+  
+  // Handle both array and single entity formats by normalizing to array
+  const entities = Array.isArray(linkedEntities) ? linkedEntities : 
+                  (linkedEntities && linkedEntities.id ? [linkedEntities] : []);
+  
+  for (const linkedEntity of entities) {
+    if (!linkedEntity || !linkedEntity.id) continue;
+    
+    try {
+      // Create link data exactly as in the documentation
+      const linkData = {};
+      linkData[linkAttr] = linkedEntity.id;
+      
+      // Create link transaction in unofficial API format
+      const linkTx = ["link", sourceNamespace, entityId, linkData];
+      
+      batchTransactions.push(linkTx);
+      
+      // Also keep our internal format for reference
+      const internalTx = {
+        type: 'link',
+        entity: sourceNamespace,
+        id: entityId,
+        attr: linkAttr,
+        target: {
+          entity: targetNamespace,
+          id: linkedEntity.id
+        }
+      };
+      
+      namespaceTxs.push(internalTx);
+      allTxs.push(internalTx);
+    } catch (err) {
+      console.error(`Error creating link for ${sourceNamespace}.${entityId}.${linkAttr} -> ${linkedEntity.id}:`, err);
+    }
+  }
+} 

--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -2114,3 +2114,6 @@ async function handleMigrate(scripts, opts) {
   
   await migrateData(appId, scripts, pkgAndAuthInfo, migrateOptions);
 }
+
+// Export utility functions for use in other modules
+export { generateSchemaTypescriptFile, readLocalSchemaFile };

--- a/client/packages/cli/src/migrate.ts
+++ b/client/packages/cli/src/migrate.ts
@@ -1,0 +1,727 @@
+import { mkdir, writeFile, readFile, readdir, copyFile } from 'fs/promises';
+import { readdirSync } from 'fs';
+import { join, dirname, basename } from 'path';
+import chalk from 'chalk';
+import ora from 'ora';
+import inquirer from 'inquirer';
+import { exportData } from './export.js';
+import { importData } from './import.js';
+
+/**
+ * Console output styling helper
+ */
+const log = {
+  header: (message: string) => console.log('\n' + chalk.bold.blue('▶︎ ' + message)),
+  step: (step: number, totalSteps: number, message: string) => console.log(chalk.bold.cyan(`[${step}/${totalSteps}] ${message}`)),
+  success: (message: string) => console.log(chalk.green('✓ ') + message),
+  warning: (message: string) => console.log(chalk.yellow('⚠ ') + message),
+  error: (message: string) => console.log(chalk.red('✗ ') + message),
+  info: (message: string) => console.log(chalk.dim('• ') + message)
+};
+
+/**
+ * Generate a timestamp string suitable for directory naming
+ * Format: YYYY-MM-DD_HH-MM-SS
+ */
+function generateTimestampDirName(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  
+  return `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+}
+
+/**
+ * Check if a path exists
+ */
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    const { stat } = await import('fs/promises');
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Sleep for the specified number of milliseconds
+ * @param ms - Milliseconds to sleep
+ * @returns Promise that resolves after the specified delay
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Find all available exports by reading metadata.json files
+ * @returns Array of export options sorted by timestamp (newest first)
+ */
+async function findExports(baseDir = 'instant-export'): Promise<Array<{
+  path: string;
+  timestamp: string;
+  appName: string;
+  entities: number;
+  exportedAt: string;
+}>> {
+  try {
+    // Check if export directory exists
+    try {
+      const { stat } = await import('fs/promises');
+      const stats = await stat(baseDir);
+      if (!stats.isDirectory()) {
+        return [];
+      }
+    } catch {
+      return [];
+    }
+    
+    // List all directories in the export folder
+    const dirs = await readdir(baseDir);
+    const exportOptions = [];
+    
+    for (const dir of dirs) {
+      const metadataPath = join(baseDir, dir, 'metadata.json');
+      try {
+        const metadata = JSON.parse(await readFile(metadataPath, 'utf-8'));
+        exportOptions.push({
+          path: join(baseDir, dir),
+          timestamp: dir,
+          appName: metadata.appName || 'Unknown app',
+          entities: metadata.summary.namespaces.reduce((sum, ns) => sum + ns.entityCount, 0),
+          exportedAt: metadata.endTimestamp || 'Unknown date'
+        });
+      } catch (err) {
+        // Skip directories without valid metadata.json
+      }
+    }
+    
+    // Sort by timestamp (newest first)
+    return exportOptions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  } catch (err) {
+    return [];
+  }
+}
+
+/**
+ * Copy a directory recursively
+ */
+async function copyDir(src: string, dest: string): Promise<void> {
+  await mkdir(dest, { recursive: true });
+  const entries = await readdir(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await copyFile(srcPath, destPath);
+    }
+  }
+}
+
+interface PackageAndAuthInfo {
+  pkgDir: string;
+  authToken: string;
+  instantModuleName?: string;
+}
+
+interface MigrateOptions {
+  base?: string;
+  publish?: boolean;
+  verbose?: boolean;
+  batchSize?: number;
+  sleep?: number;
+  force?: boolean;
+}
+
+/**
+ * Database proxy class that handles loading and saving data files
+ */
+class DBProxy {
+  private dataDir: string;
+  private _modified: boolean = false;
+  private _schema: any = null;
+  private _permissions: any = null;
+  private _entities: any = {};
+  private _schemaLoaded: boolean = false;
+  private _permissionsLoaded: boolean = false;
+  private _entitiesLoaded: boolean = false;
+
+  constructor(dataDir: string) {
+    this.dataDir = dataDir;
+  }
+
+  /**
+   * Check if any data has been modified
+   */
+  get modified() {
+    return this._modified;
+  }
+
+  /**
+   * Get schema data with lazy loading
+   */
+  get schema() {
+    if (!this._schemaLoaded) {
+      this._loadSchema();
+    }
+    return this._schema;
+  }
+
+  /**
+   * Get permissions data with lazy loading
+   */
+  get permissions() {
+    if (!this._permissionsLoaded) {
+      this._loadPermissions();
+    }
+    return this._permissions;
+  }
+
+  /**
+   * Get entities data with lazy loading
+   */
+  get entities() {
+    if (!this._entitiesLoaded) {
+      this._loadEntities();
+    }
+    return this._entities;
+  }
+
+  /**
+   * Load schema data
+   */
+  private _loadSchema() {
+    try {
+      const schemaPath = join(this.dataDir, 'schema.json');
+      const schemaData = require(schemaPath);
+      this._schema = schemaData;
+      this._schemaLoaded = true;
+      
+      // Create proxy for schema to track changes
+      this._schema = new Proxy(this._schema, {
+        set: (target, prop, value) => {
+          this._modified = true;
+          target[prop] = value;
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          this._modified = true;
+          delete target[prop];
+          return true;
+        }
+      });
+    } catch (err) {
+      this._schema = {};
+      this._schemaLoaded = true;
+    }
+  }
+
+  /**
+   * Load permissions data
+   */
+  private _loadPermissions() {
+    try {
+      const permissionsPath = join(this.dataDir, 'permissions.json');
+      if (pathExists(permissionsPath)) {
+        const permissionsData = require(permissionsPath);
+        this._permissions = permissionsData;
+      } else {
+        this._permissions = {};
+      }
+      this._permissionsLoaded = true;
+      
+      // Create proxy for permissions to track changes
+      this._permissions = new Proxy(this._permissions, {
+        set: (target, prop, value) => {
+          this._modified = true;
+          target[prop] = value;
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          this._modified = true;
+          delete target[prop];
+          return true;
+        }
+      });
+    } catch (err) {
+      this._permissions = {};
+      this._permissionsLoaded = true;
+    }
+  }
+
+  /**
+   * Load entities data
+   */
+  private _loadEntities() {
+    try {
+      const namespacesDir = join(this.dataDir, 'namespaces');
+      const namespaceFiles = readdirSync(namespacesDir);
+      
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        
+        const namespaceName = file.replace('.json', '');
+        const filePath = join(namespacesDir, file);
+        const entities = require(filePath);
+        
+        // Create an entity map by ID
+        const entityMap = {};
+        for (const entity of entities) {
+          entityMap[entity.id] = entity;
+        }
+        
+        // Create a proxy for this namespace's entities
+        this._entities[namespaceName] = new Proxy(entityMap, {
+          set: (target, prop, value) => {
+            this._modified = true;
+            target[prop] = value;
+            return true;
+          },
+          deleteProperty: (target, prop) => {
+            this._modified = true;
+            delete target[prop];
+            return true;
+          }
+        });
+      }
+      
+      // Create the top-level proxy for entities
+      this._entities = new Proxy(this._entities, {
+        set: (target, prop, value) => {
+          this._modified = true;
+          target[prop] = value;
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          this._modified = true;
+          delete target[prop];
+          return true;
+        }
+      });
+      
+      this._entitiesLoaded = true;
+    } catch (err) {
+      this._entities = {};
+      this._entitiesLoaded = true;
+    }
+  }
+
+  /**
+   * Load all data from files synchronously
+   */
+  loadSync() {
+    if (!this._schemaLoaded) this._loadSchema();
+    if (!this._permissionsLoaded) this._loadPermissions();
+    if (!this._entitiesLoaded) this._loadEntities();
+    return this;
+  }
+
+  /**
+   * Load all data from files
+   */
+  async load() {
+    // Load schema
+    const schemaPath = join(this.dataDir, 'schema.json');
+    try {
+      this._schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+      
+      // Create proxy for schema to track changes
+      this._schema = new Proxy(this._schema, {
+        set: (target, prop, value) => {
+          this._modified = true;
+          target[prop] = value;
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          this._modified = true;
+          delete target[prop];
+          return true;
+        }
+      });
+    } catch (err) {
+      this._schema = {};
+    }
+    this._schemaLoaded = true;
+    
+    // Load permissions if they exist
+    const permissionsPath = join(this.dataDir, 'permissions.json');
+    try {
+      if (await pathExists(permissionsPath)) {
+        this._permissions = JSON.parse(await readFile(permissionsPath, 'utf-8'));
+      } else {
+        this._permissions = {};
+      }
+      
+      // Create proxy for permissions to track changes
+      this._permissions = new Proxy(this._permissions, {
+        set: (target, prop, value) => {
+          this._modified = true;
+          target[prop] = value;
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          this._modified = true;
+          delete target[prop];
+          return true;
+        }
+      });
+    } catch (err) {
+      this._permissions = {};
+    }
+    this._permissionsLoaded = true;
+    
+    // Load all namespaces
+    this._entities = {};
+    const namespacesDir = join(this.dataDir, 'namespaces');
+    try {
+      const namespaceFiles = await readdir(namespacesDir);
+      
+      for (const file of namespaceFiles) {
+        if (!file.endsWith('.json')) continue;
+        
+        const namespaceName = file.replace('.json', '');
+        const entities = JSON.parse(await readFile(join(namespacesDir, file), 'utf-8'));
+        
+        // Create an entity map by ID
+        const entityMap = {};
+        for (const entity of entities) {
+          entityMap[entity.id] = entity;
+        }
+        
+        // Create a proxy for this namespace's entities
+        this._entities[namespaceName] = new Proxy(entityMap, {
+          set: (target, prop, value) => {
+            this._modified = true;
+            target[prop] = value;
+            return true;
+          },
+          deleteProperty: (target, prop) => {
+            this._modified = true;
+            delete target[prop];
+            return true;
+          }
+        });
+      }
+      
+      // Create the top-level proxy for entities
+      this._entities = new Proxy(this._entities, {
+        set: (target, prop, value) => {
+          this._modified = true;
+          target[prop] = value;
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          this._modified = true;
+          delete target[prop];
+          return true;
+        }
+      });
+    } catch (err) {
+      // Namespaces directory might not exist yet
+    }
+    this._entitiesLoaded = true;
+    
+    return this;
+  }
+
+  /**
+   * Save all modified data back to files
+   */
+  async save() {
+    if (!this._modified) {
+      return this;
+    }
+
+    // Save schema
+    await writeFile(
+      join(this.dataDir, 'schema.json'),
+      JSON.stringify(this._schema, null, 2)
+    );
+
+    // Save permissions if not empty
+    if (this._permissions && Object.keys(this._permissions).length > 0) {
+      await writeFile(
+        join(this.dataDir, 'permissions.json'),
+        JSON.stringify(this._permissions, null, 2)
+      );
+    }
+
+    // Save each namespace
+    const namespacesDir = join(this.dataDir, 'namespaces');
+    await mkdir(namespacesDir, { recursive: true });
+
+    for (const [namespace, entityMap] of Object.entries(this._entities)) {
+      // Skip empty namespaces
+      if (!entityMap || Object.keys(entityMap).length === 0) continue;
+
+      // Convert entity map back to array for storage
+      const entities = Object.values(entityMap);
+      
+      await writeFile(
+        join(namespacesDir, `${namespace}.json`),
+        JSON.stringify(entities, null, 2)
+      );
+    }
+
+    return this;
+  }
+}
+
+/**
+ * Create a migration context that will be passed to migration scripts
+ */
+async function createMigrationContext(dataDir: string) {
+  const db = new DBProxy(dataDir);
+  await db.load();
+  
+  return {
+    db,
+    log
+  };
+}
+
+/**
+ * Run a migration script
+ */
+async function runMigrationScript(scriptPath: string, context: any) {
+  try {
+    // Resolve the script path relative to the current working directory
+    const { resolve } = await import('path');
+    const absoluteScriptPath = resolve(process.cwd(), scriptPath);
+    
+    const scriptModule = await import(absoluteScriptPath);
+    
+    if (typeof scriptModule.default === 'function') {
+      await scriptModule.default(context);
+    } else if (typeof scriptModule.migrate === 'function') {
+      await scriptModule.migrate(context);
+    } else {
+      throw new Error(`Migration script ${scriptPath} does not export a default or migrate function`);
+    }
+    
+    // Save any changes after script completes
+    if (context.db.modified) {
+      await context.db.save();
+    }
+    
+    return true;
+  } catch (err) {
+    log.error(`Failed to run migration script ${scriptPath}: ${(err as Error).message}`);
+    return false;
+  }
+}
+
+/**
+ * Migrate data from an app, transform it, and optionally import it back
+ * @param appId - The app ID to migrate
+ * @param migrationScripts - Paths to migration scripts to run
+ * @param pkgAndAuthInfo - Authentication info
+ * @param opts - Migration options
+ * @returns Object indicating success or failure
+ */
+export async function migrateData(
+  appId: string,
+  migrationScripts: string[],
+  pkgAndAuthInfo: PackageAndAuthInfo,
+  opts: MigrateOptions
+): Promise<{ ok: boolean }> {
+  // Record start time
+  const startTime = new Date();
+  const timestamp = generateTimestampDirName(startTime);
+  
+  const baseDir = 'instant-migrate';
+  const migrateDir = join(baseDir, timestamp);
+  const beforeDir = join(migrateDir, 'before');
+  const afterDir = join(migrateDir, 'after');
+  
+  log.header("STARTING MIGRATION");
+  
+  // Create migration directories
+  try {
+    await mkdir(migrateDir, { recursive: true });
+    await mkdir(beforeDir, { recursive: true });
+    await mkdir(afterDir, { recursive: true });
+    log.success(`Created migration workspace at ${chalk.dim(migrateDir)}`);
+  } catch (err) {
+    log.error(`Failed to create required directories: ${(err as Error).message}`);
+    return { ok: false };
+  }
+  
+  // Step 1: Get base data (export or use specified base)
+  let baseDataDir: string;
+  
+  if (opts.base === 'select') {
+    // Let user select from available exports
+    const exports = await findExports();
+    
+    if (exports.length === 0) {
+      log.error('No exports found in instant-export directory');
+      return { ok: false };
+    }
+    
+    const { selectedExport } = await inquirer.prompt([{
+      type: 'list',
+      name: 'selectedExport',
+      message: 'Select an export to use as base:',
+      choices: exports.map(exp => ({
+        name: `${chalk.bold(exp.appName)} (${exp.entities} entities) - ${chalk.dim(exp.timestamp)}`,
+        value: exp.path
+      }))
+    }]);
+    
+    baseDataDir = selectedExport;
+  } else if (opts.base && await pathExists(opts.base)) {
+    // Use specified base directory
+    baseDataDir = opts.base;
+  } else {
+    // Export app data
+    log.info(`Exporting app ${appId} to use as migration base...`);
+    
+    const exportResult = await exportData(appId, pkgAndAuthInfo, {
+      output: beforeDir,
+      limit: 'none',
+      batchSize: opts.batchSize || 100,
+      sleep: opts.sleep || 100,
+      verbose: opts.verbose || false
+    });
+    
+    if (!exportResult.ok) {
+      log.error('Failed to export app data');
+      return { ok: false };
+    }
+    
+    baseDataDir = beforeDir;
+  }
+  
+  // Copy base data to before directory if not already there
+  if (baseDataDir !== beforeDir) {
+    log.info(`Copying base data to migration workspace...`);
+    await copyDir(baseDataDir, beforeDir);
+  }
+  
+  // Copy before directory to after directory (we'll modify this one)
+  log.info(`Preparing migration workspace...`);
+  await copyDir(beforeDir, afterDir);
+  
+  // Load migration metadata
+  const metadata = {
+    appId,
+    startTime: startTime.toISOString(),
+    scripts: migrationScripts.map(script => basename(script)),
+    changes: [] as Array<{ script: string, changes: number }>,
+    endTime: '',
+    summary: {
+      totalScripts: migrationScripts.length,
+      totalChanges: 0
+    }
+  };
+  
+  // Step 2: Run migration scripts
+  log.header("RUNNING MIGRATION SCRIPTS");
+  
+  const totalScripts = migrationScripts.length;
+  let successCount = 0;
+  
+  for (let i = 0; i < migrationScripts.length; i++) {
+    const scriptPath = migrationScripts[i];
+    const scriptName = basename(scriptPath);
+    
+    log.step(i + 1, totalScripts, `Running migration script: ${chalk.bold(scriptName)}`);
+    
+    // Create migration context with data from "after" directory
+    const context = await createMigrationContext(afterDir);
+    
+    // Run migration script
+    const spinner = ora(`Executing script...`).start();
+    const success = await runMigrationScript(scriptPath, context);
+    
+    if (!success) {
+      spinner.fail(`Script ${scriptName} failed`);
+      continue;
+    }
+    
+    // Check if changes were made
+    if (context.db.modified) {
+      spinner.succeed(`Script ${scriptName} completed with changes`);
+      
+      // Record changes in metadata
+      metadata.changes.push({
+        script: scriptName,
+        changes: 1 // We don't have an exact count, just indicating changes occurred
+      });
+      
+      metadata.summary.totalChanges += 1;
+    } else {
+      spinner.succeed(`Script ${scriptName} completed (no changes)`);
+    }
+    
+    successCount++;
+  }
+  
+  // Update and save metadata
+  metadata.endTime = new Date().toISOString();
+  await writeFile(
+    join(migrateDir, 'metadata.json'),
+    JSON.stringify(metadata, null, 2)
+  );
+  
+  log.header("MIGRATION SUMMARY");
+  log.success(`${successCount} of ${totalScripts} scripts completed successfully`);
+  log.info(`Migration workspace: ${chalk.dim(migrateDir)}`);
+  log.info(`- Before: ${chalk.dim(beforeDir)}`);
+  log.info(`- After: ${chalk.dim(afterDir)}`);
+  
+  // Step 3: Publish changes if requested
+  if (opts.publish) {
+    log.header("PUBLISHING CHANGES");
+    
+    if (successCount < totalScripts) {
+      log.warning(`Some migration scripts failed. Are you sure you want to publish?`);
+      
+      if (!opts.force) {
+        const { confirmPublish } = await inquirer.prompt([{
+          type: 'confirm',
+          name: 'confirmPublish',
+          message: 'Proceed with publishing despite script failures?',
+          default: false
+        }]);
+        
+        if (!confirmPublish) {
+          log.info('Publishing canceled');
+          return { ok: true };
+        }
+      }
+    }
+    
+    // Import the migrated data
+    log.info(`Importing migrated data to app ${appId}...`);
+    
+    const importResult = await importData(appId, pkgAndAuthInfo, {
+      input: afterDir,
+      dryRun: false,
+      batchSize: opts.batchSize || 100,
+      sleep: opts.sleep || 100,
+      verbose: opts.verbose || false,
+      force: opts.force || false
+    });
+    
+    if (!importResult.ok) {
+      log.error('Failed to import migrated data');
+      return { ok: false };
+    }
+    
+    log.success('Migration published successfully');
+  } else {
+    log.info('Migration completed without publishing changes. Use --publish to apply changes to the app.');
+  }
+  
+  return { ok: true };
+} 

--- a/client/packages/cli/src/util/linkedCLI.js
+++ b/client/packages/cli/src/util/linkedCLI.js
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+
+/**
+ * Checks if the current CLI instance is running in a linked/development state
+ * @param {string} version - The version string of the CLI
+ * @returns {boolean} - Whether the CLI is running in linked/development mode
+ */
+export function isLinkedCLI(version) {
+  // Check if we're using a dev version (this is a strong indicator of a linked version)
+  if (version.includes('-dev')) {
+    return true;
+  }
+  
+  try {
+    const moduleMain = require.resolve('instant-cli');
+    return moduleMain.includes('node_modules/.pnpm/link:') || 
+           moduleMain.includes('/node_global/') || 
+           moduleMain.includes('node_modules/.npm/link');
+  } catch (e) {
+    // If we can't resolve the module through require.resolve, check if we're running from a development path
+    const paths = process.argv[1]?.split('/') || [];
+    return paths.includes('dev') || paths.includes('instant') && paths.includes('client');
+  }
+}
+
+/**
+ * Displays a warning message for development/linked CLI usage
+ */
+export function displayLinkedWarning() {
+  const boxWidth = 63;
+  const padding = '║ ';
+  const message = 'DEVELOPMENT MODE: Using locally linked version of instant-cli';
+  console.log(chalk.cyan.bold('╔' + '═'.repeat(boxWidth) + '╗'));
+  console.log(chalk.cyan.bold(padding + message.padEnd(boxWidth - padding.length + 1) + '║'));
+  console.log(chalk.cyan.bold('╚' + '═'.repeat(boxWidth) + '╝'));
+} 

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -52,6 +52,319 @@ npx instant-cli@latest pull
 
 This will generate new `instant.schema.ts` and `instant.perms.ts` files, based on your production state.
 
+## Export
+
+You can export your database to local files using the `export` command:
+
+```shell {% showCopy=true %}
+npx instant-cli@latest export
+```
+
+### Export Features
+
+- Export schema, permissions, entities and relationships
+- Export between different apps
+- Preserve all relationship links between entities
+- Fast batch processing with configurable batch sizes
+- User-friendly CLI with progress indicators
+
+### Export Examples
+
+```shell {% showCopy=true %}
+# Preview export (dry run)
+npx instant-cli@latest export -a your-app-id --dry-run
+
+# Default export (limits to 10 entities per namespace)
+npx instant-cli@latest export -a your-app-id
+
+# Full export (only run when you're ready)
+npx instant-cli@latest export -a your-app-id --limit none
+
+# Export with custom batch size and sleep time
+npx instant-cli@latest export -a your-app-id --limit none --batch-size 50 --sleep 200
+
+# Export with verbose logging
+npx instant-cli@latest export -a your-app-id --limit none --verbose
+```
+
+### Export Directory Structure
+
+```
+instant-export/
+└── 2025-04-24_20-58-50/
+    ├── metadata.json       # Export metadata and summary
+    ├── schema.json         # Database schema
+    ├── permissions.json    # Access rules
+    └── namespaces/         # Entity data by namespace
+        ├── todos.json
+        ├── users.json
+        ├── comments.json
+        ├── $users.json     # System users table
+        └── ...
+```
+
+## Import
+
+You can import your database from local files using the `import` command:
+
+```shell {% showCopy=true %}
+npx instant-cli@latest import
+```
+
+### Import Features
+
+- Import schema, permissions, entities, and relationships
+- Import between different apps
+- Preserve all relationship links between entities
+- Prompts for backup before import
+- User mappings preserve relationships when importing to a different app
+
+### Import Examples
+
+```shell {% showCopy=true %}
+# Preview import (dry run)
+npx instant-cli@latest import -a your-app-id --dry-run
+
+# Basic import (will prompt for confirmation)
+npx instant-cli@latest import -a your-app-id
+
+# Import from specific directory with custom settings
+npx instant-cli@latest import -a your-app-id --input ./instant-export/2025-04-27_15-30-45 --batch-size 50 --sleep 200
+
+# Force import without confirmation
+npx instant-cli@latest import -a your-app-id --force
+```
+
+### Import Notes
+
+{% callout type="warning" %}
+**WARNING**: Import will clear all existing data in the destination app. Automatic backup is offered before import for safety.
+{% /callout %}
+
+- $users table is handled specially - only adds missing users, doesn't remove existing ones
+- $files table is not currently supported
+- The tool maintains metadata about imports/exports for traceability
+
+## Migrate
+
+The Migration Tool allows you to export data from an InstantDB app, transform it using JavaScript migration scripts, and optionally re-import the transformed data back to the app.
+
+```shell {% showCopy=true %}
+npx instant-cli@latest migrate ./my-migration-script.js
+```
+
+### Basic Migration Usage
+
+```shell {% showCopy=true %}
+# Run a single migration script
+npx instant-cli@latest migrate ./my-migration-script.js
+
+# Run multiple migration scripts in sequence
+npx instant-cli@latest migrate ./script1.js ./script2.js ./script3.js
+
+# Export data, run migrations, then import changes back to the app
+npx instant-cli@latest migrate ./my-migration-script.js --publish
+
+# Use an existing export as the base
+npx instant-cli@latest migrate ./my-migration-script.js --base ./instant-export/2025-04-27_12-34-56
+
+# Select an export interactively
+npx instant-cli@latest migrate ./my-migration-script.js --base select
+```
+
+### Migration Command Options
+
+```
+Options:
+  -a, --app <app-id>        App ID to migrate. Defaults to *_INSTANT_APP_ID in .env
+  -b, --base <base-dir>     Base directory to use for migration. Can be an export directory,
+                            "select" to choose from available exports, or omitted to export current app.
+  --publish                 Import migrated data back to the app after migration completes
+  --batch-size <size>       Number of entities to process in each API request batch (for export/import)
+  --sleep <ms>              Milliseconds to sleep between API request batches (for rate limiting)
+  --verbose                 Print detailed logs during migration process
+  --force                   Skip confirmation prompts
+  -h, --help                Display help
+```
+
+### Writing Migration Scripts
+
+Migration scripts are JavaScript files that export a default function or a `migrate` function. The function receives a context object with access to the database and logging utilities.
+
+Here's a simple migration script:
+
+```javascript
+// my-migration.js
+module.exports = async function({ db, log }) {
+  log.info('Starting migration');
+  
+  // Modify schema
+  if (db.schema.refs.oldReference) {
+    delete db.schema.refs.oldReference;
+    log.info('Removed old reference');
+  }
+  
+  // Update permissions
+  db.permissions.posts = {
+    allow: { view: true, create: true, update: "$user.id == entity.author.id" }
+  };
+  
+  // Update entities
+  for (const id of Object.keys(db.entities.todos)) {
+    const todo = db.entities.todos[id];
+    todo.priority = 'high';
+    log.info(`Updated todo ${id}`);
+  }
+  
+  log.success('Migration completed');
+}
+
+// Alternatively, you can export the function as 'migrate'
+// module.exports.migrate = async function({ db, log }) { ... }
+```
+
+### Migration Context
+
+The migration function receives a context object with the following properties:
+
+#### `db` Object
+
+The `db` object provides direct access to the database:
+
+- `db.schema` - Access and modify the schema
+- `db.permissions` - Access and modify permissions
+- `db.entities` - Access and modify entities by namespace and ID
+
+#### `log` Object
+
+The `log` object provides logging utilities:
+
+- `log.info(message)` - Log an informational message
+- `log.success(message)` - Log a success message
+- `log.warning(message)` - Log a warning message
+- `log.error(message)` - Log an error message
+
+### Migration Examples
+
+#### Modifying Schema
+
+```javascript
+// Add a new reference
+db.schema.refs.newRelationship = {
+  'forward-identity': ['one', 'users', 'projects'],
+  'reverse-identity': ['many', 'projects', 'members']
+};
+
+// Remove a reference
+delete db.schema.refs.oldReference;
+```
+
+#### Updating Permissions
+
+```javascript
+// Set permissions for a namespace
+db.permissions.projects = {
+  allow: {
+    create: true,
+    view: true,
+    update: "$user.id == entity.owner.id",
+    delete: "$user.id == entity.owner.id"
+  }
+};
+```
+
+#### Working with Entities
+
+```javascript
+// Get all todo IDs
+const todoIds = Object.keys(db.entities.todos);
+
+// Access an entity
+const todo = db.entities.todos['some-id'];
+
+// Update an entity
+todo.completed = true;
+todo.completedAt = new Date().toISOString();
+
+// Create a new entity
+const newId = crypto.randomUUID();
+db.entities.categories[newId] = {
+  id: newId,
+  name: 'Important',
+  color: '#FF0000'
+};
+
+// Delete an entity
+delete db.entities.temp_data['outdated-id'];
+```
+
+#### Handling Relationships
+
+```javascript
+// Scenario: Remove all posts containing a specific phrase from a user's posts list
+
+// Get the user entity
+const userId = 'user-123';
+const user = db.entities.users[userId];
+
+if (user && user.posts && Array.isArray(user.posts)) {
+  const targetPhrase = 'inappropriate content';
+  log.info(`Scanning ${user.posts.length} posts for "${targetPhrase}"`);
+  
+  // Posts to keep (we'll rebuild the list)
+  const postsToKeep = [];
+  // Track removed posts for logging
+  const removedPostIds = [];
+  
+  // Process each post reference
+  for (const postRef of user.posts) {
+    const postId = postRef.id;
+    const post = db.entities.posts[postId];
+    
+    // Skip if post doesn't exist in the database
+    if (!post) continue;
+    
+    // Check if post body contains the target phrase
+    if (post.body && post.body.toLowerCase().includes(targetPhrase.toLowerCase())) {
+      // This post contains the target phrase - don't add to postsToKeep
+      removedPostIds.push(postId);
+      
+      // Optionally, add a flag to the post entity itself
+      post.flaggedForReview = true;
+    } else {
+      // This post is clean - keep it
+      postsToKeep.push(postRef);
+    }
+  }
+  
+  // Update the user's posts array with only the posts to keep
+  user.posts = postsToKeep;
+  
+  if (removedPostIds.length > 0) {
+    log.success(`Removed ${removedPostIds.length} posts containing "${targetPhrase}" from user ${userId}`);
+    log.info(`Removed post IDs: ${removedPostIds.join(', ')}`);
+  } else {
+    log.info(`No posts found containing "${targetPhrase}"`);
+  }
+}
+```
+
+### How Migration Works
+
+1. The migration tool exports your app data (or uses an existing export).
+2. It creates a workspace with `before` and `after` directories in `instant-migrate/TIMESTAMP/`.
+3. It runs your migration scripts on the data in the `after` directory.
+4. Optionally, it imports the transformed data back to your app with the `--publish` flag.
+
+All changes are saved in the workspace, so you can review them before publishing.
+
+## Performance Tips for Data Operations
+
+- For large datasets, increase the batch size (`--batch-size 200`)
+- If hitting rate limits, increase sleep time (`--sleep 500`)
+- Use `--verbose` for detailed logging during export/import/migrate operations
+- Use `--dry-run` to preview operations before execution
+
 ## App ID
 
 Whenever you run a CLI command, we look up your app id. You can either provide an app id as an option:


### PR DESCRIPTION

# InstantDB Data Export & Import CLI

This PR adds two new commands to the Instant CLI:

- `instant-cli export` - Export your database to local files
- `instant-cli import` - Import your database from local files

## Features

✅ Export schema, permissions, entities and relationships
✅ Export & import between different apps
✅ Preserve all relationship links between entities  
✅ Fast batch processing with configurable batch sizes
✅ User-friendly CLI with progress indicators
✅ Prompts for backup before import

## Usage Examples

### Export data

```bash
# Preview export (dry run)
instant-cli export -a your-app-id --dry-run

# Default export (limits to 10 entities per namespace)
instant-cli export -a your-app-id

# Full export (only run when you're ready)
instant-cli export -a your-app-id --limit none

# Export with custom batch size and sleep time
instant-cli export -a your-app-id --limit none --batch-size 50 --sleep 200

# Export with verbose logging
instant-cli export -a your-app-id --limit none --verbose
```

### Import data

```bash
# Preview import (dry run)
instant-cli import -a your-app-id --dry-run

# Basic import (will prompt for confirmation)
instant-cli import -a your-app-id

# Import from specific directory with custom settings
instant-cli import -a your-app-id --input ./instant-export/2023-10-25_15-30-45 --batch-size 50 --sleep 200

# Force import without confirmation
instant-cli import -a your-app-id --force
```

## Export Directory Structure

```
instant-export/
└── 2025-04-24_20-58-50/
    ├── metadata.json       # Export metadata and summary
    ├── schema.json         # Database schema
    ├── permissions.json    # Access rules
    └── namespaces/         # Entity data by namespace
        ├── todos.json
        ├── users.json
        ├── comments.json
        ├── $users.json     # System users table
        └── ...
```

## Implementation Details

- Export uses paginated queries with customizable batch size
- Import processes entities first, then creates relationships
- User mappings preserve relationships when importing to a different app
- Import creates timestamped records of all operations

## Important Notes

- **WARNING**: Import will clear all existing data in the destination app
- Automatic backup is offered before import for safety
- $users table is handled specially - only adds missing users, doesn't remove existing ones
- $files table is not currently supported
- The tool maintains metadata about imports/exports for traceability

## Performance Tips

- For large datasets, increase the batch size (`--batch-size 200`)
- If hitting rate limits, increase sleep time (`--sleep 500`)
- Use `--verbose` for detailed logging during export/import
- Use `--dry-run` to preview an import before execution
