### PR TITLE
Add scopes to client-only oauth flow

### DIFF
--- a/client/packages/platform/src/index.ts
+++ b/client/packages/platform/src/index.ts
@@ -1,4 +1,4 @@
-import { InstantOAuthError } from './oauthCommon.ts';
+import { InstantOAuthError, type OAuthScope } from './oauthCommon.ts';
 import {
   type InstantDBOAuthAccessToken,
   type OAuthHandlerConfig,
@@ -19,6 +19,7 @@ export {
   type InstantAPIPlatformSchema,
   type InstantDBOAuthAccessToken,
   type OAuthHandlerConfig,
+  type OAuthScope,
   OAuthHandler,
   InstantOAuthError,
   generateSchemaTypescriptFile,

--- a/client/packages/platform/src/oauthCommon.ts
+++ b/client/packages/platform/src/oauthCommon.ts
@@ -1,3 +1,11 @@
+export type OAuthScope =
+  | 'apps-read'
+  | 'apps-write'
+  | 'data-read'
+  | 'data-write'
+  | 'storage-read'
+  | 'storage-write';
+
 export class InstantOAuthError extends Error {
   error: string;
   errorDescription: string | null | undefined;

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
       '@instantdb/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@instantdb/platform':
+        specifier: workspace:*
+        version: link:../../packages/platform
       '@instantdb/react':
         specifier: workspace:*
         version: link:../../packages/react

--- a/client/sandbox/react-nextjs/package.json
+++ b/client/sandbox/react-nextjs/package.json
@@ -11,6 +11,7 @@
     "@instantdb/admin": "workspace:*",
     "@instantdb/react": "workspace:*",
     "@instantdb/core": "workspace:*",
+    "@instantdb/platform": "workspace:*",
     "@react-oauth/google": "^0.12.1",
     "date-fns": "^2.29.3",
     "fast-check": "^3.1.1",

--- a/client/sandbox/react-nextjs/pages/platform/oauth-landing.tsx
+++ b/client/sandbox/react-nextjs/pages/platform/oauth-landing.tsx
@@ -1,0 +1,38 @@
+import { OAuthHandler } from '@instantdb/platform';
+import { OAUTH_HANDLER, ClientIdReadme } from '../play/platform-sdk-demo';
+import { useEffect, useState } from 'react';
+
+function Demo({ oauthHandler }: { oauthHandler: OAuthHandler }) {
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    try {
+      return oauthHandler.handleClientRedirect();
+    } catch (e) {
+      setError(e as Error);
+    }
+  }, []);
+
+  if (error) {
+    return (
+      <div>
+        <p>Error</p>
+        <p>{error.message}</p>
+      </div>
+    );
+  }
+  return <div>Loading...</div>;
+}
+
+export default function Page() {
+  const oauthHandler = OAUTH_HANDLER;
+  return (
+    <div className="max-w-lg flex flex-col mt-20 mx-auto">
+      {!oauthHandler ? (
+        <ClientIdReadme />
+      ) : (
+        <Demo oauthHandler={oauthHandler} />
+      )}
+    </div>
+  );
+}

--- a/client/sandbox/react-nextjs/pages/play/platform-sdk-demo.tsx
+++ b/client/sandbox/react-nextjs/pages/play/platform-sdk-demo.tsx
@@ -1,0 +1,147 @@
+import { OAuthHandler, OAuthScope, PlatformApi } from '@instantdb/platform';
+import { useState } from 'react';
+import config from '../../config';
+
+const OAUTH_CLIENT_ID = process.env.NEXT_PUBLIC_PLATFORM_OAUTH_CLIENT_ID;
+
+export const OAUTH_HANDLER = OAUTH_CLIENT_ID
+  ? new OAuthHandler({
+      clientId: OAUTH_CLIENT_ID,
+      redirectUri: 'http://localhost:4000/platform/oauth-landing',
+      apiURI: config.apiURI,
+    })
+  : null;
+
+export function ClientIdReadme() {
+  return (
+    <div>
+      <p className="p-4">
+        Add your OAuth client id to the .env file as{' '}
+        <code>NEXT_PUBLIC_PLATFORM_OAUTH_CLIENT_ID</code>
+      </p>
+      <p className="p-4">
+        Be sure to include{' '}
+        <code>http://localhost:4000/platform/oauth-landing</code> as an
+        authorized redirect url.
+      </p>
+    </div>
+  );
+}
+
+const SCOPES: OAuthScope[] = [
+  'apps-read',
+  'apps-write',
+  'data-read',
+  'data-write',
+  'storage-read',
+  'storage-write',
+];
+
+function OAuthFlow({
+  oauthHandler,
+  onAccessToken,
+}: {
+  oauthHandler: OAuthHandler;
+  onAccessToken: (token: string) => void;
+}) {
+  const [scopes, setScopes] = useState<OAuthScope[]>([]);
+
+  const handleConnect = async () => {
+    try {
+      if (!scopes.length) {
+        throw new Error('Select at least one scope.');
+      }
+      const token = await oauthHandler.startClientOnlyFlow(scopes);
+      onAccessToken(token.token);
+    } catch (e) {
+      alert((e as Error).message);
+      console.error(e);
+    }
+  };
+
+  return (
+    <div>
+      <h3>Scopes</h3>
+      {SCOPES.map((scope: OAuthScope) => {
+        return (
+          <div key={scope} className="m-2">
+            <input
+              id={scope}
+              type="checkbox"
+              checked={scopes.includes(scope)}
+              onChange={() =>
+                setScopes((scopes) =>
+                  scopes.includes(scope)
+                    ? scopes.filter((s) => s !== scope)
+                    : [...scopes, scope],
+                )
+              }
+            />
+            <label className="m-2" htmlFor={scope}>
+              {scope}
+            </label>
+          </div>
+        );
+      })}
+      <button className="bg-black text-white m-2 p-2" onClick={handleConnect}>
+        Connect to your Instant Account
+      </button>
+    </div>
+  );
+}
+
+function ApiDemo({ accessToken }: { accessToken: string }) {
+  const api = new PlatformApi({
+    auth: { token: accessToken },
+    apiURI: config.apiURI,
+  });
+  const [result, setResult] = useState<any>(null);
+
+  const getApps = async () => {
+    try {
+      setResult(await api.getApps());
+    } catch (e) {
+      setResult(e);
+    }
+  };
+
+  return (
+    <div>
+      <div>
+        <button className="bg-black text-white m-2 p-2" onClick={getApps}>
+          Get Apps
+        </button>
+      </div>
+      {result ? (
+        <div>
+          <div>Result:</div>
+          <pre>{JSON.stringify(result, null, 2)}</pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Demo({ oauthHandler }: { oauthHandler: OAuthHandler }) {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  if (!accessToken) {
+    return (
+      <OAuthFlow onAccessToken={setAccessToken} oauthHandler={oauthHandler} />
+    );
+  }
+  return <ApiDemo accessToken={accessToken} />;
+}
+
+export default function Page() {
+  const oauthHandler = OAUTH_HANDLER;
+  return (
+    <div className="max-w-lg flex flex-col mt-20 mx-auto">
+      {!oauthHandler ? (
+        <ClientIdReadme />
+      ) : (
+        <Demo oauthHandler={oauthHandler} />
+      )}
+    </div>
+  );
+}

--- a/client/www/pages/docs/auth/platform-oauth.md
+++ b/client/www/pages/docs/auth/platform-oauth.md
@@ -450,7 +450,7 @@ https://api.instantdb.com/platform/oauth/revoke?token=YOUR_TOKEN
 ### Get schema
 
 - **Description:** Views the schema for the app.
-- **Method:** `POST`
+- **Method:** `GET`
 - **Path:** `/superadmin/apps/:app_id/schema`
 - **Authentication:** Required (Bearer Token)
 - **Required OAuth Scope:** `apps-read`


### PR DESCRIPTION
I accidentally hard-coded the scopes as `apps-write`. Now you have to pass in the scopes you want when you start the OAuth flow.

Also adds a basic playground at `/play/platform-demo`