### PR TITLE
docs: fix typo modelling data

### DIFF
--- a/client/www/pages/docs/modeling-data.md
+++ b/client/www/pages/docs/modeling-data.md
@@ -170,7 +170,7 @@ const _schema = i.schema({
 });
 
 db.transact(
-  db.tx.goals[id()].update({
+  db.tx.posts[id()].update({
     title: 'abc', // <-- no published -- will throw
   }),
 );
@@ -189,7 +189,7 @@ const _schema = i.schema({
 });
 
 db.transact(
-  db.tx.goals[id()].update({
+  db.tx.posts[id()].update({
     title: 'abc', // <-- no published -- still okay
   }),
 );


### PR DESCRIPTION
i believe these are typos, it supposed to be `posts`, not `goals`