### PR TITLE
[Sandbox] Enable db.tx

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -146,6 +146,7 @@ export function Sandbox({
           throw error;
         }
       },
+      tx,
     };
 
     try {
@@ -676,7 +677,7 @@ function initialSandboxValue(name: string) {
   const namePropCode = isJsSimpleKey(name) ? `.${name}` : `["${name}"]`;
   return `
 // This is a space to hack on queries and mutations
-// \`db\`, \`id\`, \`tx\`, and \`lookup\` are all available globally
+// \`db\`, \`id\`, and \`lookup\` are all available globally
 // Press Cmd/Ctrl + Enter to run the code
 
 const res = await db.query({
@@ -693,7 +694,7 @@ console.log('${name} ID:', itemId);
 
 if (itemId) {
   await db.transact([
-    tx${namePropCode}[itemId].update({ test: 1 }),
+    db.tx${namePropCode}[itemId].update({ test: 1 }),
   ]);
 }
 `.trim();
@@ -703,6 +704,7 @@ const tsTypes = /* ts */ `
 type InstantDB = {
   transact: (steps) => Promise<number>;
   query: (iql, opts?: {ruleParams?: Record<string, any>}) => Promise<any>;
+  tx: InstantTx;
 };
 
 type InstantTx = {


### PR DESCRIPTION
Was using the sandbox to repro a potential bug and noticed we get type warnings on `db.tx` when in fact that should work and is what we recommend folks use in the docs.

This PR makes it so `db.tx` works in the Sandbox

**Before**

![CleanShot 2025-05-12 at 08 16 49@2x](https://github.com/user-attachments/assets/e495a660-d7c8-4a78-9af9-b5cc9c072ca2)


**After**

![CleanShot 2025-05-12 at 08 31 03@2x](https://github.com/user-attachments/assets/9e02a366-587a-440b-ba59-34910764c756)

