### PR TITLE
Show errors in query inspector

### DIFF
--- a/client/www/components/dash/explorer/QueryInspector.tsx
+++ b/client/www/components/dash/explorer/QueryInspector.tsx
@@ -350,8 +350,9 @@ export function QueryInspector({
         <h2 className="px-3 text-sm font-semibold mt-4 mb-1">Query results</h2>
         <div className="flex-1 border-y rounded overflow-hidden">
           <CodeEditor
-            language="json"
-            value={JSON.stringify(data || {}, null, 2)}
+            loading={isLoading}
+            language={'json'}
+            value={JSON.stringify(data || error || {}, null, 2)}
             onChange={() => {}}
           />
         </div>

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -872,9 +872,11 @@ export function CodeEditor(props: {
   onMount?: OnMount;
   path?: string;
   tabIndex?: number;
+  loading?: boolean;
 }) {
   return (
     <Editor
+      className={props.loading ? 'animate-pulse' : undefined}
       height={'100%'}
       language={props.language}
       value={props.value ?? ''}


### PR DESCRIPTION
Currently we just show "{}", [which can be confusing to users](https://discord.com/channels/1031957483243188235/1370341848304058500/1372154115609853952).

Now we'll show the error message:

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/a59cec8c-b6a1-40db-98c4-374e7b3e1adc" />
