### PR TITLE
[firefox] fix mouse-up that causes clicks when pointer-capture is involved

### DIFF
--- a/client/www/lib/patchFirefoxClicks.ts
+++ b/client/www/lib/patchFirefoxClicks.ts
@@ -1,0 +1,70 @@
+/**
+ * There's a bug in Firefox, where click events are dispatched to the wrong target element.
+ *
+ * This happens around our Monaco Editor.
+ *
+ * Here's the repro scenario:
+ *
+ * 1. Click inside our Monaco Editor, and start dragging your cursor
+ * 2. Release your cursor over a Nav item
+ * 3. Firefox will trigger a "click" event on the Nav item!
+ *
+ *
+ * Root cause
+ *
+ * Monaco editor uses `setPointerCapture` for drag and drop operations.
+ * When Monaco releases the pointer, Firefox needs to decide where the click happened.
+ * It incorrectly decides the click happened wherever the mouse is on Mouseup
+ *
+ * The fix
+ *
+ * In Firefox we track the target ourselves. if the `mouseUp` target and the `click`
+ * target aren't the same, we ignore it.
+ *
+ * @see https://github.com/microsoft/monaco-editor/issues/4379
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1556240
+ */
+export default function patchFirefoxClicks() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return;
+  }
+
+  if (!navigator.userAgent.includes('Firefox')) {
+    return;
+  }
+
+  if ((window as any).__instant_patchFirefoxClicks) {
+    return;
+  }
+
+  (window as any).__instant_patchFirefoxClicks = true;
+
+  let lastTarget: EventTarget | null = null;
+
+  const handleMouseUp = (e: Event) => {
+    lastTarget = e.target;
+  };
+
+  const handleClick = (e: Event) => {
+    if (lastTarget !== e.target) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
+    lastTarget = null;
+  };
+
+  /**
+   * Note: `capture` phase is important here.
+   *
+   * We trigger our listener in the `capture` phase, as this will happen before
+   * React itself will read the event.
+   */
+  document.addEventListener('mouseup', handleMouseUp, { capture: true });
+  document.addEventListener('click', handleClick, { capture: true });
+
+  return () => {
+    (window as any).__instant_patchFirefoxClicks = false;
+    document.removeEventListener('mouseup', handleMouseUp, { capture: true });
+    document.removeEventListener('click', handleClick, { capture: true });
+  };
+}

--- a/client/www/lib/patchFirefoxClicks.ts
+++ b/client/www/lib/patchFirefoxClicks.ts
@@ -1,20 +1,20 @@
 /**
  * There's a bug in Firefox, where click events are dispatched to the wrong target element.
- *
- * This happens around our Monaco Editor.
+ * This happens when libraries use setPointerCapture, a la our Monaco Editor.
  *
  * Here's the repro scenario:
  *
- * 1. Click inside our Monaco Editor, and start dragging your cursor
+ * 1. Click inside our Monaco Editor, start dragging your cursor
  * 2. Release your cursor over a Nav item
  * 3. Firefox will trigger a "click" event on the Nav item!
  *
+ * It _should_ have triggered a click event on the Monaco Editor, not the nav item.
  *
  * Root cause
  *
  * Monaco editor uses `setPointerCapture` for drag and drop operations.
  * When Monaco releases the pointer, Firefox needs to decide where the click happened.
- * It incorrectly decides the click happened wherever the mouse is on Mouseup
+ * It incorrectly decides the click happened wherever the mouse ended up.
  *
  * The fix
  *
@@ -23,6 +23,7 @@
  *
  * @see https://github.com/microsoft/monaco-editor/issues/4379
  * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1556240
+ * @see https://github.com/w3c/pointerevents/issues/356
  */
 export default function patchFirefoxClicks() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {

--- a/client/www/pages/_app.tsx
+++ b/client/www/pages/_app.tsx
@@ -9,6 +9,8 @@ import { DocsPage } from '@/components/DocsPage';
 import { Button } from '@/components/ui';
 import { isDev } from '@/lib/config';
 import { Dev } from '@/components/Dev';
+import patchFirefoxClicks from '@/lib/patchFirefoxClicks';
+import { useEffect } from 'react';
 
 declare global {
   function __getAppId(): any;
@@ -30,7 +32,9 @@ function App({ Component, pageProps }: AppProps) {
   ) : (
     <Component {...pageProps} />
   );
-
+  useEffect(() => {
+    return patchFirefoxClicks();
+  }, []);
   return (
     <>
       <AppHead />


### PR DESCRIPTION
# Problem

In Firefox on mac, if you:
1. When to the sandbox
2. Started to drag your mouse from the monaco editor
3. And released your mouse on a nav item
4. The _nav item_ would trigger and you'd be redirected! 

https://github.com/user-attachments/assets/c8900a14-e514-42ba-ad85-315839eb5a11

# Root Cause

This is a bug in Firefox on Mac. 

Some relevant links: 
 * Bug report in [Monaco](https://github.com/microsoft/monaco-editor/issues/4379)
 * Bug report in [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1556240)
 * W3C [discussion](https://github.com/w3c/pointerevents/issues/356) 
 * Cool [repro](https://output.jsbin.com/zuwiwep)  

What happens is: 
1. Monaco uses `setPointerCapture`
2. When it releases the setPointerCapture in mouseup, Firefox has to decide where the click happened: Is it on the origin target, or where the mouse up is? 
3. Most browsers decide it's the origin. Firefox decides it's where the mouse up is (the menu item!) 

# Solution

I wrote a custom patch for Firefox. This saves the target on mouseUp. If it's the _same_ as the target on click, we continue on as normal. 

@dwwoelfel @nezaj @tonsky 