### PR TITLE
[dash] ensure controlled component

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -886,7 +886,7 @@ function Nav({
   availableTabs: TabItem[];
 }) {
   const router = useRouter();
-  const currentApp = apps.find((a) => a.id === appId);
+  const currentApp = apps.find((a) => a.id === appId) || null;
   const [appQuery, setAppQuery] = useState('');
   const comboboxInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -919,7 +919,7 @@ function Nav({
                 'pr-8 pl-3 text-sm/6',
                 'focus:outline-none data-[focus]:outline-2 data-[focus]:-outline-offset-2 data-[focus]:outline-white/25',
               )}
-              displayValue={(app: InstantApp) => app.title}
+              displayValue={(app: InstantApp | null) => (app ? app.title : '')}
               onChange={(e) => setAppQuery(e.target.value)}
             />
             <ComboboxButton className="group absolute inset-y-0 right-0 px-2.5">


### PR DESCRIPTION
A user reported they saw a warning that said: 

client.ts:59 A component is changing from uncontrolled to controlled. 

I repro'd this by loading /dash without an pre-existing app set. 

What is happening is that `Combobox` was receiving `undefined`, which caused it to believe that it was an uncontrolled component. 

I went ahead and used `null` instead. 

@dwwoelfel @nezaj @tonsky 