### PR TITLE
Support join-and-set-presence for @instantdb/core

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -608,12 +608,11 @@ class InstantCoreDatabase<Schema extends InstantSchemaDef<any, any, any>>
   joinRoom<RoomType extends keyof RoomsOf<Schema>>(
     roomType: RoomType = '_defaultRoomType' as RoomType,
     roomId: string = '_defaultRoomId',
-    initialPresenceData?:
-      | Partial<PresenceOf<Schema, RoomType>>
-      | null
-      | undefined,
+    opts?: {
+      initialPresence?: Partial<PresenceOf<Schema, RoomType>>;
+    },
   ): RoomHandle<PresenceOf<Schema, RoomType>, TopicsOf<Schema, RoomType>> {
-    const leaveRoom = this._reactor.joinRoom(roomId, initialPresenceData);
+    const leaveRoom = this._reactor.joinRoom(roomId, opts?.initialPresence);
 
     return {
       leaveRoom,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -608,8 +608,12 @@ class InstantCoreDatabase<Schema extends InstantSchemaDef<any, any, any>>
   joinRoom<RoomType extends keyof RoomsOf<Schema>>(
     roomType: RoomType = '_defaultRoomType' as RoomType,
     roomId: string = '_defaultRoomId',
+    initialPresenceData?:
+      | Partial<PresenceOf<Schema, RoomType>>
+      | null
+      | undefined,
   ): RoomHandle<PresenceOf<Schema, RoomType>, TopicsOf<Schema, RoomType>> {
-    const leaveRoom = this._reactor.joinRoom(roomId);
+    const leaveRoom = this._reactor.joinRoom(roomId, initialPresenceData);
 
     return {
       leaveRoom,


### PR DESCRIPTION
Followup to https://github.com/instantdb/instant/pull/1176

In core, `db.joinRoom` now takes a third argument with the initial presence data:

```ts
db.joinRoom('roomType', 'room-id', {name: user.name})
```