### PR TITLE
Set up platform API to refresh tokens

### DIFF
--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -358,8 +358,6 @@ function apiSchemaAttrToLinkDef(attr: InstantDBAttr) {
       on: re,
       has: rhas,
       label: rlabel,
-      required:
-        (attr['required?'] && fhas === 'one' && rhas === 'one') || undefined,
       onDelete:
         attr['on-delete-reverse'] === 'cascade'
           ? ('cascade' as 'cascade')

--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -32,6 +32,7 @@ import {
   rels,
   sortedEntries,
 } from './util.ts';
+import { exchangeRefreshToken } from './serverOAuth.ts';
 
 type Simplify<T> = {
   [K in keyof T]: T[K];
@@ -125,6 +126,12 @@ export type InstantAPIPushPermsBody = {
 
 export type InstantAPIPushPermsResponse = {
   perms: InstantRules;
+};
+
+export type InstantAPITokenInfoResponse = {
+  expiresAt: Date;
+  scopes: string;
+  tokenType: 'Bearer';
 };
 
 type PlanStep =
@@ -351,6 +358,8 @@ function apiSchemaAttrToLinkDef(attr: InstantDBAttr) {
       on: re,
       has: rhas,
       label: rlabel,
+      required:
+        (attr['required?'] && fhas === 'one' && rhas === 'one') || undefined,
       onDelete:
         attr['on-delete-reverse'] === 'cascade'
           ? ('cascade' as 'cascade')
@@ -1038,9 +1047,39 @@ async function pushPerms(
   return { perms: result.rules.code };
 }
 
-export type PlatformApiAuth = {
-  token: string;
-};
+async function tokenInfo(
+  apiURI: string,
+  token: string,
+): Promise<InstantAPITokenInfoResponse> {
+  const result = await jsonFetch<{
+    expires_in: number;
+    scopes: string;
+    token_type: 'Bearer';
+  }>(`${apiURI}/platform/oauth/token-info?access_token=${token}`, {
+    method: 'GET',
+  });
+
+  return {
+    tokenType: result.token_type,
+    scopes: result.scopes,
+    expiresAt: new Date(Date.now() + (result.expires_in - 60) * 1000),
+  };
+}
+
+export type PlatformApiAuth =
+  | {
+      token: string;
+    }
+  | {
+      accessToken: string;
+      refreshToken: string;
+      clientId: string;
+      clientSecret: string;
+      onRefresh?: (tokenInfo: {
+        accessToken: string;
+        expiresAt: Date;
+      }) => Promise<void>;
+    };
 
 export type PlatformApiConfig = {
   auth: PlatformApiAuth;
@@ -1063,7 +1102,7 @@ export type PlatformApiConfig = {
  * ```
  */
 export class PlatformApi {
-  #token: string;
+  #auth: PlatformApiAuth;
   #apiURI: string;
 
   /**
@@ -1073,11 +1112,85 @@ export class PlatformApi {
    * @throws {Error} When `token` is missing.
    */
   constructor(config: PlatformApiConfig) {
-    this.#token = config.auth.token;
+    this.#auth = config.auth;
     this.#apiURI = config.apiURI || 'https://api.instantdb.com';
 
-    if (!this.#token) {
-      throw new Error('PlatformApi must be constructed with a token.');
+    if (!this.#auth) {
+      throw new Error('PlatformApi must be constructed with auth.');
+    }
+  }
+
+  token(): string {
+    if ('token' in this.#auth) {
+      return this.#auth.token;
+    }
+    return this.#auth.accessToken;
+  }
+
+  canRefreshToken(): boolean {
+    return (
+      'refreshToken' in this.#auth &&
+      'clientId' in this.#auth &&
+      'clientSecret' in this.#auth &&
+      this.#auth.refreshToken != null &&
+      this.#auth.clientId != null &&
+      this.#auth.clientSecret != null
+    );
+  }
+
+  async refreshToken(): Promise<null | {
+    accessToken: string;
+    expiresAt: Date;
+  }> {
+    if (
+      !this.canRefreshToken() ||
+      // Checked in canRefreshToken, but this lets
+      // typescript refine this.#auth here
+      !('clientId' in this.#auth)
+    ) {
+      return null;
+    }
+    const token = await exchangeRefreshToken({
+      apiURI: this.#apiURI,
+      clientId: this.#auth.clientId,
+      clientSecret: this.#auth.clientSecret,
+      refreshToken: this.#auth.refreshToken,
+    });
+    this.#auth.accessToken = token.accessToken;
+    if (this.#auth.onRefresh) {
+      await this.#auth.onRefresh(token);
+    }
+    return token;
+  }
+
+  async withRetry<F extends (...args: any[]) => any>(
+    f: F,
+    args: Parameters<F>,
+  ) {
+    let attempt = 0;
+    const [apiURI, tokenInArg, ...restArgs] = args;
+    let token = tokenInArg;
+    while (attempt < 2) {
+      try {
+        return await f(apiURI, token, ...restArgs);
+      } catch (e) {
+        if (
+          e instanceof InstantAPIError &&
+          (e.status === 401 ||
+            e.body?.type === 'record-expired' ||
+            (e.body?.type === 'record-not-found' &&
+              e.body.hint['record-type'].match(/token/i))) &&
+          this.canRefreshToken()
+        ) {
+          const refreshedToken = await this.refreshToken();
+          if (refreshedToken) {
+            token = refreshedToken.accessToken;
+            attempt++;
+            continue;
+          }
+        }
+        throw e;
+      }
     }
   }
 
@@ -1102,7 +1215,7 @@ export class PlatformApi {
     appId: string,
     opts?: Opts,
   ): Promise<InstantAPIGetAppResponse<Opts>> {
-    return getApp<Opts>(this.#apiURI, this.#token, appId, opts);
+    return this.withRetry(getApp, [this.#apiURI, this.token(), appId, opts]);
   }
 
   /**
@@ -1122,7 +1235,7 @@ export class PlatformApi {
   async getApps<Opts extends AppDataOpts>(
     opts?: Opts,
   ): Promise<InstantAPIListAppsResponse<Opts>> {
-    return getApps<Opts>(this.#apiURI, this.#token, opts);
+    return this.withRetry(getApps, [this.#apiURI, this.token(), opts]);
   }
 
   /**
@@ -1135,7 +1248,7 @@ export class PlatformApi {
    * @param appId -- UUID of the app
    */
   async getSchema(appId: string): Promise<InstantAPIGetAppSchemaResponse> {
-    return getAppSchema(this.#apiURI, this.#token, appId);
+    return this.withRetry(getAppSchema, [this.#apiURI, this.token(), appId]);
   }
 
   /**
@@ -1148,7 +1261,7 @@ export class PlatformApi {
    * @param appId -- UUID of the app
    */
   async getPerms(appId: string): Promise<InstantAPIGetAppPermsResponse> {
-    return getAppPerms(this.#apiURI, this.#token, appId);
+    return this.withRetry(getAppPerms, [this.#apiURI, this.token(), appId]);
   }
 
   /**
@@ -1176,7 +1289,7 @@ export class PlatformApi {
   async createApp(
     fields: InstantAPICreateAppBody,
   ): Promise<InstantAPICreateAppResponse> {
-    return createApp(this.#apiURI, this.#token, fields);
+    return this.withRetry(createApp, [this.#apiURI, this.token(), fields]);
   }
 
   /**
@@ -1195,7 +1308,12 @@ export class PlatformApi {
     appId: string,
     fields: InstantAPIUpdateAppBody,
   ): Promise<InstantAPIUpdateAppResponse> {
-    return updateApp(this.#apiURI, this.#token, appId, fields);
+    return this.withRetry(updateApp, [
+      this.#apiURI,
+      this.token(),
+      appId,
+      fields,
+    ]);
   }
 
   /**
@@ -1208,7 +1326,7 @@ export class PlatformApi {
    * @param appId -- UUID of the app
    */
   async deleteApp(appId: string): Promise<InstantAPIDeleteAppResponse> {
-    return deleteApp(this.#apiURI, this.#token, appId);
+    return this.withRetry(deleteApp, [this.#apiURI, this.token(), appId]);
   }
 
   /**
@@ -1223,7 +1341,12 @@ export class PlatformApi {
     appId: string,
     body: InstantAPISchemaPushBody,
   ): Promise<InstantAPIPlanSchemaPushResponse> {
-    return planSchemaPush(this.#apiURI, this.#token, appId, body);
+    return this.withRetry(planSchemaPush, [
+      this.#apiURI,
+      this.token(),
+      appId,
+      body,
+    ]);
   }
 
   /**
@@ -1256,7 +1379,26 @@ export class PlatformApi {
     appId: string,
     body: InstantAPISchemaPushBody,
   ): ProgressPromise<InProgressStepsSummary, InstantAPISchemaPushResponse> {
-    return schemaPush(this.#apiURI, this.#token, appId, body);
+    return new ProgressPromise(async (progress, resolve, reject) => {
+      // It's tricky to add withRetry to the background process that fetches the jobs,
+      // so we'll just refresh the token at the start.
+      if (this.canRefreshToken()) {
+        try {
+          await this.refreshToken();
+        } catch (_e) {}
+      }
+      schemaPush(this.#apiURI, this.token(), appId, body).subscribe({
+        complete(v) {
+          resolve(v);
+        },
+        error(e) {
+          reject(e);
+        },
+        next(v) {
+          progress(v);
+        },
+      });
+    });
   }
 
   /**
@@ -1277,6 +1419,10 @@ export class PlatformApi {
     appId: string,
     body: InstantAPIPushPermsBody,
   ): Promise<InstantAPIPushPermsResponse> {
-    return pushPerms(this.#apiURI, this.#token, appId, body);
+    return this.withRetry(pushPerms, [this.#apiURI, this.token(), appId, body]);
+  }
+
+  async tokenInfo(): Promise<InstantAPITokenInfoResponse> {
+    return this.withRetry(tokenInfo, [this.#apiURI, this.token()]);
   }
 }

--- a/client/packages/platform/src/index.ts
+++ b/client/packages/platform/src/index.ts
@@ -19,6 +19,7 @@ import { schemaTypescriptFileToInstantSchema } from './typescript-schema.ts';
 import version from './version.js';
 import { ProgressPromise } from './ProgressPromise.ts';
 import { i, type InstantRules } from '@instantdb/core';
+import { exchangeCodeForToken, exchangeRefreshToken } from './serverOAuth.ts';
 
 export {
   type InstantAPIPlatformSchema,
@@ -36,5 +37,7 @@ export {
   translatePlanSteps,
   PlatformApi,
   ProgressPromise,
+  exchangeCodeForToken,
+  exchangeRefreshToken,
   i,
 };

--- a/client/packages/platform/src/oauth.ts
+++ b/client/packages/platform/src/oauth.ts
@@ -128,7 +128,7 @@ async function exchangeCodeForToken({
 
   return {
     token: json.access_token,
-    expiresAt: new Date((json.expires_in - 30) * 1000),
+    expiresAt: new Date(Date.now() + (json.expires_in - 30) * 1000),
   };
 }
 


### PR DESCRIPTION
This enables automatic token refresh for the platform API.

If you provide an `auth` object with `{clientId, clientSecret, accessToken, refreshToken}`, then we'll notice when the token is expired and we'll refresh it and try again.

The way we determine that it's expired is to catch exceptions that return 401 and refresh. It might be nicer to check the expiredAt first, but I didn't want to make callers keep track of the `expiresAt` for their token. This seemed like a nicer interface.

If you want to know when the token refreshed so that you can save the new accessToken, you can provide an `onRefresh` callback in the `auth` object.

If you want to manage refreshing tokens yourself, just keep passing `{accessToken: token}` as the `auth` arg when you create the `PlatformAPI`. 