### PR TITLE
Enable pg_hints for the ea index

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -2088,9 +2088,7 @@
                                    :current-user (pr-str current-user)
                                    :admin? admin?
                                    :query (pr-str o)}}
-    (when-not (or admin?
-                  ;; Prevent infinite cycle
-                  (:testing-rule-wheres ctx))
+    (when-not (:testing-rule-wheres ctx) ;; Prevent infinite cycle
       (rule-where-testing/queue-for-testing ctx permissioned-query o))
     (if admin?
       (query ctx (dissoc o :$$ruleParams))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -274,3 +274,11 @@
 
 (defn toggled? [key]
   (get-in (query-result) [:toggles key]))
+
+(defn pg-hint-testing-toggles []
+  (reduce-kv (fn [acc k v]
+               (if (= (namespace k) "pg-hint-test")
+                 (assoc acc k v)
+                 acc))
+             {}
+             (get (query-result) :toggles)))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2610,15 +2610,14 @@
                            (run-explain :$gt data-type value))
                           ([op data-type value]
                            (let [explain
-                                 (binding [d/*use-pg-hints* true]
-                                   (d/explain (make-ctx)
-                                              {:children
-                                               {:pattern-groups
-                                                [{:patterns
-                                                  [[{:idx-key :ave, :data-type data-type}
-                                                    '?etype-0
-                                                    (get attr-ids data-type)
-                                                    {:$comparator {:op op, :value value, :data-type data-type}}]]}]}}))]
+                                 (d/explain (make-ctx)
+                                            {:children
+                                             {:pattern-groups
+                                              [{:patterns
+                                                [[{:idx-key :ave, :data-type data-type}
+                                                  '?etype-0
+                                                  (get attr-ids data-type)
+                                                  {:$comparator {:op op, :value value, :data-type data-type}}]]}]}})]
                              (-> explain
                                  first
                                  (get "QUERY PLAN")
@@ -2754,8 +2753,7 @@
           (let [{:keys [patterns]} (iq/instaql-query->patterns
                                     (make-ctx)
                                     {:user {:$ {:where {:handle "a"}}}})
-                explain (binding [d/*use-pg-hints* true]
-                          (d/explain (make-ctx) patterns))
+                explain (d/explain (make-ctx) patterns)
                 plan (-> explain
                          first
                          (get "QUERY PLAN")
@@ -2769,11 +2767,10 @@
             (is (= "av_index" (get plan "Index Name")))))
 
         (testing "query with lookup"
-          (let [explain (binding [d/*use-pg-hints* true]
-                          (d/explain (make-ctx) {:children
-                                                 {:pattern-groups
-                                                  [{:patterns
-                                                    [[:ea [(:handle attr-ids) "a"]]]}]}}))
+          (let [explain (d/explain (make-ctx) {:children
+                                               {:pattern-groups
+                                                [{:patterns
+                                                  [[:ea [(:handle attr-ids) "a"]]]}]}})
                 plan (-> explain
                          first
                          (get "QUERY PLAN")
@@ -4445,8 +4442,7 @@
                    :attrs (attr-model/get-by-app-id (:id app))}
               {:keys [patterns]} (iq/instaql-query->patterns ctx
                                                              {:users {:$ {:where {:handle "a"}}}})
-              explain (binding [d/*use-pg-hints* true]
-                        (d/explain ctx patterns))
+              explain (d/explain ctx patterns)
               warnings (loop [msgs []
                               ^PSQLWarning warnings (:warnings (meta explain))]
                          (if warnings


### PR DESCRIPTION
Enables pg_hint_plan for the ea_index. We've been testing it in production overnight and I'm not seeing any queries that are negatively impacted in the logs, whereas we know it helps queries that get the first page by serverCreatedAt (e.g. `{ posts: { $: { limit: 1 } } }`).

Also starts background testing for other indexes. To start testing an index, we just have to add a new row to `toggles` in the instant-config app with setting="pg-hint-test/postgres-index-name" (e.g. pg-hint-test/av_index), value=true.

If we have issues, we can turn it off by setting "disable-pg-hints" to true in the flag toggles.