### PR TITLE
Fix deleting the redirect url

### DIFF
--- a/client/www/components/dash/OAuthApps.tsx
+++ b/client/www/components/dash/OAuthApps.tsx
@@ -431,10 +431,10 @@ function ClientRedirectUrl({
     }
   };
   return (
-    <div className="group flex flex-row gap-4">
+    <div className="group/redirect flex flex-row gap-4">
       <Copyable value={redirectUrl} />
       <Button
-        className="hidden group-hover:block"
+        className="invisible group-hover/redirect:visible"
         size="mini"
         variant="destructive"
         onClick={removeRedirectUrl}


### PR DESCRIPTION
Fixes a bug where you couldn't click the delete button redirect because it would disappear when your mouse moved off of the url.

Changing from `display: hidden` to `visibility: hidden` keeps the button from disappearing.