### PR TITLE
Better errors duplicate ident creation

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -687,8 +687,9 @@ export function ActionButton({
       }
     } catch (error) {
       if ((error as any)?.hint) {
-        const msg = `${errorMessage}\n${(error as any).message}\n${
-          (error as any).hint?.errors?.[0]?.message
+        const hintMessage = (error as any).hint?.errors?.[0]?.message;
+        const msg = `${errorMessage}\n${(error as any).message}${
+          hintMessage ? `\n${hintMessage}` : ''
         }`;
         errorToast(msg);
       } else {

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -213,14 +213,12 @@
        (let [details (parse-unique-detail (:detail pg-data))
              etype (get details "etype")
              label (get details "label")]
-         (cond (and etype label)
-               {:message (format "`%s` already exists on `%s`"
-                                 label
-                                 etype)
-
-                :hint {:etype etype
-                       :label label}}
-               :else nil)))
+         (when (and etype label)
+           {:message (format "`%s` already exists on `%s`"
+                             label
+                             etype)
+            :hint {:etype etype
+                   :label label}})))
      pg-data
      "ex/extract-duplicate-ident-data")))
 

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -198,40 +198,70 @@
         values (parse-unique-detail-columns! i s)]
     (zipmap keys values)))
 
+(defn- safely-extract-data [f pg-data span-name]
+  (try
+    (f pg-data)
+    (catch Exception e
+      (tracer/record-exception-span! e {:name span-name})
+      nil)))
+
+(defn extract-duplicate-ident-data [pg-data]
+  (when (and (= "idents" (:table pg-data))
+             (= "app_ident_uq" (:constraint pg-data)))
+    (safely-extract-data
+     (fn [pg-data]
+       (let [details (parse-unique-detail (:detail pg-data))
+             etype (get details "etype")
+             label (get details "label")]
+         (cond (and etype label)
+               {:message (format "`%s` already exists on `%s`"
+                                 label
+                                 etype)
+
+                :hint {:etype etype
+                       :label label}}
+               :else nil)))
+     pg-data
+     "ex/extract-duplicate-ident-data")))
+
 (defn extract-unique-triple-data [pg-data]
   (when (and (= "triples" (:table pg-data))
              (= "av_index" (:constraint pg-data)))
-    (try
-      (let [details (parse-unique-detail (:detail pg-data))
-            value   (get details "json_null_to_null(value)")
-            app-id  (uuid-util/coerce (get details "app_id"))
-            attr-id (uuid-util/coerce (get details "attr_id"))
-            {:keys [etype label]} (get-attr-details app-id attr-id)]
-        (cond (and etype label value)
-              {:message (format "`%s` is a unique attribute on `%s` and an entity already exists with `%s.%s` = %s"
-                                label
-                                etype
-                                etype
-                                label
-                                value)
-               :hint {:attr-id attr-id
-                      :etype etype
-                      :label label
-                      :value value}}
+    (safely-extract-data
+     (fn [pg-data]
+       (let [details (parse-unique-detail (:detail pg-data))
+             value   (get details "json_null_to_null(value)")
+             app-id  (uuid-util/coerce (get details "app_id"))
+             attr-id (uuid-util/coerce (get details "attr_id"))
+             {:keys [etype label]} (get-attr-details app-id attr-id)]
+         (cond (and etype label value)
+               {:message (format "`%s` is a unique attribute on `%s` and an entity already exists with `%s.%s` = %s"
+                                 label
+                                 etype
+                                 etype
+                                 label
+                                 value)
+                :hint {:attr-id attr-id
+                       :etype etype
+                       :label label
+                       :value value}}
 
-              attr-id
-              {:hint {:attr-id attr-id
-                      :value value}}
+               attr-id
+               {:hint {:attr-id attr-id
+                       :value value}}
 
-              :else nil))
-      (catch Exception e
-        (tracer/record-exception-span! e {:name "ex/extract-unique-triple-data-error"})
-        nil))))
+               :else nil)))
+     pg-data
+     "ex/extract-unique-triple-data")))
+
+(defn build-not-unqiue-hint [pg-data]
+  (or (extract-duplicate-ident-data pg-data)
+      (extract-unique-triple-data pg-data)))
 
 (defn throw-record-not-unique!
   ([record-type] (throw-record-not-unique! record-type nil nil))
   ([record-type pg-data e]
-   (let [extra-hint-data (extract-unique-triple-data pg-data)]
+   (let [extra-hint-data (build-not-unqiue-hint pg-data)]
      (throw+ {::type ::record-not-unique
               ::message (or (:message extra-hint-data)
                             (format "Record not unique: %s" (name record-type)))


### PR DESCRIPTION
I noticed we don't give a helpful error message if someone un-intentionally tries to create an attr that already exists. Thought it would be nicer to have a more specific error message

**Before**

![before_error](https://github.com/user-attachments/assets/dcdbda38-5d00-49f9-b29c-87de11a7cc76)

**After**

![after_error](https://github.com/user-attachments/assets/46709217-8883-4091-986d-818d38fc9184)
