### PR TITLE
CLI: skip system namespaces during schema push

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1040,7 +1040,7 @@ function linkOptsPretty(attr) {
 async function pushSchema(appId, opts) {
   const res = await readLocalSchemaFileWithErrorLogging();
   if (!res) return { ok: false };
-  var { schema } = res;
+  const { schema } = res;
   console.log('Planning schema...');
 
   const planRes = await fetchJson({

--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1040,7 +1040,19 @@ function linkOptsPretty(attr) {
 async function pushSchema(appId, opts) {
   const res = await readLocalSchemaFileWithErrorLogging();
   if (!res) return { ok: false };
-  const { schema } = res;
+  var { schema } = res;
+
+  // skip system namespaces
+  if (schema && schema.entities) {
+    const entities = { ... schema.entities };
+    Object.keys(entities).forEach(key => {
+      if (key.startsWith('$')) {
+        delete entities[key];
+      }
+    });
+    schema = { ...schema, entities };
+  }
+
   console.log('Planning schema...');
 
   const planRes = await fetchJson({

--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1041,18 +1041,6 @@ async function pushSchema(appId, opts) {
   const res = await readLocalSchemaFileWithErrorLogging();
   if (!res) return { ok: false };
   var { schema } = res;
-
-  // skip system namespaces
-  if (schema && schema.entities) {
-    const entities = { ... schema.entities };
-    Object.keys(entities).forEach(key => {
-      if (key.startsWith('$')) {
-        delete entities[key];
-      }
-    });
-    schema = { ...schema, entities };
-  }
-
   console.log('Planning schema...');
 
   const planRes = await fetchJson({

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -29,6 +29,7 @@
             [instant.model.app-email-sender :as app-email-sender-model]
             [instant.model.instant-cli-login :as instant-cli-login-model]
             [instant.postmark :as postmark]
+            [instant.system-catalog :as system-catalog]
             [instant.util.async :refer [fut-bg]]
             [instant.util.coll :as ucoll]
             [instant.util.crypt :as crypt-util]
@@ -1011,7 +1012,7 @@
 
 (defn- remove-system-namespaces [entities]
   (ucoll/filter-keys
-   #(not (string/starts-with? (name %) "$"))
+   #(not (system-catalog/reserved? (name %)))
    entities))
 
 (defn schema-push-plan-post [req]

--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -44,6 +44,9 @@
 
 (def shortcodes-etype (map-invert etype-shortcodes))
 
+(defn reserved? [etype]
+  (string/starts-with? etype "$"))
+
 (def label-shortcodes
   {"id" "id"
    "email" "email"

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -190,6 +190,17 @@
       (assoc! m (f k) v))
     (transient (empty m)) m)))
 
+(defn filter-keys
+  "Only keep keys in `m` that return truthy for `(pred key)`"
+  [pred m]
+  (persistent!
+   (reduce-kv
+    (fn [m key _]
+      (if (pred key)
+        m
+        (dissoc! m key)))
+    (transient m) m)))
+
 (defn every?-var-args [pred & colls]
   (if (= 1 (count colls))
     (every? pred (first colls))


### PR DESCRIPTION
Users who didn’t pull make have $files/$users be marked as required from before, which breaks on push. Solution: do not try to push system namespaces at all

![Screenshot 2025-05-06 at 17 26 40](https://github.com/user-attachments/assets/f97fb641-ee5e-4dbc-a8fe-d58c320170b3)
