### PR TITLE
[Platform] Include admin-token on create

### DIFF
--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -102,7 +102,9 @@ export type InstantAPICreateAppBody = {
 };
 
 export type InstantAPICreateAppResponse = Simplify<{
-  app: InstantAPIAppDetails<{ includePerms: true; includeSchema: true }>;
+  app: InstantAPIAppDetails<{ includePerms: true; includeSchema: true }> & {
+    adminToken: string;
+  };
 }>;
 
 export type InstantAPIUpdateAppBody = { title: string };
@@ -521,7 +523,9 @@ async function createApp(
   fields: InstantAPICreateAppBody,
 ): Promise<InstantAPICreateAppResponse> {
   const { app } = await jsonFetch<{
-    app: AppResponseJSON<{ includePerms: true; includeSchema: true }>;
+    app: AppResponseJSON<{ includePerms: true; includeSchema: true }> & {
+      'admin-token': string;
+    };
   }>(`${apiURI}/superadmin/apps`, {
     method: 'POST',
     headers: {
@@ -530,11 +534,12 @@ async function createApp(
     },
     body: JSON.stringify(fields),
   });
+  const withAdminToken = {
+    ...coerceApp<{ includePerms: true; includeSchema: true }>(app),
+    adminToken: app['admin-token'],
+  };
   return {
-    app: coerceApp(app) as InstantAPIAppDetails<{
-      includePerms: true;
-      includeSchema: true;
-    }>,
+    app: withAdminToken,
   };
 }
 

--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -46,6 +46,7 @@ type AppResponseJSON<Opts extends AppDataOpts | undefined> = Simplify<
     id: string;
     title: string;
     created_at: Date;
+    'admin-token'?: string;
   } & (NonNullable<Opts>['includePerms'] extends true
     ? { perms: InstantRules }
     : {}) &
@@ -388,6 +389,7 @@ function coerceApp<Opts extends AppDataOpts>(
     id: app.id,
     title: app.title,
     createdAt: new Date(app.created_at),
+    ...(app['admin-token'] ? { adminToken: app['admin-token'] } : {}),
   };
 
   // `in` narrows the union, so it’s safe to read `perms` / `schema`

--- a/client/sandbox/react-nextjs/pages/play/platform-sdk-demo.tsx
+++ b/client/sandbox/react-nextjs/pages/play/platform-sdk-demo.tsx
@@ -122,6 +122,25 @@ function ApiDemo({ accessToken }: { accessToken: string }) {
     }
   };
 
+  const createApp = async () => {
+    try {
+      const result = await api.createApp({
+        title: 'Test App from Platform SDK Demo',
+        schema: i.schema({
+          entities: {
+            todos: i.entity({
+              title: i.string(),
+              done: i.boolean().optional(),
+            }),
+          },
+        }),
+      });
+      setResult(result);
+    } catch (e) {
+      setResult(e);
+    }
+  };
+
   return (
     <div>
       <div>
@@ -139,6 +158,9 @@ function ApiDemo({ accessToken }: { accessToken: string }) {
           onClick={() => getApps({ includePerms: true })}
         >
           Get Apps with perms
+        </button>
+        <button className="bg-blue-600 text-white m-2 p-2" onClick={createApp}>
+          Create App
         </button>
       </div>
       {result ? (


### PR DESCRIPTION
The platform api currently returns an admin token on app creation but we did not include that in the platformSDK.

This PR adds `adminToken` to `InstantAPIAppDetails` when it's returned from the server