### PR TITLE
Revert "[hz] change cluster name and instance-name (#1145)"

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -39,8 +39,8 @@
 (declare handle-broadcast-message)
 
 (defn init-hz [env store {:keys [instance-name cluster-name]
-                          :or {instance-name "instant-hz-v4"
-                               cluster-name "instant-server-v3"}}]
+                               :or {instance-name "instant-hz-v3"
+                                    cluster-name "instant-server-v2"}}]
   (-> (java.util.logging.Logger/getLogger "com.hazelcast")
       (.setLevel (if (= env :prod)
                    java.util.logging.Level/INFO


### PR DESCRIPTION
This reverts commit c7ec7ebcfd28de2287135e80eac29e0867b2735f.

It ended up not being needed. I was able to get around the hazelcast blockage, by manually stopping all instances in AWS

@dwwoelfel @nezaj @tonsky 