### PR TITLE
Replace 400 with 401 for auth errors in docs

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -342,7 +342,7 @@ class Auth {
    *   app.post('/custom_endpoint', async (req, res) => {
    *     const user = await db.auth.verifyToken(req.headers['token'])
    *     if (!user) {
-   *       return res.status(400).send('Uh oh, you are not authenticated')
+   *       return res.status(401).send('Uh oh, you are not authenticated')
    *     }
    *     // ...
    *   })

--- a/client/www/pages/docs/backend.md
+++ b/client/www/pages/docs/backend.md
@@ -334,7 +334,7 @@ app.post('/custom_endpoint', async (req, res) => {
   // verify the token this user passed in
   const user = await db.auth.verifyToken(req.headers['token']);
   if (!user) {
-    return res.status(400).send('Uh oh, you are not authenticated');
+    return res.status(401).send('Uh oh, you are not authenticated');
   }
   // ...
 });


### PR DESCRIPTION
Users implementing this would likely use `401 Unauthorized` instead of `400 Bad Request`, this PR makes the docs reflect that.