### PR TITLE
[dates] fix equality on dates without an index

### DIFF
--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -346,7 +346,10 @@
         :else
         (if (and (:checked-data-type attr)
                  (not (:checking-data-type? attr)))
-          (coerced-value-with-checked-type! state attr (:checked-data-type attr) v)
+          (let [coerced (coerced-value-with-checked-type! state attr (:checked-data-type attr) v)]
+            (if (:index? attr)
+              coerced
+              v))
           v)))
 
 (defn ->value-attr-pat


### PR DESCRIPTION
## Context

Consider a `createdAt` column: 

```js
posts: i.entity({ 
   createdAt: i.date() // unindexed
}) 
```

Insert an object:

```js
db.transact(db.tx.posts[id()].update({ createdAt: 1 }))
```

Now let's query for it: 

```js
{ posts: { $: { where: { createdAt: 1 } } }
```

## Bug

This query would return an empty result. 

## Reason 

This is because, under the hood, we would always _coerce_ a date value, to a full `Date` object. 

The intention was, that sql would write a query that looks like: 

```sql
triples_extract_date_value(#instant "1970-01-01T00:00:00.001Z") = triples_extract_date_value(v)
```

But since `createdAt` was not indexed, we can't use `triples_extract_date_value`. We would instead write: 

```sql
#instant "1970-01-01T00:00:00.001Z" = v
```

Which would eventually stringify: 

```
"1970-01-01T00:00:00.001Z" = v
```

But, since under the hood, `v` is stored as the literal `1`, we would get no match. 

## Solution

I made it so we _only_ coerce, _if_ the attr is indexed. 

Why? It's because only in the indexed case can we actually use `triple_extract_value`

## Better solutions 

It _may_ be better down the road, to normalize _how_ we store the actual underlying date. 

For unindexed dates, equality comparisons will only work right now, if we compare the underlying stored value. 

If we instead stored some normalized value, even for unindexed dates we could compare any date format and get a result. 

For now though, this fixes the bug 🫡

@nezaj @dwwoelfel @tonsky 
