### PR TITLE
Put session count on left in overview, show sessions per machine

### DIFF
--- a/client/www/pages/intern/overview.tsx
+++ b/client/www/pages/intern/overview.tsx
@@ -120,6 +120,14 @@ function flattenedSessionReports(machineToReport: any) {
   return items;
 }
 
+function makeMachineSummary(machineToReport: any): Record<string, number> {
+  const res: any = {};
+  for (const [memberId, reports] of Object.entries(machineToReport)) {
+    res[memberId] = Object.keys(reports as any).length;
+  }
+  return res;
+}
+
 const OriginColumn = ({ origins }: { origins: any }) => {
   if (!origins || Object.keys(origins).length === 0) return '-';
 
@@ -180,6 +188,7 @@ export function Main() {
   const sessions = flattenedSessionReports(
     minute.data['session-reports'],
   ).toSorted((a: any, b: any) => b.count - a.count);
+  const machineSummary = makeMachineSummary(minute.data['session-reports']);
   const totalSessions = sessions.reduce(
     (acc: number, x: any) => acc + x.count,
     0,
@@ -238,11 +247,22 @@ export function Main() {
         <div className="flex-1 p-4 space-y-2 flex flex-col min-h-0 w-1/2">
           <h3 className="text-lg">{format(minute.sentAt, 'hh:mma')}</h3>
           <div className="flex justify-between items-baseline">
-            <div className="inline-flex items-baseline space-x-4 justify-between">
+            <div className="inline-flex items-baseline space-x-4">
               <h1 className="leading-none" style={{ fontSize: 120 }}>
                 {totalSessions}
               </h1>
-              <div className="font-bold leading-none">Active Connections</div>
+
+              <div className="flex flex-col justify-between self-stretch m-4">
+                <div>
+                  {Object.entries(machineSummary).map(([machine, count]) => (
+                    <div key={machine}>
+                      {machine}: {Intl.NumberFormat().format(count)}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="font-bold leading-none">Active Connections</div>
+              </div>
             </div>
             <div className="inline-flex items-baseline space-x-4">
               <h3 className="font-bold" style={{ fontSize: 30 }}>
@@ -256,6 +276,9 @@ export function Main() {
               <tbody>
                 {sessions.map((session: any, i) => (
                   <tr key={session['app-title'] + i}>
+                    <td className="px-4 py-2 text-right">
+                      {Intl.NumberFormat().format(session.count)}
+                    </td>
                     <td className="px-4 py-2">{session['app-title']}</td>
                     <td className="px-4 py-2">
                       {session['creator-email'] || '-'}
@@ -263,7 +286,6 @@ export function Main() {
                     <td className="px-4 py-2">
                       <OriginColumn origins={session['origins']} />
                     </td>
-                    <td className="px-4 py-2 text-right">{session.count}</td>
                   </tr>
                 ))}
               </tbody>

--- a/server/src/instant/machine_summaries.clj
+++ b/server/src/instant/machine_summaries.clj
@@ -4,6 +4,7 @@
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.store :as rs])
   (:import
+   (com.hazelcast.cluster Member)
    (com.hazelcast.core HazelcastInstance IExecutorService)))
 
 (defn app-sessions->report [app-sessions]
@@ -32,7 +33,9 @@
   (let [executor (HazelcastInstance/.getExecutorService hz "session-report-executor")
         futures  (IExecutorService/.submitToAllMembers executor (hz/->Task #'session-report-task))]
     (into {} (for [[member fut] futures]
-               [(str member) @fut]))))
+               [(str (or (Member/.getAttribute member "instance-id")
+                         (Member/.getAddress member)))
+                @fut]))))
 
 (comment
   (get-all-session-reports (eph/get-hz)))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -39,8 +39,8 @@
 (declare handle-broadcast-message)
 
 (defn init-hz [env store {:keys [instance-name cluster-name]
-                               :or {instance-name "instant-hz-v3"
-                                    cluster-name "instant-server-v2"}}]
+                          :or {instance-name "instant-hz-v3"
+                               cluster-name "instant-server-v2"}}]
   (-> (java.util.logging.Logger/getLogger "com.hazelcast")
       (.setLevel (if (config/aws-env?)
                    java.util.logging.Level/INFO
@@ -55,7 +55,11 @@
         tcp-ip-config        (.getTcpIpConfig join-config)
         aws-config           (.getAwsConfig join-config)
         serialization-config (.getSerializationConfig config)
-        metrics-config       (.getMetricsConfig config)]
+        metrics-config       (.getMetricsConfig config)
+        member-attribute-config (doto (com.hazelcast.config.MemberAttributeConfig.)
+                                  (.setAttribute "instance-id" (or @config/instance-id
+                                                                   "dev")))]
+    (.setMemberAttributeConfig config member-attribute-config)
     (.setInstanceName config instance-name)
     (.setEnabled (.getMulticastConfig join-config) false)
     (case env


### PR DESCRIPTION
Couple of small changes to the overview:

1. Puts the number of sessions for an app on the left so that we don't have to scroll
2. Shows the count of sessions per instance next to the total

It will look something like this:

<img width="436" alt="image" src="https://github.com/user-attachments/assets/b38a2952-ec62-48e3-9ce1-339f6f41f92b" />
