### PR TITLE
Ignore data in join-room if it is null

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -397,6 +397,9 @@ importers:
       '@instantdb/admin':
         specifier: workspace:*
         version: link:../../packages/admin
+      '@instantdb/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@instantdb/react':
         specifier: workspace:*
         version: link:../../packages/react

--- a/client/sandbox/react-nextjs/package.json
+++ b/client/sandbox/react-nextjs/package.json
@@ -10,6 +10,7 @@
     "@clerk/nextjs": "^5.3.7",
     "@instantdb/admin": "workspace:*",
     "@instantdb/react": "workspace:*",
+    "@instantdb/core": "workspace:*",
     "@react-oauth/google": "^0.12.1",
     "date-fns": "^2.29.3",
     "fast-check": "^3.1.1",

--- a/client/sandbox/react-nextjs/pages/play/join-room-set-presence-core.tsx
+++ b/client/sandbox/react-nextjs/pages/play/join-room-set-presence-core.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Head from 'next/head';
+import { init, RoomHandle } from '@instantdb/core';
+import config from '../../config';
+
+const db = init(config);
+
+function Presence({ presenceData }: { presenceData: string }) {
+  const [presenceValues, setPresenceValues] = useState<any[]>([]);
+  const roomRef = useRef<RoomHandle<any, any> | null>(null);
+  useEffect(() => {
+    const room = db.joinRoom('main', 'set-and-join', {
+      initialPresence: { value: presenceData },
+    });
+    roomRef.current = room;
+    room.subscribePresence({}, (data: any) => {
+      setPresenceValues((current) => [data, ...current]);
+    });
+    return () => room.leaveRoom();
+  }, []);
+
+  const initialData = useRef(presenceData);
+  useEffect(() => {
+    // Don't publish unless it changes
+    if (presenceData !== initialData.current && roomRef.current) {
+      roomRef.current.publishPresence({
+        value: presenceData,
+      });
+    }
+  }, [presenceData]);
+
+  return (
+    <div>
+      <p>All presence updates:</p>
+      {presenceValues.map((v, i) => (
+        <div key={i}>
+          <pre>{JSON.stringify(v, null, 2)}</pre>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function App() {
+  const [showPresence, setShowPresence] = useState(false);
+  const [presenceData, setPresenceData] = useState('');
+  return (
+    <div>
+      <p>
+        Open two tabs. Join the room in the first tab, then join the room in the
+        second tab.
+      </p>
+      <p>You should see no updates with an empty presence value.</p>
+      <input
+        type="text"
+        value={presenceData}
+        placeholder="Set presence value"
+        onChange={(e) => setPresenceData(e.target.value)}
+      ></input>
+      <button
+        className="bg-black text-white m-2 p-2"
+        onClick={() => setShowPresence(!showPresence)}
+      >
+        {showPresence ? 'Leave room' : 'Join room'}
+      </button>
+
+      {showPresence ? <Presence presenceData={presenceData} /> : null}
+    </div>
+  );
+}
+
+function Page() {
+  return (
+    <div>
+      <Head>
+        <title>Instant Example App: Set presence when you join the room</title>
+        <meta
+          name="description"
+          content="Relational Database, on the client."
+        />
+      </Head>
+      <App />
+    </div>
+  );
+}
+
+export default Page;

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -306,7 +306,7 @@
         app-id (-> auth :app :id)
         current-user (-> auth :user)
         room-id (validate-room-id event)]
-    (eph/join-room! app-id sess-id current-user room-id (or data {}))
+    (eph/join-room! app-id sess-id current-user room-id data)
     (rs/send-event! store app-id sess-id {:op :join-room-ok
                                           :room-id room-id
                                           :client-event-id client-event-id})))

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -111,12 +111,14 @@
   (apply [_ room-data _]
     (update room-data
             session-id
-            merge
-            {:peer-id session-id
-             :user (when user-id
-                     {:id user-id})}
-            (when data
-              {:data data}))))
+            (fn [existing]
+              (merge existing
+                     {:peer-id session-id
+                      :user (when user-id
+                              {:id user-id})}
+                     (if data
+                       {:data data}
+                       {:data (or (:data existing) {})}))))))
 
 (defn join-room! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id ^UUID user-id data]
   (.merge hz-map

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -114,8 +114,9 @@
             merge
             {:peer-id session-id
              :user (when user-id
-                     {:id user-id})
-             :data data})))
+                     {:id user-id})}
+            (when data
+              {:data data}))))
 
 (defn join-room! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id ^UUID user-id data]
   (.merge hz-map

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -124,7 +124,7 @@
           {session-id {:peer-id session-id
                        :user (when user-id
                                {:id user-id})
-                       :data data}}
+                       :data (or data {})}}
           (->JoinRoomMergeV2 session-id user-id data)))
 
 (def ^ByteArraySerializer join-room-serializer


### PR DESCRIPTION
Fixes a bug where we would reset the presence to null in `@instantdb/core` if you called:

```js
  const room = db.joinRoom('name', 'id', { initialPresence: { example: 'value' } });
  room.subscribePresence({}, (response) => console.log(response));
```

`room.subscribePresence` also calls `joinRoom` with `null` for initialData (unless you call `room.subscribePresence({data: initialDataHere}, cb)`). That would set the presence data back to null until you called `setPresence` again. 

Now we'll ignore that `null` state in our join room handler.