### PR TITLE
Address problem of offline updates resurrecting entities

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -28,7 +28,7 @@
         software.amazon.awssdk.crt/aws-crt {:mvn/version "0.33.11"}
 
         juji/editscript {:mvn/version "0.6.4"}
-        io.github.tonsky/clojure-plus {:mvn/version "1.5.0"}
+        io.github.tonsky/clojure-plus {:mvn/version "1.5.1"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 

--- a/server/resources/migrations/71_deleted_entities.down.sql
+++ b/server/resources/migrations/71_deleted_entities.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE deleted_entities;

--- a/server/resources/migrations/71_deleted_entities.up.sql
+++ b/server/resources/migrations/71_deleted_entities.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE deleted_entities (
+    app_id uuid NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+    entity_id uuid NOT NULL,
+    etype text NOT NULL,
+    deleted_at bigint NOT NULL DEFAULT current_unix_timestamp_ms(),
+    PRIMARY KEY(app_id, entity_id, etype)
+);


### PR DESCRIPTION
Problem:

1. Client 1 deletes entity X
2. Client 2 updates entity X with name = “new_name”

If these updates arrive in 1-2 order to the server, entity X will be resurrected: update from client 2 will be treated as `create` operation. This seems to be against the intention.

Plan:

- [x] Create table deleted_entities(app_id, entity_id, etype)
- [x] When deleting entities, add their ids/types to deleted_entities
- [ ] Introduce new `create` operation that will throw if entity already exists
- [ ] Introduce new `change` operation that will throw if entity doesn’t already exists
- [ ] `change` on deleted entities will be silently ignored
- [ ] deprecate `update`