### PR TITLE
[Reactor] Remove eager transaction resolution

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1079,13 +1079,6 @@ export default class Reactor {
     } else {
       this._trySend(eventId, mutation);
 
-      // If a transaction is pending for over 3 seconds,
-      // we want to unblock the UX, so mark it as pending
-      // and keep trying to process the transaction in the background
-      setTimeout(() => {
-        this._finishTransaction('pending', eventId);
-      }, 3_000);
-
       setTimeout(() => {
         if (!this._isOnline) {
           return;


### PR DESCRIPTION
### Bug: `await db.transact` returns before transaction is committed
One of our users noted a bug in the dashboard that worked liked so

* Select 50 items in the dashboard
* Delete them
* See a success toast
* See the rows come back

There was no UI indicating why this happens. Upon inspecting the console, we could see that the transaction timed out.

### Investigation

Looking at our explorer code I notice that we `await db.transact` and if we don't get an error then we show a success toast. When I logged the results of the await, I noticed we were getting back a promise resolved in status pending.

Looking at the Instant core code in Reactor.js, when you call `transact()`, it goes through this flow:

1. `pushTx` → `pushOps` → `_sendMutation`
2. In `_sendMutation`, after 3 seconds, we call `_finishTransaction('pending', eventId)`
3. This resolves the promise with status 'pending' even though the transaction is still being processed

Looks like this is some old code we added back in Feb 2024, it's not clear from the PR why we added this in, since if you don't `await` the UX won't be blocked.

### Resolution

Removing this makes things work as expected, if you don't await the `transact` the UX immediately returns, otherwise it will wait until the transaction success / fails / times-out