### PR TITLE
Fix longest wait time

### DIFF
--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -69,7 +69,8 @@
                          (Map/.values)
                          (keep Queue/.peek)
                          not-empty)]
-    (- (System/currentTimeMillis) (transduce (map ::put-at) min items))))
+    (let [now (System/currentTimeMillis)]
+      (- now (transduce (map ::put-at) min now items)))))
 
 (defn start
   "Options:


### PR DESCRIPTION
This would always error when there was anything in the queue because the transducer wasn't given an initial value, so it would call `(min)`, which throws an `Wrong number of args (0) passed to: clojure.core/min` erorr.

Now we give it an initial value of `now`.