### PR TITLE
Clean up stale ephemeral sessions (1 of 3)

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -28,7 +28,7 @@
         software.amazon.awssdk.crt/aws-crt {:mvn/version "0.33.11"}
 
         juji/editscript {:mvn/version "0.6.4"}
-        io.github.tonsky/clojure-plus {:mvn/version "1.4.0"}
+        io.github.tonsky/clojure-plus {:mvn/version "1.5.0"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 
@@ -87,7 +87,7 @@
                  :extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}
                               criterium/criterium           {:mvn/version "0.4.6"}
                               spec-provider/spec-provider   {:mvn/version "0.4.14"}
-                              io.github.tonsky/clj-reload   {:mvn/version "0.9.4"}
+                              io.github.tonsky/clj-reload   {:mvn/version "0.9.7"}
                               ;; https://github.com/kkinnear/zprint/pull/351
                               io.github.tonsky/zprint       {:mvn/version "1.2.10"}}
                  :jvm-opts ["-XX:+UseZGC"

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -41,6 +41,8 @@
 (def join-room-type-id 8)
 (def patch-type-id 9)
 
+(declare patch-assoc patch-assoc-in patch-merge-in patch-dissoc patch-dissoc-in)
+
 ;; --------
 ;; Room key
 
@@ -244,6 +246,8 @@
 ;; -----------------
 ;; Path serializer
 
+;; DO NOT change implementation here. Make a new version and do three-step
+;; deploy (see comment at the top of the file)
 (defrecord Patch [edits]
   BiFunction
   (apply [_ data _]

--- a/server/test/instant/util/hazelcast_test.clj
+++ b/server/test/instant/util/hazelcast_test.clj
@@ -1,6 +1,12 @@
 (ns instant.util.hazelcast-test
-  (:require [instant.util.hazelcast :as h]
-            [clojure.test :refer [deftest is testing]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.reactive.ephemeral :as eph]
+   [instant.reactive.store :as rs]
+   [instant.util.hazelcast :as h])
+  (:import
+   (com.hazelcast.core HazelcastInstance)
+   (com.hazelcast.map IMap)))
 
 (deftest room-key-roundtrips
   (let [start (h/->RoomKeyV1 (random-uuid) "room-id")
@@ -37,3 +43,53 @@
         serializer h/set-presence-serializer]
     (is (= start (->> (.write serializer start)
                       (.read serializer))))))
+
+(deftest patch-test
+  (let [^HazelcastInstance hz
+        (:hz
+         (eph/init-hz :test
+                      (rs/init)
+                      (let [id (+ 100000 (rand-int 900000))]
+                        {:instance-name (str "test-instance-" id)
+                         :cluster-name  (str "test-cluster-" id)})))]
+    (try
+      (let [m ^IMap (.getMap hz "a-map")]
+        (is (= {} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1"] {:heartbeat 1})
+        (is (= {"i-1" {:heartbeat 1}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1" :heartbeat] 2)
+        (is (= {"i-1" {:heartbeat 2}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-2" :heartbeat] 3)
+        (is (= {"i-1" {:heartbeat 2}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1" :status] :ok)
+        (is (= {"i-1" {:heartbeat 2, :status :ok}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1" :a :b :c] :ok)
+        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok}}}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-merge-in m ["i-1" :a :b] {:c :ok-2, :d :new})
+        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok-2, :d :new}}}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-merge-in m ["i-1"] {:x 1, :status :ok-3})
+        (is (= {"i-1" {:heartbeat 2, :status :ok-3, :a {:b {:c :ok-2, :d :new}}, :x 1}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-dissoc-in m ["i-1" :status])
+        (is (= {"i-1" {:heartbeat 2, :a {:b {:c :ok-2, :d :new}}, :x 1}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-dissoc-in m ["i-1"])
+        (is (= {"i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-dissoc-in m ["i-2"])
+        (is (= {} (.getAll m (.keySet m)))))
+      (finally
+        (.shutdown hz)))))

--- a/server/test/instant/util/hazelcast_test.clj
+++ b/server/test/instant/util/hazelcast_test.clj
@@ -1,12 +1,6 @@
 (ns instant.util.hazelcast-test
-  (:require
-   [clojure.test :refer [deftest is testing]]
-   [instant.reactive.ephemeral :as eph]
-   [instant.reactive.store :as rs]
-   [instant.util.hazelcast :as h])
-  (:import
-   (com.hazelcast.core HazelcastInstance)
-   (com.hazelcast.map IMap)))
+  (:require [instant.util.hazelcast :as h]
+            [clojure.test :refer [deftest is testing]]))
 
 (deftest room-key-roundtrips
   (let [start (h/->RoomKeyV1 (random-uuid) "room-id")
@@ -43,53 +37,3 @@
         serializer h/set-presence-serializer]
     (is (= start (->> (.write serializer start)
                       (.read serializer))))))
-
-(deftest patch-test
-  (let [^HazelcastInstance hz
-        (:hz
-         (eph/init-hz :test
-                      (rs/init)
-                      (let [id (+ 100000 (rand-int 900000))]
-                        {:instance-name (str "test-instance-" id)
-                         :cluster-name  (str "test-cluster-" id)})))]
-    (try
-      (let [m ^IMap (.getMap hz "a-map")]
-        (is (= {} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1"] {:heartbeat 1})
-        (is (= {"i-1" {:heartbeat 1}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1" :heartbeat] 2)
-        (is (= {"i-1" {:heartbeat 2}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-2" :heartbeat] 3)
-        (is (= {"i-1" {:heartbeat 2}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1" :status] :ok)
-        (is (= {"i-1" {:heartbeat 2, :status :ok}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1" :a :b :c] :ok)
-        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok}}}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-merge-in m ["i-1" :a :b] {:c :ok-2, :d :new})
-        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok-2, :d :new}}}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-merge-in m ["i-1"] {:x 1, :status :ok-3})
-        (is (= {"i-1" {:heartbeat 2, :status :ok-3, :a {:b {:c :ok-2, :d :new}}, :x 1}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-dissoc-in m ["i-1" :status])
-        (is (= {"i-1" {:heartbeat 2, :a {:b {:c :ok-2, :d :new}}, :x 1}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-dissoc-in m ["i-1"])
-        (is (= {"i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-dissoc-in m ["i-2"])
-        (is (= {} (.getAll m (.keySet m)))))
-      (finally
-        (.shutdown hz)))))


### PR DESCRIPTION
I noticed it on tonsky.me, and #kosmik-js reported same recently. Sometimes ephemeral sessions get “stuck”, showing people present that are long gone, with no way to clean it up.

This PR adds periodic 30s heartbeat to every ws connection (new op `"heartbeat"`) and a periodic task on a server to clean up sessions that have not sent heartbeat in 2 to 3 intervals.