### PR TITLE
Adds oauth flow to platform SDK

### DIFF
--- a/client/packages/platform/src/crypto.ts
+++ b/client/packages/platform/src/crypto.ts
@@ -1,0 +1,28 @@
+// https://tools.ietf.org/html/rfc7636#section-4.1
+export function pkceVerifier(): string {
+  const chars =
+    '0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz-._~';
+  let s = '';
+
+  for (const value of crypto.getRandomValues(new Uint8Array(64))) {
+    s = s + chars[value % chars.length];
+  }
+
+  return s;
+}
+
+export function sha256(s: string): Promise<ArrayBuffer> {
+  return crypto.subtle.digest({ name: 'SHA-256' }, new TextEncoder().encode(s));
+}
+
+function urlSafeBase64(s: string): string {
+  return s.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+export function pkceCodeChallengeOfVerifier(verifier: string): Promise<string> {
+  return sha256(verifier).then((s) => {
+    return urlSafeBase64(
+      btoa(String.fromCharCode(...Array.from(new Uint8Array(s)))),
+    );
+  });
+}

--- a/client/packages/platform/src/index.ts
+++ b/client/packages/platform/src/index.ts
@@ -2,6 +2,7 @@ import {
   type InstantDBOAuthAccessToken,
   type OAuthHandlerConfig,
   OAuthHandler,
+  InstantOAuthError,
 } from './oauth.ts';
 import { generatePermsTypescriptFile } from './perms.ts';
 import {
@@ -16,6 +17,7 @@ export {
   type InstantDBOAuthAccessToken,
   type OAuthHandlerConfig,
   OAuthHandler,
+  InstantOAuthError,
   generateSchemaTypescriptFile,
   generatePermsTypescriptFile,
   version,

--- a/client/packages/platform/src/index.ts
+++ b/client/packages/platform/src/index.ts
@@ -1,12 +1,21 @@
 import {
+  type InstantDBOAuthAccessToken,
+  type OAuthHandlerConfig,
+  OAuthHandler,
+} from './oauth.ts';
+import { generatePermsTypescriptFile } from './perms.ts';
+import {
   type InstantAPIPlatformSchema,
   generateSchemaTypescriptFile,
 } from './schema.ts';
-import { generatePermsTypescriptFile } from './perms.ts';
+
 import version from './version.js';
 
 export {
   type InstantAPIPlatformSchema,
+  type InstantDBOAuthAccessToken,
+  type OAuthHandlerConfig,
+  OAuthHandler,
   generateSchemaTypescriptFile,
   generatePermsTypescriptFile,
   version,

--- a/client/packages/platform/src/oauth.ts
+++ b/client/packages/platform/src/oauth.ts
@@ -1,4 +1,6 @@
 import { pkceVerifier, pkceCodeChallengeOfVerifier } from './crypto.ts';
+import { version as coreVersion } from '@instantdb/core';
+import version from './version.js';
 
 export type InstantDBOAuthAccessToken = {
   /**
@@ -112,7 +114,11 @@ async function exchangeCodeForToken({
 }): Promise<InstantDBOAuthAccessToken> {
   const res = await fetch(`${apiOrigin}/platform/oauth/token`, {
     method: 'POST',
-    headers: { 'Content-type': 'application/json' },
+    headers: {
+      'Content-type': 'application/json',
+      'Instant-Platform-Version': version,
+      'Instant-Core-Version': coreVersion,
+    },
     body: JSON.stringify({
       grant_type: 'authorization_code',
       code,

--- a/client/packages/platform/src/oauth.ts
+++ b/client/packages/platform/src/oauth.ts
@@ -1,0 +1,343 @@
+import { pkceVerifier, pkceCodeChallengeOfVerifier } from './crypto.ts';
+
+export type InstantDBOAuthAccessToken = {
+  /**
+   * Token that can be used to access the Instant platform API on behalf of a user
+   */
+  token: string;
+  /**
+   * The date when the token expires (2 weeks from when it was issued by default)
+   */
+  expiresAt: Date;
+};
+
+function getWindowOpts(): string {
+  const windowWidth = Math.min(800, Math.floor(window.outerWidth * 0.8));
+  const windowHeight = Math.min(630, Math.floor(window.outerHeight * 0.5));
+  const windowArea = {
+    width: windowWidth,
+    height: windowHeight,
+    left: Math.round(window.screenX + (window.outerWidth - windowWidth) / 2),
+    top: Math.round(window.screenY + (window.outerHeight - windowHeight) / 8),
+  };
+
+  const opts: Record<string, number | string> = {
+    width: windowArea.width,
+    height: windowArea.height,
+    left: windowArea.left,
+    top: windowArea.top,
+    toolbar: 0,
+    scrollbars: 1,
+    status: 1,
+    resizable: 1,
+    menuBar: 0,
+    rel: 'opener',
+  };
+
+  return Object.keys(opts)
+    .map((k) => `${k}=${opts[k]}`)
+    .join(',');
+}
+
+let AUTH_WINDOW: null | Window = null;
+
+function oAuthStartUrl({
+  clientId,
+  state,
+  codeChallenge,
+  apiOrigin,
+  redirectUri,
+}: {
+  clientId: string;
+  state: string;
+  codeChallenge: string;
+  apiOrigin: string;
+  redirectUri: string;
+}): string {
+  const oauthUrl = new URL(`${apiOrigin}/platform/oauth/start`);
+  oauthUrl.searchParams.set('client_id', clientId);
+  oauthUrl.searchParams.set('redirect_uri', redirectUri);
+  oauthUrl.searchParams.set('scope', 'apps-write');
+  oauthUrl.searchParams.set('state', state);
+  oauthUrl.searchParams.set('response_type', 'code');
+  oauthUrl.searchParams.set('code_challenge', codeChallenge);
+  oauthUrl.searchParams.set('code_challenge_method', 'S256');
+
+  return oauthUrl.toString();
+}
+
+async function exchangeCodeForToken({
+  code,
+  clientId,
+  verifier,
+  apiOrigin,
+  redirectUri,
+}: {
+  code: string;
+  clientId: string;
+  verifier: string;
+  apiOrigin: string;
+  redirectUri: string;
+}): Promise<InstantDBOAuthAccessToken> {
+  const res = await fetch(`${apiOrigin}/platform/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      code_verifier: verifier,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    let msg;
+
+    try {
+      const json = JSON.parse(text);
+      msg = json.error || 'Uknown error authenticating with InstantDB.';
+    } catch (e) {
+      console.error(e);
+      // XXX: Log?
+      msg = 'Error authenticating with InstantDB.';
+    }
+
+    throw new Error(msg);
+  }
+
+  const json = (await res.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+
+  return {
+    token: json.access_token,
+    expiresAt: new Date((json.expires_in - 30) * 1000),
+  };
+}
+
+export function handleClientRedirect() {
+  if (typeof window === 'undefined') {
+    throw new Error('This function may only be used in a browser context.');
+  }
+
+  const searchParams = new URL(window.location.href).searchParams;
+
+  const state = searchParams.get('state');
+  const error = searchParams.get('error');
+  const errorDescription = searchParams.get('error_description');
+  const code = searchParams.get('code');
+
+  if (!state) {
+    throw new Error('Invalid redirect. The state param is missing.');
+  }
+
+  const channel = new BroadcastChannel(state);
+  channel.addEventListener('message', (event) => {
+    if (event.data.type === 'oauth-redirect-window-done') {
+      window.close();
+    }
+  });
+  channel.postMessage({
+    type: 'oauth-redirect',
+    state,
+    error,
+    errorDescription,
+    code,
+  });
+
+  return () => {
+    channel.close();
+  };
+}
+
+export function startInstantOAuthClientOnlyFlow({
+  clientId,
+  apiOrigin,
+  redirectUri,
+}: {
+  clientId: string;
+  apiOrigin: string;
+  redirectUri: string;
+}): Promise<InstantDBOAuthAccessToken> {
+  if (typeof window === 'undefined') {
+    throw new Error('OAuth flow can only be started on the client.');
+  }
+
+  const existingAuthWindow = AUTH_WINDOW;
+
+  if (existingAuthWindow) {
+    existingAuthWindow.close();
+  }
+
+  const state = crypto.randomUUID();
+
+  const verifier = pkceVerifier();
+
+  const channel = new BroadcastChannel(state);
+
+  const flowCompletePromise: Promise<InstantDBOAuthAccessToken> = new Promise(
+    (resolve, reject) => {
+      channel.addEventListener('message', async (event) => {
+        if (event.data.type !== 'oauth-redirect') {
+          return;
+        }
+
+        const { state: redirectState, error, code } = event.data;
+
+        if (!redirectState || redirectState !== state) {
+          return;
+        }
+
+        if (code) {
+          try {
+            const token = await exchangeCodeForToken({
+              clientId,
+              code,
+              verifier,
+              apiOrigin,
+              redirectUri,
+            });
+            resolve(token);
+          } catch (e) {
+            reject(
+              new Error(e instanceof Error ? e.message : 'Unknown error.'),
+            );
+          }
+        } else {
+          reject(new Error(error || 'Unknown error.'));
+        }
+
+        channel.postMessage({ type: 'oauth-redirect-window-done' });
+      });
+    },
+  );
+
+  const w = window.open(
+    // Open window synchronously to prevent popup blocker
+    '',
+    // A unqiue name prevents orphaned popups from stealing our window.open
+    `instantdb_oauth_${Math.random()}`.replace('.', ''),
+    getWindowOpts(),
+  );
+
+  if (!w) {
+    return Promise.reject({ error: 'Could not open Auth window' });
+  }
+
+  AUTH_WINDOW = w;
+
+  pkceCodeChallengeOfVerifier(verifier).then((codeChallenge) => {
+    const oauthUrl = oAuthStartUrl({
+      clientId,
+      state,
+      codeChallenge,
+      apiOrigin,
+      redirectUri,
+    });
+    w.location.href = oauthUrl;
+  });
+
+  return flowCompletePromise.finally(() => channel.close());
+}
+
+/**
+ * Configuration for {@link OAuthHandler}.
+ */
+export interface OAuthHandlerConfig {
+  /**
+   * Must exactly match one of the **Authorized Redirect URIs** in your OAuth
+   * client settings on the Instant dashboard.
+   */
+  redirectUri: string;
+
+  /** OAuth client ID from the Instant dashboard. */
+  clientId: string;
+
+  /**
+   * Optional Instant API base-URL.
+   * Defaults to `https://api.instantdb.com`.
+   */
+  apiOrigin?: string | null;
+}
+
+/**
+ * Thin wrapper that drives InstantDB’s browser-only OAuth flow.
+ */
+export class OAuthHandler {
+  /** Redirect URI that the provider will call back into. */
+  readonly redirectUri: string;
+
+  /** OAuth client ID. */
+  readonly clientId: string;
+
+  /**
+   * Base URL for InstantDB’s REST API.
+   * Defaults to `https://api.instantdb.com`.
+   */
+  readonly apiOrigin: string;
+
+  constructor(config: OAuthHandlerConfig) {
+    this.redirectUri = config.redirectUri;
+    this.apiOrigin = config.apiOrigin ?? 'https://api.instantdb.com';
+    this.clientId = config.clientId;
+  }
+
+  /**
+   * **Client-only flow** using PKCE (no client-secret required).
+   * Opens a popup to start the OAuth flow.
+   * Returns an {@link InstantDBOAuthAccessToken}.
+   * *Refresh tokens are **not** available in this flow.*
+   *
+   * @example
+   * const oauthHandler = new OAuthHandler({
+   *   clientId: YOUR_CLIENT_ID,
+   *   redirectUri: YOUR_REDIRECT_URI,
+   * });
+   *
+   * function ConnectToInstant() {
+   *   const handleConnect = async () => {
+   *     try {
+   *       const token = await oauthHandler.startClientOnlyFlow();
+   *       console.log('success!', token)
+   *     } catch (e) {
+   *       console.log('OAuth flow failed', e);
+   *     }
+   *   }
+   *   return <button onClick={handleConnect}>Connect to Instant</button>
+   * }
+   */
+  startClientOnlyFlow(): Promise<InstantDBOAuthAccessToken> {
+    return startInstantOAuthClientOnlyFlow({
+      clientId: this.clientId,
+      apiOrigin: this.apiOrigin,
+      redirectUri: this.redirectUri,
+    });
+  }
+
+  /**
+   * Call from the page served at {@link OAuthHandlerConfig.redirectUri}.
+   * Parses `state` & `code` from the URL, exchanges them for an access token,
+   * then automatically closes the popup/window.
+   *
+   * @example
+   * ```tsx
+   * const oauthHandler = new OAuthHandler({
+   *   clientId: YOUR_CLIENT_ID,
+   *   redirectUri: YOUR_REDIRECT_URI,
+   * })
+   *
+   * function RedirectPage() {
+   *   useEffect(() => {
+   *     return oauthHandler.handleClientRedirect();
+   *   }, []);
+   *   return <div>Loading…</div>;
+   * }
+   * ```
+   */
+  handleClientRedirect(): () => void {
+    return handleClientRedirect();
+  }
+}

--- a/client/packages/platform/src/oauth.ts
+++ b/client/packages/platform/src/oauth.ts
@@ -30,7 +30,7 @@ export class InstantOAuthError extends Error {
     // Maintain proper stack trace for where our error was thrown
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InstantOAuthError);
-    }    
+    }
 
     this.name = 'InstantOAuthError';
     this.error = config.error;

--- a/client/packages/platform/src/oauth.ts
+++ b/client/packages/platform/src/oauth.ts
@@ -15,16 +15,12 @@ export class InstantOAuthError extends Error {
   error: string;
   errorDescription: string | null | undefined;
 
-  constructor({
-    message,
-    error,
-    errorDescription,
-  }: {
+  constructor(config: {
     message: string;
     error: string;
     errorDescription?: string | null | undefined;
   }) {
-    super(message);
+    super(config.message);
 
     const actualProto = new.target.prototype;
     if (Object.setPrototypeOf) {
@@ -34,11 +30,11 @@ export class InstantOAuthError extends Error {
     // Maintain proper stack trace for where our error was thrown
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InstantOAuthError);
-    }
+    }    
 
     this.name = 'InstantOAuthError';
-    this.error = error;
-    this.errorDescription = errorDescription;
+    this.error = config.error;
+    this.errorDescription = config.errorDescription;
   }
 
   get [Symbol.toStringTag]() {


### PR DESCRIPTION
Adds a new `OAuthHandler` to `@instantdb/platform` with helpers for performing the client-only PKCE oauth flow.

How to use:

On the page where you start the OAuth flow:

```tsx
import { useState } from 'react';
import { OAuthHandler } from '@instantdb/platform';

const handler = new OAuthHandler({
  clientId: 'instant-oauth-client-id',
  redirectUri: 'https://example.com/oauth/instant/redirect',
});

function ConnectPage() {
  const [token, setToken] = useState(null);

  const handleConnect = async () => {
    try {
      const token = await handler.startClientOnlyFlow();
      setToken(token);
    } catch (e /*InstantOAuthError*/) {
      console.log(e);
    }
  };

  return token ? (
    <div>Connected!</div>
  ) : (
    <button onClick={handleConnect}>Connect to your Instant Account</button>
  );
}
```

On the redirect page (`/oauth/instant/redirect` in our case):

```tsx
import { useEffect } from 'react';
import { OAuthHandler } from '@instantdb/platform';

const handler = new OAuthHandler({
  clientId: 'instant-oauth-client-id',
  redirectUri: 'https://example.com/oauth/instant/redirect',
});

function RedirectPage() {
  useEffect(() => {
    return handler.handleClientRedirect();
  }, []);
  return <div>Loading...</div>;
}
```
