### PR TITLE
OAuth apps fixes

### DIFF
--- a/client/www/components/dash/OAuthApps.tsx
+++ b/client/www/components/dash/OAuthApps.tsx
@@ -1395,6 +1395,10 @@ export default function OAuthApps({ appId }: { appId: string }) {
       ...data,
       apps: [app, ...(data?.apps || [])],
     });
+    const params = new URLSearchParams(encode(router.query));
+    params.set('oauthapp', app.id);
+    const href = `${router.pathname}?${params.toString()}`;
+    router.push(href);
   };
 
   const handleUpdateApp = (app: OAuthApp) => {

--- a/client/www/lib/config.ts
+++ b/client/www/lib/config.ts
@@ -76,6 +76,6 @@ export const cliOauthParamName = '_cli_oauth_ticket';
 export const discordInviteUrl = 'https://discord.com/invite/VU53p7uQcE';
 
 export const discordOAuthAppsFeedbackInviteUrl =
-  'https://discord.gg/2rnGtfFQup';
+  'https://discord.gg/GrvbPTBDEX';
 
 export const bugsAndQuestionsInviteUrl = 'https://discord.gg/unA5vyV6mP';


### PR DESCRIPTION
1. Fixes the discord invite URL
2. Opens the OAuth app after you create it. I found it surprising when I had to click through to the next step after creating the app.