### PR TITLE
Convert InstantAPIPlatformSchema to InstantSchemaDef in platform package

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -2,6 +2,7 @@
 
 import {
   generatePermsTypescriptFile,
+  apiSchemaToInstantSchemaDef,
   generateSchemaTypescriptFile,
   translatePlanSteps,
 } from '@instantdb/platform';
@@ -817,7 +818,7 @@ async function pullSchema(appId, { pkgDir, instantModuleName }) {
     schemaPath,
     generateSchemaTypescriptFile(
       prev?.schema,
-      pullRes.data.schema,
+      apiSchemaToInstantSchemaDef(pullRes.data.schema),
       instantModuleName,
     ),
     'utf-8',

--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -1,6 +1,8 @@
 import type { RoomSchemaShape } from './presence.ts';
 
 export class DataAttrDef<ValueType, IsRequired extends RequirementKind> {
+  public metadata: Record<string, unknown> = {};
+
   constructor(
     public valueType: ValueTypes,
     public required: IsRequired,

--- a/client/packages/platform/__tests__/src/schema.test.ts
+++ b/client/packages/platform/__tests__/src/schema.test.ts
@@ -435,9 +435,9 @@ const _schema = i.schema({
   // run \`push schema\` again to enforce the types.
   entities: {
     "$files": i.entity({
-      "metadata": i.json().optional(),
+      "metadata": i.any().optional(),
       "path": i.string().unique().indexed().optional(),
-      "url": i.json().optional(),
+      "url": i.any().optional(),
     }),
     "$users": i.entity({
       "email": i.string().unique().indexed().optional(),
@@ -446,12 +446,12 @@ const _schema = i.schema({
       "description": i.string().optional(),
       "isbn13": i.string().unique().optional(),
       "pageCount": i.number().indexed().optional(),
-      "thumbnail": i.json().optional(),
+      "thumbnail": i.any().optional(),
       "title": i.string().indexed(),
     }),
     "bookshelves": i.entity({
       "desc": i.string().optional(),
-      "name": i.json().optional(),
+      "name": i.any().optional(),
       "order": i.number().indexed().optional(),
     }),
     "onlyId": i.entity({}),

--- a/client/packages/platform/__tests__/src/schema.test.ts
+++ b/client/packages/platform/__tests__/src/schema.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from 'vitest';
 
 import { generateSchemaTypescriptFile } from '../../src/schema';
+import { apiSchemaToInstantSchemaDef } from '../../src/api';
 import { i } from '@instantdb/core';
 
 test('generates schema', () => {
@@ -23,7 +24,7 @@ test('generates schema', () => {
           },
         },
       }),
-      {
+      apiSchemaToInstantSchemaDef({
         refs: {
           '["bookshelves" "books" "books" "bookshelves"]': {
             'required?': false,
@@ -67,6 +68,23 @@ test('generates schema', () => {
           },
         },
         blobs: {
+          onlyId: {
+            id: {
+              'required?': false,
+              'forward-identity': [
+                '9203a9d8-b345-47d7-8caf-b800101bc814',
+                'books',
+                'id',
+              ],
+              id: '54f72bd0-aa44-4b3f-a8d7-d55cf45e72d4',
+              'unique?': true,
+              cardinality: 'one',
+              'inferred-types': ['string'],
+              'value-type': 'blob',
+              catalog: 'user',
+              'index?': true,
+            },
+          },
           books: {
             description: {
               'required?': false,
@@ -132,7 +150,7 @@ test('generates schema', () => {
               'index?': true,
             },
             title: {
-              'required?': false,
+              'required?': true,
               'forward-identity': [
                 'c0afd326-3458-405c-b746-bb834150cbd9',
                 'books',
@@ -404,7 +422,7 @@ test('generates schema', () => {
             },
           },
         },
-      },
+      }),
       '@instantdb/core',
     ),
   ).toEqual(`// Docs: https://www.instantdb.com/docs/modeling-data
@@ -417,31 +435,32 @@ const _schema = i.schema({
   // run \`push schema\` again to enforce the types.
   entities: {
     "$files": i.entity({
-      "metadata": i.any().optional(),
+      "metadata": i.json().optional(),
       "path": i.string().unique().indexed().optional(),
-      "url": i.any().optional()
+      "url": i.json().optional(),
     }),
     "$users": i.entity({
-      "email": i.string().unique().indexed().optional()
+      "email": i.string().unique().indexed().optional(),
     }),
     "books": i.entity({
       "description": i.string().optional(),
       "isbn13": i.string().unique().optional(),
       "pageCount": i.number().indexed().optional(),
-      "thumbnail": i.any().optional(),
-      "title": i.string().indexed().optional()
+      "thumbnail": i.json().optional(),
+      "title": i.string().indexed(),
     }),
     "bookshelves": i.entity({
       "desc": i.string().optional(),
-      "name": i.any().optional(),
-      "order": i.number().indexed().optional()
+      "name": i.json().optional(),
+      "order": i.number().indexed().optional(),
     }),
+    "onlyId": i.entity({}),
     "users": i.entity({
       "createdAt": i.date().optional(),
       "email": i.string().unique().indexed().optional(),
       "fullName": i.string().optional(),
-      "handle": i.string().unique().indexed().optional()
-    })
+      "handle": i.string().unique().indexed().optional(),
+    }),
   },
   links: {
     "bookshelvesBooks": {

--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -301,8 +301,8 @@ function attrDefForType(
 }
 
 function apiSchemaAttrToDataAttrDef(attr: InstantDBAttr) {
-  const { type, origin } = deriveClientType(attr);
-  let i: DataAttrDef<string, boolean> = attrDefForType(type);
+  const derivedType = deriveClientType(attr);
+  let i: DataAttrDef<string, boolean> = attrDefForType(derivedType.type);
   if (attr['unique?']) {
     i = i.unique();
   }
@@ -312,7 +312,7 @@ function apiSchemaAttrToDataAttrDef(attr: InstantDBAttr) {
   if (!attr['required?']) {
     i = i.optional();
   }
-  i.metadata.typeOrigin = origin;
+  i.metadata.derivedType = derivedType;
   return i;
 }
 

--- a/client/packages/platform/src/index.ts
+++ b/client/packages/platform/src/index.ts
@@ -9,7 +9,11 @@ import {
   type InstantAPIPlatformSchema,
   generateSchemaTypescriptFile,
 } from './schema.ts';
-import { PlatformApi, translatePlanSteps } from './api.ts';
+import {
+  apiSchemaToInstantSchemaDef,
+  PlatformApi,
+  translatePlanSteps,
+} from './api.ts';
 
 import version from './version.js';
 import { ProgressPromise } from './ProgressPromise.ts';
@@ -25,6 +29,7 @@ export {
   InstantOAuthError,
   generateSchemaTypescriptFile,
   generatePermsTypescriptFile,
+  apiSchemaToInstantSchemaDef,
   version,
   translatePlanSteps,
   PlatformApi,

--- a/client/packages/platform/src/schema.ts
+++ b/client/packages/platform/src/schema.ts
@@ -250,8 +250,12 @@ export type InstantAPISchemaPushStep =
   | InstantAPISchemaPushCheckDataTypeStep
   | InstantAPISchemaPushRemoveDataTypeStep;
 
-function attrDefToCodeString([name, attr]: [string, DataAttrDef<any, any>]) {
-  const type = attr['valueType'] || 'any';
+function attrDefToCodeString([name, attr]: [
+  string,
+  DataAttrDef<string, boolean>,
+]) {
+  const type =
+    (attr.metadata.derivedType as any)?.type || attr.valueType || 'any';
   const unique = attr.config.unique ? '.unique()' : '';
   const index = attr.config.indexed ? '.indexed()' : '';
   const required = attr.required ? '' : '.optional()';
@@ -374,7 +378,7 @@ export function generateSchemaTypescriptFile(
 
   for (const entity of Object.values(newSchema.entities)) {
     for (const attr of Object.values(entity.attrs)) {
-      if (attr.metadata.typeOrigin === 'inferred') {
+      if ((attr.metadata.derivedType as any)?.origin === 'inferred') {
         inferredAttrs.push(attr);
       }
     }

--- a/client/packages/platform/src/schema.ts
+++ b/client/packages/platform/src/schema.ts
@@ -1,16 +1,22 @@
-import type {
+import {
   AttrsDefs,
   CardinalityKind,
-  EntitiesDef,
+  DataAttrDef,
   EntityDef,
   InstantDBAttr,
   InstantDBCheckedDataType,
   InstantDBIdent,
   InstantSchemaDef,
   LinkAttrDef,
-  LinksDef,
   RoomsDef,
 } from '@instantdb/core';
+
+import {
+  indentLines,
+  joinWithTrailingSep,
+  sortedEntries,
+  formatKey,
+} from './util.ts';
 
 export type InstantAPIPlatformSchema = {
   refs: Record<string, InstantDBAttr>;
@@ -244,66 +250,14 @@ export type InstantAPISchemaPushStep =
   | InstantAPISchemaPushCheckDataTypeStep
   | InstantAPISchemaPushRemoveDataTypeStep;
 
-function sortedEntries<T>(o: Record<string, T>): [string, T][] {
-  return Object.entries(o).sort(([a], [b]) => a.localeCompare(b));
+function attrDefToCodeString([name, attr]: [string, DataAttrDef<any, any>]) {
+  const type = attr['valueType'] || 'any';
+  const unique = attr.config.unique ? '.unique()' : '';
+  const index = attr.config.indexed ? '.indexed()' : '';
+  const required = attr.required ? '' : '.optional()';
+  return `${formatKey(name)}: i.${type}()${unique}${index}${required}`;
 }
 
-function capitalizeFirstLetter(string: string): string {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-function indentLines(s: string, n = 2) {
-  const space = ' '.repeat(n);
-  return s
-    .split('\n')
-    .map((l) => `${space}${l}`)
-    .join('\n');
-}
-
-/**
- * Generates code for a single attr:
- *   attr2: i.number.index()
- */
-function attrToCodeString([name, config]: [string, InstantDBAttr]) {
-  const { type } = deriveClientType(config);
-  const unique = config['unique?'] ? '.unique()' : '';
-  const index = config['index?'] ? '.indexed()' : '';
-  const required = config['required?'] ? '' : '.optional()';
-  return `"${name}": i.${type}()${unique}${index}${required}`;
-}
-
-/**
- * Generates code for an entity:
- *  i.entity({
- *    attr1: i.string(),
- *    attr2: i.number.index()
- * })
- *
- */
-function schemaBlobToCodeStr(
-  name: string,
-  attrs: InstantAPIPlatformSchema['blobs'][string],
-) {
-  const attrBlock = sortedEntries(attrs)
-    .filter(([name]) => name !== 'id')
-    .map((attr) => attrToCodeString(attr))
-    .join(',\n');
-  return `"${name}": i.entity({
-${indentLines(attrBlock, 2)}
-})`;
-}
-
-/**
- * Note:
- * This is _very_ similar to `schemaBlobToCodeStr`.
- *
- * Right now, the frontend and backend have slightly different data structures for storing entity info.
- *
- * The backend returns {etype: attrs}, where attr keep things like `value-type`
- * The frontend stores {etype: EntityDef}, where EntityDef has a `valueType` field.
- *
- * For now, keeping the two functions separate.
- */
 function entityDefToCodeStr(
   name: string,
   edef: EntityDef<
@@ -312,35 +266,14 @@ function entityDefToCodeStr(
     any
   >,
 ) {
-  // a block of code for each entity
-  return [
-    `  `,
-    `"${name}"`,
-    `: `,
-    `i.entity`,
-    `({`,
-    `\n`,
-    // a line of code for each attribute in the entity
-    sortedEntries(edef.attrs)
-      .map(([name, attr]) => {
-        const type = attr['valueType'] || 'any';
+  const attrBlock = joinWithTrailingSep(
+    sortedEntries(edef.attrs).map(attrDefToCodeString),
+    ',\n',
+    ',',
+  );
 
-        return [
-          `    `,
-          `"${name}"`,
-          `: `,
-          `i.${type}()`,
-          attr?.config['unique'] ? '.unique()' : '',
-          attr?.config['indexed'] ? '.indexed()' : '',
-          `,`,
-        ].join('');
-      })
-      .join('\n'),
-    `\n`,
-    `  `,
-    `})`,
-    `,`,
-  ].join('');
+  // a block of code for each entity
+  return `${formatKey(name)}: i.entity({${attrBlock.length ? '\n' : ''}${indentLines(attrBlock, 2)}${attrBlock.length ? '\n' : ''}})`;
 }
 
 export function identEtype(ident: InstantDBIdent) {
@@ -381,58 +314,22 @@ export function attrRevName(attr: InstantDBAttr) {
   }
 }
 
-function inferredType(attr: InstantDBAttr) {
-  if (attr.catalog === 'system') {
-    return null;
-  }
-
-  const inferredList = attr['inferred-types'];
-  const hasJustOne = inferredList?.length === 1;
-
-  if (!hasJustOne) {
-    return null;
-  }
-
-  return inferredList[0];
-}
-
-function deriveClientType(attr: InstantDBAttr) {
-  if (attr['checked-data-type']) {
-    return { type: attr['checked-data-type'], origin: 'checked' };
-  }
-
-  const inferred = inferredType(attr);
-
-  if (inferred) {
-    return { type: inferred, origin: 'inferred' };
-  }
-
-  return { type: 'any', origin: 'unknown' };
-}
-
 function easyPlural(strn: string, n: number) {
   return n === 1 ? strn : strn + 's';
 }
-
-const rels = {
-  'many-false': ['many', 'many'],
-  'one-true': ['one', 'one'],
-  'many-true': ['many', 'one'],
-  'one-false': ['one', 'many'],
-};
 
 function roomDefToCodeStr(room: RoomsDef[string]) {
   let ret = '{';
 
   if (room.presence) {
-    ret += `\n${indentLines(entityDefToCodeStr('presence', room.presence), 2)}`;
+    ret += `\n${indentLines(entityDefToCodeStr('presence', room.presence), 4)},`;
   }
 
   if (room.topics) {
     ret += `\n    topics: {`;
 
     for (const [topicName, topicConfig] of Object.entries(room.topics)) {
-      ret += `\n${indentLines(entityDefToCodeStr(topicName, topicConfig), 4)}`;
+      ret += `\n${indentLines(entityDefToCodeStr(topicName, topicConfig), 6)},`;
     }
     ret += `\n    }`;
   }
@@ -446,32 +343,42 @@ function roomsCodeStr(rooms: RoomsDef) {
   let ret = '{';
 
   for (const [roomType, roomDef] of Object.entries(rooms)) {
-    ret += `\n  "${roomType}": ${roomDefToCodeStr(roomDef)},`;
+    ret += `\n  ${formatKey(roomType)}: ${roomDefToCodeStr(roomDef)},`;
   }
   ret += ret === '{' ? '}' : '\n}';
 
   return ret;
 }
 
+type GenericSchemaDef = InstantSchemaDef<
+  Record<string, EntityDef<AttrsDefs, any, any>>,
+  any,
+  any
+>;
+
 export function generateSchemaTypescriptFile(
-  prevSchema:
-    | InstantSchemaDef<EntitiesDef, LinksDef<EntitiesDef>, RoomsDef>
-    | null
-    | undefined,
-  newSchema: InstantAPIPlatformSchema,
+  prevSchema: GenericSchemaDef | null | undefined,
+  newSchema: GenericSchemaDef,
   instantModuleName: string,
 ): string {
   // entities
-  const entitiesEntriesCode = sortedEntries(newSchema.blobs)
-    .map(([name, attrs]) => schemaBlobToCodeStr(name, attrs))
-    .join(',\n');
-  const inferredAttrs = Object.values(newSchema.blobs)
-    .flatMap(Object.values)
-    .filter(
-      (attr) =>
-        attrFwdLabel(attr) !== 'id' &&
-        deriveClientType(attr).origin === 'inferred',
-    );
+  const entitiesEntriesCode = joinWithTrailingSep(
+    sortedEntries(newSchema.entities).map(([etype, entityDef]) =>
+      entityDefToCodeStr(etype, entityDef),
+    ),
+    ',\n',
+    ',',
+  );
+
+  const inferredAttrs: DataAttrDef<string, boolean>[] = [];
+
+  for (const entity of Object.values(newSchema.entities)) {
+    for (const attr of Object.values(entity.attrs)) {
+      if (attr.metadata.typeOrigin === 'inferred') {
+        inferredAttrs.push(attr);
+      }
+    }
+  }
 
   const entitiesObjCode = `{\n${indentLines(entitiesEntriesCode, 2)}\n}`;
 
@@ -482,33 +389,7 @@ export function generateSchemaTypescriptFile(
 // run \`push schema\` again to enforce the types.`
       : '';
 
-  // links
-  const linksEntries = Object.fromEntries(
-    sortedEntries(newSchema.refs).map(([_name, config]) => {
-      const [, fe, flabel] = config['forward-identity'];
-      const [, re, rlabel] = config['reverse-identity']!;
-      const [fhas, rhas] = rels[`${config.cardinality}-${config['unique?']}`];
-      const desc = {
-        forward: {
-          on: fe,
-          has: fhas,
-          label: flabel,
-          required: config['required?'] || undefined,
-          onDelete: config['on-delete'] === 'cascade' ? 'cascade' : undefined,
-        },
-        reverse: {
-          on: re,
-          has: rhas,
-          label: rlabel,
-          onDelete:
-            config['on-delete-reverse'] === 'cascade' ? 'cascade' : undefined,
-        },
-      };
-
-      return [`${fe}${capitalizeFirstLetter(flabel)}`, desc];
-    }),
-  );
-  const linksEntriesCode = JSON.stringify(linksEntries, null, 2).trim();
+  const linksEntriesCode = JSON.stringify(newSchema.links, null, 2).trim();
 
   // rooms
   const rooms = prevSchema?.rooms || {};
@@ -518,7 +399,7 @@ export function generateSchemaTypescriptFile(
     return indentLines(res, 2);
   };
 
-  return `// Docs: https://www.instantdb.com/docs/modeling-data
+  const code = `// Docs: https://www.instantdb.com/docs/modeling-data
 
 import { i } from "${instantModuleName ?? '@instantdb/core'}";
 
@@ -536,4 +417,6 @@ const schema: AppSchema = _schema;
 export type { AppSchema }
 export default schema;
 `;
+
+  return code;
 }

--- a/client/packages/platform/src/util.ts
+++ b/client/packages/platform/src/util.ts
@@ -1,0 +1,87 @@
+import {
+  CardinalityKind,
+  InstantDBAttr,
+  InstantDBCheckedDataType,
+  InstantDBInferredType,
+} from '@instantdb/core';
+
+export function sortedEntries<T>(o: Record<string, T>): [string, T][] {
+  return Object.entries(o).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function capitalizeFirstLetter(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+export const rels: Record<string, CardinalityKind[]> = {
+  'many-false': ['many', 'many'],
+  'one-true': ['one', 'one'],
+  'many-true': ['many', 'one'],
+  'one-false': ['one', 'many'],
+};
+
+export function indentLines(s: string, n = 2) {
+  if (!s) {
+    return s;
+  }
+  const space = ' '.repeat(n);
+  return s
+    .split('\n')
+    .map((l) => `${space}${l}`)
+    .join('\n');
+}
+
+export function joinWithTrailingSep(
+  arr: string[],
+  sep: string,
+  trailingSep: string = sep,
+): string {
+  const s = arr.join(sep);
+  if (arr.length) {
+    return s + trailingSep;
+  }
+  return s;
+}
+
+export function inferredType(attr: InstantDBAttr) {
+  if (attr.catalog === 'system') {
+    return null;
+  }
+
+  const inferredList = attr['inferred-types'];
+  const hasJustOne = inferredList?.length === 1;
+
+  if (!hasJustOne) {
+    return null;
+  }
+
+  return inferredList[0];
+}
+
+export function deriveClientType(attr: InstantDBAttr): {
+  type: InstantDBCheckedDataType | InstantDBInferredType | 'any';
+  origin: 'checked' | 'inferred' | 'unknown';
+} {
+  if (attr['checked-data-type']) {
+    return { type: attr['checked-data-type'], origin: 'checked' };
+  }
+
+  const inferred = inferredType(attr);
+
+  if (inferred) {
+    return { type: inferred, origin: 'inferred' };
+  }
+
+  return { type: 'any', origin: 'unknown' };
+}
+
+export function formatKey(key: string) {
+  return `"${key}"`;
+  // It would be nice to generate unquoted keys, but we use JSON.stringify
+  // for some things so we can't be consistent with it unless we write our own
+  // stringify function. If we do, here's the code for formatting keys:
+  // if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)) {
+  //   return key;
+  // }
+  // return `"${key}"`;
+}

--- a/client/sandbox/react-nextjs/pages/play/platform-sdk-demo.tsx
+++ b/client/sandbox/react-nextjs/pages/play/platform-sdk-demo.tsx
@@ -1,4 +1,10 @@
-import { OAuthHandler, OAuthScope, PlatformApi, i } from '@instantdb/platform';
+import {
+  OAuthHandler,
+  OAuthScope,
+  PlatformApi,
+  i,
+  generateSchemaTypescriptFile,
+} from '@instantdb/platform';
 import { useState } from 'react';
 import config from '../../config';
 
@@ -7,6 +13,7 @@ globalThis._dev = {
   i,
   PlatformApi,
   OAuthHandler,
+  generateSchemaTypescriptFile,
 };
 
 const OAUTH_CLIENT_ID = process.env.NEXT_PUBLIC_PLATFORM_OAUTH_CLIENT_ID;
@@ -107,9 +114,9 @@ function ApiDemo({ accessToken }: { accessToken: string }) {
   globalThis._dev.api = api;
   const [result, setResult] = useState<any>(null);
 
-  const getApps = async () => {
+  const getApps = async (opts: any) => {
     try {
-      setResult(await api.getApps());
+      setResult(await api.getApps(opts));
     } catch (e) {
       setResult(e);
     }
@@ -120,6 +127,18 @@ function ApiDemo({ accessToken }: { accessToken: string }) {
       <div>
         <button className="bg-black text-white m-2 p-2" onClick={getApps}>
           Get Apps
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => getApps({ includeSchema: true })}
+        >
+          Get Apps with schema
+        </button>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => getApps({ includePerms: true })}
+        >
+          Get Apps with perms
         </button>
       </div>
       {result ? (


### PR DESCRIPTION
This PR hides the API format of the schema from the `@instantdb/platform` consumer.

Whenever we return the schema from the API, we always convert it to the `InstantSchemaDef` format (e.g. `i.schema({entities: {...}})`).

When you call any of the functions that would return a schema, like `api.getSchema(appId)`, we'll convert it before we return it, and you'll get a `InstantSchemaDef` back instead.

The code that generates the typescript `instant.schema.ts` file also takes a `InstantSchemaDef` now. I had to make one small change to `DataAttrDef` so that we could keep track of which attrs were inferred. It now has a `metadata` field that you can write to. I store whether the type was inferred there.

~~The code generation also generates `i.json()` instead of `i.any()` now. If that's a problem, I think I could just revert to the old way by always outputting `i.any()` when I see a DataAttrDef with type `json` to keep the behavior.~~ (updated to keep the old behavior)

Also fixes a bug where we weren't converting the app into the js format (e.g. the type said createdAt, but we returned created_at).