### PR TITLE
Make deny-redirect throw if there is no redirect

### DIFF
--- a/server/src/instant/model/oauth_app.clj
+++ b/server/src/instant/model/oauth_app.clj
@@ -613,16 +613,19 @@
                               {:args [{:redirect-id redirect-id}]})
            (assert-not-expired! :oauth-app-redirect))))))
 
-(defn deny-redirect
+(defn deny-redirect!
   "Deletes the redirect without returning it."
   ([params]
-   (deny-redirect (aurora/conn-pool :write) params))
+   (deny-redirect! (aurora/conn-pool :write) params))
   ([conn {:keys [redirect-id]}]
    (let [lookup-key (crypt-util/uuid->sha256 redirect-id)
          q {:delete-from :instant_oauth_app_redirects
             :where [:= :lookup-key lookup-key]
-            :returning :*}]
-     (sql/execute-one! ::deny-redirect conn (hsql/format q)))))
+            :returning :*}
+         record (sql/execute-one! ::deny-redirect conn (hsql/format q))]
+     (-> record
+         (ex/assert-record! :oauth-app-redirect
+                            {:args [{:redirect-id redirect-id}]})))))
 
 (defn create-code
   ([params]

--- a/server/src/instant/oauth_apps/routes.clj
+++ b/server/src/instant/oauth_apps/routes.clj
@@ -232,7 +232,7 @@
                                                             :user-id (:id user)}))
                      (not (get-member-role (:app_id oauth-app)
                                            (:id user))))
-            (oauth-app-model/deny-redirect {:redirect-id redirect-id})
+            (oauth-app-model/deny-redirect! {:redirect-id redirect-id})
             (ex/throw+ {::ex/type ::ex/permission-denied
                         ::ex/message
                         (cond (not (:is_public oauth-app))
@@ -320,7 +320,7 @@
         grant-token (ex/get-param! req
                                    [:params :grant_token]
                                    uuid-util/coerce)
-        redirect (oauth-app-model/deny-redirect {:redirect-id redirect-id
+        redirect (oauth-app-model/deny-redirect! {:redirect-id redirect-id
                                                  :grant-token grant-token})
 
         cookie-param (get-in req [:cookies cookie-name :value])


### PR DESCRIPTION
Fixes the error stopa ran into when clicking deny (I think the request had previously been approved, maybe?). Right now it just returns JSON. It would be nicer if we returned an HTML page, but I think that's a bigger project.