### PR TITLE
Change `uploadFile` typing to allow uploading `Blob`s

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -55,7 +55,7 @@ Now all requests will go to your local backend at [localhost:8888](http://localh
 The instant client can show development logs. You can turn this on by writing:
 
 ```javascript
-localStorage.setItem("__instantLogging", true);
+localStorage.setItem('__instantLogging', true);
 ```
 
 ### Running a local app

--- a/client/README.md
+++ b/client/README.md
@@ -72,11 +72,11 @@ You can create local apps by following these steps
 You can then connect to this app in a new project with the following snippet
 
 ```javascript
-const APP_ID = '<your app id from your own server>'
+const APP_ID = '<your app id from your own server>';
 const db = init({
   appId: APP_ID,
-  apiURI: "http://localhost:8888",
-  websocketURI: "ws://localhost:8888/runtime/session",
+  apiURI: 'http://localhost:8888',
+  websocketURI: 'ws://localhost:8888/runtime/session',
 });
 ```
 

--- a/client/README.md
+++ b/client/README.md
@@ -54,7 +54,7 @@ Now all requests will go to your local backend at [localhost:8888](http://localh
 
 The instant client can show development logs. You can turn this on by writing:
 
-```
+```javascript
 localStorage.setItem("__instantLogging", true);
 ```
 
@@ -71,7 +71,7 @@ You can create local apps by following these steps
 
 You can then connect to this app in a new project with the following snippet
 
-```
+```javascript
 const APP_ID = '<your app id from your own server>'
 const db = init({
   appId: APP_ID,

--- a/client/packages/core/src/StorageAPI.ts
+++ b/client/packages/core/src/StorageAPI.ts
@@ -24,7 +24,7 @@ export async function uploadFile({
   apiURI: string;
   appId: string;
   path: string;
-  file: File;
+  file: File | Blob;
   refreshToken?: string;
   contentType?: string;
   contentDisposition?: string;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -397,7 +397,7 @@ class Storage {
    */
   uploadFile = (
     path: string,
-    file: File,
+    file: File | Blob,
     opts: FileOpts = {},
   ): Promise<UploadFileResponse> => {
     return this.db.uploadFile(path, file, opts);


### PR DESCRIPTION
changed the typing of `uploadFile` to allow uploading a `Blob`s bcz its already supported and its common to have `Blob`s in JS

also minor change in client README to add syntax highlighting

btw great work. thanks!