### PR TITLE
Remove cloudflare-specific header

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -5,7 +5,6 @@
    [clojure.java.io :as io]
    [clojure.tools.logging :as log]
    [compojure.core :refer [defroutes GET POST routes wrap-routes]]
-   [compojure.route :as route]
    [instant.admin.routes :as admin-routes]
    [instant.auth.jwt :as jwt]
    [instant.auth.oauth :as oauth]

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -105,6 +105,9 @@
 
     true))
 
+(defn not-found [_req]
+  (response/not-found {:message "Oops! We couldn't match this route."}))
+
 (defn handler []
   (routes (-> stripe-webhook-routes
               (wrap-routes http-util/tracer-record-route)
@@ -136,7 +139,7 @@
               (wrap-cors :access-control-allow-origin allow-cors-origin?
                          :access-control-allow-methods [:get :put :post :delete])
               (http-util/tracer-wrap-span))
-          (route/not-found "Oops! We couldn't match this route.")))
+          (wrap-json-response not-found)))
 
 (defonce ^Undertow server
   nil)

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -50,7 +50,8 @@
    [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
    [ring.middleware.keyword-params :refer [wrap-keyword-params]]
    [ring.middleware.multipart-params :refer [wrap-multipart-params]]
-   [ring.middleware.params :refer [wrap-params]])
+   [ring.middleware.params :refer [wrap-params]]
+   [ring.util.http-response :as response])
   (:import
    (clojure.lang IFn)
    (io.undertow Undertow UndertowOptions Undertow$Builder Undertow$ListenerInfo)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -334,13 +334,15 @@
     (try
       (crypt-util/hex-string->bytes trace-id)
       (catch Exception _
-        (ex/throw+ {::type ::param-malformed
-                    ::hint {:trace-id trace-id}})))
+        (ex/throw+ {::ex/type ::ex/param-malformed
+                    ::ex/message "Invalid trace id"
+                    ::ex/hint {:trace-id trace-id}})))
     (try
       (crypt-util/hex-string->bytes span-id)
       (catch Exception _
-        (ex/throw+ {::type ::param-malformed
-                    ::hint {:span-id span-id}})))
+        (ex/throw+ {::ex/type ::ex/param-malformed
+                    ::ex/message "Invalid span id"
+                    ::ex/hint {:span-id span-id}})))
 
     (response/ok {:urls [{:label "View trace in Honeycomb"
                           :url (tracer/honeycomb-uri {:trace-id trace-id

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -133,7 +133,9 @@
 
 (defn socket-ip [{:keys [^WebSocketHttpExchange http-req]}]
   (some-> http-req
-          (.getRequestHeader "cf-connecting-ip")))
+          (.getRequestHeader "x-forwarded-for")
+          (String/.split ",")
+          last))
 
 (defn report-active-sessions [store]
   (let [db @(:sessions store)]


### PR DESCRIPTION
Removes the cloudflare-specific "cf-connecting-ip" in favor of taking the last ip from `x-forwarded-for`. Should be the same and it's dependent on Cloudflare.

Also fixes a bug where I did `::type` instead of `::ex/type`, using the wrong namespace prefix.

And returns a JSON payload from our not found handler.