### PR TITLE
Fix x-forwarded-for, add cdn trace ids

### DIFF
--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -135,7 +135,10 @@
   (some-> http-req
           (.getRequestHeader "x-forwarded-for")
           (String/.split ",")
-          last))
+          ;; Drop the ip added by the elb
+          drop-last
+          last
+          string/trim))
 
 (defn report-active-sessions [store]
   (let [db @(:sessions store)]

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -51,7 +51,7 @@
                  ;; cloudflare tracking id
                  :cf-ray-id (get headers "cf-ray")
                  ;; cloudfront tracking id
-                 :amz-fc-id (get headers "x-amz-cf-id")
+                 :amz-cf-id (get headers "x-amz-cf-id")
                  ;; amazon load balancer trace id
                  :amzn-trace-id (get headers "x-amzn-trace-id")}]
       (tracer/add-data! {:attributes attrs})

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -47,7 +47,13 @@
                  :app-id app-id
                  :cli-version cli-version
                  :core-version core-version
-                 :admin-version admin-version}]
+                 :admin-version admin-version
+                 ;; cloudflare tracking id
+                 :cf-ray-id (get headers "cf-ray")
+                 ;; cloudfront tracking id
+                 :amz-fc-id (get headers "x-amz-cf-id")
+                 ;; amazon load balancer trace id
+                 :amzn-trace-id (get headers "x-amzn-trace-id")}]
       (tracer/add-data! {:attributes attrs})
       (handler request))))
 


### PR DESCRIPTION
Fixes the x-forwarded-for header. The load balancer appends to x-forwarded-for also, so we need to remove the one it added (it will see the cdn's IP address) to get the user's IP.

Also adds the cdn and load balancer trace ids to the http-req span.