### PR TITLE
Add `etype` and `label` to `attrs` table (part 1 of 2)

### DIFF
--- a/server/resources/migrations/68_attrs_etype_label_schema.down.sql
+++ b/server/resources/migrations/68_attrs_etype_label_schema.down.sql
@@ -1,0 +1,10 @@
+DROP TRIGGER IF EXISTS trg_attrs_unique_names ON attrs;
+DROP FUNCTION check_attrs_unique_names;
+
+ALTER TABLE attrs DROP CONSTRAINT attrs_etype_label_unique;
+ALTER TABLE attrs DROP CONSTRAINT attrs_reverse_etype_label_unique;
+
+ALTER TABLE attrs DROP COLUMN etype;
+ALTER TABLE attrs DROP COLUMN label;
+ALTER TABLE attrs DROP COLUMN reverse_etype;
+ALTER TABLE attrs DROP COLUMN reverse_label;

--- a/server/resources/migrations/68_attrs_etype_label_schema.up.sql
+++ b/server/resources/migrations/68_attrs_etype_label_schema.up.sql
@@ -1,0 +1,46 @@
+ALTER TABLE attrs ADD COLUMN etype text;
+ALTER TABLE attrs ADD COLUMN label text;
+ALTER TABLE attrs ADD COLUMN reverse_etype text;
+ALTER TABLE attrs ADD COLUMN reverse_label text;
+
+ALTER TABLE attrs
+ADD CONSTRAINT attrs_etype_label_unique UNIQUE (app_id, etype, label);
+
+ALTER TABLE attrs
+ADD CONSTRAINT attrs_reverse_etype_label_unique UNIQUE (app_id, reverse_etype, reverse_label);
+
+CREATE OR REPLACE FUNCTION check_attrs_unique_names ()
+  RETURNS TRIGGER
+  AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM attrs
+     WHERE (app_id, reverse_etype, reverse_label) = (NEW.app_id, NEW.etype, NEW.label)
+  ) THEN
+    RAISE EXCEPTION 'trigger violation trg_attrs_unique_names'
+       USING DETAIL = format('Key (app_id, reverse_etype, reverse_label)=(%s, %s, %s) already exists', NEW.app_id, NEW.etype, NEW.label),
+              TABLE = 'attrs',
+            ERRCODE = '23505';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM attrs
+     WHERE (app_id, etype, label) = (NEW.app_id, NEW.reverse_etype, NEW.reverse_label)
+  ) THEN
+    RAISE EXCEPTION 'trigger violation trg_attrs_unique_names'
+       USING DETAIL = format('Key (app_id, etype, label)=(%s, %s, %s) already exists', NEW.app_id, NEW.reverse_etype, NEW.reverse_label),
+              TABLE = 'attrs',
+            ERRCODE = '23505';
+  END IF;
+
+  RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_attrs_unique_names
+  BEFORE INSERT OR UPDATE
+  ON attrs
+  FOR EACH ROW EXECUTE FUNCTION check_attrs_unique_names ();


### PR DESCRIPTION
Currently almost all operations that include `attrs` have to join `idents` table to get an attr name or a namespace name.

This PR adds these columns directly to `attrs` table (`etype`, `label`, `reverse_etype`, `reverse_label`). It saves us an extra join at the cost of a little denormalization.

`idents` table is kept around for backwards compatibility, it might take some doing to get rid of it.

Not queries have been updated to use new fields. This is more to simplify writing future queries. But I did update some just to demonstrate how it feels.

Deploy plan:

1. Upgrade schema to 68
2. Deploy this PR #1212
3. Upgrade schema to 69
4. Deploy PR #1215