### PR TITLE
New rules type that accepts a schema

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -85,6 +85,7 @@ import type {
   LinkParams,
   RuleParams,
 } from './schemaTypes.ts';
+import type { InstantRules } from './rulesTypes.ts';
 import type { UploadFileResponse, DeleteFileResponse } from './StorageAPI.ts';
 
 import type {
@@ -769,19 +770,6 @@ function handleDevtool(appId: string, devtool: boolean | DevtoolConfig) {
 
   createDevtool(appId, config);
 }
-
-type InstantRules = {
-  [EntityName: string]: {
-    allow: {
-      view?: string;
-      create?: string;
-      update?: string;
-      delete?: string;
-      $default?: string;
-    };
-    bind?: string[];
-  };
-};
 
 /**
  * @deprecated

--- a/client/packages/core/src/rulesTypes.ts
+++ b/client/packages/core/src/rulesTypes.ts
@@ -1,0 +1,21 @@
+import { InstantSchemaDef, InstantUnknownSchema } from './schemaTypes.ts';
+
+export type InstantRulesAllowBlock = {
+  $default?: string | null | undefined;
+  view?: string | null | undefined;
+  create?: string | null | undefined;
+  update?: string | null | undefined;
+  delete?: string | null | undefined;
+};
+
+export type InstantRules<
+  Schema extends InstantSchemaDef<any, any, any> = InstantUnknownSchema,
+> = {
+  $default?: { bind?: string[]; allow: InstantRulesAllowBlock };
+  attrs: { bind?: string[]; allow: InstantRulesAllowBlock };
+} & {
+  [EntityName in keyof Schema['entities']]: {
+    bind?: string[];
+    allow: InstantRulesAllowBlock;
+  };
+};

--- a/client/packages/core/src/rulesTypes.ts
+++ b/client/packages/core/src/rulesTypes.ts
@@ -12,7 +12,7 @@ export type InstantRules<
   Schema extends InstantSchemaDef<any, any, any> = InstantUnknownSchema,
 > = {
   $default?: { bind?: string[]; allow: InstantRulesAllowBlock };
-  attrs: { bind?: string[]; allow: InstantRulesAllowBlock };
+  attrs?: { bind?: string[]; allow: InstantRulesAllowBlock };
 } & {
   [EntityName in keyof Schema['entities']]: {
     bind?: string[];

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -11,7 +11,7 @@ import {
   Fragment,
   PropsWithChildren,
 } from 'react';
-import { Editor, OnMount } from '@monaco-editor/react';
+import { Editor, Monaco, OnMount } from '@monaco-editor/react';
 import {
   Dialog as HeadlessDialog,
   Popover,
@@ -907,9 +907,28 @@ export function JSONEditor(props: {
 }) {
   const [draft, setDraft] = useState(props.value);
 
+  const [monacoInstance, setMonacomonacoInstance] = useState<Monaco | null>(
+    null,
+  );
+
   useEffect(() => {
     setDraft(props.value);
   }, [props.value]);
+
+  useEffect(() => {
+    if (monacoInstance && props.schema) {
+      monacoInstance.languages.json.jsonDefaults.setDiagnosticsOptions({
+        validate: true,
+        schemas: [
+          {
+            uri: 'http://myserver/myJsonTypeSchema', // A URI for your schema (can be a dummy URI)
+            fileMatch: ['*'], // Associate with your model
+            schema: props.schema,
+          },
+        ],
+      });
+    }
+  }, [monacoInstance, props.schema]);
 
   return (
     <div className="flex flex-col gap-2 h-full min-h-0">
@@ -923,22 +942,11 @@ export function JSONEditor(props: {
           value={props.value}
           onChange={(draft) => setDraft(draft)}
           onMount={function handleEditorDidMount(editor, monaco) {
+            setMonacomonacoInstance(monaco);
             // cmd+S binding to save
             editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () =>
               props.onSave(editor.getValue()),
             );
-
-            if (!props.schema) return;
-            monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-              validate: true,
-              schemas: [
-                {
-                  uri: 'http://myserver/myJsonTypeSchema', // A URI for your schema (can be a dummy URI)
-                  fileMatch: ['*'], // Associate with your model
-                  schema: props.schema,
-                },
-              ],
-            });
           }}
         />
       </div>

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -511,7 +511,11 @@ function Dashboard() {
                 ) : tab === 'sandbox' ? (
                   <Sandbox key={appId} app={app} db={connection.db} />
                 ) : tab === 'perms' ? (
-                  <Perms app={app} dashResponse={dashResponse} />
+                  <Perms
+                    app={app}
+                    dashResponse={dashResponse}
+                    db={connection.db}
+                  />
                 ) : tab === 'auth' ? (
                   <AppAuth
                     app={app}


### PR DESCRIPTION
Updates the `InstantRules` type to accept a schema for better intellisense.

Also updates the json schema for the rules editor to autocomplete with your type names.

Intellisense:
<img width="507" alt="image" src="https://github.com/user-attachments/assets/ef942c02-b1db-466d-ba02-92251bb29ff0" />

Permissions editor:
<img width="577" alt="image" src="https://github.com/user-attachments/assets/3163fc29-7008-4360-9973-1aefc784cdeb" />
