### PR TITLE
[reactor] make sure you can't start a shut down reactor

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -976,6 +976,7 @@ export default class Reactor {
   };
 
   shutdown() {
+    this._log.info('[shutdown]', this.config.appId);
     this._isShutdown = true;
     this._ws?.close();
   }
@@ -1184,6 +1185,14 @@ export default class Reactor {
   };
 
   _startSocket() {
+    if (this._isShutdown) {
+      this._log.info(
+        '[socket][start]',
+        this.config.appId,
+        'Reactor has been shut down and will not start a new socket',
+      );
+      return;
+    }
     if (this._ws && this._ws.readyState == WS_CONNECTING_STATUS) {
       // Our current websocket is in a 'connecting' state.
       // There's no need to start another one, as the socket is


### PR DESCRIPTION
While debugging in the dashboard, I noticed that we started _two_ Reactor instances. 

**Why?** 

https://github.com/instantdb/instant/blob/main/client/www/pages/dash/index.tsx#L352-L368

In dev, React's useEffect quickly runs twice. We would start two reactor instances. The first one would shut down immediately. But, `startSocket` happened after it was shut down. 

**Fix**

I made sure in startSocket, we give up if the Reactor is shut down. 

@dwwoelfel @nezaj @tonsky 