### PR TITLE
Clean up stale ephemeral sessions (2 of 3) 

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -28,7 +28,7 @@
         software.amazon.awssdk.crt/aws-crt {:mvn/version "0.33.11"}
 
         juji/editscript {:mvn/version "0.6.4"}
-        io.github.tonsky/clojure-plus {:mvn/version "1.4.0"}
+        io.github.tonsky/clojure-plus {:mvn/version "1.5.0"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 
@@ -87,7 +87,7 @@
                  :extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}
                               criterium/criterium           {:mvn/version "0.4.6"}
                               spec-provider/spec-provider   {:mvn/version "0.4.14"}
-                              io.github.tonsky/clj-reload   {:mvn/version "0.9.4"}
+                              io.github.tonsky/clj-reload   {:mvn/version "0.9.7"}
                               ;; https://github.com/kkinnear/zprint/pull/351
                               io.github.tonsky/zprint       {:mvn/version "1.2.10"}}
                  :jvm-opts ["-XX:+UseZGC"

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -37,7 +37,7 @@
 (def global-type-id 5)
 (def room-broadcast-type-id 6)
 (def task-type-id 7)
-(def join-room-type-id 8)
+(def join-room-type-id 8) ;; TODO remove after deploy
 (def join-room-v3-type-id 9)
 
 ;; --------
@@ -118,6 +118,7 @@
 ;; Join room
 
 ;; Helper to add a session to the room in the hazelcast map
+;; TODO remove after deploy
 (defrecord JoinRoomMergeV2 [^UUID session-id ^UUID user-id data]
   BiFunction
   (apply [_ room-data _]
@@ -132,15 +133,7 @@
                        {:data data}
                        {:data (or (:data existing) {})}))))))
 
-(defn join-room! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id ^UUID user-id data]
-  (.merge hz-map
-          room-key
-          {session-id {:peer-id session-id
-                       :user    (when user-id
-                                  {:id user-id})
-                       :data    (or data {})}}
-          (->JoinRoomMergeV2 session-id user-id data)))
-
+;; TODO remove after deploy
 (def ^ByteArraySerializer join-room-serializer
   (reify ByteArraySerializer
     (getTypeId [_]
@@ -153,6 +146,7 @@
         (->JoinRoomMergeV2 session-id user-id data)))
     (destroy [_])))
 
+;; TODO remove after deploy
 (def join-room-config
   (make-serializer-config JoinRoomMergeV2
                           join-room-serializer))
@@ -187,6 +181,16 @@
 (def join-room-v3-config
   (make-serializer-config JoinRoomMergeV3
                           join-room-v3-serializer))
+
+(defn join-room! [^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id ^String instance-id ^UUID user-id data]
+  (.merge hz-map
+          room-key
+          {session-id {:peer-id     session-id
+                       :instance-id instance-id
+                       :user        (when user-id
+                                      {:id user-id})
+                       :data        (or data {})}}
+          (->JoinRoomMergeV3 session-id instance-id user-id data)))
 
 ;; ------------
 ;; Set presence
@@ -290,7 +294,7 @@
 (def serializer-configs
   [remove-session-config
    room-broadcast-config
-   join-room-config
+   join-room-config ;; TODO remove after deploy
    join-room-v3-config
    set-presence-config
    room-key-config

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -41,6 +41,8 @@
 (def join-room-type-id 8)
 (def patch-type-id 9)
 
+(declare patch-assoc patch-assoc-in patch-merge-in patch-dissoc patch-dissoc-in)
+
 ;; --------
 ;; Room key
 
@@ -244,6 +246,8 @@
 ;; -----------------
 ;; Path serializer
 
+;; DO NOT change implementation here. Make a new version and do three-step
+;; deploy (see comment at the top of the file)
 (defrecord Patch [edits]
   BiFunction
   (apply [_ data _]

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -776,9 +776,10 @@
         (is (eph/in-room? movies-app-id rid sess-id))
 
         ;; session data is empty
-        (is (= {sess-id {:peer-id sess-id
-                         :user nil
-                         :data {}}}
+        (is (= {sess-id {:peer-id     sess-id
+                         :instance-id "dev"
+                         :user        nil
+                         :data        {}}}
                (eph/get-room-data movies-app-id rid)))
 
         ;; set session data
@@ -789,9 +790,10 @@
                   :room-id rid
                   :edits   [[[sess-id :data] :r {:a "a" :b "b" :c "c" :d "d" :e "e"}]]}}
                (read-msgs 2 socket)))
-        (is (= {sess-id {:peer-id sess-id
-                         :user    nil
-                         :data    d1}}
+        (is (= {sess-id {:peer-id     sess-id
+                         :instance-id "dev"
+                         :user        nil
+                         :data        d1}}
                (eph/get-room-data movies-app-id rid)))
 
         ;; udpate session data
@@ -803,9 +805,10 @@
                             [[sess-id :data :e] :r "E"]
                             [[sess-id :data :f] :+ "F"]]}}
                (read-msgs 2 socket)))
-        (is (= {sess-id {:peer-id sess-id
-                         :user    nil
-                         :data    d2}}
+        (is (= {sess-id {:peer-id     sess-id
+                         :instance-id "dev"
+                         :user        nil
+                         :data        d2}}
                (eph/get-room-data movies-app-id rid)))))))
 
 (deftest set-presence-two-sessions
@@ -825,7 +828,7 @@
 
         (send-msg socket-1 {:op :join-room, :room-id rid})
         (is (= #{{:op :join-room-ok, :room-id rid}
-                 {:op :refresh-presence, :room-id rid, :data {sess-id-1 {:data {}, :peer-id sess-id-1, :user nil}}}}
+                 {:op :refresh-presence, :room-id rid, :data {sess-id-1 {:data {}, :instance-id "dev", :peer-id sess-id-1, :user nil}}}}
                (read-msgs 2 socket-1)))
 
         (send-msg socket-1 {:op :set-presence, :room-id rid, :data d1})
@@ -841,18 +844,21 @@
         (is (= #{{:op :join-room-ok, :room-id rid}
                  {:op      :refresh-presence
                   :room-id rid
-                  :data    {sess-id-1 {:data    d1
-                                       :peer-id sess-id-1
-                                       :user    nil}
-                            sess-id-2 {:data    {}
-                                       :peer-id sess-id-2
-                                       :user    nil}}}}
+                  :data    {sess-id-1 {:data        d1
+                                       :peer-id     sess-id-1
+                                       :instance-id "dev"
+                                       :user        nil}
+                            sess-id-2 {:data        {}
+                                       :peer-id     sess-id-2
+                                       :instance-id "dev"
+                                       :user        nil}}}}
                (read-msgs 2 socket-2)))
         (is (= {:op      :patch-presence
                 :room-id rid
-                :edits   [[[sess-id-2] :+ {:data {}
-                                           :peer-id sess-id-2
-                                           :user nil}]]}
+                :edits   [[[sess-id-2] :+ {:data        {}
+                                           :peer-id     sess-id-2
+                                           :instance-id "dev"
+                                           :user        nil}]]}
                (read-msg socket-1)))
 
         ;; socket-1 updating

--- a/server/test/instant/util/hazelcast_test.clj
+++ b/server/test/instant/util/hazelcast_test.clj
@@ -1,6 +1,12 @@
 (ns instant.util.hazelcast-test
-  (:require [instant.util.hazelcast :as h]
-            [clojure.test :refer [deftest is testing]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.reactive.ephemeral :as eph]
+   [instant.reactive.store :as rs]
+   [instant.util.hazelcast :as h])
+  (:import
+   (com.hazelcast.core HazelcastInstance)
+   (com.hazelcast.map IMap)))
 
 (deftest room-key-roundtrips
   (let [start (h/->RoomKeyV1 (random-uuid) "room-id")
@@ -37,3 +43,53 @@
         serializer h/set-presence-serializer]
     (is (= start (->> (.write serializer start)
                       (.read serializer))))))
+
+(deftest patch-test
+  (let [^HazelcastInstance hz
+        (:hz
+         (eph/init-hz :test
+                      (rs/init)
+                      (let [id (+ 100000 (rand-int 900000))]
+                        {:instance-name (str "test-instance-" id)
+                         :cluster-name  (str "test-cluster-" id)})))]
+    (try
+      (let [m ^IMap (.getMap hz "a-map")]
+        (is (= {} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1"] {:heartbeat 1})
+        (is (= {"i-1" {:heartbeat 1}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1" :heartbeat] 2)
+        (is (= {"i-1" {:heartbeat 2}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-2" :heartbeat] 3)
+        (is (= {"i-1" {:heartbeat 2}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1" :status] :ok)
+        (is (= {"i-1" {:heartbeat 2, :status :ok}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-assoc-in m ["i-1" :a :b :c] :ok)
+        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok}}}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-merge-in m ["i-1" :a :b] {:c :ok-2, :d :new})
+        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok-2, :d :new}}}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-merge-in m ["i-1"] {:x 1, :status :ok-3})
+        (is (= {"i-1" {:heartbeat 2, :status :ok-3, :a {:b {:c :ok-2, :d :new}}, :x 1}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-dissoc-in m ["i-1" :status])
+        (is (= {"i-1" {:heartbeat 2, :a {:b {:c :ok-2, :d :new}}, :x 1}
+                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-dissoc-in m ["i-1"])
+        (is (= {"i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
+
+        (h/patch-dissoc-in m ["i-2"])
+        (is (= {} (.getAll m (.keySet m)))))
+      (finally
+        (.shutdown hz)))))

--- a/server/test/instant/util/hazelcast_test.clj
+++ b/server/test/instant/util/hazelcast_test.clj
@@ -1,12 +1,6 @@
 (ns instant.util.hazelcast-test
-  (:require
-   [clojure.test :refer [deftest is testing]]
-   [instant.reactive.ephemeral :as eph]
-   [instant.reactive.store :as rs]
-   [instant.util.hazelcast :as h])
-  (:import
-   (com.hazelcast.core HazelcastInstance)
-   (com.hazelcast.map IMap)))
+  (:require [instant.util.hazelcast :as h]
+            [clojure.test :refer [deftest is testing]]))
 
 (deftest room-key-roundtrips
   (let [start (h/->RoomKeyV1 (random-uuid) "room-id")
@@ -43,53 +37,3 @@
         serializer h/set-presence-serializer]
     (is (= start (->> (.write serializer start)
                       (.read serializer))))))
-
-(deftest patch-test
-  (let [^HazelcastInstance hz
-        (:hz
-         (eph/init-hz :test
-                      (rs/init)
-                      (let [id (+ 100000 (rand-int 900000))]
-                        {:instance-name (str "test-instance-" id)
-                         :cluster-name  (str "test-cluster-" id)})))]
-    (try
-      (let [m ^IMap (.getMap hz "a-map")]
-        (is (= {} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1"] {:heartbeat 1})
-        (is (= {"i-1" {:heartbeat 1}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1" :heartbeat] 2)
-        (is (= {"i-1" {:heartbeat 2}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-2" :heartbeat] 3)
-        (is (= {"i-1" {:heartbeat 2}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1" :status] :ok)
-        (is (= {"i-1" {:heartbeat 2, :status :ok}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-assoc-in m ["i-1" :a :b :c] :ok)
-        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok}}}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-merge-in m ["i-1" :a :b] {:c :ok-2, :d :new})
-        (is (= {"i-1" {:heartbeat 2, :status :ok, :a {:b {:c :ok-2, :d :new}}}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-merge-in m ["i-1"] {:x 1, :status :ok-3})
-        (is (= {"i-1" {:heartbeat 2, :status :ok-3, :a {:b {:c :ok-2, :d :new}}, :x 1}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-dissoc-in m ["i-1" :status])
-        (is (= {"i-1" {:heartbeat 2, :a {:b {:c :ok-2, :d :new}}, :x 1}
-                "i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-dissoc-in m ["i-1"])
-        (is (= {"i-2" {:heartbeat 3}} (.getAll m (.keySet m))))
-
-        (h/patch-dissoc-in m ["i-2"])
-        (is (= {} (.getAll m (.keySet m)))))
-      (finally
-        (.shutdown hz)))))


### PR DESCRIPTION
Continuing #1216, this actually adds `instance-id` to all ephemeral session data and schedules a job to clean orphaned sessions. Session is considered orphaned if:

- it has no `instance-id` (leftovers from previous deploy)
- it has `instance-id` that is no longer part of the hz cluster
- `instance-id` matches current machine and `rs/session` returns `nil`

Third PR will just clean up JoinRoomV2 message type