### PR TITLE
[rn-google-signin] remove scopes

### DIFF
--- a/client/www/pages/docs/auth/google-oauth.md
+++ b/client/www/pages/docs/auth/google-oauth.md
@@ -475,7 +475,6 @@ const APP_ID = '__APP_ID__';
 const db = init({ appId: APP_ID });
 
 GoogleSignin.configure({
-  scopes: ['https://www.googleapis.com/auth/drive.readonly'],
   // See https://react-native-google-signin.github.io/docs/original#configure
   iosClientId: 'YOUR_IOS_CLIENT_ID',
 });


### PR DESCRIPTION
You don't need the `drive.readonly` scope to get auth to work. Originally included this, from perusing rn-google-signin's docs. 

One of our users mentioned that webClientId is required as well. I tried running this in my iOS simulator, and it worked, but maybe it's necessary in some other context. I will get some more info from them and push up a fix. 

@dwwoelfel @nezaj @tonsky 