### PR TITLE
Handle non-json error payloads in admin sdk

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -176,10 +176,24 @@ async function jsonFetch(
     'Instant-Core-Version': coreVersion,
   };
   const res = await fetch(input, { ...defaultFetchOpts, ...init, headers });
-  const json = await res.json();
-  return res.status === 200
-    ? Promise.resolve(json)
-    : Promise.reject(new InstantAPIError({ status: res.status, body: json }));
+  if (res.status === 200) {
+    const json = await res.json();
+    return Promise.resolve(json);
+  }
+  const body = await res.text();
+  try {
+    const json = JSON.parse(body);
+    return Promise.reject(
+      new InstantAPIError({ status: res.status, body: json }),
+    );
+  } catch (_e) {
+    return Promise.reject(
+      new InstantAPIError({
+        status: res.status,
+        body: { type: undefined, message: body },
+      }),
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Returns error messages as text if we can't parse it as JSON instead of throwing a JSON parse error.

Before:

```
 ⨯ SyntaxError: Unexpected token 'w', "whoops" is not valid JSON
    at JSON.parse (<anonymous>) {
  digest: '936232253'
}
```

After:

```
 ⨯ Error [InstantAPIError]: whoops
    at eval (../../src/index.ts:191:6)
    at Generator.next (<anonymous>)
    at fulfilled (webpack-internal:///(rsc)/../../packages/admin/dist/module/index.js:22:32)
  189 |   } catch (_e) {
  190 |     return Promise.reject(
> 191 |       new InstantAPIError({
      |      ^
  192 |         status: res.status,
  193 |         body: { type: undefined, message: body },
  194 |       }), {
  status: 400,
  body: { type: undefined, message: 'whoops' },
  digest: '301343937'
}

```