### PR TITLE
[llms] Enable md extension to get raw docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ client/www/public/sitemap.xml
 client/www/public/llms.txt
 client/www/public/llms-full.txt
 
+# static docs
+client/www/public/docs
+client/www/public/docs*
+
 # production
 www/build
 

--- a/client/www/lib/markdoc.ts
+++ b/client/www/lib/markdoc.ts
@@ -1,0 +1,54 @@
+// Extract frontmatter from markdoc content and separate it from the
+// markdoc content
+function parseFrontmatter(content: string): {
+  frontmatter: any;
+  content: string;
+} {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { frontmatter: {}, content };
+  }
+
+  const frontmatterStr = match[1];
+  const remainingContent = match[2];
+
+  const frontmatter: Record<string, string> = {};
+  const lines = frontmatterStr.split('\n');
+  for (const line of lines) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex !== -1) {
+      const key = line.slice(0, colonIndex).trim();
+      const value = line.slice(colonIndex + 1).trim();
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, content: remainingContent };
+}
+
+// Remove `{% ... %}` tags from markdown content
+function sanitizeMarkdown(content: string): string {
+  return content.replace(/{%[\s\S]*?%}/g, '');
+}
+
+// Transform markdoc content into a markdown format that's sanitized for
+// llms
+function transformContent(content: string): string {
+  const { frontmatter, content: markdownContent } = parseFrontmatter(content);
+  let result = '';
+
+  if (frontmatter.title) {
+    result += `# ${frontmatter.title}\n\n`;
+  }
+
+  if (frontmatter.description) {
+    result += `${frontmatter.description}\n\n`;
+  }
+
+  const sanitizedContent = sanitizeMarkdown(markdownContent);
+  return result + sanitizedContent;
+}
+
+export { parseFrontmatter, transformContent };

--- a/client/www/package.json
+++ b/client/www/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "gen-llms": "pnpm exec tsx scripts/gen-llms-txt.ts",
-    "postbuild": "pnpm gen-llms && next-sitemap",
+    "gen-docs": "pnpm exec tsx scripts/gen-md-docs.ts",
+    "postbuild": "pnpm gen-docs && pnpm gen-llms && next-sitemap",
     "start": "next start",
     "test": "jest --watch"
   },

--- a/client/www/pages/docs/using-llms.md
+++ b/client/www/pages/docs/using-llms.md
@@ -25,6 +25,10 @@ If you are ever interrupted while outputting a file and need to continue start t
 // [llms.txt and llms-full.txt pasted below]
 ```
 
+You can also attach `.md` to the end of any doc page url to get the raw markdown
+you can copy and paste into your LLM. For example, here's the [Getting
+Started page](/docs.md)
+
 If you have any feedback on your experience using LLMs w/ Instant we would love
 to hear it! Feel free to use the feedback buttons below or reach out to us on
 [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/client/www/scripts/gen-llms-txt.ts
+++ b/client/www/scripts/gen-llms-txt.ts
@@ -60,7 +60,7 @@ async function findMarkdownFiles(dir: string): Promise<string[]> {
 }
 
 function getDocumentUrl(href: string): string {
-  return `https://instantdb.com/api/markdown${href}.md`;
+  return `https://instantdb.com${href}.md`;
 }
 
 async function processMarkdownFile(filePath: string): Promise<Document | null> {

--- a/client/www/scripts/gen-llms-txt.ts
+++ b/client/www/scripts/gen-llms-txt.ts
@@ -10,7 +10,7 @@
  * The output files are saved in the public directory. Sections are in the same
  * order as our docs navigation.
  *
- * Usage: pnpm exec tsx gen-llms-txt.ts
+ * Usage: pnpm exec tsx scripts/gen-llms-txt.ts
  */
 
 import fs from 'fs/promises';
@@ -18,6 +18,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import navigation from '../data/docsNavigation.js';
+import { parseFrontmatter, transformContent } from '../lib/markdoc.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,55 +34,6 @@ interface Document {
   content: string;
   url: string;
   href: string;
-}
-
-function parseFrontmatter(content: string): {
-  frontmatter: any;
-  content: string;
-} {
-  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
-  const match = content.match(frontmatterRegex);
-
-  if (!match) {
-    return { frontmatter: {}, content };
-  }
-
-  const frontmatterStr = match[1];
-  const remainingContent = match[2];
-
-  const frontmatter: Record<string, string> = {};
-  const lines = frontmatterStr.split('\n');
-  for (const line of lines) {
-    const colonIndex = line.indexOf(':');
-    if (colonIndex !== -1) {
-      const key = line.slice(0, colonIndex).trim();
-      const value = line.slice(colonIndex + 1).trim();
-      frontmatter[key] = value;
-    }
-  }
-
-  return { frontmatter, content: remainingContent };
-}
-
-// Remove `{% ... %}` tags from markdown content
-function sanitizeMarkdown(content: string): string {
-  return content.replace(/{%[\s\S]*?%}/g, '');
-}
-
-function transformContent(content: string): string {
-  const { frontmatter, content: markdownContent } = parseFrontmatter(content);
-  let result = '';
-
-  if (frontmatter.title) {
-    result += `# ${frontmatter.title}\n\n`;
-  }
-
-  if (frontmatter.description) {
-    result += `${frontmatter.description}\n\n`;
-  }
-
-  const sanitizedContent = sanitizeMarkdown(markdownContent);
-  return result + sanitizedContent;
 }
 
 async function findMarkdownFiles(dir: string): Promise<string[]> {
@@ -108,7 +60,7 @@ async function findMarkdownFiles(dir: string): Promise<string[]> {
 }
 
 function getDocumentUrl(href: string): string {
-  return `https://instantdb.com${href}`;
+  return `https://instantdb.com/api/markdown${href}.md`;
 }
 
 async function processMarkdownFile(filePath: string): Promise<Document | null> {

--- a/client/www/scripts/gen-md-docs.ts
+++ b/client/www/scripts/gen-md-docs.ts
@@ -1,0 +1,102 @@
+/**
+ * Exports our docs to public/docs directory and transforms the content
+ * to be markdown compatible with LLMs.
+ *
+ * Usage: pnpm exec tsx scripts/gen-md-docs.ts
+ */
+
+import fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { transformContent } from '../lib/markdoc.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const CONFIG = {
+  DOCS_PATH: path.resolve(__dirname, '../pages/docs'),
+  OUTPUT_PATH: path.resolve(__dirname, '../public/docs'),
+  PUBLIC_PATH: path.resolve(__dirname, '../public'),
+};
+
+async function findMarkdownFiles(dir: string): Promise<string[]> {
+  let results: string[] = [];
+
+  try {
+    const items = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const item of items) {
+      const fullPath = path.join(dir, item.name);
+
+      if (item.isDirectory()) {
+        const subResults = await findMarkdownFiles(fullPath);
+        results = [...results, ...subResults];
+      } else if (item.isFile() && item.name.endsWith('.md')) {
+        results.push(fullPath);
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading directory ${dir}:`, error);
+  }
+
+  return results;
+}
+
+async function exportDocsToPublic(): Promise<void> {
+  const markdownFiles = await findMarkdownFiles(CONFIG.DOCS_PATH);
+  console.log(`Found ${markdownFiles.length} markdown files in docs directory`);
+
+  for (const sourceFilePath of markdownFiles) {
+    try {
+      const content = await fs.readFile(sourceFilePath, 'utf8');
+      const transformedContent = transformContent(content);
+
+      const relativePath = path.relative(CONFIG.DOCS_PATH, sourceFilePath);
+
+      // Special case for index.md - also save it as docs.md in the public root
+      if (relativePath === 'index.md') {
+        const docsRootPath = path.join(CONFIG.PUBLIC_PATH, 'docs.md');
+        await fs.writeFile(docsRootPath, transformedContent);
+      }
+
+      const outputPath = path.join(CONFIG.OUTPUT_PATH, relativePath);
+
+      // For handling subdirectorys like docs/auth/apple
+      const outputDir = path.dirname(outputPath);
+      if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+      }
+
+      await fs.writeFile(outputPath, transformedContent);
+      console.log(`Exported: ${relativePath}`);
+    } catch (error) {
+      console.error(`Error processing file ${sourceFilePath}:`, error);
+    }
+  }
+}
+
+async function main() {
+  try {
+    console.log('Starting docs export to public/docs...');
+
+    // Make sure the output directory exists
+    if (!existsSync(CONFIG.OUTPUT_PATH)) {
+      mkdirSync(CONFIG.OUTPUT_PATH, { recursive: true });
+    }
+
+    await exportDocsToPublic();
+    console.log(`Successfully exported markdown docs to ${CONFIG.OUTPUT_PATH}`);
+  } catch (error) {
+    console.error('Failed to export docs:', error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Error in main function:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
With this PR you can add `.md` to the end of our doc urls to get the extracted markdown. This can be useful for customizing context in an llm setting.

Also updates our llms.txt to point directly to these urls

See [Getting Started](https://instant-www-js-enable-md-jsv.vercel.app/docs.md) as an example

or [explore the docs ](https://instant-www-js-enable-md-jsv.vercel.app/docs) and add `.md` at the end