### PR TITLE
Better index selection for pg_hint_plan

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -946,34 +946,39 @@
    defined at this point in the query."
   [named-p symbol-map]
   (let [components [:e :a :v]
-        known-components (set (filter (fn [c]
-                                        (let [[tag value] (get named-p c)]
-                                          (case tag
-                                            :constant true
-                                            :any false
-                                            :function true
-                                            :variable (contains? symbol-map value))))
-                                      components))
+
+        known-components
+        (set (filter (fn [c]
+                       (let [[tag value] (get named-p c)]
+                         (case tag
+                           :constant true
+                           :any false
+                           :function true
+                           :variable (contains? symbol-map value))))
+                     components))
+
         ;; it may be a good idea to give something a better score if it's a
         ;; constant rather than in the symbol-map
-        scored-indexes (map (fn [{:keys [cols] :as idx-config}]
-                              (let [score (if (or (and (:idx-key idx-config)
-                                                       (not= (:idx-key idx-config)
-                                                             (idx-key (:idx named-p))))
-                                                  (and (:data-type idx-config)
-                                                       (not (= (:data-type idx-config)
-                                                               (idx-data-type (:idx named-p))))))
-                                            -1
-                                            (+ (if (and (:idx-key idx-config)
-                                                        (= (:idx-key idx-config)
-                                                           (idx-key (:idx named-p))))
-                                                 0.5
-                                                 0)
-                                               (count (take-while (fn [col]
-                                                                    (contains? known-components col))
-                                                                  cols))))]
-                                (assoc idx-config :score score)))
-                            index-configs)
+        scored-indexes
+        (map (fn [{:keys [cols] :as idx-config}]
+               (let [score (if (or (and (:idx-key idx-config)
+                                        (not= (:idx-key idx-config)
+                                              (idx-key (:idx named-p))))
+                                   (and (:data-type idx-config)
+                                        (not (= (:data-type idx-config)
+                                                (idx-data-type (:idx named-p))))))
+                             -1
+                             (+ (if (and (:idx-key idx-config)
+                                         (= (:idx-key idx-config)
+                                            (idx-key (:idx named-p))))
+                                  0.5
+                                  0)
+                                (count (take-while (fn [col]
+                                                     (contains? known-components col))
+                                                   cols))))]
+                 (assoc idx-config :score score)))
+             index-configs)
+
         best-index (last (sort-by :score scored-indexes))]
     best-index))
 

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -238,14 +238,12 @@
 
 (defn clean-orphan-sessions [_time]
   (tracer/with-span! {:name "clean-orphan-sessions"}
-    (let [instance-ids (if (config/aws-env?)
-                         (aws-util/active-instance-ids)
-                         (-> (:hz @hz)
-                             HazelcastInstance/.getCluster
-                             Cluster/.getMembers
-                             (->>
-                              (map #(Member/.getAttribute % "instance-id"))
-                              (into #{}))))]
+    (let [instance-ids (-> (:hz @hz)
+                           HazelcastInstance/.getCluster
+                           Cluster/.getMembers
+                           (->>
+                            (map #(Member/.getAttribute % "instance-id"))
+                            (into #{})))]
       (doseq [^Map$Entry entry (IMap/.entrySet (:hz-rooms-map @hz))
               :let [{:keys [app-id room-id]} (.getKey entry)
                     v (.getValue entry)]

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -238,12 +238,14 @@
 
 (defn clean-orphan-sessions [_time]
   (tracer/with-span! {:name "clean-orphan-sessions"}
-    (let [instance-ids (-> (:hz @hz)
-                           HazelcastInstance/.getCluster
-                           Cluster/.getMembers
-                           (->>
-                            (map #(Member/.getAttribute % "instance-id"))
-                            (into #{})))]
+    (let [instance-ids (if (config/aws-env?)
+                         (aws-util/active-instance-ids)
+                         (-> (:hz @hz)
+                             HazelcastInstance/.getCluster
+                             Cluster/.getMembers
+                             (->>
+                              (map #(Member/.getAttribute % "instance-id"))
+                              (into #{}))))]
       (doseq [^Map$Entry entry (IMap/.entrySet (:hz-rooms-map @hz))
               :let [{:keys [app-id room-id]} (.getKey entry)
                     v (.getValue entry)]

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2585,131 +2585,132 @@
              ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))}))))))
 
 (deftest comparators
-  (with-zeneca-checked-data-app
-    (fn [app _r]
-      (let [attr-ids {:string (random-uuid)
-                      :number (random-uuid)
-                      :boolean (random-uuid)
-                      :date (random-uuid)}
-            label-attr-id (random-uuid)
-            labels ["a" "b" "c" "d" "e"]
-            make-ctx (fn []
-                       (let [attrs (attr-model/get-by-app-id (:id app))]
-                         {:db {:conn-pool (aurora/conn-pool :write)}
-                          :app-id (:id app)
-                          :attrs attrs}))
-            run-query (fn [return-field q]
-                        (let [ctx (make-ctx)]
-                          (->> (iq/permissioned-query ctx q)
-                               (instaql-nodes->object-tree ctx)
-                               (#(get % "etype"))
-                               (map #(get % (name return-field)))
-                               set)))
-            run-explain (fn run-explain
-                          ([data-type value]
-                           (run-explain :$gt data-type value))
-                          ([op data-type value]
-                           (let [explain
-                                 (d/explain (make-ctx)
-                                            {:children
-                                             {:pattern-groups
-                                              [{:patterns
-                                                [[{:idx-key :ave, :data-type data-type}
-                                                  '?etype-0
-                                                  (get attr-ids data-type)
-                                                  {:$comparator {:op op, :value value, :data-type data-type}}]]}]}})]
-                             (-> explain
-                                 first
-                                 (get "QUERY PLAN")
-                                 first
-                                 (get-in ["Plan" "Plans" 0 "Index Name"])))))]
-        (tx/transact! (aurora/conn-pool :write)
-                      (attr-model/get-by-app-id (:id app))
-                      (:id app)
-                      (concat
-                       [[:add-attr {:id (random-uuid)
-                                    :forward-identity [(random-uuid) "etype" "id"]
-                                    :unique? true
-                                    :index? true
-                                    :value-type :blob
-                                    :checked-data-type :string
-                                    :cardinality :one}]
-                        [:add-attr {:id label-attr-id
-                                    :forward-identity [(random-uuid) "etype" "label"]
-                                    :unique? true
-                                    :index? true
-                                    :value-type :blob
-                                    :checked-data-type :string
-                                    :cardinality :one}]]
-                       (for [[t attr-id] attr-ids]
-                         [:add-attr {:id attr-id
-                                     :forward-identity [(random-uuid) "etype" (name t)]
-                                     :unique? false
-                                     :index? true
-                                     :value-type :blob
-                                     :checked-data-type t
-                                     :cardinality :one}])
+  (binding [d/*testing-pg-hints* true]
+    (with-zeneca-checked-data-app
+      (fn [app _r]
+        (let [attr-ids {:string (random-uuid)
+                        :number (random-uuid)
+                        :boolean (random-uuid)
+                        :date (random-uuid)}
+              label-attr-id (random-uuid)
+              labels ["a" "b" "c" "d" "e"]
+              make-ctx (fn []
+                         (let [attrs (attr-model/get-by-app-id (:id app))]
+                           {:db {:conn-pool (aurora/conn-pool :write)}
+                            :app-id (:id app)
+                            :attrs attrs}))
+              run-query (fn [return-field q]
+                          (let [ctx (make-ctx)]
+                            (->> (iq/permissioned-query ctx q)
+                                 (instaql-nodes->object-tree ctx)
+                                 (#(get % "etype"))
+                                 (map #(get % (name return-field)))
+                                 set)))
+              run-explain (fn run-explain
+                            ([data-type value]
+                             (run-explain :$gt data-type value))
+                            ([op data-type value]
+                             (let [explain
+                                   (d/explain (make-ctx)
+                                              {:children
+                                               {:pattern-groups
+                                                [{:patterns
+                                                  [[{:idx-key :ave, :data-type data-type}
+                                                    '?etype-0
+                                                    (get attr-ids data-type)
+                                                    {:$comparator {:op op, :value value, :data-type data-type}}]]}]}})]
+                               (-> explain
+                                   first
+                                   (get "QUERY PLAN")
+                                   first
+                                   (get-in ["Plan" "Plans" 0 "Index Name"])))))]
+          (tx/transact! (aurora/conn-pool :write)
+                        (attr-model/get-by-app-id (:id app))
+                        (:id app)
+                        (concat
+                         [[:add-attr {:id (random-uuid)
+                                      :forward-identity [(random-uuid) "etype" "id"]
+                                      :unique? true
+                                      :index? true
+                                      :value-type :blob
+                                      :checked-data-type :string
+                                      :cardinality :one}]
+                          [:add-attr {:id label-attr-id
+                                      :forward-identity [(random-uuid) "etype" "label"]
+                                      :unique? true
+                                      :index? true
+                                      :value-type :blob
+                                      :checked-data-type :string
+                                      :cardinality :one}]]
+                         (for [[t attr-id] attr-ids]
+                           [:add-attr {:id attr-id
+                                       :forward-identity [(random-uuid) "etype" (name t)]
+                                       :unique? false
+                                       :index? true
+                                       :value-type :blob
+                                       :checked-data-type t
+                                       :cardinality :one}])
 
-                       (mapcat
-                        (fn [i]
-                          (let [id (random-uuid)]
-                            [[:add-triple id label-attr-id (nth labels i)]
-                             [:add-triple id (:string attr-ids) (str i)]
-                             [:add-triple id (:number attr-ids) i]
-                             [:add-triple id (:date attr-ids) i]
-                             [:add-triple id (:boolean attr-ids) (zero? (mod i 2))]]))
-                        (range (count labels)))))
-        (when (= :test (config/get-env))
-          (sql/select (aurora/conn-pool :write) ["ANALYZE triples"]))
-        (testing "string"
-          (is (= #{"3" "4"}  (run-query :string {:etype {:$ {:where {:string {:$gt "2"}}}}})))
-          (is (= #{"2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$gte "2"}}}}})))
-          (is (= #{"0" "1"} (run-query :string {:etype {:$ {:where {:string {:$lt "2"}}}}})))
-          (is (= #{"0" "1" "2"} (run-query :string {:etype {:$ {:where {:string {:$lte "2"}}}}})))
-          (is (= #{"1"} (run-query :string {:etype {:$ {:where {:string "1"}}}})))
-          (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
+                         (mapcat
+                          (fn [i]
+                            (let [id (random-uuid)]
+                              [[:add-triple id label-attr-id (nth labels i)]
+                               [:add-triple id (:string attr-ids) (str i)]
+                               [:add-triple id (:number attr-ids) i]
+                               [:add-triple id (:date attr-ids) i]
+                               [:add-triple id (:boolean attr-ids) (zero? (mod i 2))]]))
+                          (range (count labels)))))
+          (when (= :test (config/get-env))
+            (sql/select (aurora/conn-pool :write) ["ANALYZE triples"]))
+          (testing "string"
+            (is (= #{"3" "4"}  (run-query :string {:etype {:$ {:where {:string {:$gt "2"}}}}})))
+            (is (= #{"2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$gte "2"}}}}})))
+            (is (= #{"0" "1"} (run-query :string {:etype {:$ {:where {:string {:$lt "2"}}}}})))
+            (is (= #{"0" "1" "2"} (run-query :string {:etype {:$ {:where {:string {:$lte "2"}}}}})))
+            (is (= #{"1"} (run-query :string {:etype {:$ {:where {:string "1"}}}})))
+            (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
 
-          (testing "uses index"
-            (is (= "triples_string_trgm_gist_idx" (run-explain :string "2"))))
+            (testing "uses index"
+              (is (= "triples_string_trgm_gist_idx" (run-explain :string "2"))))
 
-          (testing "like uses index"
-            (is (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa")))))
+            (testing "like uses index"
+              (is (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa")))))
 
-        (testing "number"
-          (is (= #{3 4} (run-query :number {:etype {:$ {:where {:number {:$gt 2}}}}})))
-          (is (= #{2 3 4} (run-query :number {:etype {:$ {:where {:number {:$gte 2}}}}})))
-          (is (= #{0 1} (run-query :number {:etype {:$ {:where {:number {:$lt 2}}}}})))
-          (is (= #{0 1 2} (run-query :number {:etype {:$ {:where {:number {:$lte 2}}}}})))
-          (is (= #{1} (run-query :number {:etype {:$ {:where {:number 1}}}})))
-          (is (= #{0 2 3 4} (run-query :number {:etype {:$ {:where {:number {:$not 1}}}}})))
+          (testing "number"
+            (is (= #{3 4} (run-query :number {:etype {:$ {:where {:number {:$gt 2}}}}})))
+            (is (= #{2 3 4} (run-query :number {:etype {:$ {:where {:number {:$gte 2}}}}})))
+            (is (= #{0 1} (run-query :number {:etype {:$ {:where {:number {:$lt 2}}}}})))
+            (is (= #{0 1 2} (run-query :number {:etype {:$ {:where {:number {:$lte 2}}}}})))
+            (is (= #{1} (run-query :number {:etype {:$ {:where {:number 1}}}})))
+            (is (= #{0 2 3 4} (run-query :number {:etype {:$ {:where {:number {:$not 1}}}}})))
 
-          (testing "uses index"
-            (is (= "triples_number_type_idx" (run-explain :number 2)))))
+            (testing "uses index"
+              (is (= "triples_number_type_idx" (run-explain :number 2)))))
 
-        (testing "date"
-          (is (= #{3 4} (run-query :date {:etype {:$ {:where {:date {:$gt 2}}}}})))
-          (is (= #{2 3 4} (run-query :date {:etype {:$ {:where {:date {:$gte 2}}}}})))
-          (is (= #{0 1} (run-query :date {:etype {:$ {:where {:date {:$lt 2}}}}})))
-          (is (= #{0 1 2} (run-query :date {:etype {:$ {:where {:date {:$lte 2}}}}})))
-          (is (= #{1} (run-query :date {:etype {:$ {:where {:date 1}}}})))
-          (is (= #{1} (run-query :date {:etype {:$ {:where {:date (.toString (Instant/ofEpochMilli 1))}}}})))
-          (is (= #{0 2 3 4} (run-query :date {:etype {:$ {:where {:date {:$not 1}}}}})))
+          (testing "date"
+            (is (= #{3 4} (run-query :date {:etype {:$ {:where {:date {:$gt 2}}}}})))
+            (is (= #{2 3 4} (run-query :date {:etype {:$ {:where {:date {:$gte 2}}}}})))
+            (is (= #{0 1} (run-query :date {:etype {:$ {:where {:date {:$lt 2}}}}})))
+            (is (= #{0 1 2} (run-query :date {:etype {:$ {:where {:date {:$lte 2}}}}})))
+            (is (= #{1} (run-query :date {:etype {:$ {:where {:date 1}}}})))
+            (is (= #{1} (run-query :date {:etype {:$ {:where {:date (.toString (Instant/ofEpochMilli 1))}}}})))
+            (is (= #{0 2 3 4} (run-query :date {:etype {:$ {:where {:date {:$not 1}}}}})))
 
-          (testing "uses index"
-            (is (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2))))))
+            (testing "uses index"
+              (is (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2))))))
 
-        (testing "boolean"
-          (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt true}}}}})))
-          (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt false}}}}})))
-          (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gte true}}}}})))
-          (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt false}}}}})))
-          (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt true}}}}})))
-          (is (= #{false true} (run-query :boolean {:etype {:$ {:where {:boolean {:$lte true}}}}})))
-          (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean true}}}})))
-          (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$not true}}}}})))
+          (testing "boolean"
+            (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt true}}}}})))
+            (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt false}}}}})))
+            (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gte true}}}}})))
+            (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt false}}}}})))
+            (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt true}}}}})))
+            (is (= #{false true} (run-query :boolean {:etype {:$ {:where {:boolean {:$lte true}}}}})))
+            (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean true}}}})))
+            (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$not true}}}}})))
 
-          (testing "uses index"
-            (is (= "triples_boolean_type_idx" (run-explain :boolean true)))))))))
+            (testing "uses index"
+              (is (= "triples_boolean_type_idx" (run-explain :boolean true))))))))))
 
 (deftest $not-with-refs
   (with-zeneca-checked-data-app
@@ -2759,80 +2760,81 @@
                                     ("eid-nonfiction" :bookshelves/order 1))}))))))
 
 (deftest lookup-unique-uses-the-av-index
-  (with-zeneca-app
-    (fn [app _r]
-      (let [attr-ids {:id (random-uuid)
-                      :handle (random-uuid)}
-            make-ctx (fn []
-                       (let [attrs (attr-model/get-by-app-id (:id app))]
-                         {:db {:conn-pool (aurora/conn-pool :read)}
-                          :app-id (:id app)
-                          :attrs attrs}))
-            _ (tx/transact! (aurora/conn-pool :write)
-                            (attr-model/get-by-app-id (:id app))
-                            (:id app)
-                            (concat [[:add-attr {:id (:id attr-ids)
-                                                 :forward-identity [(random-uuid) "user" "id"]
-                                                 :unique? true
-                                                 :index? false
-                                                 :value-type :blob
-                                                 :cardinality :one}]
-                                     [:add-attr {:id (:handle attr-ids)
-                                                 :forward-identity [(random-uuid) "user" "handle"]
-                                                 :unique? true
-                                                 :index? false
-                                                 :value-type :blob
-                                                 :cardinality :one}]]
-                                    (let [id (random-uuid)]
-                                      [[:add-triple id (:id attr-ids) (str id)]
-                                       [:add-triple id (:handle attr-ids) "a"]])
-                                    (let [id (random-uuid)]
-                                      [[:add-triple id (:id attr-ids) (str id)]
-                                       [:add-triple id (:handle attr-ids) "b"]])
-                                    (mapcat (fn [i]
-                                              (let [id (random-uuid)]
-                                                [[:add-triple id (:id attr-ids) (str id)]
-                                                 [:add-triple id (:handle attr-ids) (str i)]]))
-                                            (range 5000))))]
-        (when (= :test (config/get-env))
-          (sql/select (aurora/conn-pool :write) ["ANALYZE triples"]))
-        (testing "query on unique attr"
-          (let [{:keys [patterns]} (iq/instaql-query->patterns
-                                    (make-ctx)
-                                    {:user {:$ {:where {:handle "a"}}}})
-                explain (d/explain (make-ctx) patterns)
-                plan (-> explain
-                         first
-                         (get "QUERY PLAN")
-                         first
-                         (get-in ["Plan" "Plans" 0]))
-                ;; Make sure it's using the full index
-                expected-index-cond (format "((t0.app_id = '%s'::uuid) AND (t0.attr_id = '%s'::uuid) AND (CASE WHEN (t0.value = 'null'::jsonb) THEN NULL::jsonb ELSE t0.value END = '\"a\"'::jsonb))"
-                                            (:id app)
-                                            (:handle attr-ids))]
-            (is (= expected-index-cond (get plan "Index Cond")))
-            (is (= "av_index" (get plan "Index Name")))))
+  (binding [d/*testing-pg-hints* true]
+    (with-zeneca-app
+      (fn [app _r]
+        (let [attr-ids {:id (random-uuid)
+                        :handle (random-uuid)}
+              make-ctx (fn []
+                         (let [attrs (attr-model/get-by-app-id (:id app))]
+                           {:db {:conn-pool (aurora/conn-pool :read)}
+                            :app-id (:id app)
+                            :attrs attrs}))
+              _ (tx/transact! (aurora/conn-pool :write)
+                              (attr-model/get-by-app-id (:id app))
+                              (:id app)
+                              (concat [[:add-attr {:id (:id attr-ids)
+                                                   :forward-identity [(random-uuid) "user" "id"]
+                                                   :unique? true
+                                                   :index? false
+                                                   :value-type :blob
+                                                   :cardinality :one}]
+                                       [:add-attr {:id (:handle attr-ids)
+                                                   :forward-identity [(random-uuid) "user" "handle"]
+                                                   :unique? true
+                                                   :index? false
+                                                   :value-type :blob
+                                                   :cardinality :one}]]
+                                      (let [id (random-uuid)]
+                                        [[:add-triple id (:id attr-ids) (str id)]
+                                         [:add-triple id (:handle attr-ids) "a"]])
+                                      (let [id (random-uuid)]
+                                        [[:add-triple id (:id attr-ids) (str id)]
+                                         [:add-triple id (:handle attr-ids) "b"]])
+                                      (mapcat (fn [i]
+                                                (let [id (random-uuid)]
+                                                  [[:add-triple id (:id attr-ids) (str id)]
+                                                   [:add-triple id (:handle attr-ids) (str i)]]))
+                                              (range 5000))))]
+          (when (= :test (config/get-env))
+            (sql/select (aurora/conn-pool :write) ["ANALYZE triples"]))
+          (testing "query on unique attr"
+            (let [{:keys [patterns]} (iq/instaql-query->patterns
+                                      (make-ctx)
+                                      {:user {:$ {:where {:handle "a"}}}})
+                  explain (d/explain (make-ctx) patterns)
+                  plan (-> explain
+                           first
+                           (get "QUERY PLAN")
+                           first
+                           (get-in ["Plan" "Plans" 0]))
+                  ;; Make sure it's using the full index
+                  expected-index-cond (format "((t0.app_id = '%s'::uuid) AND (t0.attr_id = '%s'::uuid) AND (CASE WHEN (t0.value = 'null'::jsonb) THEN NULL::jsonb ELSE t0.value END = '\"a\"'::jsonb))"
+                                              (:id app)
+                                              (:handle attr-ids))]
+              (is (= expected-index-cond (get plan "Index Cond")))
+              (is (= "av_index" (get plan "Index Name")))))
 
-        (testing "query with lookup"
-          (let [explain (d/explain (make-ctx) {:children
-                                               {:pattern-groups
-                                                [{:patterns
-                                                  [[:ea [(:handle attr-ids) "a"]]]}]}})
-                plan (-> explain
-                         first
-                         (get "QUERY PLAN")
-                         first
-                         (get-in ["Plan" "Plans"])
-                         first
-                         (get "Plans")
-                         first)
-                ;; Make sure it's using the full index
-                expected-index-cond (format "((triples.app_id = '%s'::uuid) AND (triples.attr_id = '%s'::uuid) AND (CASE WHEN (triples.value = 'null'::jsonb) THEN NULL::jsonb ELSE triples.value END = '\"a\"'::jsonb))"
-                                            (:id app)
-                                            (:handle attr-ids))]
+          (testing "query with lookup"
+            (let [explain (d/explain (make-ctx) {:children
+                                                 {:pattern-groups
+                                                  [{:patterns
+                                                    [[:ea [(:handle attr-ids) "a"]]]}]}})
+                  plan (-> explain
+                           first
+                           (get "QUERY PLAN")
+                           first
+                           (get-in ["Plan" "Plans"])
+                           first
+                           (get "Plans")
+                           first)
+                  ;; Make sure it's using the full index
+                  expected-index-cond (format "((triples.app_id = '%s'::uuid) AND (triples.attr_id = '%s'::uuid) AND (CASE WHEN (triples.value = 'null'::jsonb) THEN NULL::jsonb ELSE triples.value END = '\"a\"'::jsonb))"
+                                              (:id app)
+                                              (:handle attr-ids))]
 
-            (is (= expected-index-cond (get plan "Index Cond")))
-            (is (= "av_index" (get plan "Index Name")))))))))
+              (is (= expected-index-cond (get plan "Index Cond")))
+              (is (= "av_index" (get plan "Index Name"))))))))))
 
 (deftest arbitrary-order-by-all-types
   (with-empty-app
@@ -4479,28 +4481,27 @@
 (deftest pg-hint-plan-is-working
   (with-zeneca-app
     (fn [app _r]
-      (next-jdbc/with-transaction [conn (aurora/conn-pool :read)]
-        (println (next-jdbc/execute! conn ["select set_config('pg_hint_plan.debug_print', 'verbose', true)"]))
-        (next-jdbc/execute! conn ["select set_config('pg_hint_plan.message_level', 'warning', true)"])
-        (let [ctx {:db {:conn-pool conn}
-                   :app-id (:id app)
-                   :attrs (attr-model/get-by-app-id (:id app))}
-              {:keys [patterns]} (iq/instaql-query->patterns ctx
-                                                             {:users {:$ {:where {:handle "a"}}}})
-              explain (d/explain ctx patterns)
-              warnings (loop [msgs []
-                              ^PSQLWarning warnings (:warnings (meta explain))]
-                         (if warnings
-                           (recur (conj msgs (.getMessage warnings))
-                                  (.getNextWarning warnings))
-                           msgs))
-              hint-state-dump (ucoll/seek (fn [msg]
-                                            (string/includes? msg "HintStateDump"))
-                                          warnings)]
-          (is (not (nil? hint-state-dump)))
-          ;; Testing using ea index only
-          ;; (is (string/includes? hint-state-dump "used hints:IndexScan(t0 av_index)IndexScan(t2 ea_index)"))
-          (is (string/includes? hint-state-dump "used hints:IndexScan(t2 ea_index)")))))))
+      (binding [d/*testing-pg-hints* true]
+        (next-jdbc/with-transaction [conn (aurora/conn-pool :read)]
+          (next-jdbc/execute! conn ["select set_config('pg_hint_plan.debug_print', 'verbose', true)"])
+          (next-jdbc/execute! conn ["select set_config('pg_hint_plan.message_level', 'warning', true)"])
+          (let [ctx {:db {:conn-pool conn}
+                     :app-id (:id app)
+                     :attrs (attr-model/get-by-app-id (:id app))}
+                {:keys [patterns]} (iq/instaql-query->patterns ctx
+                                                               {:users {:$ {:where {:handle "a"}}}})
+                explain (d/explain ctx patterns)
+                warnings (loop [msgs []
+                                ^PSQLWarning warnings (:warnings (meta explain))]
+                           (if warnings
+                             (recur (conj msgs (.getMessage warnings))
+                                    (.getNextWarning warnings))
+                             msgs))
+                hint-state-dump (ucoll/seek (fn [msg]
+                                              (string/includes? msg "HintStateDump"))
+                                            warnings)]
+            (is (not (nil? hint-state-dump)))
+            (is (string/includes? hint-state-dump "used hints:IndexScan(t0 av_index)IndexScan(t2 ea_index)"))))))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Analyzes the datalog pattern to determine which index we should use based on which columns are known.

Consider this datalog query:

```clojure
[:ea ?tbl-0 :tbl/id _]
```

We generate a query that looks like:

```sql
SELECT * FROM triples WHERE (app_id = :app) AND ea AND (attr_id = :tbl/id)
```

We know that `a` is a constant, but `e` and `v` are unknown, so we should use an index that starts with `a`. The only index like that in the `triples` table is the `triples_created_at_idx`, so we use that. 

Before we would try to use the `ea` index, which doesn't help us at all because it has `e` before the `a`.

I'll run this in testing mode to see if there are any queries that it makes worse, but I didn't find any when testing the usual suspects locally.
