### PR TITLE
[routes] default 404 in our api routes

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -5,6 +5,7 @@
    [clojure.java.io :as io]
    [clojure.tools.logging :as log]
    [compojure.core :refer [defroutes GET POST routes wrap-routes]]
+   [compojure.route :as route]
    [instant.admin.routes :as admin-routes]
    [instant.auth.jwt :as jwt]
    [instant.auth.oauth :as oauth]
@@ -134,7 +135,8 @@
               wrap-json-response
               (wrap-cors :access-control-allow-origin allow-cors-origin?
                          :access-control-allow-methods [:get :put :post :delete])
-              (http-util/tracer-wrap-span))))
+              (http-util/tracer-wrap-span))
+          (route/not-found "Oops! We couldn't match this route.")))
 
 (defonce ^Undertow server
   nil)
@@ -145,36 +147,36 @@
 (defn start []
   (tracer/record-info! {:name "server/start" :attributes {:port (config/get-server-port)}})
   (lang/set-var! server
-    (undertow-adapter/run-undertow
-     (handler)
-     (merge
-      {:host "0.0.0.0"
-       :port (config/get-server-port)
-       :configurator (fn [^Undertow$Builder builder]
-                       (.setServerOption builder UndertowOptions/ENABLE_STATISTICS true))}
-      (when (.exists (io/file "dev-resources/certs/dev.jks"))
-        {:ssl-port 8889
-         :keystore "dev-resources/certs/dev.jks"
-         :key-password "changeit"}))))
+                 (undertow-adapter/run-undertow
+                  (handler)
+                  (merge
+                   {:host "0.0.0.0"
+                    :port (config/get-server-port)
+                    :configurator (fn [^Undertow$Builder builder]
+                                    (.setServerOption builder UndertowOptions/ENABLE_STATISTICS true))}
+                   (when (.exists (io/file "dev-resources/certs/dev.jks"))
+                     {:ssl-port 8889
+                      :keystore "dev-resources/certs/dev.jks"
+                      :key-password "changeit"}))))
   (lang/set-var! stop-gauge
-    (gauges/add-gauge-metrics-fn
-     (fn [_]
-       (let [^Undertow server server
-             ^Undertow$ListenerInfo listener (some-> server
-                                                     (.getListenerInfo)
-                                                     first)]
-         (when-let [stats (some-> listener
-                                  (.getConnectorStatistics))]
-           [{:path "instant.server.active-connections"
-             :value (.getActiveConnections stats)}
-            {:path "instant.server.active-requests"
-             :value (.getActiveRequests stats)}
-            {:path "instant.server.max-active-connections"
-             :value (.getMaxActiveConnections stats)}
-            {:path "instant.server.max-active-requests"
-             :value (.getMaxActiveRequests stats)}
-            {:path "instant.server.max-processing-time"
-             :value (.getMaxProcessingTime stats)}]))))))
+                 (gauges/add-gauge-metrics-fn
+                  (fn [_]
+                    (let [^Undertow server server
+                          ^Undertow$ListenerInfo listener (some-> server
+                                                                  (.getListenerInfo)
+                                                                  first)]
+                      (when-let [stats (some-> listener
+                                               (.getConnectorStatistics))]
+                        [{:path "instant.server.active-connections"
+                          :value (.getActiveConnections stats)}
+                         {:path "instant.server.active-requests"
+                          :value (.getActiveRequests stats)}
+                         {:path "instant.server.max-active-connections"
+                          :value (.getMaxActiveConnections stats)}
+                         {:path "instant.server.max-active-requests"
+                          :value (.getMaxActiveRequests stats)}
+                         {:path "instant.server.max-processing-time"
+                          :value (.getMaxProcessingTime stats)}]))))))
 
 (defn stop []
   (lang/clear-var! server Undertow/.stop)


### PR DESCRIPTION
I noticed that if I made api calls to misspelled routes, I would get an empty 200 response.

Updated so we get a 404. 

@dwwoelfel @nezaj @tonsky 