### PR TITLE
[custom-emails] add domain verification instructions

### DIFF
--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -239,12 +239,12 @@ export function Email({
       </div>
 
       {senderVerification && (
-        <div className="flex flex-col gap-4 mt-4">
+        <div className="flex flex-col gap-2 border p-3 bg-gray-50 rounded">
           {/* Header with Verify Button for Both Sections */}
           <div className="flex items-center justify-between">
-            <div className="text-sm font-medium text-gray-700">
+            <SubsectionHeading>
               Verify {senderVerification.EmailAddress}
-            </div>
+            </SubsectionHeading>
             <Button
               onClick={checkVerification}
               loading={isCheckingVerification}
@@ -260,18 +260,16 @@ export function Email({
             <div className="flex items-center justify-between mb-2">
               <div className="font-medium text-sm">Email Confirmation</div>
               <div className="flex items-center gap-2">
+                <StatusCircle
+                  isLoading={isCheckingVerification}
+                  isSuccess={senderVerification.Confirmed}
+                />
                 {senderVerification.Confirmed ? (
-                  <div className="flex items-center gap-2 text-green-600 text-xs">
-                    <div className="w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
-                      <span className="text-white text-xs">✓</span>
-                    </div>
+                  <div className="text-green-600 text-xs font-medium">
                     Confirmed
                   </div>
                 ) : (
-                  <div className="flex items-center gap-2 text-gray-500 text-xs">
-                    <div
-                      className={`w-3 h-3 rounded-full ${isCheckingVerification ? 'bg-gray-400' : 'bg-red-500'}`}
-                    ></div>
+                  <div className="text-gray-500 text-xs">
                     Pending confirmation
                   </div>
                 )}
@@ -298,28 +296,20 @@ export function Email({
             </Content>
 
             <div className="border rounded-lg overflow-hidden mb-3">
-              {/* Table Header */}
               <div className="grid grid-cols-[1fr_80px_2fr] bg-gray-50 border-b text-sm font-medium text-gray-700 px-4 py-3">
                 <div>Record</div>
                 <div>Type</div>
                 <div>Value</div>
               </div>
-
-              {/* DKIM Record Row */}
               <div className="grid grid-cols-[1fr_80px_2fr] border-b px-4 py-3 text-sm">
-                <div className="flex items-center gap-3">
+                <div className="flex gap-3">
                   <div>
                     <div className="font-medium">DKIM</div>
-                    <div className="flex items-center gap-2 text-xs">
-                      {isCheckingVerification ? (
-                        <div className="w-3 h-3 rounded-full bg-gray-400"></div>
-                      ) : senderVerification?.DKIMVerified ? (
-                        <div className="w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
-                          <span className="text-white text-xs">✓</span>
-                        </div>
-                      ) : (
-                        <div className="w-3 h-3 rounded-full bg-red-500"></div>
-                      )}
+                    <div className="flex gap-2 text-xs">
+                      <StatusCircle
+                        isLoading={isCheckingVerification}
+                        isSuccess={senderVerification?.DKIMVerified || false}
+                      />
                       <span className="text-gray-500">
                         {senderVerification?.DKIMVerified
                           ? 'Verified'
@@ -330,9 +320,7 @@ export function Email({
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center text-gray-600 text-sm">
-                  TXT
-                </div>
+                <div className="flex text-gray-600 text-sm">TXT</div>
                 <div className="flex flex-col gap-2">
                   <div>
                     <div className="text-xs text-gray-600 mb-1">Hostname:</div>
@@ -355,15 +343,12 @@ export function Email({
                   <div>
                     <div className="font-medium">Return-Path</div>
                     <div className="flex items-center gap-2 text-xs">
-                      {isCheckingVerification ? (
-                        <div className="w-3 h-3 rounded-full bg-gray-400"></div>
-                      ) : senderVerification?.ReturnPathDomainVerified ? (
-                        <div className="w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
-                          <span className="text-white text-xs">✓</span>
-                        </div>
-                      ) : (
-                        <div className="w-3 h-3 rounded-full bg-red-500"></div>
-                      )}
+                      <StatusCircle
+                        isLoading={isCheckingVerification}
+                        isSuccess={
+                          senderVerification?.ReturnPathDomainVerified || false
+                        }
+                      />
                       <span className="text-gray-500">
                         {senderVerification?.ReturnPathDomainVerified
                           ? 'Verified'
@@ -481,4 +466,26 @@ function validateHtml(xmlStr: string) {
   if (errorNode) {
     return { error: 'Invalid HTML' };
   }
+}
+
+function StatusCircle({
+  isLoading,
+  isSuccess,
+}: {
+  isLoading?: boolean;
+  isSuccess: boolean;
+}) {
+  if (isLoading) {
+    return <div className="w-3 h-3 rounded-full bg-gray-400"></div>;
+  }
+
+  if (isSuccess) {
+    return (
+      <div className="w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
+        <span className="text-white text-xs">✓</span>
+      </div>
+    );
+  }
+
+  return <div className="w-3 h-3 rounded-full bg-red-500"></div>;
 }

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -303,20 +303,7 @@ export function Email({
               </div>
               <div className="grid grid-cols-[1fr_80px_2fr] border-b px-4 py-3 text-sm">
                 <div className="flex gap-3">
-                  <div>
-                    <div className="font-medium">DKIM</div>
-                    <div className="flex gap-2 text-xs">
-                      <StatusCircle
-                        isLoading={isVerifying}
-                        isSuccess={verification?.DKIMVerified}
-                      />
-                      <span className="text-gray-500">
-                        {verification?.DKIMVerified
-                          ? 'Verified'
-                          : 'Not verified'}
-                      </span>
-                    </div>
-                  </div>
+                  <div className="font-medium">DKIM</div>
                 </div>
                 <div className="flex text-gray-600 text-sm">TXT</div>
                 <div className="flex flex-col gap-2">
@@ -337,20 +324,7 @@ export function Email({
               </div>
               <div className="grid grid-cols-[1fr_80px_2fr] px-4 py-3 text-sm">
                 <div className="flex items-center gap-3">
-                  <div>
-                    <div className="font-medium">Return-Path</div>
-                    <div className="flex items-center gap-2 text-xs">
-                      <StatusCircle
-                        isLoading={isVerifying}
-                        isSuccess={verification.ReturnPathDomainVerified}
-                      />
-                      <span className="text-gray-500">
-                        {verification.ReturnPathDomainVerified
-                          ? 'Verified'
-                          : 'Not verified'}
-                      </span>
-                    </div>
-                  </div>
+                  <div className="font-medium">Return-Path</div>
                 </div>
                 <div className="flex items-center text-gray-600 text-sm">
                   CNAME

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -27,23 +27,15 @@ export type EmailValues = {
 };
 
 export type SenderVerificationInfo = {
-  ID: number;
-  Domain: string;
+  id: number;
   EmailAddress: string;
-  Name: string;
   Confirmed: boolean;
-  SPFHost: string;
-  SPFVerified: boolean;
-  SPFTextValue: string;
   DKIMHost?: string;
-  DKIMVerified: boolean;
-  DKIMUpdateStatus: string;
   DKIMPendingHost?: string;
   DKIMPendingTextValue?: string;
   DKIMTextValue?: string;
-  ReturnPathDomainVerified: boolean;
-  ReturnPathDomainCNAMEValue: string;
   ReturnPathDomain: string;
+  ReturnPathDomainCNAMEValue: string;
 };
 
 export function getSenderVerification({

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -227,11 +227,14 @@ export function Email({
       </div>
 
       <div className="flex flex-col gap-2 border p-3 bg-gray-50 rounded">
-        <SubsectionHeading>Use a custom 'From' address</SubsectionHeading>
+        <SubsectionHeading>
+          Use a custom 'From' address (optional)
+        </SubsectionHeading>
         <Content className="text-sm">
           By default emails are sent from our domain. Add a custom sender to
-          send emails from your own domain and build trust with recipients. You
-          need access to this email to confirm ownership.
+          send emails from your own domain and build trust with recipients. Our
+          email partner will send a confirmation to the provided address with a
+          link to verify.
         </Content>
         <TextInput
           {...form.inputProps('senderEmail')}

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -27,7 +27,7 @@ export type EmailValues = {
 };
 
 export type SenderVerificationInfo = {
-  id: number;
+  ID: number;
   EmailAddress: string;
   Confirmed: boolean;
   DKIMHost?: string;

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -35,14 +35,15 @@ export type SenderVerificationInfo = {
   SPFHost: string;
   SPFVerified: boolean;
   SPFTextValue: string;
-  DKIMHost: string;
+  DKIMHost?: string;
   DKIMVerified: boolean;
   DKIMUpdateStatus: string;
-  DKIMPendingHost: string;
-  DKIMPendingTextValue: string;
-  DKIMTextValue: string;
+  DKIMPendingHost?: string;
+  DKIMPendingTextValue?: string;
+  DKIMTextValue?: string;
   ReturnPathDomainVerified: boolean;
   ReturnPathDomainCNAMEValue: string;
+  ReturnPathDomain: string;
 };
 
 export function getSenderVerification({
@@ -307,7 +308,7 @@ export function Email({
                     <div className="flex gap-2 text-xs">
                       <StatusCircle
                         isLoading={isVerifying}
-                        isSuccess={verification?.DKIMVerified || false}
+                        isSuccess={verification?.DKIMVerified}
                       />
                       <span className="text-gray-500">
                         {verification?.DKIMVerified
@@ -322,13 +323,14 @@ export function Email({
                   <div>
                     <div className="text-xs text-gray-600 mb-1">Hostname:</div>
                     <code className="text-xs bg-gray-100 px-2 py-1 rounded break-all select-all block">
-                      {verification.DKIMPendingHost}
+                      {verification.DKIMPendingHost || verification.DKIMHost}
                     </code>
                   </div>
                   <div>
                     <div className="text-xs text-gray-600 mb-1">Value:</div>
                     <code className="text-xs bg-gray-100 px-2 py-1 rounded break-all select-all block">
-                      {verification.DKIMPendingTextValue}
+                      {verification.DKIMPendingTextValue ||
+                        verification.DKIMTextValue}
                     </code>
                   </div>
                 </div>
@@ -353,10 +355,19 @@ export function Email({
                 <div className="flex items-center text-gray-600 text-sm">
                   CNAME
                 </div>
-                <div className="flex items-center">
-                  <code className="text-xs bg-gray-100 px-2 py-1 rounded break-all select-all">
-                    {verification.ReturnPathDomainCNAMEValue}
-                  </code>
+                <div className="flex flex-col gap-2">
+                  <div>
+                    <div className="text-xs text-gray-600 mb-1">Hostname:</div>
+                    <code className="text-xs bg-gray-100 px-2 py-1 rounded break-all select-all block">
+                      {verification.ReturnPathDomain}
+                    </code>
+                  </div>
+                  <div>
+                    <div className="text-xs text-gray-600 mb-1">Value:</div>
+                    <code className="text-xs bg-gray-100 px-2 py-1 rounded break-all select-all block">
+                      {verification.ReturnPathDomainCNAMEValue}
+                    </code>
+                  </div>
                 </div>
               </div>
             </div>

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -944,12 +944,12 @@
 ;; Email templates
 
 (defn sender-verification-get [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :admin req)
+  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         {postmark-id :postmark_id}
         (app-email-template-model/get-by-app-id-and-email-type
          {:app-id app-id :email-type "magic-code"})]
     (response/ok {:verification (when postmark-id
-                                  (postmark/get-sender! {:id postmark-id}))})))
+                                  (:body (postmark/get-sender! {:id postmark-id})))})))
 
 (defn email-template-post [req]
   (let [{app :app user :user} (req->app-and-user! :admin req)
@@ -1534,8 +1534,10 @@
   (DELETE "/dash/apps/:app_id/members/remove" [] team-member-remove-delete)
   (POST "/dash/apps/:app_id/members/update" [] team-member-update-post)
 
+  (GET "/dash/apps/:app_id/sender-verification" [] sender-verification-get)
   (POST "/dash/apps/:app_id/email_templates" [] email-template-post)
   (DELETE "/dash/apps/:app_id/email_templates/:id" [] email-template-delete)
+
 
   (POST "/dash/invites/accept" [] team-member-invite-accept-post)
   (POST "/dash/invites/decline" [] team-member-invite-decline-post)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -944,7 +944,7 @@
 ;; Email templates
 
 (defn sender-verification-get [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-and-user! :admin req)
         {postmark-id :postmark_id}
         (app-email-template-model/get-by-app-id-and-email-type
          {:app-id app-id :email-type "magic-code"})]
@@ -1538,7 +1538,6 @@
   (POST "/dash/apps/:app_id/email_templates" [] email-template-post)
   (DELETE "/dash/apps/:app_id/email_templates/:id" [] email-template-delete)
 
-
   (POST "/dash/invites/accept" [] team-member-invite-accept-post)
   (POST "/dash/invites/decline" [] team-member-invite-decline-post)
 
@@ -1576,5 +1575,4 @@
   (POST "/dash/apps/:app_id/oauth-app-clients/:client_id" [] oauth-app-client-post)
   (DELETE "/dash/apps/:app_id/oauth-app-clients/:client_id" [] oauth-app-client-delete)
   (POST "/dash/apps/:app_id/oauth-app-clients/:client_id/client-secrets" [] oauth-app-client-secrets)
-
   (DELETE "/dash/apps/:app_id/oauth-app-client-secrets/:client_secret_id" [] oauth-app-client-secret-delete))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -949,7 +949,12 @@
         (app-email-template-model/get-by-app-id-and-email-type
          {:app-id app-id :email-type "magic-code"})]
     (response/ok {:verification (when postmark-id
-                                  (:body (postmark/get-sender! {:id postmark-id})))})))
+                                  (-> (postmark/get-sender! {:id postmark-id})
+                                      :body
+                                      (select-keys [:ID :EmailAddress :Confirmed
+                                                    :DKIMHost :DKIMPendingHost
+                                                    :DKIMPendingTextValue :DKIMTextValue
+                                                    :ReturnPathDomain :ReturnPathDomainCNAMEValue])))})))
 
 (defn email-template-post [req]
   (let [{app :app user :user} (req->app-and-user! :admin req)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -943,6 +943,14 @@
 ;; ---------------
 ;; Email templates
 
+(defn sender-verification-get [req]
+  (let [{{app-id :id} :app} (req->app-and-user! :admin req)
+        {postmark-id :postmark_id}
+        (app-email-template-model/get-by-app-id-and-email-type
+         {:app-id app-id :email-type "magic-code"})]
+    (response/ok {:verification (when postmark-id
+                                  (postmark/get-sender! {:id postmark-id}))})))
+
 (defn email-template-post [req]
   (let [{app :app user :user} (req->app-and-user! :admin req)
         email-type (ex/get-param! req [:body :email-type] string-util/coerce-non-blank-str)


### PR DESCRIPTION
A user let us know that protonmail was showing a suspicious-looking error on custom email magic code sends. 

This is because they were stricter about domain checks: specifically with the DKIM value. 

Well, When we create a sender signature, we actually also get the DKIM value that the user can add to their records. 

I went ahead and: 

1. Started to show the DKIM value
2. I also showed the confirmation status for the email.

![image](https://github.com/user-attachments/assets/a9adb3a3-e292-4f41-894c-aa583ce4f498)

**Some further work:** 
1. Right now it will take some time for Postmark to pick up the DKIM status. They do have an endpoint that lets us specifically check for DNS records -- it may be nice to push run that when someone says "Refresh status" 

@nezaj @dwwoelfel @tonsky 