### PR TITLE
Add config to sample logs

### DIFF
--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -34,6 +34,10 @@ const graph = i.graph(
     "rate-limited-apps": i.entity({
       appId: i.string().unique(),
     }),
+    "log-sampled-apps": i.entity({
+      appId: i.string().unique(),
+      sampleRate: i.number(),
+    }),
     "storage-whitelist": i.entity({
       appId: i.string().unique().indexed(),
       email: i.string(),

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -20,6 +20,7 @@
             :drop-refresh-spam {}
             :promo-emails {}
             :rate-limited-apps {}
+            :log-sampled-apps {}
             :welcome-email-config {}
             :e2e-logging {}
             :threading {}
@@ -98,6 +99,11 @@
                                   #{}
                                   (get result "rate-limited-apps"))
 
+        log-sampled-apps (reduce (fn [acc {:strs [appId sampleRate]}]
+                                   (assoc acc appId sampleRate))
+                                 {}
+                                 (get result "log-sampled-apps"))
+
         app-deletion-sweeper (when-let [flag (->  (get result "app-deletion-sweeper")
                                                   first)]
                                {:disabled? (get flag "disabled" false)})
@@ -138,6 +144,7 @@
      :promo-code-emails promo-code-emails
      :drop-refresh-spam drop-refresh-spam
      :rate-limited-apps rate-limited-apps
+     :log-sampled-apps log-sampled-apps
      :e2e-logging e2e-logging
      :welcome-email-config welcome-email-config
      :threading threading
@@ -182,6 +189,10 @@
 (defn storage-disabled? [app-id]
   (let [app-id (str app-id)]
     (contains? (storage-block-list) app-id)))
+
+(defn log-sampled-apps [app-id]
+  (let [app-id (str app-id)]
+    (get-in (query-result) [:log-sampled-apps app-id] nil)))
 
 (defn use-patch-presence? [app-id]
   (let [flag (:use-patch-presence (query-result))


### PR DESCRIPTION
Adds a config so we sample logs for heavier apps. The hunch is sampling one or a few apps could significantly reduce our cloudwatch bill!

Steps to make it live:

1) Merge code
2) Push config 
3) Add app id(s)
4) Deploy