### PR TITLE
Schema push improvements for platform sdk

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1089,7 +1089,9 @@
     (response/ok {:job job})))
 
 (defn indexing-jobs-group-get [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-and-user-accepting-platform-tokens! :collaborator
+                                                                          :apps/write
+                                                                          req)
         group-id (ex/get-param! req [:params :group_id] uuid-util/coerce)
         jobs (indexing-jobs/get-by-group-id-for-client app-id group-id)]
     (response/ok {:jobs jobs})))


### PR DESCRIPTION
A few small changes to make the platform SDK a bit nicer:

1. Allows the platform token to fetch a group of indexing jobs. I set the scope to `:apps/write`, since you'd only need this if you were modifying the schema.
2. The required job puts a list of failed entity ids into an error_data field on the job. I include those in the common `invalid-triples-sample` field when you fetch the job for the client.
3. I include the job-id in the steps we return from schema/push/apply so that it's easier to tie the job to the step. This lets me return a list of `steps` from platform sdk that includes information about the background job.