### PR TITLE
Add `data-read` and `data-write` scopes to oauth-apps

### DIFF
--- a/client/www/pages/platform/oauth/start.tsx
+++ b/client/www/pages/platform/oauth/start.tsx
@@ -74,6 +74,27 @@ const scopeDescriptions = [
     description: 'Create new apps in your Instant account.',
     applies: (scopes: string[]) => scopes.includes('apps-write'),
   },
+  {
+    description: 'Query all of the data in any of your Instant databases.',
+    applies: (scopes: string[]) =>
+      scopes.includes('data-read') || scopes.includes('data-write'),
+  },
+  {
+    description:
+      'Create, update, and delete data in any of your Instant databases.',
+    applies: (scopes: string[]) => scopes.includes('data-write'),
+  },
+  {
+    description:
+      'Download storage ($files) data from any of your Instant databases.',
+    applies: (scopes: string[]) =>
+      scopes.includes('storage-read') || scopes.includes('storage-write'),
+  },
+  {
+    description:
+      'Upload, update, and delete storage ($files) data from any of your Instant databases.',
+    applies: (scopes: string[]) => scopes.includes('storage-write'),
+  },
 ];
 
 type ClaimResult = {

--- a/server/src/instant/model/oauth_app.clj
+++ b/server/src/instant/model/oauth_app.clj
@@ -17,9 +17,17 @@
 
 (def apps-read-scope "apps-read")
 (def apps-write-scope "apps-write")
+(def data-read-scope "data-read")
+(def data-write-scope "data-write")
+(def storage-read-scope "storage-read")
+(def storage-write-scope "storage-write")
 
 (def all-scopes (set [apps-read-scope
-                      apps-write-scope]))
+                      apps-write-scope
+                      data-read-scope
+                      data-write-scope
+                      storage-read-scope
+                      storage-write-scope]))
 
 (def default-expires-at [:+ :%now [:interval "10 minutes"]])
 
@@ -27,7 +35,15 @@
   (condp = scope
     apps-read-scope (or (ucoll/exists? #(= % apps-read-scope) scopes)
                         (ucoll/exists? #(= % apps-write-scope) scopes))
-    apps-write-scope (ucoll/exists? #(= % apps-write-scope) scopes)))
+    apps-write-scope (ucoll/exists? #(= % apps-write-scope) scopes)
+
+    data-read-scope (or (ucoll/exists? #(= % data-read-scope) scopes)
+                        (ucoll/exists? #(= % data-write-scope) scopes))
+    data-write-scope (ucoll/exists? #(= % data-write-scope) scopes)
+
+    storage-read-scope (or (ucoll/exists? #(= % storage-read-scope) scopes)
+                           (ucoll/exists? #(= % storage-write-scope) scopes))
+    storage-write-scope (ucoll/exists? #(= % storage-write-scope) scopes)))
 
 (defn hash-client-secret ^bytes [^String client-secret]
   (crypt-util/str->sha256 client-secret))

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -31,8 +31,12 @@
             (oauth-app-model/access-token-by-token-value!
              {:access-token (token-util/platform-access-token-value token)})
             scope-str (case scope
-                        :apps/read "apps-read"
-                        :apps/write "apps-write"
+                        :apps/read oauth-app-model/apps-read-scope
+                        :apps/write oauth-app-model/apps-write-scope
+                        :data/read oauth-app-model/data-read-scope
+                        :data/write oauth-app-model/data-write-scope
+                        :storage/read oauth-app-model/storage-read-scope
+                        :storage/write oauth-app-model/storage-write-scope
                         ;; We don't let the OAuth app transfer apps,
                         ;; using an unused scope to prevent it.
                         :apps/transfer "apps-transfer")]


### PR DESCRIPTION
Also adds `storage-read` and `storage-write`.

The new scopes allow oauth apps to use the admin sdk (`@instantdb/admin`) to query (data-read/data-write), transact (data-write), download files (storage-read), and modify files (storage-write).

You can use it with the admin sdk like a regular admin token:

```ts
import { init } from '@instantdb/admin';
const db = init({appId: 'some-app-id', adminToken: 'oauth-access-token'})

await db.query({posts: {}})
```

Here's what the scopes look like in the /oauth/start page:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/4561991a-e247-40e4-b45e-b0c50650518e" />
