### PR TITLE
Include mcp usage in the @instantdb/mcp readme

### DIFF
--- a/client/packages/mcp/README.md
+++ b/client/packages/mcp/README.md
@@ -28,8 +28,25 @@ Welcome to [Instant's](http://instantdb.com) MCP server.
 This MCP is a wrapper around the Instant Platform SDK. Add this MCP to your
 editor to enable creating, managing, and updating your InstantDB applications,
 
-**This README contains info on how to locally develop against this MCP server. To
-learn how to use this MCP in your own editor/apps, see [the public docs](https://www.instantdb.com/docs/using-llms)**
+## Remote MCP server
+
+Instant hosts the latest version of the server at `https://mcp.instantdb.com`.
+
+For modern clients that support streamable HTTP use `https://mcp.instantdb.com/mcp`.
+
+For legacy clients that require SSE use `https://mcp.instantdb.com/sse`.
+
+For more editor-specific instructions, see [the public docs](https://www.instantdb.com/docs/using-llms).
+
+## Local MCP server
+
+If you haven't already, make sure to get a [personal access token from your Instant dashboard](https://www.instantdb.com/dash?s=personal-access-tokens).
+
+Run the server in stdio mode with `npx -y @instantdb/mcp --token <token>`.
+
+For more editor-specific instructions, see [the public docs](https://www.instantdb.com/docs/using-llms).
+
+# Contributing
 
 ## Quick Start
 


### PR DESCRIPTION
This is a requirement for getting listed on the Cline marketplace. They want a README in the repo that will tell them how to install the MCP server: https://github.com/cline/mcp-marketplace?tab=readme-ov-file