### PR TITLE
Disable hints for pagination also

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1471,8 +1471,10 @@
                          [(has-prev-tbl table)
                           {:select [[[:exists has-previous-query]]]}
                           :not-materialized])
-             :pg-hints (into (:pg-hints (:query match-query))
-                             pg-hints)
+             :pg-hints (if true ;; disable hints for pagination until we can generate better plans
+                         []
+                         (into (:pg-hints (:query match-query))
+                               pg-hints))
              :select (kw last-row-table :.*)
              :from last-table-name}
      :symbol-map symbol-map

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -3,7 +3,6 @@
    [clojure.set :as set :refer [map-invert]]
    [clojure.spec.alpha :as s]
    [clojure.string :as string]
-   [clojure.walk :as walk]
    [honey.sql :as hsql]
    [instant.data.resolvers :as resolvers]
    [instant.db.cel :as cel]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -20,6 +20,7 @@
    [instant.util.coll :as ucoll]
    [instant.util.exception :as ex]
    [instant.util.io :as io]
+   [instant.util.instaql :refer [forms-hash]]
    [instant.util.json :refer [->json]]
    [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util]
@@ -1172,33 +1173,6 @@
     {:patterns {:children {:pattern-groups pattern-groups}}
      :forms forms
      :referenced-etypes referenced-etypes}))
-
-(defn clean-where-for-hash [where]
-  (walk/postwalk (fn [x]
-                   (cond (string? x)
-                         :string
-                         (number? x)
-                         :number
-                         (uuid? x)
-                         :uuid
-                         (boolean? x)
-                         :boolean
-                         :else x))
-                 where))
-
-(defn clean-forms-for-hash [forms]
-  (walk/postwalk (fn [v]
-                   (if (and (map? v)
-                            (contains? v :$))
-                     (-> v
-                         (update-existing-in [:$ :where] clean-where-for-hash)
-                         (update-existing-in [:$ :before] (constantly :cursor))
-                         (update-existing-in [:$ :after] (constantly :cursor)))
-                     v))
-                 forms))
-
-(defn forms-hash [forms]
-  (hash (clean-forms-for-hash forms)))
 
 (defn query-normal
   "Generates and runs a nested datalog query, then collects the results into nodes."

--- a/server/src/instant/db/rule_where_testing.clj
+++ b/server/src/instant/db/rule_where_testing.clj
@@ -11,7 +11,7 @@
 
 ;; DWW: Temporarily hijacking this ns to test out pg_hint_plan
 
-(def seen (cache/ttl-cache-factory {} :ttl (* 1000 60 5)))
+(def seen (cache/ttl-cache-factory {} :ttl (* 1000 60)))
 
 (defn run-test [ctx permissioned-query-fn o]
   (let [start (System/nanoTime)

--- a/server/src/instant/db/rule_where_testing.clj
+++ b/server/src/instant/db/rule_where_testing.clj
@@ -1,14 +1,17 @@
 (ns instant.db.rule-where-testing
   (:require [clojure.core.async :as a]
+            [clojure.core.cache.wrapped :as cache]
             [instant.db.datalog :as d]
             [instant.flags :as flags]
             [instant.jdbc.sql :as sql]
             ;; [instant.model.rule :as rule-model]
             ;; [instant.util.coll :as ucoll]
             [instant.util.tracer :as tracer]
-            [instant.util.instaql :refer [instaql-nodes->object-tree]]))
+            [instant.util.instaql :refer [instaql-nodes->object-tree forms-hash]]))
 
 ;; DWW: Temporarily hijacking this ns to test out pg_hint_plan
+
+(def seen (cache/ttl-cache-factory {} :ttl (* 1000 60 5)))
 
 (defn run-test [ctx permissioned-query-fn o]
   (let [start (System/nanoTime)
@@ -22,7 +25,8 @@
      :result res
      :error? (instance? Exception res)}))
 
-(defn test-rule-wheres [ctx permissioned-query-fn o]
+(defn test-rule-wheres [ctx permissioned-query-fn o query-hash]
+  (cache/lookup-or-miss seen query-hash (constantly true))
   (binding [tracer/*span* nil] ;; Create new root span
     (tracer/with-span! {:name "test-pg-hint-plan"
                         :attributes {:query o
@@ -74,14 +78,16 @@
                                (rule-model/get-program! rules (name field) "view"))
                              (keys o))))))
 
-(defn worth-testing? [_ctx _o]
-  (flags/test-rule-wheres?))
+(defn worth-testing? [_ctx _o query-hash]
+  (and (flags/test-rule-wheres?)
+       (not (cache/lookup seen query-hash))))
 
 (defonce process-chan (atom (a/chan (a/sliding-buffer 10))))
 
 (defn queue-for-testing [ctx permissioned-query-fn o]
-  (when (worth-testing? ctx o)
-    (a/put! @process-chan [ctx permissioned-query-fn o])))
+  (let [query-hash (forms-hash o)]
+    (when (worth-testing? ctx o query-hash)
+      (a/put! @process-chan [ctx permissioned-query-fn o query-hash]))))
 
 (defn start []
   (reset! process-chan (a/chan (a/sliding-buffer 10)))

--- a/server/src/instant/util/instaql.clj
+++ b/server/src/instant/util/instaql.clj
@@ -1,9 +1,11 @@
 (ns instant.util.instaql
-  (:require [instant.db.model.attr :as attr-model]
+  (:require [clojure.walk :as walk]
+            [instant.db.model.attr :as attr-model]
             [instant.db.model.attr-pat :as attr-pat]
             [instant.db.model.entity :as entity-model]
             [instant.util.uuid :as uuid-util]
-            [instant.db.model.triple :as triple-model]))
+            [instant.db.model.triple :as triple-model]
+            [medley.core :refer [update-existing-in]]))
 
 (declare instaql-ref-nodes->object-tree)
 
@@ -98,3 +100,30 @@
   (let [enriched-nodes
         (map (fn [n] (update n :data (fn [d] (assoc d :etype (:k d))))) nodes)]
     (instaql-ref-nodes->object-tree ctx enriched-nodes)))
+
+(defn- clean-where-for-hash [where]
+  (walk/postwalk (fn [x]
+                   (cond (string? x)
+                         :string
+                         (number? x)
+                         :number
+                         (uuid? x)
+                         :uuid
+                         (boolean? x)
+                         :boolean
+                         :else x))
+                 where))
+
+(defn- clean-forms-for-hash [forms]
+  (walk/postwalk (fn [v]
+                   (if (and (map? v)
+                            (contains? v :$))
+                     (-> v
+                         (update-existing-in [:$ :where] clean-where-for-hash)
+                         (update-existing-in [:$ :before] (constantly :cursor))
+                         (update-existing-in [:$ :after] (constantly :cursor)))
+                     v))
+                 forms))
+
+(defn forms-hash [forms]
+  (hash (clean-forms-for-hash forms)))


### PR DESCRIPTION
Saw some bad plans for queries that use pagination, so let's just ignore hints for that part of the query for now.

I also noticed we're getting a lot of the same queries in the test pipeline, so I added a cache to try to filter out queries we've already seen. It uses a ttl cache with a ttl of 1 minute--if we see the same query hash twice in that period, then we'll only run the query once (that's not exactly true, b/c we check when we put the query in the queue, but don't set the flag until the query executes, but it's close enough).