### PR TITLE
Show the logged in user in the oauth confirmation page

### DIFF
--- a/client/www/pages/platform/oauth/start.tsx
+++ b/client/www/pages/platform/oauth/start.tsx
@@ -99,6 +99,7 @@ const scopeDescriptions = [
 
 type ClaimResult = {
   appName: string;
+  userEmail: string;
   supportEmail: string | null;
   appPrivacyPolicyLink: string | null;
   appLogo: string | null;
@@ -159,6 +160,9 @@ function OAuthForm({ redirectId }: { redirectId: string }) {
           <span className="font-mono text-sm lowercase text-gray-400">
             Instant
           </span>
+        </span>
+        <span className="text-gray-700 italic text-sm">
+          Logged in as <span className="font-semibold">{data.userEmail}</span>
         </span>
         <div className="flex flex-row gap-4 items-center">
           <div className="flex h-full">

--- a/server/src/instant/oauth_apps/routes.clj
+++ b/server/src/instant/oauth_apps/routes.clj
@@ -241,6 +241,7 @@
                               "Redirects to localhost can only be used by members of the app."
                               :else (throw (Exception. "Unhandled case")))}))]
     (response/ok {:appName (:app_name oauth-app)
+                  :userEmail (:email user)
                   :supportEmail (:support_email oauth-app)
                   :appPrivacyPolicyLink (:app_privacy_policy_link oauth-app)
                   :appLogo (some-> oauth-app


### PR DESCRIPTION
Allows the user to see which Instant account they're giving access to.

Looks like this:

<img width="630" alt="image" src="https://github.com/user-attachments/assets/b8fe54a6-f202-4c1d-ac80-115c2f804d94" />
