### PR TITLE
[Growth] Send welcome email to all business users

### DIFF
--- a/server/src/instant/scripts/welcome_email.clj
+++ b/server/src/instant/scripts/welcome_email.clj
@@ -4,6 +4,7 @@
    [instant.util.date :as date]
    [instant.postmark :as postmark]
    [chime.core :as chime-core]
+   [clojure.string :as string]
    [clojure.tools.logging :as log]
    [instant.grab :as grab]
    [instant.jdbc.aurora :as aurora]
@@ -38,19 +39,39 @@
   ([conn]
    (sql/select :welcome-email-users conn set-welcome-users-query)))
 
-(def html-body
+(def html-body-personal
   "<p>Hey there! Welcome to Instant! Full disclosure: this is an automated
 email, but if you respond, a real human (likely Joe or Stopa, the
 founders) will read it and get back to you!</p>
 <p>How’s your experience with Instant been so far? Any feedback to
 share?</p>")
 
-(def text-body
+(def text-body-personal
   "Hey there! Welcome to Instant! Full disclosure: this is an automated email, but
 if you respond, a real human (likely Joe or Stopa, the founders) will read it and get back to you!
 
 How's your experience with Instant been so far? Any feedback to share?")
 
+(def html-body-business
+  "<p>Hey there! Welcome to Instant! Full disclosure: this is an automated
+email, but if you respond, a real human (likely Joe or Stopa, the
+founders) will read it and get back to you!</p>
+<p>Were you thinking of using Instant for your company? How's your experience been so far? If you're up for it, we'd love to talk :)</p>")
+
+(def text-body-business
+  "Hey there! Welcome to Instant! Full disclosure: this is an automated email, but
+if you respond, a real human (likely Joe or Stopa, the founders) will read it and get back to you!
+
+Were you thinking of using Instant for your company? How's your experience been so far? If you're up for it, we'd love to talk :)")
+
+(defn personal-email? [email]
+  (let [personal-domains #{"gmail.com" "yahoo.com" "hotmail.com" "outlook.com" "aol.com"
+                           "icloud.com" "protonmail.com" "mail.com" "zoho.com" "yandex.com"
+                           "gmx.com" "live.com" "me.com" "inbox.com" "hey.com"}
+        domain (-> (string/split email #"@") last)]
+    (contains? personal-domains domain)))
+
+(def limit 10)
 (defn send-welcome-email! []
   (let [{:keys [enabled? limit]} (flags/welcome-email-config)
         date-str (-> (date/pst-now)
@@ -61,23 +82,30 @@ How's your experience with Instant been so far? Any feedback to share?")
        (fn []
          (tracer/with-span! {:name "welcome-email/send-emails"}
            (let [emails (map :email (find-welcome-users))
-                 shuffled (cond->> (shuffle emails)
-                            limit (take limit))]
-             (tracer/add-data! {:attributes {:emails shuffled
+                 business-emails (remove personal-email? emails)
+                 personal-emails (filter personal-email? emails)
+                 shuffled (cond->> (shuffle personal-emails)
+                            limit (take limit))
+                 all-emails (concat shuffled business-emails)]
+             (tracer/add-data! {:attributes {:personal-emails shuffled
+                                             :business-emails business-emails
                                              :limit limit
-                                             :num-emails (count shuffled)}})
-             (doseq [to shuffled]
-               (try
-                 (postmark/send! {:from "founders@pm.instantdb.com"
-                                  :to to
-                                  :reply-to "founders@instantdb.com"
-                                  :subject "Welcome to Instant!"
-                                  :html html-body
-                                  :text text-body})
-                 (catch Exception e
-                   (tracer/add-exception! e {:escaping? false})
-                   ;; send next email
-                   nil))))))))))
+                                             :num-emails (count all-emails)}})
+             (doseq [to all-emails]
+               (let [[html text] (if (personal-email? to)
+                                   [html-body-personal text-body-personal]
+                                   [html-body-business text-body-business])]
+                 (try
+                   (postmark/send! {:from "founders@pm.instantdb.com"
+                                    :to to
+                                    :reply-to "founders@instantdb.com"
+                                    :subject "Welcome to Instant!"
+                                    :html html
+                                    :text text})
+                   (catch Exception e
+                     (tracer/add-exception! e {:escaping? false})
+                     ;; send next email
+                     nil)))))))))))
 
 (defn period []
   (let [now (date/pst-now)

--- a/server/src/instant/scripts/welcome_email.clj
+++ b/server/src/instant/scripts/welcome_email.clj
@@ -13,7 +13,7 @@
    [instant.util.tracer :as tracer])
   (:import
    (java.lang AutoCloseable)
-   (java.time Period DayOfWeek ZonedDateTime)))
+   (java.time Period ZonedDateTime)))
 
 ;; Find recent users and set the welcome-email flag to ensure
 ;; we don't send multiple emails to the same user.
@@ -116,12 +116,7 @@ Were you thinking of using Instant for your company? How's your experience been 
                       send-at-pst
                       (Period/ofDays 1))]
     (->> periodic-seq
-         (filter (fn [^ZonedDateTime x] (.isAfter x now)))
-         ;; Only run Monday through Friday
-         (filter (fn [^ZonedDateTime x]
-                   (let [day-of-week (.getDayOfWeek x)]
-                     (not (contains? #{DayOfWeek/SATURDAY DayOfWeek/SUNDAY}
-                                     day-of-week))))))))
+         (filter (fn [^ZonedDateTime x] (.isAfter x now))))))
 
 (defonce schedule (atom nil))
 


### PR DESCRIPTION
We thought it would be nice to follow up with all non-personal email signups. Feels like it could be an easy win to get more engagement from business users!

![CleanShot 2025-04-29 at 15 03 11@2x](https://github.com/user-attachments/assets/08d06fac-c327-4d8a-9e65-7730fc89e1d0)
