### PR TITLE
RFC: Set `required` on reverse attr for one-to-one required links

### DIFF
--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -352,7 +352,7 @@ function apiSchemaAttrToLinkDef(attr: InstantDBAttr) {
       has: rhas,
       label: rlabel,
       required:
-        (attr['required?'] && fhas === 'one' && rhas === 'one') || undefined,      
+        (attr['required?'] && fhas === 'one' && rhas === 'one') || undefined,
       onDelete:
         attr['on-delete-reverse'] === 'cascade'
           ? ('cascade' as 'cascade')


### PR DESCRIPTION
It seems right to set the `required` flag if the link is one-to-one and it's required on the forward attribute. This makes the types nicer, e.g.:

```js
const authors = await db.query({ authors: { profile: {} }});
const author = authors[0];
if (!author) { throw('No author') }
// no errors
const name = author.profile.name;
```

Opening as an RFC in case I'm overlooking something.

