### PR TITLE
User-friendly constraint violation errors

### DIFF
--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -351,10 +351,6 @@
    (mark-error-from-ex-info! (aurora/conn-pool :write) e job))
   ([conn ^ExceptionInfo e job]
    (let [error-data (ex-data e)
-         validation-error (some-> error-data
-                                  ::ex/hint
-                                  :errors
-                                  first)
          job-error-fields (case (::ex/type error-data)
                             ::ex/record-not-unique
                             {:error triple-not-unique-error
@@ -365,16 +361,16 @@
                                                     :jsonb]}
 
                             ::ex/validation-failed
-                            (if (and (some-> validation-error
-                                             :hint
+                            (if (and (some-> error-data
+                                             ::ex/hint
                                              :entity-id)
-                                     (some-> validation-error
-                                             :hint
+                                     (some-> error-data
+                                             ::ex/hint
                                              :value-too-large?))
                               {:error triple-too-large-error
                                :invalid-entity-id [:cast
-                                                   (-> validation-error
-                                                       :hint
+                                                   (-> error-data
+                                                       ::ex/hint
                                                        :entity-id)
                                                    :uuid]}
                               {:error unexpected-error})

--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -304,6 +304,12 @@
         (for [[entity_id etype] (set (concat ids+etypes ids+etypes'))]
           [:delete-entity entity_id etype])))))
 
+(defn get-attr-for-exception
+  "Used by exception.clj to lookup the attr by its attr id when it gets an attr id
+   in a sql exception."
+  [attrs attr-id]
+  (attr-model/seek-by-id attr-id attrs))
+
 (defn transact-without-tx-conn-impl! [conn attrs app-id grouped-tx-steps opts]
   (binding [ex/*get-attr-for-exception* (partial get-attr-for-exception attrs)]
     (let [tx-steps (apply concat (vals grouped-tx-steps))]
@@ -380,9 +386,6 @@
   ([conn attrs app-id tx-steps opts]
    (let [grouped-tx-steps (preprocess-tx-steps conn attrs app-id tx-steps)]
      (transact-without-tx-conn-impl! conn attrs app-id grouped-tx-steps opts))))
-
-(defn get-attr-for-exception [attrs attr-id]
-  (attr-model/seek-by-id attr-id attrs))
 
 (defn transact!
   ([conn attrs app-id tx-steps]

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -468,7 +468,7 @@
                              uuid-util/coerce
                              get-attr))
               attr-name (when attr
-                          (format "%s.%s."
+                          (format "%s.%s"
                                   (-> attr
                                       :forward-identity
                                       second)
@@ -487,7 +487,7 @@
               msg (case (:constraint data)
                     "valid_value_data_type" (str "Invalid value type"
                                                  (if attr
-                                                   (format " for %s" attr-name)
+                                                   (format " for %s." attr-name)
                                                    ".")
                                                  (when-let [data-type (:checked-data-type triple)]
                                                    (str " Value must be a " data-type

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -5,7 +5,7 @@
    [clojure.walk :as w]
    [inflections.core :as inflections]
    [instant.jdbc.pgerrors :as pgerrors]
-   [instant.util.json :refer [<-json]]
+   [instant.util.json :as json :refer [<-json]]
    [instant.util.string :refer [indexes-of safe-name]]
    [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util])
@@ -443,6 +443,8 @@
            ::pg-error-data data}
           e))
 
+(def ^:dynamic *get-attr-for-exception* nil)
+
 (defn translate-and-throw-psql-exception!
   [^PSQLException e]
   (let [{:keys [server-message condition table] :as data} (pgerrors/extract-data e)
@@ -460,33 +462,62 @@
 
       :check-violation
       (if-let [triple (extract-triple-from-constraint data)]
-        (let [value (try
-                      (some-> (:value triple)
-                              <-json)
-                      (catch Exception _e
-                        ;; We may get a truncated value, so just give that back to the user
-                        (:value triple)))]
-          (throw-validation-err!
-           :triple
-           value
-           [{:message (case (:constraint data)
-                        "valid_value_data_type" "Invalid value type for triple."
+        (let [attr (when-let [get-attr *get-attr-for-exception*]
+                     (some-> triple
+                             :attr-id
+                             uuid-util/coerce
+                             get-attr))
+              attr-name (when attr
+                          (format "%s.%s."
+                                  (-> attr
+                                      :forward-identity
+                                      second)
+                                  (-> attr
+                                      :forward-identity
+                                      last)))
+              {:keys [value truncated-value?]}
+              (try
+                {:value (some-> (:value triple)
+                                <-json)
+                 :truncated-value? false}
+                (catch Exception _e
+                  ;; We may get a truncated value, so just give that back to the user
+                  {:value (:value triple)
+                   :truncated-value? true}))
+              msg (case (:constraint data)
+                    "valid_value_data_type" (str "Invalid value type"
+                                                 (if attr
+                                                   (format " for %s" attr-name)
+                                                   ".")
+                                                 (when-let [data-type (:checked-data-type triple)]
+                                                   (str " Value must be a " data-type
+                                                        (if truncated-value?
+                                                          "."
+                                                          (str " but the provided value type is " (json/json-type-of-clj value) ".")))))
 
-                        "indexed_values_are_constrained"
-                        (if (= "t" (:av triple))
-                          "Value is too large for a unique attribute."
-                          "Value is too large for an indexed attribute.")
-                        "valid_ref_value" "Linked value must be a valid uuid."
+                    "indexed_values_are_constrained"
+                    (if (= "t" (:av triple))
+                      "Value is too large for a unique attribute."
+                      "Value is too large for an indexed attribute.")
+                    "valid_ref_value" "Linked value must be a valid uuid."
 
-                        (format "Check Violation: %s" (name (:constraint data))))
-             :hint (merge
-                    {:value value
-                     :checked-data-type (:checked-data-type triple)
-                     :attr-id (:attr-id triple)
-                     :entity-id (:entity-id triple)}
-                    (when (= (:constraint data)
-                             "indexed_values_are_constrained")
-                      {:value-too-large? true}))}]))
+                    (format "Check Violation: %s" (name (:constraint data))))]
+          (throw+ {::type ::validation-failed
+                   ::message msg
+                   ::hint (merge (when attr
+                                   {:namespace (-> attr
+                                                   :forward-identity
+                                                   second)
+                                    :attribute (-> attr
+                                                   :forward-identity
+                                                   last)})
+                                 {:value value
+                                  :checked-data-type (:checked-data-type triple)
+                                  :attr-id (:attr-id triple)
+                                  :entity-id (:entity-id triple)}
+                                 (when (= (:constraint data)
+                                          "indexed_values_are_constrained")
+                                   {:value-too-large? true}))}))
         (throw+ {::type ::record-check-violation
                  ::message (format "Check Violation: %s" (name condition))
                  ::hint hint

--- a/server/src/instant/util/json.clj
+++ b/server/src/instant/util/json.clj
@@ -39,6 +39,7 @@
         (nil? v)
         "null"
         (or (vector? v)
-            (list? v))
+            (list? v)
+            (seq? v))
         "array"
         :else "object"))

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -701,10 +701,7 @@
                     (attr-model/get-by-app-id app-id)
                     app-id
                     [[:add-triple stopa-eid tag-attr-id {:foo "bar"}]]))
-                  ::ex/hint
-                  :errors
-                  first
-                  :message))))))))
+                  ::ex/message))))))))
 
 (deftest tx-ref-many-to-one
   (with-empty-app
@@ -2105,9 +2102,6 @@
                (::ex/type ex)))
         (is (= "" (-> ex
                       ::ex/hint
-                      :errors
-                      first
-                      :hint
                       :value)))))))
 
 (deftest rejects-invalid-data-for-checked-attrs
@@ -2144,16 +2138,13 @@
           (let [eid (random-uuid)]
             (is (= #:instant.util.exception{:type
                                             :instant.util.exception/validation-failed,
-                                            :message "Validation failed for triple",
-                                            :hint
-                                            {:data-type :triple,
-                                             :input 10,
-                                             :errors
-                                             [{:message "Invalid value type for triple.",
-                                               :hint {:value 10,
-                                                      :checked-data-type "string",
-                                                      :attr-id (str email-attr-id)
-                                                      :entity-id (str eid)}}]}}
+                                            :message "Invalid value type for users.email. Value must be a string but the provided value type is number.",
+                                            :hint {:namespace "users",
+                                                   :attribute "email",
+                                                   :value 10,
+                                                   :checked-data-type "string",
+                                                   :attr-id (str email-attr-id)
+                                                   :entity-id (str eid)}}
                    (dissoc (test-util/instant-ex-data
                              (tx/transact! (aurora/conn-pool :write)
                                            (attr-model/get-by-app-id app-id)
@@ -2193,17 +2184,15 @@
           (let [eid (random-uuid)]
             (is (= #:instant.util.exception{:type
                                             :instant.util.exception/validation-failed,
-                                            :message "Validation failed for triple",
-                                            :hint
-                                            {:data-type :triple,
-                                             :input "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
-                                             :errors
-                                             [{:message "Value is too large for an indexed attribute.",
-                                               :hint {:value "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
-                                                      :checked-data-type "string",
-                                                      :attr-id (str email-attr-id)
-                                                      :entity-id (str eid)
-                                                      :value-too-large? true}}]}}
+                                            :message "Value is too large for an indexed attribute."
+                                            :hint {:namespace "users",
+                                                   :attribute "email",
+                                                   :value
+                                                   "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...",
+                                                   :checked-data-type "string",
+                                                   :attr-id (str email-attr-id)
+                                                   :entity-id (str eid)
+                                                   :value-too-large? true}}
                    (dissoc (test-util/instant-ex-data
                              (tx/transact! (aurora/conn-pool :write)
                                            (attr-model/get-by-app-id app-id)
@@ -2214,17 +2203,15 @@
           (let [eid (random-uuid)]
             (is (= #:instant.util.exception{:type
                                             :instant.util.exception/validation-failed,
-                                            :message "Validation failed for triple",
+                                            :message "Value is too large for a unique attribute.",
                                             :hint
-                                            {:data-type :triple,
-                                             :input "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
-                                             :errors
-                                             [{:message "Value is too large for a unique attribute.",
-                                               :hint {:value "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
-                                                      :checked-data-type "string",
-                                                      :attr-id (str unique-attr-id)
-                                                      :entity-id (str eid)
-                                                      :value-too-large? true}}]}}
+                                            {:namespace "users",
+                                             :attribute "unique",
+                                             :value "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
+                                             :checked-data-type "string",
+                                             :attr-id (str unique-attr-id)
+                                             :entity-id (str eid)
+                                             :value-too-large? true}}
                    (dissoc
                     (test-util/instant-ex-data
                       (tx/transact! (aurora/conn-pool :write)


### PR DESCRIPTION
Updates constraint violation errors to be a little more user friendly:

1. Puts the problem in the message, e.g. "Validation failed for triple" -> "Invalid value type for posts.title. Value must be a string but the provided value type is number."
2. Shows the attribute name and namespace that caused the failure
3. For invalid values, tells you the type of the input (if it wasn't truncated)
4. Removes some weird nesting, where we put a list of `errors` in the `hint` field.

Before:

```js
​​{
​​  "name": "InstantAPIError",
​​  "status": 400,
​​  "body": {
​​    "type": "validation-failed",
​​    "message": "Validation failed for triple",
​​    "hint": {
​​      "data-type": "triple",
​​      "input": "2",
​​      "errors": [
​​        {
​​          "message": "Invalid value type for triple.",
​​          "hint": {
​​            "value": "2",
​​            "checked-data-type": "number",
​​            "attr-id": "e1b4f835-b28f-44ae-ad30-2d6834aab5cc",
​​            "entity-id": "447784a6-1096-43f5-8253-70d3413a6a8a"
​​          }
​​        }
​​      ]
​​    },
​​    "trace-id": "cb09c2f4e83e2d8a6b55435e37bd94f0"
​​  }
​​}
```

After:

```js
{
  "name": "InstantAPIError",
  "status": 400,
  "body": {
    "type": "validation-failed",
    "message": "Invalid value type for posts.num. Value must be a number but the provided value type is string.",
    "hint": {
      "namespace": "posts",
      "attribute": "num",
      "value": "2",
      "checked-data-type": "number",
      "attr-id": "d2876b87-42d5-4a8e-935a-8cfe9253ca1f",
      "entity-id": "07c8fc86-3285-4d76-8999-24ed737da2e4"
    },
    "trace-id": "7ca82705fff33c8db74bc167c356ad7c"
  }
}
```

