### PR TITLE
[dash] allow for '' in number input

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -123,8 +123,9 @@ function parseFieldValue(value: any, type: FieldType) {
       cleaned === '-' ||
       cleaned === '.' ||
       cleaned === '-.'
-    )
+    ) {
       return cleaned;
+    }
     const match = cleaned.match(/^(-?\d*\.?\d*)\.?$/);
     return match ? Number(match[0]) : '';
   } else if (type === 'boolean') {

--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -118,7 +118,13 @@ function parseFieldValue(value: any, type: FieldType) {
 
   if (type === 'number') {
     const cleaned = String(value).replace(/[^\d.-]/g, '');
-    if (cleaned === '-' || cleaned === '.' || cleaned === '-.') return cleaned;
+    if (
+      cleaned === '' ||
+      cleaned === '-' ||
+      cleaned === '.' ||
+      cleaned === '-.'
+    )
+      return cleaned;
     const match = cleaned.match(/^(-?\d*\.?\d*)\.?$/);
     return match ? Number(match[0]) : '';
   } else if (type === 'boolean') {


### PR DESCRIPTION
I noticed an annoying bug when editing rows in the Dashboard. 

If you:
- Erase a number input, you automatically get a `0`
- There's no way to erase this zero and type the number `12` for example
- You invariably type `012`, or `120` 

I updated the code, so we allow an empty state for the number input. 

@dwwoelfel @nezaj @tonsky 