### PR TITLE
Remove old join-room code

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -260,13 +260,6 @@
   [app-id room-id sess-id]
   (contains? (get-room-data app-id room-id) sess-id))
 
-(defn join-room-old! [app-id sess-id current-user room-id]
-  (register-session! app-id room-id sess-id)
-  (hazelcast/join-room-old! (get-hz-rooms-map)
-                            (hazelcast/room-key app-id room-id)
-                            sess-id
-                            (:id current-user)))
-
 (defn join-room! [app-id sess-id current-user room-id data]
   (register-session! app-id room-id sess-id)
   (hazelcast/join-room! (get-hz-rooms-map)

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -306,9 +306,7 @@
         app-id (-> auth :app :id)
         current-user (-> auth :user)
         room-id (validate-room-id event)]
-    (if (flags/toggled? :join-room-v2)
-      (eph/join-room! app-id sess-id current-user room-id (or data {}))
-      (eph/join-room-old! app-id sess-id current-user room-id))
+    (eph/join-room! app-id sess-id current-user room-id (or data {}))
     (rs/send-event! store app-id sess-id {:op :join-room-ok
                                           :room-id room-id
                                           :client-event-id client-event-id})))


### PR DESCRIPTION
Followup to https://github.com/instantdb/instant/pull/1176

Removes the deprecated join-room hazelcast code.