### PR TITLE
Fix getTriples value filtering

### DIFF
--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -584,6 +584,7 @@ export function getTriples(store, [e, a, v]) {
           res.push(...triplesByValue(store, aMap, v));
         }
       }
+      return res;
     }
     default: {
       return allMapValues(store.eav, 3);


### PR DESCRIPTION
(created by codex)

We forgot to return the triples when filtering by `v` in `getTriples`. I think we still do a filtering step in the datalog, so we shouldn't have been returning invalid data. But this will reduce the amount of work we have to do for a query.

------
https://chatgpt.com/codex/tasks/task_e_684c887330b4832787b39466b9f0c19e