### PR TITLE
[sm] better error for admin api

### DIFF
--- a/server/src/instant/admin/model.clj
+++ b/server/src/instant/admin/model.clj
@@ -208,7 +208,11 @@
       "ruleParams" (expand-rule-params attrs args)
       "add-attr" (expand-add-attr attrs args)
       "delete-attr" (expand-delete-attr attrs args)
-      (throw (ex-info (str "unsupported action " action) {})))))
+      (ex/throw-validation-err!
+       :action
+       action
+       [{:message (str "Unsupported action " action)
+         :hint {:value action}}]))))
 
 (defn create-object-attr
   ([etype label] (create-object-attr etype label nil))


### PR DESCRIPTION
I realize we threw an `ex-info` when an unsupported action was provided. I updated this to be a 400 error. 

**Why?**

Previously, we made this a 500, because only our client SDKs provided the `steps`. But now some users call the api directly. In this case, they _could_ provide invalid steps. 

@nezaj @tonsky @dwwoelfel 