### PR TITLE
Only remove hints from the single pagination cte

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1480,7 +1480,9 @@
                           {:select [[[:exists has-previous-query]]]}
                           :not-materialized])
              :pg-hints (if true ;; disable hints for pagination until we can generate better plans
-                         []
+                         (if *testing-pg-hints*
+                           (:pg-hints (:query match-query))
+                           [])
                          (into (:pg-hints (:query match-query))
                                pg-hints))
              :select (kw last-row-table :.*)


### PR DESCRIPTION
In [a previous PR](https://github.com/instantdb/instant/pull/1244), I disabled a bit too much for the pagination hints. Instead of just disabling the hint for the cte that was doing pagination, I also disabled hints for any ctes before the pagination cte.

Now it only removes the hint for the single pagination cte.

I put it behind the testing flag so that we can see how it will affect queries before rolling it out to production.