### PR TITLE
Allow app admin tokens in the platform SDK

### DIFF
--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -71,6 +71,18 @@
   ([conn params]
    (ex/assert-record! (get-by-id conn params) :app {:args [params]})))
 
+(defn get-by-admin-token
+  ([params]
+   (get-by-admin-token (aurora/conn-pool :read) params))
+  ([conn {:keys [token]}]
+   (sql/select-one ::get-by-admin-token
+                   conn
+                   (hsql/format {:select :*
+                                 :from :apps
+                                 :where [:= :id {:select :app_id
+                                                 :from :app_admin_tokens
+                                                 :where [:= :token token]}]}))))
+
 (defn list-by-creator-id
   ([user-id] (list-by-creator-id (aurora/conn-pool :read) user-id))
   ([conn user-id]

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -58,6 +58,22 @@
                                                :app-id id})]
     {:user user :app app}))
 
+(defn req->superadmin-app! [scope req]
+  (let [token (http-util/req->bearer-token! req)]
+    (tool/def-locals)
+    (if (or (token-util/is-platform-access-token? token)
+            (token-util/is-personal-access-token? token)
+            (instant-user-model/get-by-personal-access-token
+             {:personal-access-token
+              (token-util/->PersonalAccessToken (str token))}))
+      (:app (req->superadmin-user-and-app! scope req))
+
+
+      (if-let [app (app-model/get-by-admin-token {:token token})]
+        app
+        (ex/throw+ {::ex/type ::ex/record-not-found
+                    ::ex/message "Record not found: token"})))))
+
 ;; --------
 ;; App crud
 
@@ -118,17 +134,17 @@
                                        (attr-model/get-by-app-id (:id app))))})))
 
 (defn app-details-get [req]
-  (let [{:keys [app]} (req->superadmin-user-and-app! :apps/read req)]
+  (let [app (req->superadmin-app! :apps/read req)]
     (response/ok {:app app})))
 
 (defn app-update-post [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/write req)
+  (let [{app-id :id} (req->superadmin-app! :apps/write req)
         title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         app (app-model/rename-by-id! {:id app-id :title title})]
     (response/ok {:app app})))
 
 (defn app-delete [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/write req)
+  (let [{app-id :id} (req->superadmin-app! :apps/write req)
         app (app-model/mark-for-deletion! {:id app-id})]
     (response/ok {:app app})))
 
@@ -183,12 +199,12 @@
 ;; Rules
 
 (defn app-rules-get [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/read req)
+  (let [{app-id :id} (req->superadmin-app! :apps/read req)
         {:keys [code]} (rule-model/get-by-app-id {:app-id app-id})]
     (response/ok {:perms code})))
 
 (defn app-rules-post [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/write req)
+  (let [{app-id :id} (req->superadmin-app! :apps/write req)
         code (ex/get-param! req [:body :code] w/stringify-keys)]
     (ex/assert-valid! :rule code (rule-model/validation-errors code))
     (response/ok {:rules (rule-model/put! {:app-id app-id
@@ -198,13 +214,13 @@
 ;; Schema
 
 (defn app-schema-get [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/read req)
+  (let [{app-id :id} (req->superadmin-app! :apps/read req)
         attrs (attr-model/get-by-app-id app-id)
         schema (schema-model/attrs->schema attrs)]
     (response/ok {:schema schema})))
 
 (defn app-schema-plan-post [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/read req)
+  (let [{app-id :id} (req->superadmin-app! :apps/read req)
         client-defs (-> req :body :schema)
         check-types? (-> req :body :check_types)
         background-updates? (-> req :body :supports_background_updates)]
@@ -214,7 +230,7 @@
                                      client-defs))))
 
 (defn app-schema-apply-post [req]
-  (let [{{app-id :id} :app} (req->superadmin-user-and-app! :apps/write req)
+  (let [{app-id :id} (req->superadmin-app! :apps/write req)
         client-defs (-> req :body :schema)
         check-types? (-> req :body :check_types)
         background-updates? (-> req :body :supports_background_updates)

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -60,7 +60,6 @@
 
 (defn req->superadmin-app! [scope req]
   (let [token (http-util/req->bearer-token! req)]
-    (tool/def-locals)
     (if (or (token-util/is-platform-access-token? token)
             (token-util/is-personal-access-token? token)
             (instant-user-model/get-by-personal-access-token


### PR DESCRIPTION
Allows the admin token for an app to be used with the platform SDK for operations that take an appId.

Example:

```
const api = new PlatformApi({auth: {token: 'YOUR_APP_ADMIN_TOKEN'}});
await api.getSchema('YOUR_APP_ID');
```