### PR TITLE
[CLI] Include admin token on init

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -284,10 +284,10 @@ function globalOption(flags, description, argParser) {
 function warnDeprecation(oldCmd, newCmd) {
   warn(
     chalk.yellow('`instant-cli ' + oldCmd + '` is deprecated.') +
-    ' Use ' +
-    chalk.green('`instant-cli ' + newCmd + '`') +
-    ' instead.' +
-    '\n',
+      ' Use ' +
+      chalk.green('`instant-cli ' + newCmd + '`') +
+      ' instead.' +
+      '\n',
   );
 }
 
@@ -320,7 +320,7 @@ program
     '-a --app <app-id>',
     'If you have an existing app ID, we can pull schema and perms from there.',
   )
-  .action(async function(opts) {
+  .action(async function (opts) {
     await handlePull('all', opts);
   });
 
@@ -387,7 +387,7 @@ program
     "Don't check types on the server when pushing schema",
   )
   .description('Push schema and perm files to production.')
-  .action(async function(arg, inputOpts) {
+  .action(async function (arg, inputOpts) {
     const ret = convertPushPullToCurrentFormat('push', arg, inputOpts);
     if (!ret.ok) return process.exit(1);
     const { bag, opts } = ret;
@@ -429,7 +429,7 @@ program
     'App ID to push to. Defaults to *_INSTANT_APP_ID in .env',
   )
   .description('Pull schema and perm files from production.')
-  .action(async function(arg, inputOpts) {
+  .action(async function (arg, inputOpts) {
     const ret = convertPushPullToCurrentFormat('pull', arg, inputOpts);
     if (!ret.ok) return process.exit(1);
     const { bag, opts } = ret;
@@ -1599,9 +1599,9 @@ async function readLocalSchemaFileWithErrorLogging() {
     error("We couldn't find your schema export.");
     error(
       'In your ' +
-      chalk.green('`instant.schema.ts`') +
-      ' file, make sure you ' +
-      chalk.green('`export default schema`'),
+        chalk.green('`instant.schema.ts`') +
+        ' file, make sure you ' +
+        chalk.green('`export default schema`'),
     );
     return;
   }

--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -507,7 +507,7 @@ function printDotEnvInfo(envType, appId) {
   console.log(terminalLink('Dashboard:', appDashUrl(appId)) + '\n');
 }
 
-async function handleEnvFile(pkgAndAuthInfo, appId) {
+async function handleEnvFile(pkgAndAuthInfo, { appId, appToken }) {
   const { pkgDir } = pkgAndAuthInfo;
   const envType = await detectEnvType(pkgAndAuthInfo);
   const envName = potentialEnvs[envType];
@@ -533,16 +533,23 @@ async function handleEnvFile(pkgAndAuthInfo, appId) {
     );
     return;
   }
-  await writeFile(join(pkgDir, '.env'), `${envName}=${appId}`, 'utf-8');
+  const content =
+    [
+      [envName, appId],
+      ['INSTANT_APP_ADMIN_TOKEN', appToken],
+    ]
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n') + '\n';
+  await writeFile(join(pkgDir, '.env'), content, 'utf-8');
   console.log(`Created ${chalk.green('`.env`')} file!`);
 }
 
 async function detectOrCreateAppAndWriteToEnv(pkgAndAuthInfo, opts) {
   const ret = await detectOrCreateAppWithErrorLogging(opts);
   if (!ret.ok) return ret;
-  const { appId, source } = ret;
+  const { appId, appToken, source } = ret;
   if (source === 'created' || source === 'imported') {
-    await handleEnvFile(pkgAndAuthInfo, appId);
+    await handleEnvFile(pkgAndAuthInfo, { appId, appToken });
   }
   return ret;
 }

--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -284,10 +284,10 @@ function globalOption(flags, description, argParser) {
 function warnDeprecation(oldCmd, newCmd) {
   warn(
     chalk.yellow('`instant-cli ' + oldCmd + '` is deprecated.') +
-      ' Use ' +
-      chalk.green('`instant-cli ' + newCmd + '`') +
-      ' instead.' +
-      '\n',
+    ' Use ' +
+    chalk.green('`instant-cli ' + newCmd + '`') +
+    ' instead.' +
+    '\n',
   );
 }
 
@@ -320,7 +320,7 @@ program
     '-a --app <app-id>',
     'If you have an existing app ID, we can pull schema and perms from there.',
   )
-  .action(async function (opts) {
+  .action(async function(opts) {
     await handlePull('all', opts);
   });
 
@@ -387,7 +387,7 @@ program
     "Don't check types on the server when pushing schema",
   )
   .description('Push schema and perm files to production.')
-  .action(async function (arg, inputOpts) {
+  .action(async function(arg, inputOpts) {
     const ret = convertPushPullToCurrentFormat('push', arg, inputOpts);
     if (!ret.ok) return process.exit(1);
     const { bag, opts } = ret;
@@ -429,7 +429,7 @@ program
     'App ID to push to. Defaults to *_INSTANT_APP_ID in .env',
   )
   .description('Pull schema and perm files from production.')
-  .action(async function (arg, inputOpts) {
+  .action(async function(arg, inputOpts) {
     const ret = convertPushPullToCurrentFormat('pull', arg, inputOpts);
     if (!ret.ok) return process.exit(1);
     const { bag, opts } = ret;
@@ -1592,9 +1592,9 @@ async function readLocalSchemaFileWithErrorLogging() {
     error("We couldn't find your schema export.");
     error(
       'In your ' +
-        chalk.green('`instant.schema.ts`') +
-        ' file, make sure you ' +
-        chalk.green('`export default schema`'),
+      chalk.green('`instant.schema.ts`') +
+      ' file, make sure you ' +
+      chalk.green('`export default schema`'),
     );
     return;
   }


### PR DESCRIPTION
The create app endpoint returns the admin token and I thought it would be nicer for us to include that in the `.env` file we generate on `init` to make it slightly easier for folks who want to get started with Instant on the backend