### PR TITLE
@instantdb/platform helper to parse a schema file into an InstantSchemaDef

### DIFF
--- a/client/packages/platform/README.md
+++ b/client/packages/platform/README.md
@@ -393,12 +393,45 @@ Some failed steps will include an `invalidTriplesSample` in the background job, 
 The platform package includes helpers for generating the `instant.schema.ts` and `instant.perms.ts` config files from the schema and perms data returned from the API.
 
 ```ts
-import { generateSchemaTypescriptFile, generatePermsTypescriptFile } from '@instantdb/platform;
+import {
+  generateSchemaTypescriptFile,
+  generatePermsTypescriptFile,
+} from '@instantdb/platform';
 
-console.log(generateSchemaTypescriptFile(null, shemaFromApi, '@instantdb/core'));
+console.log(
+  generateSchemaTypescriptFile(null, shemaFromApi, '@instantdb/core'),
+);
 
 console.log(generatePermsTypescriptFile(permsFromApi, '@instantdb/core'));
 ```
+
+Use `schemaTypescriptFileToInstantSchema` to recover an `InstantSchemaDef` from the typescript file:
+
+```ts
+import {
+  i,
+  generateSchemaTypescriptFile,
+  schemaTypescriptFileToInstantSchema,
+} from '@instantdb/platform';
+
+// Example schema
+const schema = i.schema({
+  entities: {
+    books: i.entity({
+      title: i.string().unique(),
+    }),
+  },
+});
+
+// Example of the typescript file that was generated for a schema
+const code = generateTypescriptFile(null, schema, '@instantdb/core');
+
+const recoveredSchema = schemaTypescriptFileToInstantSchema(code);
+
+schema == recoveredSchema;
+```
+
+This is useful when parsing a schema that the user manually edited or pulled with `npx instant-cli pull`.
 
 # Questions?
 

--- a/client/packages/platform/__tests__/src/schema.test.ts
+++ b/client/packages/platform/__tests__/src/schema.test.ts
@@ -494,7 +494,7 @@ const _schema = i.schema({
         "name": i.string(),
         "status": i.string(),
       }),
-      topics: {
+      "topics": {
         "sendEmoji": i.entity({
           "emoji": i.string(),
         }),

--- a/client/packages/platform/__tests__/src/typescript-schema.test.ts
+++ b/client/packages/platform/__tests__/src/typescript-schema.test.ts
@@ -1,0 +1,115 @@
+import { i } from '@instantdb/core';
+import { test, expect } from 'vitest';
+import { generateSchemaTypescriptFile } from '../../src/schema';
+import { schemaTypescriptFileToInstantSchema } from '../../src/typescript-schema';
+import prettier from '@prettier/sync';
+
+test('roundtrips schema', () => {
+  const originalCode = generateSchemaTypescriptFile(
+    schema,
+    schema,
+    '@instantdb/core',
+  );
+  const extractedSchema = schemaTypescriptFileToInstantSchema(originalCode);
+  expect(extractedSchema).toEqual(schema);
+  expect(generateSchemaTypescriptFile(null, schema, '@instantdb/core')).toEqual(
+    generateSchemaTypescriptFile(null, extractedSchema, '@instantdb/core'),
+  );
+});
+
+function format(code: string): string {
+  return prettier.format(code, { parser: 'typescript' });
+}
+
+test('roundtrips schema with prettier-ed code', () => {
+  const originalCode = format(
+    generateSchemaTypescriptFile(schema, schema, '@instantdb/core'),
+  );
+
+  const extractedSchema = schemaTypescriptFileToInstantSchema(originalCode);
+  expect(extractedSchema).toEqual(schema);
+  expect(
+    format(generateSchemaTypescriptFile(null, schema, '@instantdb/core')),
+  ).toEqual(
+    format(
+      generateSchemaTypescriptFile(null, extractedSchema, '@instantdb/core'),
+    ),
+  );
+});
+
+const schema = i.schema({
+  entities: {
+    $files: i.entity({
+      metadata: i.any().optional(),
+      path: i.string().unique().indexed().optional(),
+      url: i.any().optional(),
+    }),
+    $users: i.entity({
+      email: i.string().unique().indexed().optional(),
+    }),
+    books: i.entity({
+      description: i.string().optional(),
+      isbn13: i.string().unique().optional(),
+      pageCount: i.number().indexed().optional(),
+      thumbnail: i.any().optional(),
+      title: i.string().indexed(),
+    }),
+    bookshelves: i.entity({
+      desc: i.string().optional(),
+      name: i.any().optional(),
+      order: i.number().indexed().optional(),
+    }),
+    onlyId: i.entity({}),
+    users: i.entity({
+      createdAt: i.date().optional(),
+      email: i.string().unique().indexed().optional(),
+      fullName: i.string().optional(),
+      handle: i.string().unique().indexed().optional(),
+    }),
+    'key-as-string': i.entity({
+      prop: i.string().unique(),
+    }),
+  },
+  links: {
+    bookshelvesBooks: {
+      forward: {
+        on: 'bookshelves',
+        has: 'many',
+        label: 'books',
+      },
+      reverse: {
+        on: 'books',
+        has: 'many',
+        label: 'bookshelves',
+      },
+    },
+    usersBookshelves: {
+      forward: {
+        on: 'users',
+        has: 'many',
+        label: 'bookshelves',
+      },
+      reverse: {
+        on: 'bookshelves',
+        has: 'many',
+        label: 'users',
+      },
+    },
+  },
+  rooms: {
+    chat: {
+      presence: i.entity({
+        name: i.string(),
+        status: i.string(),
+      }),
+      topics: {
+        'send-emoji': i.entity({
+          emoji: i.string(),
+        }),
+      },
+    },
+    noTopics: {
+      presence: i.entity({ name: i.string() }),
+    },
+  },
+});

--- a/client/packages/platform/package.json
+++ b/client/packages/platform/package.json
@@ -42,19 +42,24 @@
     "publish-package": "pnpm publish --access public --no-git-checks"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
+    "@babel/types": "^7.27.6",
+    "@prettier/sync": "^0.5.5",
     "@types/node": "^18.11.18",
     "@types/uuid": "^8.3.4",
     "@types/websocket": "^1.0.5",
     "fake-indexeddb": "^6.0.0",
     "tshy": "^3.0.2",
-    "@arethetypeswrong/cli": "^0.17.4",
     "typescript": "^5.8.3",
     "vite": "^5.2.0",
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@babel/parser": "^8.0.0-beta.0",
+    "@babel/traverse": "^8.0.0-beta.0",
+    "@babel/types": "^8.0.0-beta.0",
     "@instantdb/core": "workspace:*"
   }
 }

--- a/client/packages/platform/package.json
+++ b/client/packages/platform/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@babel/parser": "^8.0.0-beta.0",
-    "@babel/traverse": "^8.0.0-beta.0",
     "@babel/types": "^8.0.0-beta.0",
     "@instantdb/core": "workspace:*"
   }

--- a/client/packages/platform/src/index.ts
+++ b/client/packages/platform/src/index.ts
@@ -14,6 +14,7 @@ import {
   PlatformApi,
   translatePlanSteps,
 } from './api.ts';
+import { schemaTypescriptFileToInstantSchema } from './typescript-schema.ts';
 
 import version from './version.js';
 import { ProgressPromise } from './ProgressPromise.ts';
@@ -30,6 +31,7 @@ export {
   generateSchemaTypescriptFile,
   generatePermsTypescriptFile,
   apiSchemaToInstantSchemaDef,
+  schemaTypescriptFileToInstantSchema,
   version,
   translatePlanSteps,
   PlatformApi,

--- a/client/packages/platform/src/schema.ts
+++ b/client/packages/platform/src/schema.ts
@@ -16,6 +16,7 @@ import {
   joinWithTrailingSep,
   sortedEntries,
   formatKey,
+  GenericSchemaDef,
 } from './util.ts';
 
 export type InstantAPIPlatformSchema = {
@@ -330,7 +331,7 @@ function roomDefToCodeStr(room: RoomsDef[string]) {
   }
 
   if (room.topics) {
-    ret += `\n    topics: {`;
+    ret += `\n    "topics": {`;
 
     for (const [topicName, topicConfig] of Object.entries(room.topics)) {
       ret += `\n${indentLines(entityDefToCodeStr(topicName, topicConfig), 6)},`;
@@ -353,12 +354,6 @@ function roomsCodeStr(rooms: RoomsDef) {
 
   return ret;
 }
-
-type GenericSchemaDef = InstantSchemaDef<
-  Record<string, EntityDef<AttrsDefs, any, any>>,
-  any,
-  any
->;
 
 export function generateSchemaTypescriptFile(
   prevSchema: GenericSchemaDef | null | undefined,

--- a/client/packages/platform/src/typescript-schema.ts
+++ b/client/packages/platform/src/typescript-schema.ts
@@ -42,9 +42,8 @@ function astToJson(node: Node | null): JsonValue | null {
       const objNode = node as ObjectExpression;
       return objNode.properties.reduce(
         (obj: { [key: string]: JsonValue }, prop) => {
-          // Using prop.type directly for checks
           if (prop.type === 'ObjectProperty') {
-            const objectProperty = prop as ObjectProperty; // Cast to ObjectProperty
+            const objectProperty = prop as ObjectProperty;
             let key: string | number;
             if (objectProperty.key.type === 'Identifier') {
               key = (objectProperty.key as Identifier).name;
@@ -81,7 +80,6 @@ function astToJson(node: Node | null): JsonValue | null {
           if (element && element.type === 'SpreadElement') {
             return undefined;
           }
-          // element can be Expression, SpreadElement or null
           return astToJson(element as Expression | SpreadElement | null);
         })
         .filter((value) => value !== undefined) as JsonValue[];
@@ -349,20 +347,6 @@ function roomsNodeToRoomsDef(
     }
 
     rooms[roomName] = roomNodeToRoomDef(roomName, property.value);
-
-    // if (
-    //   property.value.type !== 'CallExpression' ||
-    //   property.value.callee.type !== 'MemberExpression' ||
-    //   property.value.callee.object.type !== 'Identifier' ||
-    //   property.value.callee.object.name !== 'i' ||
-    //   property.value.arguments.length !== 1 ||
-    //   property.value.arguments[0].type !== 'ObjectExpression'
-    // ) {
-    //   throw new Error(
-    //     `Could not extract entity \`${etype}\`. Expected a call to \`i.entity()\`, got something else.`,
-    //   );
-    // }
-    // entities[etype] = entityNodeToEntityDef(etype, property.value.arguments[0]);
   }
 
   return rooms;

--- a/client/packages/platform/src/typescript-schema.ts
+++ b/client/packages/platform/src/typescript-schema.ts
@@ -1,0 +1,453 @@
+import { parse, type ParseResult, type File } from '@babel/parser';
+import traverse from '@babel/traverse';
+import type {
+  CallExpression,
+  ObjectExpression,
+  ObjectProperty,
+  Node,
+  Expression,
+  Identifier,
+  StringLiteral,
+  NumericLiteral,
+  ArrayExpression,
+  SpreadElement,
+  BooleanLiteral,
+} from '@babel/types';
+
+import { GenericSchemaDef } from './util.ts';
+import { AttrsDefs, DataAttrDef, i } from '@instantdb/core';
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Converts a Babel AST node into a JavaScript object/value,
+ * suitable for JSON serialization.
+ * Throws errors for unsupported AST structures.
+ * @param {Node | null} node - The Babel AST node to convert.
+ * @returns {JsonValue | null} The JavaScript representation.
+ * @throws {Error} If the AST node or its structure is not convertible to JSON.
+ */
+function astToJson(node: Node | null): JsonValue | null {
+  if (!node) {
+    return null;
+  }
+
+  switch (node.type) {
+    case 'ObjectExpression':
+      const objNode = node as ObjectExpression;
+      return objNode.properties.reduce(
+        (obj: { [key: string]: JsonValue }, prop) => {
+          // Using prop.type directly for checks
+          if (prop.type === 'ObjectProperty') {
+            const objectProperty = prop as ObjectProperty; // Cast to ObjectProperty
+            let key: string | number;
+            if (objectProperty.key.type === 'Identifier') {
+              key = (objectProperty.key as Identifier).name;
+            } else if (
+              objectProperty.key.type === 'StringLiteral' ||
+              objectProperty.key.type === 'NumericLiteral'
+            ) {
+              key = (objectProperty.key as StringLiteral | NumericLiteral)
+                .value;
+            } else {
+              throw new Error(
+                `Unsupported key type in ObjectProperty: ${objectProperty.key.type}`,
+              );
+            }
+            obj[key] = astToJson(objectProperty.value);
+          } else if (
+            prop.type !== 'SpreadElement' &&
+            prop.type !== 'ObjectMethod'
+          ) {
+            throw new Error(
+              // @ts-expect-error: prop is `never` here
+              `Unsupported property type in ObjectExpression: ${prop.type}`,
+            );
+          }
+          return obj;
+        },
+        {},
+      );
+
+    case 'ArrayExpression':
+      const arrNode = node as ArrayExpression;
+      return arrNode.elements
+        .map((element) => {
+          if (element && element.type === 'SpreadElement') {
+            return undefined;
+          }
+          // element can be Expression, SpreadElement or null
+          return astToJson(element as Expression | SpreadElement | null);
+        })
+        .filter((value) => value !== undefined) as JsonValue[];
+
+    case 'ObjectProperty':
+      const objPropNode = node as ObjectProperty;
+      let objectPropertyKey: string | number;
+      if (objPropNode.key.type === 'Identifier') {
+        objectPropertyKey = (objPropNode.key as Identifier).name;
+      } else if (
+        objPropNode.key.type === 'StringLiteral' ||
+        objPropNode.key.type === 'NumericLiteral'
+      ) {
+        objectPropertyKey = (objPropNode.key as StringLiteral | NumericLiteral)
+          .value;
+      } else {
+        throw new Error(
+          `Unsupported key type for standalone ObjectProperty: ${objPropNode.key.type}`,
+        );
+      }
+      const newObj: { [key: string]: JsonValue } = {};
+      newObj[objectPropertyKey] = astToJson(objPropNode.value);
+      return newObj;
+
+    case 'StringLiteral':
+    case 'NumericLiteral':
+    case 'BooleanLiteral':
+      return (node as StringLiteral | NumericLiteral | BooleanLiteral).value;
+
+    case 'NullLiteral':
+      return null;
+
+    default:
+      throw new Error(
+        `Unsupported AST node type for JSON conversion: ${node.type}`,
+      );
+  }
+}
+
+function keyName(property: ObjectProperty): string {
+  switch (property.key.type) {
+    case 'Identifier':
+      return property.key.name;
+    case 'StringLiteral':
+      return property.key.value;
+    default:
+      throw new Error(
+        `Could not extract entities, expected object key to be an \`Identifier\` or \`StringLiteral\`, got \`${property.key.type}\`.`,
+      );
+  }
+}
+
+function entityNodeToEntityDef(
+  etype: string,
+  node: ObjectExpression,
+): GenericSchemaDef['entities'][string] {
+  const attrs: AttrsDefs = {};
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      throw new Error(
+        `Expected i.entity for \`${etype}\` to contain only \`ObjectProperty\`, got \`${property.type}\`.`,
+      );
+    }
+    const label = keyName(property);
+
+    const props = [];
+
+    if (property.value.type !== 'CallExpression') {
+      throw new Error(
+        `Could not extract \`${etype}.${label}\`. Expected a call to \`i.string()\`, \`i.number()\`, etc. Got something else.`,
+      );
+    }
+    let next: CallExpression | null = property.value;
+    if (label === 'path') {
+    }
+    let attrDef: DataAttrDef<string, boolean> | null = null;
+    while (next) {
+      if (
+        next.callee.type !== 'MemberExpression' ||
+        next.callee.property.type !== 'Identifier' ||
+        !(
+          next.callee.object.type === 'CallExpression' ||
+          (next.callee.object.type === 'Identifier' &&
+            next.callee.object.name === 'i')
+        )
+      ) {
+        throw new Error(
+          `Could not extract \`${etype}.${label}\`. Expected a call to \`i.string()\`, \`i.number()\`, etc. Got something else.`,
+        );
+      }
+
+      if (next.callee.object.type === 'CallExpression') {
+        props.push(next.callee.property.name);
+        next = next.callee.object;
+      } else {
+        switch (next.callee.property.name) {
+          case 'string': {
+            attrDef = i.string();
+            break;
+          }
+          case 'number': {
+            attrDef = i.number();
+            break;
+          }
+          case 'boolean': {
+            attrDef = i.boolean();
+            break;
+          }
+          case 'date': {
+            attrDef = i.date();
+            break;
+          }
+          case 'json': {
+            attrDef = i.json();
+            break;
+          }
+          case 'any': {
+            attrDef = i.any();
+            break;
+          }
+        }
+        next = null;
+      }
+    }
+
+    if (!attrDef) {
+      throw new Error(
+        `Could not extract \`${etype}.${label}\`. Found no call to \`i.string()\`, \`i.number()\`, etc.`,
+      );
+    }
+
+    for (const prop of props.reverse()) {
+      switch (prop) {
+        case 'indexed': {
+          attrDef = attrDef.indexed();
+          break;
+        }
+        case 'unique': {
+          attrDef = attrDef.unique();
+          break;
+        }
+        case 'optional': {
+          attrDef = attrDef.optional();
+          break;
+        }
+        case 'clientRequired': {
+          attrDef = attrDef.clientRequired();
+          break;
+        }
+        default: {
+          throw new Error(
+            `Could not extract \`${etype}.${label}\`. Found a call to \`${prop}()\` that is not recognized.`,
+          );
+        }
+      }
+    }
+
+    attrs[label] = attrDef;
+  }
+
+  return i.entity(attrs);
+}
+
+function entitiesNodeToEntitiesDef(
+  node: ObjectExpression,
+): GenericSchemaDef['entities'] {
+  const entities: GenericSchemaDef['entities'] = {};
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      throw new Error(
+        `Expected entities to contain only \`ObjectProperty\`, got \`${property.type}\`.`,
+      );
+    }
+    const etype = keyName(property);
+    if (
+      property.value.type !== 'CallExpression' ||
+      property.value.callee.type !== 'MemberExpression' ||
+      property.value.callee.object.type !== 'Identifier' ||
+      property.value.callee.object.name !== 'i' ||
+      property.value.arguments.length !== 1 ||
+      property.value.arguments[0].type !== 'ObjectExpression'
+    ) {
+      throw new Error(
+        `Could not extract entity \`${etype}\`. Expected a call to \`i.entity()\`, got something else.`,
+      );
+    }
+    entities[etype] = entityNodeToEntityDef(etype, property.value.arguments[0]);
+  }
+
+  return entities;
+}
+
+function roomNodeToRoomDef(
+  roomName: string,
+  node: ObjectExpression,
+): GenericSchemaDef['rooms'][string] {
+  let presence: GenericSchemaDef['rooms'][string]['presence'] | null = null;
+  let topics: GenericSchemaDef['rooms'][string]['topics'] | undefined =
+    undefined;
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      throw new Error(
+        `Expected entities to contain only \`ObjectProperty\`, got \`${property.type}\`.`,
+      );
+    }
+    const propName = keyName(property);
+    switch (propName) {
+      case 'topics': {
+        if (property.value.type !== 'ObjectExpression') {
+          throw new Error(
+            `Could not exxtract \`rooms.${roomName}.topics\`. Expected an object, got \`${property.value.type}\`.`,
+          );
+        }
+        topics = entitiesNodeToEntitiesDef(property.value);
+        break;
+      }
+      case 'presence': {
+        if (
+          property.value.type !== 'CallExpression' ||
+          property.value.callee.type !== 'MemberExpression' ||
+          property.value.callee.object.type !== 'Identifier' ||
+          property.value.callee.object.name !== 'i' ||
+          property.value.arguments.length !== 1 ||
+          property.value.arguments[0].type !== 'ObjectExpression'
+        ) {
+          throw new Error(
+            `Could not extract \`rooms.${roomName}.presence\`. Expected a call to \`i.entity()\`, got something else.`,
+          );
+        }
+        presence = entityNodeToEntityDef(roomName, property.value.arguments[0]);
+        break;
+      }
+      default: {
+        throw new Error(
+          `Could not extract \`rooms.${roomName}\`. Unexpected property \`${propName}\`.`,
+        );
+      }
+    }
+  }
+  if (!presence) {
+    throw new Error(
+      `Could not extract room ${roomName}, \`presence\` key was missing from room definition.`,
+    );
+  }
+  return { presence, topics };
+}
+
+function roomsNodeToRoomsDef(
+  node: ObjectExpression,
+): GenericSchemaDef['rooms'] {
+  const rooms: GenericSchemaDef['rooms'] = {};
+  for (const property of node.properties) {
+    if (property.type !== 'ObjectProperty') {
+      throw new Error(
+        `Expected entities to contain only \`ObjectProperty\`, got \`${property.type}\`.`,
+      );
+    }
+
+    const roomName = keyName(property);
+
+    if (property.value.type !== 'ObjectExpression') {
+      throw new Error(
+        `Could not extract room \`${roomName}\`. Expected an object with topics and presence keys, got \`${property.value.type}\`.`,
+      );
+    }
+
+    rooms[roomName] = roomNodeToRoomDef(roomName, property.value);
+
+    // if (
+    //   property.value.type !== 'CallExpression' ||
+    //   property.value.callee.type !== 'MemberExpression' ||
+    //   property.value.callee.object.type !== 'Identifier' ||
+    //   property.value.callee.object.name !== 'i' ||
+    //   property.value.arguments.length !== 1 ||
+    //   property.value.arguments[0].type !== 'ObjectExpression'
+    // ) {
+    //   throw new Error(
+    //     `Could not extract entity \`${etype}\`. Expected a call to \`i.entity()\`, got something else.`,
+    //   );
+    // }
+    // entities[etype] = entityNodeToEntityDef(etype, property.value.arguments[0]);
+  }
+
+  return rooms;
+}
+
+function astToSchemaDef(ast: ParseResult<File>): GenericSchemaDef {
+  let entities: GenericSchemaDef['entities'] | null = null;
+  let links = {};
+  let rooms = {};
+
+  traverse(ast, {
+    VariableDeclarator(path) {
+      const node = path.node;
+      if (node.id.type === 'Identifier' && node.id.name === '_schema') {
+        // We're in `const _schema = ...`
+        path.stop();
+
+        if (
+          !node.init ||
+          node.init.type !== 'CallExpression' ||
+          node.init.callee.type !== 'MemberExpression' ||
+          node.init.callee.object.type !== 'Identifier' ||
+          node.init.callee.object.name !== 'i' ||
+          node.init.arguments.length !== 1 ||
+          node.init.arguments[0].type !== 'ObjectExpression'
+        ) {
+          throw new Error(
+            `Could not extract schema. Expected a call to \`i.schema()\`, got something else.`,
+          );
+        }
+
+        for (const property of node.init.arguments[0].properties) {
+          if (property.type !== 'ObjectProperty') {
+            throw new Error(
+              `Could not extra schema property, expected an \`ObjectProperty\`, got \`${property.type}\'.`,
+            );
+          }
+          const section = keyName(property);
+          if (property.value.type !== 'ObjectExpression') {
+            throw new Error(
+              `Failed to extract ${section}, expected an \`ObjectExpression\`, got \`${property.value.type}\`.`,
+            );
+          }
+          switch (keyName(property)) {
+            case 'entities': {
+              entities = entitiesNodeToEntitiesDef(property.value);
+              break;
+            }
+            case 'links': {
+              links = astToJson(property.value) || {};
+              break;
+            }
+            case 'rooms': {
+              rooms = roomsNodeToRoomsDef(property.value);
+              break;
+            }
+          }
+        }
+      }
+    },
+  });
+
+  if (!entities) {
+    throw new Error('Could not extract schema, did not find any entities.');
+  }
+
+  return i.schema({ entities, links, rooms });
+}
+
+export function schemaTypescriptFileToInstantSchema(
+  content: string,
+  sourceFilename: string = 'instant.schema.ts',
+): GenericSchemaDef {
+  const ast = parse(content, {
+    sourceFilename,
+    sourceType: 'module',
+    errorRecovery: false,
+    plugins: ['typescript'],
+  });
+  if (ast.errors?.length) {
+    throw new Error(
+      `Could not parse schema file. ${ast.errors[0].reasonCode}.`,
+    );
+  }
+
+  return astToSchemaDef(ast);
+}

--- a/client/packages/platform/src/util.ts
+++ b/client/packages/platform/src/util.ts
@@ -1,8 +1,13 @@
 import {
+  AttrsDefs,
   CardinalityKind,
+  EntityDef,
   InstantDBAttr,
   InstantDBCheckedDataType,
   InstantDBInferredType,
+  InstantSchemaDef,
+  LinksDef,
+  RoomsDef,
 } from '@instantdb/core';
 
 export function sortedEntries<T>(o: Record<string, T>): [string, T][] {
@@ -85,3 +90,9 @@ export function formatKey(key: string) {
   // }
   // return `"${key}"`;
 }
+
+export type GenericSchemaDef = InstantSchemaDef<
+  Record<string, EntityDef<AttrsDefs, any, any>>,
+  LinksDef<Record<string, EntityDef<AttrsDefs, any, any>>>,
+  RoomsDef
+>;

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       '@babel/parser':
         specifier: ^8.0.0-beta.0
         version: 8.0.0-beta.0
-      '@babel/traverse':
-        specifier: ^8.0.0-beta.0
-        version: 8.0.0-beta.0
       '@babel/types':
         specifier: ^8.0.0-beta.0
         version: 8.0.0-beta.0
@@ -993,10 +990,6 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@8.0.0-beta.0':
-    resolution: {integrity: sha512-Bws+VjMNVNqB3HXD6UxscrDnnIcsUp+SzX5nw3KvxEsLOuVTClyP2/G/BPrl6xcICS0QcB6SthW1+DclN717DQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@babel/compat-data@7.26.5':
     resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
     engines: {node: '>=6.9.0'}
@@ -1016,10 +1009,6 @@ packages:
   '@babel/generator@7.27.5':
     resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/generator@8.0.0-beta.0':
-    resolution: {integrity: sha512-1mS+6SWMkuRY0294/DzAI1L6ag4lC4CFvXtHp1iQD4iroYm/mYuRxDgP0Ojx8oi9MOybXEOsw9YoRo+6siK04g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-annotate-as-pure@7.25.9':
     resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
@@ -1730,17 +1719,9 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@8.0.0-beta.0':
-    resolution: {integrity: sha512-rEjNhNa3wKLASwZQEKecArXcO5qIgwtnvjUvwdK0j71MRfEt8BFbKC10xUcWVlIgZMrwu6OHxMQbYJPnwmHwFQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@babel/traverse@7.27.4':
     resolution: {integrity: sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@8.0.0-beta.0':
-    resolution: {integrity: sha512-BVIHvvWcy52CqLgXGbvzzUmKJ/SZibO2fPuHQl6JGWCEoi0ahxB74AQbDo9PsaP9gqtRonXMuWXgfyancd6UcA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/types@7.19.0':
     resolution: {integrity: sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==}
@@ -2631,7 +2612,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.20.3':
     resolution: {integrity: sha512-+nL2f6ZPV6e4yXS0P02jChstSJePihfFluapqnRM8+4pH4wsBOL1GoOc7hVFfwsP0vRE3HDqn5EEzrO+ZaCbpQ==}
@@ -8216,9 +8197,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@8.0.3:
-    resolution: {integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==}
-
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -12414,12 +12392,6 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/code-frame@8.0.0-beta.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 8.0.0-beta.0
-      js-tokens: 8.0.3
-      picocolors: 1.1.1
-
   '@babel/compat-data@7.26.5': {}
 
   '@babel/core@7.26.7':
@@ -12462,14 +12434,6 @@ snapshots:
     dependencies:
       '@babel/parser': 7.27.5
       '@babel/types': 7.27.6
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 3.1.0
-
-  '@babel/generator@8.0.0-beta.0':
-    dependencies:
-      '@babel/parser': 8.0.0-beta.0
-      '@babel/types': 8.0.0-beta.0
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
@@ -13331,12 +13295,6 @@ snapshots:
       '@babel/parser': 7.27.5
       '@babel/types': 7.27.6
 
-  '@babel/template@8.0.0-beta.0':
-    dependencies:
-      '@babel/code-frame': 8.0.0-beta.0
-      '@babel/parser': 8.0.0-beta.0
-      '@babel/types': 8.0.0-beta.0
-
   '@babel/traverse@7.27.4':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -13346,18 +13304,6 @@ snapshots:
       '@babel/types': 7.27.6
       debug: 4.4.0
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@8.0.0-beta.0':
-    dependencies:
-      '@babel/code-frame': 8.0.0-beta.0
-      '@babel/generator': 8.0.0-beta.0
-      '@babel/parser': 8.0.0-beta.0
-      '@babel/template': 8.0.0-beta.0
-      '@babel/types': 8.0.0-beta.0
-      debug: 4.4.0
-      globals: 15.14.0
     transitivePeerDependencies:
       - supports-color
 
@@ -20921,8 +20867,6 @@ snapshots:
   js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@8.0.3: {}
 
   js-tokens@9.0.1: {}
 

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -173,6 +173,15 @@ importers:
 
   packages/platform:
     dependencies:
+      '@babel/parser':
+        specifier: ^8.0.0-beta.0
+        version: 8.0.0-beta.0
+      '@babel/traverse':
+        specifier: ^8.0.0-beta.0
+        version: 8.0.0-beta.0
+      '@babel/types':
+        specifier: ^8.0.0-beta.0
+        version: 8.0.0-beta.0
       '@instantdb/core':
         specifier: workspace:*
         version: link:../core
@@ -186,6 +195,9 @@ importers:
       '@babel/preset-env':
         specifier: ^7.16.11
         version: 7.26.7(@babel/core@7.26.7)
+      '@prettier/sync':
+        specifier: ^0.5.5
+        version: 0.5.5(prettier@3.4.2)
       '@types/node':
         specifier: ^18.11.18
         version: 18.19.74
@@ -322,7 +334,7 @@ importers:
         version: 3.3.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.13.0)(typescript@5.8.3)
+        version: 10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3)
     devDependencies:
       '@types/body-parser':
         specifier: ^1.19.5
@@ -399,7 +411,7 @@ importers:
         version: 2.0.1(react-native@0.76.1(@babel/core@7.26.7)(@babel/preset-env@7.26.7(@babel/core@7.26.7))(@react-native-community/cli-server-api@15.1.3)(@types/react@18.3.1)(react@18.3.1))(react@18.3.1)
       nativewind:
         specifier: ^2.0.11
-        version: 2.0.11(react@18.3.1)(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3)))
+        version: 2.0.11(react@18.3.1)(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3)))
       postcss:
         specifier: ^8.4.23
         version: 8.5.1
@@ -426,7 +438,7 @@ importers:
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss:
         specifier: 3.3.2
-        version: 3.3.2(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3))
+        version: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3))
     devDependencies:
       '@babel/core':
         specifier: ^7.20.0
@@ -439,7 +451,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^5.3.7
-        version: 5.7.5(next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.7.5(next@15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@instantdb/admin':
         specifier: workspace:*
         version: link:../../packages/admin
@@ -466,7 +478,7 @@ importers:
         version: 1.2.5(react@18.3.1)
       next:
         specifier: latest
-        version: 15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -497,7 +509,7 @@ importers:
         version: 8.5.1
       tailwindcss:
         specifier: ^3.1.2
-        version: 3.3.2(ts-node@10.9.2(@types/node@17.0.35)(typescript@5.5.4))
+        version: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.35)(typescript@5.5.4))
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -724,17 +736,17 @@ importers:
         version: 2.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)))
+        version: 1.0.7(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)))
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
     devDependencies:
       '@tailwindcss/forms':
         specifier: ^0.5.2
-        version: 0.5.10(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)))
+        version: 0.5.10(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)))
       '@tailwindcss/typography':
         specifier: ^0.5.2
-        version: 0.5.16(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)))
+        version: 0.5.16(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)))
       '@testing-library/jest-dom':
         specifier: 6.6.3
         version: 6.6.3
@@ -782,7 +794,7 @@ importers:
         version: link:../packages/cli
       jest:
         specifier: 28.1.0
-        version: 28.1.0(@types/node@17.0.4)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+        version: 28.1.0(@types/node@17.0.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0
@@ -797,7 +809,7 @@ importers:
         version: 0.1.13(prettier@3.4.2)
       tailwindcss:
         specifier: ^3.0.7
-        version: 3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+        version: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -981,6 +993,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0-beta.0':
+    resolution: {integrity: sha512-Bws+VjMNVNqB3HXD6UxscrDnnIcsUp+SzX5nw3KvxEsLOuVTClyP2/G/BPrl6xcICS0QcB6SthW1+DclN717DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/compat-data@7.26.5':
     resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
     engines: {node: '>=6.9.0'}
@@ -996,6 +1012,14 @@ packages:
   '@babel/generator@7.27.1':
     resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.5':
+    resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@8.0.0-beta.0':
+    resolution: {integrity: sha512-1mS+6SWMkuRY0294/DzAI1L6ag4lC4CFvXtHp1iQD4iroYm/mYuRxDgP0Ojx8oi9MOybXEOsw9YoRo+6siK04g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-annotate-as-pure@7.25.9':
     resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
@@ -1064,13 +1088,13 @@ packages:
     resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@8.0.0-beta.0':
+    resolution: {integrity: sha512-JQSmsLB9YavJZiDNYJIPwCVMdmQMLiJiVTiRFD9izmL1J+Dz4mld5ztikogjPN6SeQ9BvGTRA9K3CExzigZddA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
@@ -1079,6 +1103,10 @@ packages:
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.0-beta.0':
+    resolution: {integrity: sha512-vk2UDvO5vaggpE/UmaAO3P8Sp+S1x2NEkjDZ0GpF0guuc/WgKsw9GAp1lsSKxjd2GP4W7qF7DA5L3MXFuki2tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-option@7.25.9':
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
@@ -1096,14 +1124,14 @@ packages:
     resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.7':
-    resolution: {integrity: sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==}
+  '@babel/parser@7.27.5':
+    resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.27.2':
-    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
-    engines: {node: '>=6.0.0'}
+  '@babel/parser@8.0.0-beta.0':
+    resolution: {integrity: sha512-qtov8PDRzRsTolcpLMs9Xn9nc/0R0fXI+YxxKaM9vZUCeYDt+lsMUCFCW1vEjOuXwX83xz8sapts31GIsbEFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9':
@@ -1702,13 +1730,17 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.26.7':
-    resolution: {integrity: sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==}
+  '@babel/template@8.0.0-beta.0':
+    resolution: {integrity: sha512-rEjNhNa3wKLASwZQEKecArXcO5qIgwtnvjUvwdK0j71MRfEt8BFbKC10xUcWVlIgZMrwu6OHxMQbYJPnwmHwFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/traverse@7.27.4':
+    resolution: {integrity: sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.27.1':
-    resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
-    engines: {node: '>=6.9.0'}
+  '@babel/traverse@8.0.0-beta.0':
+    resolution: {integrity: sha512-BVIHvvWcy52CqLgXGbvzzUmKJ/SZibO2fPuHQl6JGWCEoi0ahxB74AQbDo9PsaP9gqtRonXMuWXgfyancd6UcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/types@7.19.0':
     resolution: {integrity: sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==}
@@ -1718,13 +1750,13 @@ packages:
     resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.26.7':
-    resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
+  '@babel/types@7.27.6':
+    resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.27.1':
-    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
-    engines: {node: '>=6.9.0'}
+  '@babel/types@8.0.0-beta.0':
+    resolution: {integrity: sha512-djhZqI9fBlsHXiCpPFsydn6laWPRg+Zg6clvh4FsBjmUjK61bMg8ySnpmjH2bFGTwo4MX5pitzxvCQOgHDLM7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -1815,9 +1847,6 @@ packages:
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
-
-  '@emnapi/runtime@1.3.1':
-    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
 
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
@@ -2602,7 +2631,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.20.3':
     resolution: {integrity: sha512-+nL2f6ZPV6e4yXS0P02jChstSJePihfFluapqnRM8+4pH4wsBOL1GoOc7hVFfwsP0vRE3HDqn5EEzrO+ZaCbpQ==}
@@ -2752,8 +2781,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.34.2':
+    resolution: {integrity: sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.33.5':
     resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.2':
+    resolution: {integrity: sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
@@ -2763,8 +2804,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-x64@1.0.4':
     resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -2773,13 +2824,33 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-arm64@1.1.0':
+    resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
 
+  '@img/sharp-libvips-linux-arm@1.1.0':
+    resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.1.0':
+    resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.1.0':
+    resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
 
@@ -2788,8 +2859,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-x64@1.1.0':
+    resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
+    resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
 
@@ -2798,8 +2879,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linuxmusl-x64@1.1.0':
+    resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.2':
+    resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
@@ -2810,8 +2902,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@img/sharp-linux-arm@0.34.2':
+    resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.2':
+    resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
@@ -2822,8 +2926,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linux-x64@0.34.2':
+    resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.2':
+    resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
@@ -2834,10 +2950,27 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-x64@0.34.2':
+    resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
+
+  '@img/sharp-wasm32@0.34.2':
+    resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.2':
+    resolution: {integrity: sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@img/sharp-win32-ia32@0.33.5':
     resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
@@ -2845,8 +2978,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.34.2':
+    resolution: {integrity: sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.33.5':
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.2':
+    resolution: {integrity: sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -3135,8 +3280,8 @@ packages:
   '@mux/playback-core@0.25.2':
     resolution: {integrity: sha512-vrBbCgLHwmPpVxF0QGj+sXHUVXSxgDJJhVm8pxPXEkbw0vjPNHTXgAd/Ty6JA0vZ0ZjoQuAa17AxJ+c02JYeWQ==}
 
-  '@napi-rs/wasm-runtime@0.2.9':
-    resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
+  '@napi-rs/wasm-runtime@0.2.10':
+    resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
 
   '@netlify/binary-info@1.0.0':
     resolution: {integrity: sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==}
@@ -3176,8 +3321,8 @@ packages:
   '@next/env@15.1.6':
     resolution: {integrity: sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==}
 
-  '@next/env@15.2.3':
-    resolution: {integrity: sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==}
+  '@next/env@15.3.3':
+    resolution: {integrity: sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==}
 
   '@next/swc-darwin-arm64@15.1.6':
     resolution: {integrity: sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==}
@@ -3185,8 +3330,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@15.2.3':
-    resolution: {integrity: sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==}
+  '@next/swc-darwin-arm64@15.3.3':
+    resolution: {integrity: sha512-WRJERLuH+O3oYB4yZNVahSVFmtxRNjNF1I1c34tYMoJb0Pve+7/RaLAJJizyYiFhjYNGHRAE1Ri2Fd23zgDqhg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -3197,8 +3342,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.2.3':
-    resolution: {integrity: sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==}
+  '@next/swc-darwin-x64@15.3.3':
+    resolution: {integrity: sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -3209,8 +3354,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@15.2.3':
-    resolution: {integrity: sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==}
+  '@next/swc-linux-arm64-gnu@15.3.3':
+    resolution: {integrity: sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3221,8 +3366,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.2.3':
-    resolution: {integrity: sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==}
+  '@next/swc-linux-arm64-musl@15.3.3':
+    resolution: {integrity: sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3233,8 +3378,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.2.3':
-    resolution: {integrity: sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==}
+  '@next/swc-linux-x64-gnu@15.3.3':
+    resolution: {integrity: sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3245,8 +3390,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.2.3':
-    resolution: {integrity: sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==}
+  '@next/swc-linux-x64-musl@15.3.3':
+    resolution: {integrity: sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3257,8 +3402,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@15.2.3':
-    resolution: {integrity: sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==}
+  '@next/swc-win32-arm64-msvc@15.3.3':
+    resolution: {integrity: sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -3269,8 +3414,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.2.3':
-    resolution: {integrity: sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==}
+  '@next/swc-win32-x64-msvc@15.3.3':
+    resolution: {integrity: sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3500,6 +3645,11 @@ packages:
   '@poppinss/exception@1.2.1':
     resolution: {integrity: sha512-aQypoot0HPSJa6gDPEPTntc1GT6QINrSbgRlRhadGW2WaYqUK3tK4Bw9SBMZXhmxd3GeAlZjVcODHgiu+THY7A==}
     engines: {node: '>=18'}
+
+  '@prettier/sync@0.5.5':
+    resolution: {integrity: sha512-6BMtNr7aQhyNcGzmumkL0tgr1YQGfm9d7ZdmRpWqWuqpc9vZBind4xMe5NMiRECOhjuSiWHfBWLBnXkpeE90bw==}
+    peerDependencies:
+      prettier: '*'
 
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
@@ -4378,11 +4528,83 @@ packages:
     resolution: {integrity: sha512-pKS3wZnJoL1iTyGBXAvCwduNNeghJHY6QSRSNNvpYnrrQrLZ6Owsazjyynu0e0ObRgks0i7Rv+pe2M7/MBTZpQ==}
     engines: {node: '>=12.16'}
 
+  '@swc/core-darwin-arm64@1.11.29':
+    resolution: {integrity: sha512-whsCX7URzbuS5aET58c75Dloby3Gtj/ITk2vc4WW6pSDQKSPDuONsIcZ7B2ng8oz0K6ttbi4p3H/PNPQLJ4maQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.11.29':
+    resolution: {integrity: sha512-S3eTo/KYFk+76cWJRgX30hylN5XkSmjYtCBnM4jPLYn7L6zWYEPajsFLmruQEiTEDUg0gBEWLMNyUeghtswouw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.11.29':
+    resolution: {integrity: sha512-o9gdshbzkUMG6azldHdmKklcfrcMx+a23d/2qHQHPDLUPAN+Trd+sDQUYArK5Fcm7TlpG4sczz95ghN0DMkM7g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.11.29':
+    resolution: {integrity: sha512-sLoaciOgUKQF1KX9T6hPGzvhOQaJn+3DHy4LOHeXhQqvBgr+7QcZ+hl4uixPKTzxk6hy6Hb0QOvQEdBAAR1gXw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.11.29':
+    resolution: {integrity: sha512-PwjB10BC0N+Ce7RU/L23eYch6lXFHz7r3NFavIcwDNa/AAqywfxyxh13OeRy+P0cg7NDpWEETWspXeI4Ek8otw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.11.29':
+    resolution: {integrity: sha512-i62vBVoPaVe9A3mc6gJG07n0/e7FVeAvdD9uzZTtGLiuIfVfIBta8EMquzvf+POLycSk79Z6lRhGPZPJPYiQaA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.11.29':
+    resolution: {integrity: sha512-YER0XU1xqFdK0hKkfSVX1YIyCvMDI7K07GIpefPvcfyNGs38AXKhb2byySDjbVxkdl4dycaxxhRyhQ2gKSlsFQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.11.29':
+    resolution: {integrity: sha512-po+WHw+k9g6FAg5IJ+sMwtA/fIUL3zPQ4m/uJgONBATCVnDDkyW6dBA49uHNVtSEvjvhuD8DVWdFP847YTcITw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.11.29':
+    resolution: {integrity: sha512-h+NjOrbqdRBYr5ItmStmQt6x3tnhqgwbj9YxdGPepbTDamFv7vFnhZR0YfB3jz3UKJ8H3uGJ65Zw1VsC+xpFkg==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.11.29':
+    resolution: {integrity: sha512-Q8cs2BDV9wqDvqobkXOYdC+pLUSEpX/KvI0Dgfun1F+LzuLotRFuDhrvkU9ETJA6OnD2+Fn/ieHgloiKA/Mn/g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.11.29':
+    resolution: {integrity: sha512-g4mThMIpWbNhV8G2rWp5a5/Igv8/2UFRJx2yImrLGMgrDDYZIopqZ/z0jZxDgqNA1QDx93rpwNF7jGsxVWcMlA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.21':
+    resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
 
   '@tailwindcss/forms@0.5.10':
     resolution: {integrity: sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==}
@@ -6172,6 +6394,10 @@ packages:
 
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
   detect-newline@3.1.0:
@@ -7990,6 +8216,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@8.0.3:
+    resolution: {integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -8356,6 +8585,9 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  make-synchronized@0.4.2:
+    resolution: {integrity: sha512-EwEJSg8gSGLicKXp/VzNi1tvzhdmNBxOzslkkJSoNUCQFZKH/NIUIp7xlfN+noaHrz4BJDN73gne8IHnjl/F/A==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -8843,8 +9075,8 @@ packages:
       sass:
         optional: true
 
-  next@15.2.3:
-    resolution: {integrity: sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==}
+  next@15.3.3:
+    resolution: {integrity: sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -10338,6 +10570,10 @@ packages:
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.34.2:
+    resolution: {integrity: sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@1.2.0:
@@ -12178,6 +12414,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0-beta.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.0-beta.0
+      js-tokens: 8.0.3
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.26.5': {}
 
   '@babel/core@7.26.7':
@@ -12188,10 +12430,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.7)
       '@babel/helpers': 7.26.7
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.27.5
       '@babel/template': 7.25.9
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -12202,23 +12444,39 @@ snapshots:
 
   '@babel/generator@7.26.5':
     dependencies:
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
   '@babel/generator@7.27.1':
     dependencies:
-      '@babel/parser': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/generator@7.27.5':
+    dependencies:
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/generator@8.0.0-beta.0':
+    dependencies:
+      '@babel/parser': 8.0.0-beta.0
+      '@babel/types': 8.0.0-beta.0
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.27.6
 
   '@babel/helper-compilation-targets@7.26.5':
     dependencies:
@@ -12236,7 +12494,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -12261,19 +12519,19 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.27.1
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.27.6
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -12282,13 +12540,13 @@ snapshots:
       '@babel/core': 7.26.7
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
 
   '@babel/helper-plugin-utils@7.26.5': {}
 
@@ -12297,7 +12555,7 @@ snapshots:
       '@babel/core': 7.26.7
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-wrap-function': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12306,39 +12564,41 @@ snapshots:
       '@babel/core': 7.26.7
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.25.9': {}
-
   '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-string-parser@8.0.0-beta.0': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-identifier@8.0.0-beta.0': {}
 
   '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helper-wrap-function@7.25.9':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.27.1
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.26.7':
     dependencies:
       '@babel/template': 7.25.9
-      '@babel/types': 7.26.7
+      '@babel/types': 7.27.6
 
   '@babel/highlight@7.25.9':
     dependencies:
@@ -12347,19 +12607,19 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/parser@7.26.7':
+  '@babel/parser@7.27.5':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.27.6
 
-  '@babel/parser@7.27.2':
+  '@babel/parser@8.0.0-beta.0':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 8.0.0-beta.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12386,7 +12646,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.7
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12557,7 +12817,7 @@ snapshots:
       '@babel/core': 7.26.7
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.7)
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12603,7 +12863,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.7)
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -12670,7 +12930,7 @@ snapshots:
       '@babel/core': 7.26.7
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12716,7 +12976,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.7)
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12833,7 +13093,7 @@ snapshots:
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.7)
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13020,7 +13280,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.7
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/types': 7.26.7
+      '@babel/types': 7.27.6
       esutils: 2.0.3
 
   '@babel/preset-react@7.26.3(@babel/core@7.26.7)':
@@ -13062,59 +13322,65 @@ snapshots:
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
 
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
 
-  '@babel/traverse@7.26.7':
+  '@babel/template@8.0.0-beta.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.5
-      '@babel/parser': 7.26.7
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.7
+      '@babel/code-frame': 8.0.0-beta.0
+      '@babel/parser': 8.0.0-beta.0
+      '@babel/types': 8.0.0-beta.0
+
+  '@babel/traverse@7.27.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.6
       debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.27.1':
+  '@babel/traverse@8.0.0-beta.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.2
-      '@babel/template': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/code-frame': 8.0.0-beta.0
+      '@babel/generator': 8.0.0-beta.0
+      '@babel/parser': 8.0.0-beta.0
+      '@babel/template': 8.0.0-beta.0
+      '@babel/types': 8.0.0-beta.0
       debug: 4.4.0
-      globals: 11.12.0
+      globals: 15.14.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/types@7.19.0':
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
       to-fast-properties: 2.0.0
 
   '@babel/types@7.26.10':
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@babel/types@7.26.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-
-  '@babel/types@7.27.1':
+  '@babel/types@7.27.6':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@8.0.0-beta.0':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-beta.0
+      '@babel/helper-validator-identifier': 8.0.0-beta.0
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -13139,14 +13405,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.4.1
 
-  '@clerk/nextjs@5.7.5(next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@5.7.5(next@15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 1.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.26.0
       crypto-js: 4.2.0
-      next: 15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       server-only: 0.0.1
@@ -13212,11 +13478,6 @@ snapshots:
   '@emnapi/core@1.4.3':
     dependencies:
       '@emnapi/wasi-threads': 1.0.2
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.3.1':
-    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -13876,9 +14137,9 @@ snapshots:
   '@expo/metro-config@0.19.0-preview.3':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/generator': 7.26.5
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/generator': 7.27.1
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       '@expo/config': 10.0.2
       '@expo/env': 0.4.1
       '@expo/json-file': 9.0.1
@@ -14045,33 +14306,70 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
     optional: true
 
+  '@img/sharp-darwin-arm64@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.1.0
+    optional: true
+
   '@img/sharp-darwin-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.1.0
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.1.0':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.1.0':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.1.0':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.1.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.1.0':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.1.0':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.1.0':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     optional: true
 
   '@img/sharp-linux-arm64@0.33.5':
@@ -14079,9 +14377,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.0.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.1.0
+    optional: true
+
   '@img/sharp-linux-arm@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.1.0
     optional: true
 
   '@img/sharp-linux-s390x@0.33.5':
@@ -14089,9 +14397,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.0.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.1.0
+    optional: true
+
   '@img/sharp-linux-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.1.0
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
@@ -14099,20 +14417,44 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.0.4
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.34.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.1.0
+    optional: true
+
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.3.1
+      '@emnapi/runtime': 1.4.3
+    optional: true
+
+  '@img/sharp-wasm32@0.34.2':
+    dependencies:
+      '@emnapi/runtime': 1.4.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.2':
     optional: true
 
   '@img/sharp-win32-ia32@0.33.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.34.2':
+    optional: true
+
   '@img/sharp-win32-x64@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.2':
     optional: true
 
   '@inquirer/checkbox@2.5.0':
@@ -14284,7 +14626,7 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
-  '@jest/core@28.1.3(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))':
+  '@jest/core@28.1.3(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 28.1.3
       '@jest/reporters': 28.1.3
@@ -14298,7 +14640,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@22.13.0)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      jest-config: 28.1.3(@types/node@22.13.0)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -14618,7 +14960,7 @@ snapshots:
       hls.js: 1.5.20
       mux-embed: 5.2.1
 
-  '@napi-rs/wasm-runtime@0.2.9':
+  '@napi-rs/wasm-runtime@0.2.10':
     dependencies:
       '@emnapi/core': 1.4.3
       '@emnapi/runtime': 1.4.3
@@ -14673,7 +15015,7 @@ snapshots:
 
   '@netlify/zip-it-and-ship-it@10.0.7(rollup@4.40.2)':
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.5
       '@babel/types': 7.26.10
       '@netlify/binary-info': 1.0.0
       '@netlify/serverless-functions-api': 1.38.0
@@ -14716,54 +15058,54 @@ snapshots:
 
   '@next/env@15.1.6': {}
 
-  '@next/env@15.2.3': {}
+  '@next/env@15.3.3': {}
 
   '@next/swc-darwin-arm64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-arm64@15.2.3':
+  '@next/swc-darwin-arm64@15.3.3':
     optional: true
 
   '@next/swc-darwin-x64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-x64@15.2.3':
+  '@next/swc-darwin-x64@15.3.3':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.2.3':
+  '@next/swc-linux-arm64-gnu@15.3.3':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.2.3':
+  '@next/swc-linux-arm64-musl@15.3.3':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.2.3':
+  '@next/swc-linux-x64-gnu@15.3.3':
     optional: true
 
   '@next/swc-linux-x64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.2.3':
+  '@next/swc-linux-x64-musl@15.3.3':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.2.3':
+  '@next/swc-win32-arm64-msvc@15.3.3':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.2.3':
+  '@next/swc-win32-x64-msvc@15.3.3':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -15010,7 +15352,7 @@ snapshots:
 
   '@oxc-parser/binding-wasm32-wasi@0.68.1':
     dependencies:
-      '@napi-rs/wasm-runtime': 0.2.9
+      '@napi-rs/wasm-runtime': 0.2.10
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.68.1':
@@ -15102,6 +15444,11 @@ snapshots:
       supports-color: 10.0.0
 
   '@poppinss/exception@1.2.1': {}
+
+  '@prettier/sync@0.5.5(prettier@3.4.2)':
+    dependencies:
+      make-synchronized: 0.4.2
+      prettier: 3.4.2
 
   '@radix-ui/primitive@1.1.1': {}
 
@@ -15648,7 +15995,7 @@ snapshots:
       '@babel/plugin-transform-sticky-regex': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.26.7)
       '@babel/plugin-transform-unicode-regex': 7.25.9(@babel/core@7.26.7)
-      '@babel/template': 7.25.9
+      '@babel/template': 7.27.2
       '@react-native/babel-plugin-codegen': 0.76.6(@babel/preset-env@7.26.7(@babel/core@7.26.7))
       babel-plugin-syntax-hermes-parser: 0.25.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.26.7)
@@ -15659,7 +16006,7 @@ snapshots:
 
   '@react-native/codegen@0.76.1(@babel/preset-env@7.26.7(@babel/core@7.26.7))':
     dependencies:
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.27.5
       '@babel/preset-env': 7.26.7(@babel/core@7.26.7)
       glob: 7.2.3
       hermes-parser: 0.23.1
@@ -15673,7 +16020,7 @@ snapshots:
 
   '@react-native/codegen@0.76.6(@babel/preset-env@7.26.7(@babel/core@7.26.7))':
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.5
       '@babel/preset-env': 7.26.7(@babel/core@7.26.7)
       glob: 7.2.3
       hermes-parser: 0.23.1
@@ -16120,24 +16467,76 @@ snapshots:
 
   '@stripe/stripe-js@3.5.0': {}
 
+  '@swc/core-darwin-arm64@1.11.29':
+    optional: true
+
+  '@swc/core-darwin-x64@1.11.29':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.11.29':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.11.29':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.11.29':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.11.29':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.11.29':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.11.29':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.11.29':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.11.29':
+    optional: true
+
+  '@swc/core@1.11.29':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.21
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.11.29
+      '@swc/core-darwin-x64': 1.11.29
+      '@swc/core-linux-arm-gnueabihf': 1.11.29
+      '@swc/core-linux-arm64-gnu': 1.11.29
+      '@swc/core-linux-arm64-musl': 1.11.29
+      '@swc/core-linux-x64-gnu': 1.11.29
+      '@swc/core-linux-x64-musl': 1.11.29
+      '@swc/core-win32-arm64-msvc': 1.11.29
+      '@swc/core-win32-ia32-msvc': 1.11.29
+      '@swc/core-win32-x64-msvc': 1.11.29
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.10(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)))':
+  '@swc/types@0.1.21':
+    dependencies:
+      '@swc/counter': 0.1.3
+    optional: true
+
+  '@tailwindcss/forms@0.5.10(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
 
-  '@tailwindcss/typography@0.5.16(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)))':
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
 
   '@tanstack/react-virtual@3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16149,7 +16548,7 @@ snapshots:
 
   '@testing-library/dom@8.20.1':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.26.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
@@ -16200,24 +16599,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.27.6
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.27.6
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -16548,8 +16947,8 @@ snapshots:
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
       '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5(acorn@8.14.0)
+      acorn: 8.14.1
+      acorn-import-attributes: 1.9.5(acorn@8.14.1)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -16567,8 +16966,8 @@ snapshots:
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0
       '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5(acorn@8.14.0)
+      acorn: 8.14.1
+      acorn-import-attributes: 1.9.5(acorn@8.14.1)
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -16662,8 +17061,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.7)
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
       '@vue/babel-helper-vue-transform-on': 1.4.0
       '@vue/babel-plugin-resolve-type': 1.4.0(@babel/core@7.26.7)
       '@vue/shared': 3.5.13
@@ -16678,14 +17077,14 @@ snapshots:
       '@babel/core': 7.26.7
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.5
       '@vue/compiler-sfc': 3.5.13
     transitivePeerDependencies:
       - supports-color
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.27.5
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -16698,7 +17097,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.27.5
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
@@ -16819,12 +17218,12 @@ snapshots:
 
   acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       acorn-walk: 8.3.4
 
-  acorn-import-attributes@1.9.5(acorn@8.14.0):
+  acorn-import-attributes@1.9.5(acorn@8.14.1):
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
 
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
@@ -16832,7 +17231,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
 
   acorn@8.14.0: {}
 
@@ -17067,7 +17466,7 @@ snapshots:
 
   ast-kit@1.4.3:
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.5
       pathe: 2.0.3
 
   ast-module-types@5.0.0: {}
@@ -17078,7 +17477,7 @@ snapshots:
 
   ast-walker-scope@0.6.2:
     dependencies:
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.27.5
       ast-kit: 1.4.3
 
   astral-regex@1.0.0: {}
@@ -17164,14 +17563,14 @@ snapshots:
   babel-plugin-jest-hoist@28.1.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
@@ -18216,6 +18615,9 @@ snapshots:
   detect-libc@1.0.3: {}
 
   detect-libc@2.0.3: {}
+
+  detect-libc@2.0.4:
+    optional: true
 
   detect-newline@3.1.0: {}
 
@@ -20041,7 +20443,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -20106,16 +20508,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)):
+  jest-cli@28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      '@jest/core': 28.1.3(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.2.0
-      jest-config: 28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      jest-config: 28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -20125,7 +20527,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)):
+  jest-config@28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.26.7
       '@jest/test-sequencer': 28.1.3
@@ -20151,11 +20553,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 17.0.4
-      ts-node: 10.9.2(@types/node@17.0.4)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@28.1.3(@types/node@22.13.0)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)):
+  jest-config@28.1.3(@types/node@22.13.0)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.26.7
       '@jest/test-sequencer': 28.1.3
@@ -20181,7 +20583,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.13.0
-      ts-node: 10.9.2(@types/node@17.0.4)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -20287,7 +20689,7 @@ snapshots:
 
   jest-message-util@28.1.3:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@jest/types': 28.1.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -20299,7 +20701,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -20403,10 +20805,10 @@ snapshots:
   jest-snapshot@28.1.3:
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/generator': 7.26.5
+      '@babel/generator': 7.27.5
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.7)
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
       '@jest/expect-utils': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
@@ -20488,11 +20890,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@28.1.0(@types/node@17.0.4)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)):
+  jest@28.1.0(@types/node@17.0.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 28.1.3(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      '@jest/core': 28.1.3(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       import-local: 3.2.0
-      jest-cli: 28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      jest-cli: 28.1.3(@types/node@17.0.4)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -20520,6 +20922,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@8.0.3: {}
+
   js-tokens@9.0.1: {}
 
   js-yaml@3.14.1:
@@ -20538,7 +20942,7 @@ snapshots:
   jscodeshift@0.14.0(@babel/preset-env@7.26.7(@babel/core@7.26.7)):
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.27.5
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.26.7)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.26.7)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.26.7)
@@ -20885,8 +21289,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       source-map-js: 1.2.1
 
   make-dir@2.1.0:
@@ -20903,6 +21307,8 @@ snapshots:
       semver: 7.7.2
 
   make-error@1.3.6: {}
+
+  make-synchronized@0.4.2: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -21075,9 +21481,9 @@ snapshots:
 
   metro-source-map@0.81.1:
     dependencies:
-      '@babel/traverse': 7.26.7
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.27.1'
-      '@babel/types': 7.26.7
+      '@babel/traverse': 7.27.4
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.27.4'
+      '@babel/types': 7.27.6
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.81.1
@@ -21102,9 +21508,9 @@ snapshots:
   metro-transform-plugins@0.81.1:
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/generator': 7.27.1
+      '@babel/generator': 7.27.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.27.4
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -21113,9 +21519,9 @@ snapshots:
   metro-transform-worker@0.81.1:
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.2
-      '@babel/types': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       flow-enums-runtime: 0.0.6
       metro: 0.81.1
       metro-babel-transformer: 0.81.1
@@ -21132,13 +21538,13 @@ snapshots:
 
   metro@0.81.1:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/core': 7.26.7
-      '@babel/generator': 7.26.5
-      '@babel/parser': 7.26.7
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/generator': 7.27.1
+      '@babel/parser': 7.27.5
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.27.4
+      '@babel/types': 7.27.6
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -21464,7 +21870,7 @@ snapshots:
 
   nanotar@0.2.0: {}
 
-  nativewind@2.0.11(react@18.3.1)(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3))):
+  nativewind@2.0.11(react@18.3.1)(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3))):
     dependencies:
       '@babel/generator': 7.26.5
       '@babel/helper-module-imports': 7.18.6
@@ -21478,7 +21884,7 @@ snapshots:
       postcss-css-variables: 0.18.0(postcss@8.5.1)
       postcss-nested: 5.0.6(postcss@8.5.1)
       react-is: 18.3.1
-      tailwindcss: 3.3.2(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3))
+      tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3))
       use-sync-external-store: 1.4.0(react@18.3.1)
     transitivePeerDependencies:
       - react
@@ -21537,9 +21943,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.2.3
+      '@next/env': 15.3.3
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -21549,15 +21955,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.26.7)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.2.3
-      '@next/swc-darwin-x64': 15.2.3
-      '@next/swc-linux-arm64-gnu': 15.2.3
-      '@next/swc-linux-arm64-musl': 15.2.3
-      '@next/swc-linux-x64-gnu': 15.2.3
-      '@next/swc-linux-x64-musl': 15.2.3
-      '@next/swc-win32-arm64-msvc': 15.2.3
-      '@next/swc-win32-x64-msvc': 15.2.3
-      sharp: 0.33.5
+      '@next/swc-darwin-arm64': 15.3.3
+      '@next/swc-darwin-x64': 15.3.3
+      '@next/swc-linux-arm64-gnu': 15.3.3
+      '@next/swc-linux-arm64-musl': 15.3.3
+      '@next/swc-linux-x64-gnu': 15.3.3
+      '@next/swc-linux-x64-musl': 15.3.3
+      '@next/swc-win32-arm64-msvc': 15.3.3
+      '@next/swc-win32-x64-msvc': 15.3.3
+      sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -21710,7 +22116,7 @@ snapshots:
 
   node-source-walk@6.0.2:
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.5
 
   node-stream-zip@1.15.0: {}
 
@@ -22369,29 +22775,29 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.1
 
-  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@17.0.35)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.35)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.1
-      ts-node: 10.9.2(@types/node@17.0.35)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@17.0.35)(typescript@5.5.4)
 
-  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.1
-      ts-node: 10.9.2(@types/node@17.0.4)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)
 
-  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3)):
+  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.1
-      ts-node: 10.9.2(@types/node@22.13.0)(typescript@5.8.3)
+      ts-node: 10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3)
 
   postcss-merge-longhand@7.0.5(postcss@8.5.3):
     dependencies:
@@ -23467,6 +23873,35 @@ snapshots:
       '@img/sharp-win32-x64': 0.33.5
     optional: true
 
+  sharp@0.34.2:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.4
+      semver: 7.7.2
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.2
+      '@img/sharp-darwin-x64': 0.34.2
+      '@img/sharp-libvips-darwin-arm64': 1.1.0
+      '@img/sharp-libvips-darwin-x64': 1.1.0
+      '@img/sharp-libvips-linux-arm': 1.1.0
+      '@img/sharp-libvips-linux-arm64': 1.1.0
+      '@img/sharp-libvips-linux-ppc64': 1.1.0
+      '@img/sharp-libvips-linux-s390x': 1.1.0
+      '@img/sharp-libvips-linux-x64': 1.1.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.1.0
+      '@img/sharp-linux-arm': 0.34.2
+      '@img/sharp-linux-arm64': 0.34.2
+      '@img/sharp-linux-s390x': 0.34.2
+      '@img/sharp-linux-x64': 0.34.2
+      '@img/sharp-linuxmusl-arm64': 0.34.2
+      '@img/sharp-linuxmusl-x64': 0.34.2
+      '@img/sharp-wasm32': 0.34.2
+      '@img/sharp-win32-arm64': 0.34.2
+      '@img/sharp-win32-ia32': 0.34.2
+      '@img/sharp-win32-x64': 0.34.2
+    optional: true
+
   shebang-command@1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -23866,11 +24301,11 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))):
     dependencies:
-      tailwindcss: 3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
 
-  tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.35)(typescript@5.5.4)):
+  tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.35)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23889,7 +24324,7 @@ snapshots:
       postcss: 8.5.1
       postcss-import: 15.1.0(postcss@8.5.1)
       postcss-js: 4.0.1(postcss@8.5.1)
-      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@17.0.35)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.35)(typescript@5.5.4))
       postcss-nested: 6.2.0(postcss@8.5.1)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
@@ -23898,7 +24333,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.3.2(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4)):
+  tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23917,7 +24352,7 @@ snapshots:
       postcss: 8.5.1
       postcss-import: 15.1.0(postcss@8.5.1)
       postcss-js: 4.0.1(postcss@8.5.1)
-      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4))
       postcss-nested: 6.2.0(postcss@8.5.1)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
@@ -23926,7 +24361,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.3.2(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3)):
+  tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23945,7 +24380,7 @@ snapshots:
       postcss: 8.5.1
       postcss-import: 15.1.0(postcss@8.5.1)
       postcss-js: 4.0.1(postcss@8.5.1)
-      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3))
+      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3))
       postcss-nested: 6.2.0(postcss@8.5.1)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
@@ -24015,7 +24450,7 @@ snapshots:
   terser@5.37.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
+      acorn: 8.14.1
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -24115,7 +24550,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@17.0.35)(typescript@5.5.4):
+  ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.35)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24132,9 +24567,11 @@ snapshots:
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.11.29
     optional: true
 
-  ts-node@10.9.2(@types/node@17.0.4)(typescript@5.5.4):
+  ts-node@10.9.2(@swc/core@1.11.29)(@types/node@17.0.4)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24151,9 +24588,11 @@ snapshots:
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.11.29
     optional: true
 
-  ts-node@10.9.2(@types/node@22.13.0)(typescript@5.8.3):
+  ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.13.0)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24170,6 +24609,8 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.11.29
 
   tshy@3.0.2:
     dependencies:
@@ -24457,7 +24898,7 @@ snapshots:
 
   unplugin-vue-router@0.12.0(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3)):
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.6
       '@vue-macros/common': 1.16.1(vue@3.5.13(typescript@5.8.3))
       ast-walker-scope: 0.6.2
       chokidar: 4.0.3
@@ -24479,7 +24920,7 @@ snapshots:
 
   unplugin@1.16.1:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.14.1
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.3.2:


### PR DESCRIPTION
Adds `schemaTypescriptFileToInstantSchema` to `@instantdb/platform`. 

You can use it to parse a schema file generated by the CLI into an `InstantSchemaDef` (e.g. `i.schema({...})`). 

It's not as robust as the parser we use in the `cli`. The `cli` uses a package called `unconfig`, which requires node APIs that aren't available in the browser.

The code to parse the schema file is pretty inflexible. It parses the typescript with babel, then walks the ast to find all of the `entities`, `links` and `rooms`. I think we could make it a lot nicer if we used `@babel/traverse`, but that doubles our bundle size. With just `@babel/parse`, our bundle is 88kb gzipped. But you'll only pay that bundle cost if you import the `schemaTypescriptFileToInstantSchema` helper. Otherwise it's closer to 13kb gzipped.

Example:

```ts
import { schemaTypescriptFileToInstantSchema } from '@instantdb/platform';

const code = `// Docs: https://www.instantdb.com/docs/modeling-data

import { i } from '@instantdb/core';

const _schema = i.schema({
  entities: {
    books: i.entity({
      title: i.string().unique(),
    }),
  },
});

// This helps Typescript display nicer intellisense
type _AppSchema = typeof _schema;
interface AppSchema extends _AppSchema {}
const schema: AppSchema = _schema;

export type { AppSchema };
export default schema;
`;

const schema = schemaTypescriptFileToInstantSchema(code);

// schema == i.schema({ entities: { books: i.entity({ title: i.string().unique() }) } })
```