### PR TITLE
[ui] add a "now" button for dates

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -28,6 +28,7 @@ import {
 } from '@heroicons/react/24/solid';
 import { validate } from 'uuid';
 import clsx from 'clsx';
+import { ClockIcon } from '@heroicons/react/24/outline';
 
 type FieldType = 'string' | 'number' | 'boolean' | 'json';
 type FieldTypeOption = { value: FieldType; label: string };
@@ -906,50 +907,57 @@ export function EditRowDialog({
               </div>
               <div className="flex gap-1 flex-col">
                 {!isNullField ? (
-                  <>
-                    {type === 'json' ? (
-                      <div className="h-32 border rounded w-full">
-                        <CodeEditor
+                  <div className="flex space-x-2">
+                    <div className="flex-1">
+                      {type === 'json' ? (
+                        <div className="h-32 border rounded w-full">
+                          <CodeEditor
+                            tabIndex={tabIndex}
+                            language="json"
+                            value={json}
+                            onChange={(code) =>
+                              handleUpdateJson(attr.name, code)
+                            }
+                          />
+                        </div>
+                      ) : type === 'boolean' ? (
+                        <Select
                           tabIndex={tabIndex}
-                          language="json"
-                          value={json}
-                          onChange={(code) => handleUpdateJson(attr.name, code)}
+                          value={value}
+                          options={[
+                            { value: 'false', label: 'false' },
+                            { value: 'true', label: 'true' },
+                          ]}
+                          onChange={(option) =>
+                            handleUpdateFieldValue(attr.name, option!.value)
+                          }
                         />
-                      </div>
-                    ) : type === 'boolean' ? (
-                      <Select
-                        tabIndex={tabIndex}
-                        value={value}
-                        options={[
-                          { value: 'false', label: 'false' },
-                          { value: 'true', label: 'true' },
-                        ]}
-                        onChange={(option) =>
-                          handleUpdateFieldValue(attr.name, option!.value)
-                        }
-                      />
-                    ) : type === 'number' ? (
-                      <input
-                        tabIndex={tabIndex}
-                        type="number"
-                        className="flex w-full flex-1 rounded-sm border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400"
-                        value={value ?? ''}
-                        onChange={(num) =>
-                          handleUpdateFieldValue(attr.name, num.target.value)
-                        }
-                      />
-                    ) : (
-                      <input
-                        tabIndex={tabIndex}
-                        className="flex w-full flex-1 rounded-sm border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400"
-                        value={value ?? ''}
-                        onChange={(e) =>
-                          handleUpdateFieldValue(attr.name, e.target.value)
-                        }
-                      />
-                    )}
+                      ) : type === 'number' ? (
+                        <input
+                          tabIndex={tabIndex}
+                          type="number"
+                          className="flex w-full flex-1 rounded-sm border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400"
+                          value={value ?? ''}
+                          onChange={(num) =>
+                            handleUpdateFieldValue(attr.name, num.target.value)
+                          }
+                        />
+                      ) : (
+                        <input
+                          tabIndex={tabIndex}
+                          className="flex w-full flex-1 rounded-sm border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400"
+                          value={value ?? ''}
+                          onChange={(e) =>
+                            handleUpdateFieldValue(attr.name, e.target.value)
+                          }
+                        />
+                      )}
+                    </div>
                     {attr.checkedDataType === 'date' && (
-                      <button
+                      <Button
+                        variant="subtle"
+                        size="mini"
+                        className="border"
                         onClick={() => {
                           handleUpdateFieldValue(
                             attr.name,
@@ -959,10 +967,11 @@ export function EditRowDialog({
                           );
                         }}
                       >
+                        <ClockIcon height={14} />
                         now
-                      </button>
+                      </Button>
                     )}
-                  </>
+                  </div>
                 ) : (
                   <div className="flex-1 rounded-sm border border-gray-200 bg-gray-50 px-3 py-1 text-gray-500 italic">
                     null

--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -907,7 +907,7 @@ export function EditRowDialog({
               </div>
               <div className="flex gap-1 flex-col">
                 {!isNullField ? (
-                  <div className="flex space-x-2">
+                  <div className="flex space-x-1">
                     <div className="flex-1">
                       {type === 'json' ? (
                         <div className="h-32 border rounded w-full">

--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -948,6 +948,20 @@ export function EditRowDialog({
                         }
                       />
                     )}
+                    {attr.checkedDataType === 'date' && (
+                      <button
+                        onClick={() => {
+                          handleUpdateFieldValue(
+                            attr.name,
+                            type === 'number'
+                              ? Date.now()
+                              : new Date().toISOString(),
+                          );
+                        }}
+                      >
+                        now
+                      </button>
+                    )}
                   </>
                 ) : (
                   <div className="flex-1 rounded-sm border border-gray-200 bg-gray-50 px-3 py-1 text-gray-500 italic">


### PR DESCRIPTION
A user once asked us to include a "now" button for dates. I went ahead and added the button. 

![CleanShot 2025-06-11 at 16 36 29@2x](https://github.com/user-attachments/assets/f84f726b-f8e6-45e4-b8b7-fc530ba70eab)

@dwwoelfel @nezaj @tonsky  