### PR TITLE
[client] Schema updates should propagate in a hot reload

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -224,6 +224,15 @@ export default class Reactor {
     }
   }
 
+  updateSchema(schema) {
+    this.config = {
+      ...this.config,
+      schema: schema,
+      cardinalityInference: Boolean(schema),
+    };
+    this._linkIndex = schema ? createLinkIndex(this.config.schema) : null;
+  }
+
   _initStorage(Storage) {
     this._persister = new Storage(`instant_${this.config.appId}_5`);
     this.querySubs = new PersistedObject(

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -985,6 +985,7 @@ export default class Reactor {
   };
 
   shutdown() {
+    this._log.info('[shutdown]', this.config.appId);
     this._isShutdown = true;
     this._ws?.close();
   }

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -985,7 +985,6 @@ export default class Reactor {
   };
 
   shutdown() {
-    this._log.info('[shutdown]', this.config.appId);
     this._isShutdown = true;
     this._ws?.close();
   }

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -654,7 +654,11 @@ class InstantCoreDatabase<Schema extends InstantSchemaDef<any, any, any>>
   }
 }
 
-function schemaHash(schema: InstantSchemaDef<any, any, any> | string): string {
+function schemaHash(schema?: InstantSchemaDef<any, any, any>): string {
+  if (!schema) {
+    return '0';
+  }
+
   if (schemaHashStore.get(schema)) {
     console.log('getting cached schema');
     return schemaHashStore.get(schema);
@@ -670,8 +674,7 @@ function schemaChanged(
   newSchema?: InstantSchemaDef<any, any, any>,
 ): boolean {
   return (
-    schemaHash(existingClient._reactor.config.schema || 'no-schema') !==
-    schemaHash(newSchema || 'no-schema')
+    schemaHash(existingClient._reactor.config.schema) !== schemaHash(newSchema)
   );
 }
 

--- a/client/sandbox/react-nextjs/pages/play/schema-hot-reloading.tsx
+++ b/client/sandbox/react-nextjs/pages/play/schema-hot-reloading.tsx
@@ -1,38 +1,91 @@
-import { i, init } from '@instantdb/react';
+import React, { useEffect, useState } from 'react';
+import { i, init, id } from '@instantdb/react';
 import config from '../../config';
-import { useEffect, useState } from 'react';
 
 const schema = i.schema({
   entities: {
-    posts: i.entity({ title1: i.string() }),
+    posts: i.entity({
+      title: i.string(),
+      // -> change this to trigger hot reloading
+      // body: i.string().optional(),
+    }),
   },
 });
 
 const db = init({ ...config, schema });
 
-function App() {
-  const queryResult = db.useQuery({ posts: {} });
+function PostsQuery() {
+  const { data, isLoading, error } = db.useQuery({ posts: {} });
 
-  const [currSchema, setCurrSchema] = useState<any>(null);
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrSchema(db._core._reactor.config.schema);
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [db]);
   return (
-    <div>
-      <h1>Schema Hot Reloading!!</h1>
-      <div>
-        Schema:
-        <pre>{JSON.stringify(currSchema, null, 2)}</pre>
-      </div>
-      <div>
-        Posts:
-        <pre>{JSON.stringify({ queryResult }, null, 2)}</pre>
+    <ul className="space-y-1">
+      <li>
+        <span className="font-semibold">isLoading:</span>{' '}
+        {isLoading ? 'true' : 'false'}
+      </li>
+      <li>
+        <span className="font-semibold">error:</span>{' '}
+        {error ? error.message : 'none'}
+      </li>
+      <li className="font-semibold">posts:</li>
+      {data?.posts.map((p) => (
+        <li key={p.id} className="ml-4 list-disc">
+          {JSON.stringify(p)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function App() {
+  const [currSchema, setSchema] = useState(db._core._reactor.config.schema);
+
+  useEffect(() => {
+    const t = setInterval(
+      () => setSchema(db._core._reactor.config.schema),
+      1000,
+    );
+    return () => clearInterval(t);
+  }, []);
+
+  const addPost = async () => {
+    const postId = id();
+    await db.transact(
+      db.tx.posts[postId].update({ title: `Post ${Date.now()}` }),
+    );
+  };
+
+  return (
+    <div className="font-sans p-6 space-y-8">
+      <h1 className="text-2xl font-bold">InstantDB Hot-Reload Playground</h1>
+
+      {/* Two-column layout */}
+      <div className="md:grid md:grid-cols-2 gap-10 space-y-8 md:space-y-0">
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Test 1: Changing schema</h2>
+          <pre className="bg-gray-100 rounded p-3 text-sm overflow-auto max-h-64">
+            {JSON.stringify(currSchema, null, 2)}
+          </pre>
+          <p>
+            Edit the schema object at the top of this file and save.
+            Fast-Refresh should update the JSON above without a full reload.
+          </p>
+        </section>
+
+        {/* ──────────  Query & mutation demo  ────────── */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Test 2: Live query</h2>
+          <PostsQuery />
+          <button onClick={addPost} className="text-white bg-black p-2">
+            Add post
+          </button>
+          <p>
+            Click “Add post”, then tweak the schema again and add another post.
+            The same&nbsp;
+            <code>&lt;PostsQuery&gt;</code> instance keeps receiving updates.
+          </p>
+        </section>
       </div>
     </div>
   );
 }
-
-export default App;

--- a/client/sandbox/react-nextjs/pages/play/schema-hot-reloading.tsx
+++ b/client/sandbox/react-nextjs/pages/play/schema-hot-reloading.tsx
@@ -12,28 +12,52 @@ const schema = i.schema({
   },
 });
 
-const db = init({ ...config, schema });
+const db = init({
+  ...config,
+  schema, // feel free to comment this out too
+});
 
 function PostsQuery() {
   const { data, isLoading, error } = db.useQuery({ posts: {} });
 
+  const addPost = async () => {
+    const postId = id();
+    await db.transact(
+      db.tx.posts[postId].update({ title: `Post ${Date.now()}` }),
+    );
+  };
+  const deletePosts = async () => {
+    const { posts } = data || {};
+    if (!posts) return;
+    await db.transact(posts.map((post) => db.tx.posts[post.id].delete()));
+  };
   return (
-    <ul className="space-y-1">
-      <li>
-        <span className="font-semibold">isLoading:</span>{' '}
-        {isLoading ? 'true' : 'false'}
-      </li>
-      <li>
-        <span className="font-semibold">error:</span>{' '}
-        {error ? error.message : 'none'}
-      </li>
-      <li className="font-semibold">posts:</li>
-      {data?.posts.map((p) => (
-        <li key={p.id} className="ml-4 list-disc">
-          {JSON.stringify(p)}
+    <div className="space-y-4">
+      <ul className="space-y-1">
+        <li>
+          <span className="font-semibold">isLoading:</span>{' '}
+          {isLoading ? 'true' : 'false'}
         </li>
-      ))}
-    </ul>
+        <li>
+          <span className="font-semibold">error:</span>{' '}
+          {error ? error.message : 'none'}
+        </li>
+        <li className="font-semibold">posts:</li>
+        {data?.posts.map((p) => (
+          <li key={p.id} className="ml-4 list-disc">
+            {JSON.stringify(p)}
+          </li>
+        ))}
+      </ul>
+      <div className="space-x-2">
+        <button onClick={addPost} className="text-white bg-black p-2">
+          Add post
+        </button>
+        <button onClick={deletePosts} className="text-white bg-black p-2">
+          Delete posts
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -47,13 +71,6 @@ export default function App() {
     );
     return () => clearInterval(t);
   }, []);
-
-  const addPost = async () => {
-    const postId = id();
-    await db.transact(
-      db.tx.posts[postId].update({ title: `Post ${Date.now()}` }),
-    );
-  };
 
   return (
     <div className="font-sans p-6 space-y-8">
@@ -76,9 +93,6 @@ export default function App() {
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">Test 2: Live query</h2>
           <PostsQuery />
-          <button onClick={addPost} className="text-white bg-black p-2">
-            Add post
-          </button>
           <p>
             Click “Add post”, then tweak the schema again and add another post.
             The same&nbsp;

--- a/client/sandbox/react-nextjs/pages/play/schema-hot-reloading.tsx
+++ b/client/sandbox/react-nextjs/pages/play/schema-hot-reloading.tsx
@@ -1,0 +1,38 @@
+import { i, init } from '@instantdb/react';
+import config from '../../config';
+import { useEffect, useState } from 'react';
+
+const schema = i.schema({
+  entities: {
+    posts: i.entity({ title1: i.string() }),
+  },
+});
+
+const db = init({ ...config, schema });
+
+function App() {
+  const queryResult = db.useQuery({ posts: {} });
+
+  const [currSchema, setCurrSchema] = useState<any>(null);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrSchema(db._core._reactor.config.schema);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [db]);
+  return (
+    <div>
+      <h1>Schema Hot Reloading!!</h1>
+      <div>
+        Schema:
+        <pre>{JSON.stringify(currSchema, null, 2)}</pre>
+      </div>
+      <div>
+        Posts:
+        <pre>{JSON.stringify({ queryResult }, null, 2)}</pre>
+      </div>
+    </div>
+  );
+}
+
+export default App;


### PR DESCRIPTION
## Bug

Users reported a bug that worked like so: 

1. Take a schema
2. Change it
3. Make a transaction, which _should_ include the changes to your schema
4. But turns out, **it does not**

## Reason

We cache calls to `init`. This means that when hot-reload triggered a new `init` call, we would return the previously cached `db` instance. The rub? The previous db includes the _old_ schema

## Solution

Now we detect if the schema has changed. If it _did_ change, we patch the existing client, with the new schema.

## Alternatives considered

You may be wondering: 

**Why not _replace_ the reactor?** 

There's a _lot_ of state in the existing reactor instance. For example, we include current subscriptions there. If we shut down and start a new reactor instance, we'd have to be extra careful to make sure that previous callers don't accidentally end up stranded

## Cached states

One known issue, is that we currently pass `linkIndex` around to stores, and that info is cached in a bunch of places. Thinking it through, I don't think it matters for our case. _However_, I think it would be so much nicer to remove that extra caching in store.js. 

I will look into that in a follow-on PR. 

@dwwoelfel @nezaj @tonsky 