### PR TITLE
Prefix personal access tokens

### DIFF
--- a/server/resources/migrations/67_personal_access_token_lookup.down.sql
+++ b/server/resources/migrations/67_personal_access_token_lookup.down.sql
@@ -1,0 +1,1 @@
+alter table instant_personal_access_tokens drop column lookup_key;

--- a/server/resources/migrations/67_personal_access_token_lookup.up.sql
+++ b/server/resources/migrations/67_personal_access_token_lookup.up.sql
@@ -1,0 +1,7 @@
+alter table instant_personal_access_tokens add column lookup_key bytea;
+
+update instant_personal_access_tokens set lookup_key = sha256(cast(cast(id as text) as bytea));
+
+alter table instant_personal_access_tokens alter column lookup_key set not null;
+
+create index on instant_personal_access_tokens (lookup_key);

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -904,15 +904,16 @@
 (defn personal-access-tokens-get [req]
   (let [{user-id :id} (req->auth-user! req)
         personal-access-tokens (instant-personal-access-token-model/list-by-user-id! {:user-id user-id})]
-    (response/ok {:data personal-access-tokens})))
+    (response/ok {:data (map instant-personal-access-token-model/format-token-for-api
+                             personal-access-tokens)})))
 
 (defn personal-access-tokens-post [req]
   (let [{user-id :id} (req->auth-user! req)
         name (ex/get-param! req [:body :name] string-util/coerce-non-blank-str)
-        personal-access-tokens (instant-personal-access-token-model/create! {:id (UUID/randomUUID)
-                                                                             :user-id user-id
-                                                                             :name name})]
-    (response/ok {:data personal-access-tokens})))
+        personal-access-token (instant-personal-access-token-model/create! {:user-id user-id
+                                                                            :name name})]
+    (response/ok {:data (instant-personal-access-token-model/format-token-for-api
+                         personal-access-token)})))
 
 (defn personal-access-tokens-delete [req]
   (let [{user-id :id} (req->auth-user! req)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1,71 +1,73 @@
 (ns instant.dash.routes
   (:require [clj-http.client :as clj-http]
-            [clojure.string :as string]
+            [clojure.core.cache.wrapped :as cache]
             [clojure.set :as set]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [compojure.core :refer [defroutes GET POST DELETE PUT] :as compojure]
+            [clojure.walk :as w]
+            [compojure.core :as compojure :refer [defroutes DELETE GET POST PUT]]
+            [instant.config :as config]
             [instant.dash.admin :as dash-admin]
-            [instant.model.app :as app-model]
-            [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
-            [instant.model.app-oauth-client :as app-oauth-client-model]
-            [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
-            [instant.model.instant-user-magic-code :as  instant-user-magic-code-model]
-            [instant.model.outreach :as outreach-model]
-            [instant.discord :as discord]
-            [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
-            [instant.model.instant-user :as instant-user-model]
-            [instant.model.app-member-invites :as instant-app-member-invites-model]
-            [instant.model.app-members :as instant-app-members]
-            [instant.model.instant-oauth-code :as instant-oauth-code-model]
-            [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
-            [instant.model.oauth-app :as oauth-app-model]
+            [instant.dash.ephemeral-app :as ephemeral-app]
             [instant.db.indexing-jobs :as indexing-jobs]
             [instant.db.model.attr :as attr-model]
-            [instant.flags :refer [admin-email?] :as flags]
-            [instant.model.rule :as rule-model]
-            [instant.model.instant-profile :as instant-profile-model]
-            [instant.model.instant-subscription :as instant-subscription-model]
-            [instant.model.app-email-template :as app-email-template-model]
+            [instant.discord :as discord]
+            [instant.fixtures :as fixtures]
+            [instant.flags :as flags :refer [admin-email?]]
+            [instant.intern.metrics :as metrics]
+            [instant.jdbc.aurora :as aurora]
+            [instant.lib.ring.websocket :as ws]
+            [instant.machine-summaries :as machine-summaries]
+            [instant.model.app :as app-model]
+            [instant.model.app-admin-token :as app-admin-token-model]
+            [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
             [instant.model.app-email-sender :as app-email-sender-model]
+            [instant.model.app-email-template :as app-email-template-model]
+            [instant.model.app-file :as app-file-model]
+            [instant.model.app-member-invites :as instant-app-member-invites-model]
+            [instant.model.app-members :as instant-app-members]
+            [instant.model.app-oauth-client :as app-oauth-client-model]
+            [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
             [instant.model.instant-cli-login :as instant-cli-login-model]
+            [instant.model.instant-oauth-code :as instant-oauth-code-model]
+            [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
+            [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
+            [instant.model.instant-profile :as instant-profile-model]
+            [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
+            [instant.model.instant-subscription :as instant-subscription-model]
+            [instant.model.instant-user :as instant-user-model]
+            [instant.model.instant-user-magic-code :as instant-user-magic-code-model]
+            [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
+            [instant.model.oauth-app :as oauth-app-model]
+            [instant.model.outreach :as outreach-model]
+            [instant.model.rule :as rule-model]
+            [instant.model.schema :as schema-model]
             [instant.postmark :as postmark]
+            [instant.reactive.ephemeral :as eph]
+            [instant.session-counter :as session-counter]
+            [instant.storage.coordinator :as storage-coordinator]
+            [instant.stripe :as stripe]
+            [instant.superadmin.routes :refer [req->superadmin-user-and-app!]]
             [instant.system-catalog :as system-catalog]
             [instant.util.async :refer [fut-bg]]
             [instant.util.coll :as ucoll]
             [instant.util.crypt :as crypt-util]
+            [instant.util.date :as date]
             [instant.util.email :as email]
+            [instant.util.exception :as ex]
+            [instant.util.http :as http-util]
             [instant.util.json :as json]
+            [instant.util.number :as number-util]
+            [instant.util.semver :as semver]
+            [instant.util.string :as string-util]
+            [instant.util.token :as token-util]
             [instant.util.tracer :as tracer]
             [instant.util.url :as url-util]
             [instant.util.uuid :as uuid-util]
-            [instant.util.semver :as semver]
-            [instant.util.string :as string-util]
-            [instant.util.number :as number-util]
-            [instant.session-counter :as session-counter]
-            [ring.middleware.cookies :refer [wrap-cookies]]
-            [ring.util.http-response :as response]
-            [instant.model.app-admin-token :as app-admin-token-model]
-            [clojure.walk :as w]
-            [instant.config :as config]
-            [instant.fixtures :as fixtures]
-            [instant.dash.ephemeral-app :as ephemeral-app]
-            [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
-            [instant.util.date :as date]
-            [instant.util.exception :as ex]
-            [instant.util.http :as http-util]
-            [next.jdbc :as next-jdbc]
-            [instant.lib.ring.websocket :as ws]
-            [instant.jdbc.aurora :as aurora]
-            [instant.stripe :as stripe]
-            [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
-            [instant.model.schema :as schema-model]
-            [instant.intern.metrics :as metrics]
             [medley.core :as medley]
-            [instant.reactive.ephemeral :as eph]
-            [instant.machine-summaries :as machine-summaries]
-            [instant.storage.coordinator :as storage-coordinator]
-            [instant.model.app-file :as app-file-model]
-            [clojure.core.cache.wrapped :as cache])
+            [next.jdbc :as next-jdbc]
+            [ring.middleware.cookies :refer [wrap-cookies]]
+            [ring.util.http-response :as response])
   (:import
    (com.stripe.model.checkout Session)
    (io.undertow.websockets.core WebSocketChannel)
@@ -127,6 +129,12 @@
         (= user-id app-creator-id) :owner
         (stripe/pro-plan? subscription) (get-member-role app-id user-id)))
      {:app app :user user :subscription subscription})))
+
+(defn req->app-and-user-accepting-platform-tokens! [least-privilege scope req]
+  (let [token (http-util/req->bearer-token! req)]
+    (if (token-util/is-platform-token? token)
+      (req->superadmin-user-and-app! scope req)
+      (req->app-and-user! least-privilege req))))
 
 (defn with-team-app-fixtures [role f]
   (fixtures/with-team-app
@@ -426,7 +434,9 @@
 ;; Rules
 
 (defn rules-post [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-and-user-accepting-platform-tokens! :collaborator
+                                                                          :apps/write
+                                                                          req)
         code (ex/get-param! req [:body :code] w/stringify-keys)]
     (ex/assert-valid! :rule code (rule-model/validation-errors code))
     (response/ok {:rules (rule-model/put! {:app-id app-id
@@ -930,7 +940,7 @@
   (personal-access-tokens-get {:headers headers})
   (personal-access-tokens-delete {:headers headers :params {:id (-> record :body :data :id)}}))
 
-;; --- 
+;; ---------------
 ;; Email templates
 
 (defn email-template-post [req]
@@ -1022,7 +1032,9 @@
    entities))
 
 (defn schema-push-plan-post [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-and-user-accepting-platform-tokens! :collaborator
+                                                                          :apps/read
+                                                                          req)
         client-defs         (-> req
                                 :body
                                 :schema
@@ -1035,7 +1047,9 @@
                                      client-defs))))
 
 (defn schema-push-apply-post [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-and-user-accepting-platform-tokens! :collaborator
+                                                                          :apps/write
+                                                                          req)
         client-defs         (-> req
                                 :body
                                 :schema
@@ -1050,13 +1064,17 @@
     (response/ok (merge r plan-result))))
 
 (defn schema-pull-get [req]
-  (let [{{app-id :id app-title :title} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id app-title :title} :app} (req->app-and-user-accepting-platform-tokens! :collaborator
+                                                                                           :apps/read
+                                                                                           req)
         current-attrs (attr-model/get-by-app-id app-id)
         current-schema (schema-model/attrs->schema current-attrs)]
     (response/ok {:schema current-schema :app-title app-title})))
 
 (defn perms-pull-get [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-and-user-accepting-platform-tokens! :collaborator
+                                                                          :apps/write
+                                                                          req)
         perms (rule-model/get-by-app-id {:app-id app-id})
         r {:perms (:code perms)}]
     (response/ok r)))
@@ -1120,7 +1138,7 @@
   (schema-push-plan-post {:params {:app_id counters-app-id}
                           :headers {"authorization" (str "Bearer " (:id r))}}))
 
-;; --- 
+;; --------
 ;; CLI auth
 
 (defn cli-auth-register-post [_]
@@ -1154,19 +1172,19 @@
         res {:token token :email email}]
     (response/ok res)))
 
-;; --- 
-;; WS playground 
+;; -------------
+;; WS playground
 
 (def id-atom (atom 0))
 (defn ws-playground-get
-  "This is a simple websocket playground, to play with undertow's websocket behavior. 
-  
-   To try it out, 
+  "This is a simple websocket playground, to play with undertow's websocket behavior.
+
+   To try it out,
    ```bash
-   brew install websocat 
-   websocat ws://localhost:8888/dash/ws_playground 
-   hi 
-   break 
+   brew install websocat
+   websocat ws://localhost:8888/dash/ws_playground
+   hi
+   break
    ```"
   [_]
   (let [id (swap! id-atom inc)]

--- a/server/src/instant/model/instant_personal_access_token.clj
+++ b/server/src/instant/model/instant_personal_access_token.clj
@@ -1,17 +1,29 @@
 (ns instant.model.instant-personal-access-token
   (:require [instant.jdbc.aurora :as aurora]
             [instant.jdbc.sql :as sql]
-            [instant.model.instant-user :as instant-user-model])
+            [instant.model.instant-user :as instant-user-model]
+            [instant.util.crypt :as crypt-util]
+            [instant.util.token :as token-util])
   (:import
    (java.util UUID)))
 
+(defn format-token-for-api [token]
+  (select-keys token [:token :id :user_id :name :created_at]))
+
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
-  ([conn {:keys [id user-id name]}]
-   (sql/execute-one! conn
-                     ["INSERT INTO instant_personal_access_tokens (id, user_id, name)
-                       VALUES (?::uuid, ?::uuid, ?::text)"
-                      id user-id name])))
+  ([conn {:keys [user-id name]}]
+   (let [id (random-uuid)
+         token (token-util/generate-personal-access-token)
+         res (sql/execute-one!
+              conn
+              ["INSERT INTO instant_personal_access_tokens (id, user_id, name, lookup_key)
+                     VALUES (?::uuid, ?::uuid, ?::text, ?::bytea)"
+               id
+               user-id
+               name
+               (crypt-util/str->sha256 token)])]
+     (assoc res :token token))))
 
 (defn list-by-user-id!
   ([params] (list-by-user-id! (aurora/conn-pool :read) params))
@@ -32,7 +44,6 @@
 
 (comment
   (def user (instant-user-model/get-by-email {:email "alex@instantdb.com"}))
-  (def record (create! {:id (UUID/randomUUID) :user-id (:id user) :name "Default Token"}))
+  (def record (create! {:user-id (:id user) :name "Default Token"}))
   (list-by-user-id! {:user-id (:id user)})
   (delete-by-id! {:id (:id record) :user-id (:id user)}))
-

--- a/server/src/instant/model/instant_personal_access_token.clj
+++ b/server/src/instant/model/instant_personal_access_token.clj
@@ -3,9 +3,7 @@
             [instant.jdbc.sql :as sql]
             [instant.model.instant-user :as instant-user-model]
             [instant.util.crypt :as crypt-util]
-            [instant.util.token :as token-util])
-  (:import
-   (java.util UUID)))
+            [instant.util.token :as token-util]))
 
 (defn format-token-for-api [token]
   (select-keys token [:token :id :user_id :name :created_at]))

--- a/server/src/instant/model/oauth_app.clj
+++ b/server/src/instant/model/oauth_app.clj
@@ -6,8 +6,8 @@
             [instant.util.coll :as ucoll]
             [instant.util.crypt :as crypt-util]
             [instant.util.exception :as ex]
-            [instant.util.token :refer [platform-refresh-token-prefix
-                                        platform-access-token-prefix]]
+            [instant.util.token :refer [generate-platform-refresh-token
+                                        generate-platform-access-token]]
             [next.jdbc :as next-jdbc])
   (:import (java.nio ByteBuffer)
            (java.nio.charset StandardCharsets)
@@ -665,8 +665,8 @@
 
 (defn new-token [type]
   (case type
-    :access (str platform-access-token-prefix (crypt-util/random-hex 32))
-    :refresh (str platform-refresh-token-prefix (crypt-util/random-hex 32))))
+    :access (generate-platform-access-token)
+    :refresh (generate-platform-refresh-token)))
 
 (defn create-refresh-token
   ([params]

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -40,8 +40,12 @@
                                                   scope-str)
           (ex/throw-missing-scope! scope-str)
           (instant-user-model/get-by-id! {:id (:user_id access-token-record)})))
-      (instant-user-model/get-by-personal-access-token!
-       {:personal-access-token token}))))
+      (let [personal-access-token (if (token-util/is-personal-access-token? token)
+                                    token
+                                    ;; Backwards compatibility for tokens generated before 5/16/2025
+                                    (token-util/->PersonalAccessToken (str token)))]
+        (instant-user-model/get-by-personal-access-token!
+         {:personal-access-token personal-access-token})))))
 
 (defn req->superadmin-user-and-app! [scope req]
   (let [{user-id :id :as user} (req->superadmin-user! scope req)

--- a/server/src/instant/util/token.clj
+++ b/server/src/instant/util/token.clj
@@ -1,23 +1,47 @@
 (ns instant.util.token
   (:require [clojure.string :as string]
+            [instant.util.crypt :as crypt-util]
             [instant.util.uuid :as uuid-util]))
 
 (def platform-refresh-token-prefix "prt_")
 (def platform-access-token-prefix "pat_")
+(def personal-access-token-prefix "per_")
 
 (deftype PlatformAccessToken [value]
+  Object
+  (toString [_] "<secret>"))
+
+(deftype PersonalAccessToken [value]
   Object
   (toString [_] "<secret>"))
 
 (defn platform-access-token-value [^PlatformAccessToken t]
   (.value t))
 
+(defn personal-access-token-value [^PersonalAccessToken t]
+  (.value t))
+
 (defn is-platform-access-token? [t]
-  (or (instance? PlatformAccessToken t)
-      (and (string? t)
-           (string/starts-with? t platform-refresh-token-prefix))))
+  (instance? PlatformAccessToken t))
+
+(defn is-personal-access-token? [t]
+  (instance? PersonalAccessToken t))
 
 (defn coerce-token-from-string [^String s]
-  (if (string/starts-with? s platform-access-token-prefix)
-    (->PlatformAccessToken s)
-    (uuid-util/coerce s)))
+  (cond (string/starts-with? s platform-access-token-prefix)
+        (->PlatformAccessToken s)
+
+        (string/starts-with? s personal-access-token-prefix)
+        (->PersonalAccessToken s)
+
+        :else
+        (uuid-util/coerce s)))
+
+(defn generate-platform-access-token []
+  (str platform-access-token-prefix (crypt-util/random-hex 32)))
+
+(defn generate-platform-refresh-token []
+  (str platform-access-token-prefix (crypt-util/random-hex 32)))
+
+(defn generate-personal-access-token []
+  (str personal-access-token-prefix (crypt-util/random-hex 32)))

--- a/server/src/instant/util/token.clj
+++ b/server/src/instant/util/token.clj
@@ -27,6 +27,10 @@
 (defn is-personal-access-token? [t]
   (instance? PersonalAccessToken t))
 
+(defn is-platform-token? [t]
+  (or (is-platform-access-token? t)
+      (is-personal-access-token? t)))
+
 (defn coerce-token-from-string [^String s]
   (cond (string/starts-with? s platform-access-token-prefix)
         (->PlatformAccessToken s)


### PR DESCRIPTION
Prefixes the personal access tokens with `per_` so that we can dispatch on the token type.

I want to allow platform tokens to do `instant-cli push` and `instant-cli pull`, but I need a way to identify that it's a platform token and not a regular user token.

Also changes how we display the tokens--we'll now hash the token when we store it and look it up by the hash. We'll only show you the token when you first create it.

There's a migration to allow older tokens to still function as they did before (but only newer tokens will be able to do `push` and `pull`).

Also includes the changes from https://github.com/instantdb/instant/pull/1206

### Migration plan
1. Merge into main
2. run migration
3. deploy code (there will be a short period between step 2 and 3 where people won't be able to generate tokens)