### PR TITLE
[DOCS] Add docs for cli create-app

### DIFF
--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -5,6 +5,15 @@ description: How to use the Instant CLI to manage schema and permissions.
 
 The Instant CLI was designed to drive your Instant application entirely from a project's codebase. You can create apps, define your data model, and update your permissions, **all through your terminal**.
 
+## Login
+To get started, you need to log in to your Instant account. You can do this by running:
+
+```shell {% showCopy=true %}
+npx instant-cli@latest login
+```
+
+This will open a browser window where you can authenticate with your Instant account. Once authenticated you'll be able to run commands that interact with your Instant apps!
+
 ## Init
 
 To get started, head on over to your project's root repository, and write:

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -6,6 +6,7 @@ description: How to use the Instant CLI to manage schema and permissions.
 The Instant CLI was designed to drive your Instant application entirely from a project's codebase. You can create apps, define your data model, and update your permissions, **all through your terminal**.
 
 ## Login
+
 To get started, you need to log in to your Instant account. You can do this by running:
 
 ```shell {% showCopy=true %}
@@ -62,6 +63,7 @@ npx instant-cli@latest pull
 This will generate new `instant.schema.ts` and `instant.perms.ts` files, based on your production state.
 
 ## Create App
+
 Sometimes you may just want to create a new Instant app without overwriting your
 existing schema and permission files. This is convenient when you want to create
 a new app for testing schema changes or permissions. You can use the `create-app` command to generate a new app without affecting your current files:

--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -61,6 +61,18 @@ npx instant-cli@latest pull
 
 This will generate new `instant.schema.ts` and `instant.perms.ts` files, based on your production state.
 
+## Create App
+Sometimes you may just want to create a new Instant app without overwriting your
+existing schema and permission files. This is convenient when you want to create
+a new app for testing schema changes or permissions. You can use the `create-app` command to generate a new app without affecting your current files:
+
+```shell {% showCopy=true %}
+npx instant-cli@latest create-app
+```
+
+You can then run `npx instant-cli@latest push --app <your-new-app-id>` to push
+the schema and permissions for this new app.
+
 ## App ID
 
 Whenever you run a CLI command, we look up your app id. You can either provide an app id as an option:


### PR DESCRIPTION
What it says on the tin! We've seen focus sometimes be surprised that they need to run `login` first before `init` so thought it would be nice to include a blurb about that too