### PR TITLE
Too many params error

### DIFF
--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -436,7 +436,7 @@
                      (string/trim (subs detail (inc start) end)))
                    (partition 2 1 borders))))))
 
-(defn default-psql-throw! [e {:keys [server-message condition table] :as data} hint]
+(defn default-psql-throw! [e {:keys [condition] :as data} hint]
   (throw+ {::type ::sql-exception
            ::message (format "SQL Exception: %s" (name condition))
            ::hint hint

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -47,6 +47,24 @@
 (s/def ::trace-id string?)
 (s/def ::instant-exception (s/keys :req [::type ::message ::trace-id]))
 
+(def bad-request-types #{::record-not-found
+                         ::record-expired
+                         ::record-not-unique
+                         ::record-foreign-key-invalid
+                         ::record-check-violation
+                         ::sql-raise
+                         ::timeout
+                         ::rate-limited
+
+                         ::permission-denied
+                         ::permission-evaluation-failed
+                         ::parameter-limit-exceeded
+
+                         ::param-missing
+                         ::param-malformed
+
+                         ::validation-failed})
+
 (comment
   (s/explain-data ::instant-exception {::type ::record-not-found
                                        ::message "Record not found"

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -505,7 +505,7 @@
         (throw+ {::type ::parameter-limit-exceeded
                  ::message "There are too many parameters in the transaction or query."
                  ::hint {:message "Consider batching transactions to reduce the number of writes in a single transaction."
-                         :docs "https://www.instantdb.com/docs/instaml#batching-transactions"}
+                         :doc-urls ["https://www.instantdb.com/docs/instaml#batching-transactions"]}
                  ::pg-error-data data})
         (default-psql-throw! e data hint))
 

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -83,22 +83,7 @@
 (defn- instant-ex->bad-request [instant-ex]
   (let [{:keys [::ex/type ::ex/message ::ex/hint ::ex/trace-id]} (ex-data instant-ex)]
     (condp contains? type
-      #{::ex/record-not-found
-        ::ex/record-expired
-        ::ex/record-not-unique
-        ::ex/record-foreign-key-invalid
-        ::ex/record-check-violation
-        ::ex/sql-raise
-        ::ex/timeout
-        ::ex/rate-limited
-
-        ::ex/permission-denied
-        ::ex/permission-evaluation-failed
-
-        ::ex/param-missing
-        ::ex/param-malformed
-
-        ::ex/validation-failed}
+      ex/bad-request-types
       (cond-> {:type (keyword (name type))
                :message message
                :hint hint}

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -3158,7 +3158,7 @@
 (deftest too-many-params
   (with-zeneca-app
     (fn [app r]
-      (let [txes (for [i (range 100000)
+      (let [txes (for [_i (range 100000)
                        :let [id (random-uuid)]]
                    [:add-triple id (resolvers/->uuid r :users/id) (str id)])
 

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -3155,5 +3155,21 @@
               deleted-triples (count (:delete-entity (:results res)))]
           (is (= (-> @children (* 2) (+ 1)) deleted-triples)))))))
 
+(deftest too-many-params
+  (with-zeneca-app
+    (fn [app r]
+      (let [txes (for [i (range 100000)
+                       :let [id (random-uuid)]]
+                   [:add-triple id (resolvers/->uuid r :users/id) (str id)])
+
+            instant-ex-data (test-util/instant-ex-data
+                              (tx/transact!
+                               (aurora/conn-pool :write)
+                               (attr-model/get-by-app-id (:id app))
+                               (:id app)
+                               txes))]
+        (is (= ::ex/parameter-limit-exceeded
+               (::ex/type instant-ex-data)))))))
+
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Give a better error when we get a transaction with too many params. This can happen when you do a transaction that writes a lot of entities at the same time.

```json
{
  "name": "InstantAPIError",
  "status": 400,
  "body": {
    "type": "parameter-limit-exceeded",
    "message": "There are too many parameters in the transaction or query.",
    "hint": {
      "message": "Consider batching transactions to reduce the number of writes in a single transaction.",
      "doc-urls": [
        "https://www.instantdb.com/docs/instaml#batching-transactions"
      ]
    },
    "trace-id": "64972e6c3cef4051940b96c5268905a3"
  }
}
```