### PR TITLE
Faster check to validated required attrs in the indexing job

### DIFF
--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -801,20 +801,24 @@
                                   {::ex/type ::missing-required
                                    ::ex/hint {:attr-id attr-id
                                               :etype attr-etype}})])
-        (let [query {:select 't-id/entity-id
-                     :from [['triples 't-id]]
+        (let [query {:select :t-id/entity-id
+                     :from [[:triples :t-id]]
                      :where [:and
-                             [:= 't-id/app-id app-id]
-                             [:= 't-id/attr-id (:id id-attr)]
+                             [:= :t-id/app-id app-id]
+                             [:= :t-id/attr-id (:id id-attr)]
+                             ;; hsql will filter the nil out
+                             (when (and (:unique? id-attr)
+                                        (not (:setting-unique? id-attr)))
+                               :t-id/av)
                              [:not
                               [:exists
                                {:select :1
-                                :from [['triples 't-a]]
+                                :from [[:triples :t-a]]
                                 :where [:and
-                                        [:= 't-a/entity-id 't-id/entity-id]
-                                        [:= 't-a/app-id app-id]
-                                        [:= 't-a/attr-id attr-id]
-                                        [:not= 't-a/value [:cast "null" :jsonb]]]}]]]}
+                                        [:= :t-a/entity-id :t-id/entity-id]
+                                        [:= :t-a/app-id app-id]
+                                        [:= :t-a/attr-id attr-id]
+                                        [:not= :t-a/value [:cast "null" :jsonb]]]}]]]}
               res (sql/select conn (hsql/format query))]
           (when (seq res)
             (update-attr! conn {:app-id  app-id

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -797,7 +797,7 @@
         (do (update-attr! conn {:app-id  app-id
                                 :attr-id attr-id
                                 :set     {:is-required false}})
-            [::exception (ex-info (str "Could not find id attribute for entity.")
+            [::exception (ex-info "Could not find id attribute for entity."
                                   {::ex/type ::missing-required
                                    ::ex/hint {:attr-id attr-id
                                               :etype attr-etype}})])

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -649,7 +649,6 @@
                           :job-type "required"})
 
               _ (jobs/enqueue-job job-queue title-job)
-              _ (tool/def-locals)
               _ (wait-for (fn []
                             (every? (fn [{:keys [id]}]
                                       (= "errored" (:job_status (jobs/get-by-id id))))
@@ -703,7 +702,6 @@
                           :job-type "required"})
 
               _ (jobs/enqueue-job job-queue title-job)
-              _ (tool/def-locals)
               _ (wait-for (fn []
                             (every? (fn [{:keys [id]}]
                                       (= "errored" (:job_status (jobs/get-by-id id))))

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -595,12 +595,12 @@
                             (every? (fn [{:keys [id]}]
                                       (= "completed" (:job_status (jobs/get-by-id id))))
                                     [title-job]))
-                          wait-timeout)]
+                          wait-timeout)
+              attrs (attr-model/get-by-app-id (:id app))]
 
-          (let [attrs (attr-model/get-by-app-id (:id app))]
-            (is (-> (resolvers/->uuid r :books/title)
-                    (attr-model/seek-by-id attrs)
-                    :required?))))
+          (is (-> (resolvers/->uuid r :books/title)
+                  (attr-model/seek-by-id attrs)
+                  :required?)))
         (testing "remove-required-works"
           (let [title-job (jobs/create-job!
                            {:app-id (:id app)
@@ -612,12 +612,12 @@
                               (every? (fn [{:keys [id]}]
                                         (= "completed" (:job_status (jobs/get-by-id id))))
                                       [title-job]))
-                            wait-timeout)]
+                            wait-timeout)
+                attrs (attr-model/get-by-app-id (:id app))]
 
-            (let [attrs (attr-model/get-by-app-id (:id app))]
-              (is (not (-> (resolvers/->uuid r :books/title)
-                           (attr-model/seek-by-id attrs)
-                           :required?))))))))))
+            (is (not (-> (resolvers/->uuid r :books/title)
+                         (attr-model/seek-by-id attrs)
+                         :required?)))))))))
 
 
 (deftest required-works-with-errors


### PR DESCRIPTION
Patches an issue where setting required causes the query to time out while we verify that there are no entities that are missing the attribute.

If I'm reading it right, the old query checked for all entities that had any attribute with a matching etype to the required attr. The new query just looks for entities with the id attr. That should be equivalent.

The new query also looks up the id-attr from the `attrs` on the clojure side instead of doing it in the database.

I think we will eventually need an approach where we perform the check in batches, but this should hold us off for a little longer.

It also might help to require that the attribute is indexed to set it as required?

Also adds tests for "required" and "remove-required" jobs.