### PR TITLE
Silence expected group-queue-test error

### DIFF
--- a/server/test/instant/grouped_queue_test.clj
+++ b/server/test/instant/grouped_queue_test.clj
@@ -117,15 +117,16 @@
         stopped (promise)
         q (grouped-queue/start
            {:group-key-fn :group
-            :max-workers 1
-            :process-fn (fn [_group items]
+            :max-workers  1
+            :process-fn   (fn [_group items]
                           (if (< 3 (count (swap! processed conj items)))
                             (do
                               (deliver stopped true)
                               (grouped-queue/stop @q-promise))
                             (do
                               (grouped-queue/put! @q-promise {:group 2})
-                              (grouped-queue/put! @q-promise {:group 1}))))})]
+                              (grouped-queue/put! @q-promise {:group 1}))))
+            :error-fn     (fn [_])})]
     (deliver q-promise q)
 
     (grouped-queue/put! q {:group 1})


### PR DESCRIPTION
Right now, when running `grouped-queue-test/the-queue-is-fair` test, an error get printed out by uncaught exception handler. We expect this error, so there’s no point in printing it out

```
Testing instant.grouped-queue-test... 5 ms
╶───╴
Ran 1 tests containing 1 assertions in 5 ms.
0 failures, 0 errors.
RejectedExecutionException: Task instant.grouped_queue.ProcessTask@67bf8e1a rejected from java.util.concurrent.ThreadPoolExecutor@45d190ca[Shutting down, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 3]
  ThreadPoolExecutor$AbortPolicy.rejectedExecution  ThreadPoolExecutor.java 2081
  ThreadPoolExecutor.reject                         ThreadPoolExecutor.java 841
  ThreadPoolExecutor.execute                        ThreadPoolExecutor.java 1376
  instant.grouped-queue/execute                     grouped_queue.clj 14
  instant.grouped-queue/process                     grouped_queue.clj 70
  instant.grouped-queue.ProcessTask/run             grouped_queue.clj 40
  ThreadPoolExecutor.runWorker                      ThreadPoolExecutor.java 1144
  ThreadPoolExecutor$Worker.run                     ThreadPoolExecutor.java 642
  Thread.run                                        Thread.java 1570
```

This PR silences it