### PR TITLE
Made sandbox package names match folder names, made logs quieter

### DIFF
--- a/client/sandbox/admin-sdk-express/package.json
+++ b/client/sandbox/admin-sdk-express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-node",
+  "name": "sandbox/admin-sdk-express",
   "version": "0.0.1",
   "description": "Test script for admin SDK",
   "type": "module",

--- a/client/sandbox/cli-nodejs/package.json
+++ b/client/sandbox/cli-nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-cli",
+  "name": "sandbox/cli-nodejs",
   "private": true,
   "dependencies": {
     "@instantdb/admin": "workspace:*",

--- a/client/sandbox/react-native-expo/package.json
+++ b/client/sandbox/react-native-expo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-expo",
+  "name": "sandbox/react-native-expo",
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {

--- a/client/sandbox/react-nextjs/package.json
+++ b/client/sandbox/react-nextjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sandbox-nextjs",
+  "name": "sandbox/react-nextjs",
   "private": true,
   "scripts": {
     "dev": "next dev -p 4000",

--- a/client/sandbox/strong-init-vite/package.json
+++ b/client/sandbox/strong-init-vite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "strong-init-vite",
+  "name": "sandbox/strong-init-vite",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/client/sandbox/vanilla-js-nuxt/nuxt.config.ts
+++ b/client/sandbox/vanilla-js-nuxt/nuxt.config.ts
@@ -5,4 +5,9 @@ export default defineNuxtConfig({
   devServer: {
     port: 3060,
   },
+  telemetry: false,
+  vite: {
+    clearScreen: false,
+    logLevel: 'warn',
+  },
 });

--- a/client/sandbox/vanilla-js-nuxt/package.json
+++ b/client/sandbox/vanilla-js-nuxt/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "issue-demo-idbinwisr",
+  "name": "sandbox/vanilla-js-nuxt",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/sandbox/vanilla-js-vite/package.json
+++ b/client/sandbox/vanilla-js-vite/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vanilla-js-vite",
+  "name": "sandbox/vanilla-js-vite",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/client/sandbox/vanilla-js-vite/vie.config.ts
+++ b/client/sandbox/vanilla-js-vite/vie.config.ts
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   clearScreen: false,
   logLevel: 'warn',
-  plugins: [react()],
-  server: {
-    port: 3015,
-  },
 });


### PR DESCRIPTION
It was unnecessarily hard to see `issue-demo-idbinwisr` in logs and figure out that it corresponds to `sandbox/vanilla-js-nuxt`