### PR TITLE
Use ave index for string operations

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -585,7 +585,7 @@
          [:json_null_to_null :value]
          :value)
        (value->jsonb val)]
-      (data-type-comparison :is-distinct-from :value val))))
+      (data-type-comparison data-type :is-distinct-from :value val))))
 
 (defn- in-or-eq-value [idx v-set]
   (let [[tag idx-val] idx

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1321,6 +1321,9 @@
                              (= :date order-col-type)
                              (triple-model/parse-date-value cursor-val)
 
+                             (= :string order-col-type)
+                             (->json cursor-val)
+
                              :else
                              cursor-val)
                        (case order-col-type

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -670,7 +670,7 @@
                                                 :eav)
                                               (if-let [data-type (:indexed-checked-type val)]
                                                 [:ave
-                                                 (data-type-comparison data-type :not= :tvalue nil)]
+                                                 (data-type-comparison data-type :not= :t.value nil)]
                                                 [[:not= :t.value [:cast (->json nil) :jsonb]]]))})]]
                   :$comparator (let [{:keys [op value data-type]} val]
                                  [(data-type-comparison data-type

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -555,12 +555,23 @@
 (defn- value->jsonb [x]
   [:cast (->json x) :jsonb])
 
-(defn extract-value-fn [data-type]
+(defn extract-value-fn [data-type op]
   (case data-type
-    :date :triples_extract_date_value
+    :date  :triples_extract_date_value
     :number :triples_extract_number_value
-    :string :triples_extract_string_value
+    :string (case op
+              (:like :ilike) :triples_extract_string_value
+              nil)
     :boolean :triples_extract_boolean_value))
+
+(defn data-type-comparison [data-type op col val]
+  (if-let [f (extract-value-fn data-type op)]
+    [:and
+     [op [f col] val]
+     [:=
+      :checked_data_type
+      [:cast [:inline (name data-type)] :checked_data_type]]]
+    [op col (value->jsonb val)]))
 
 (defn- not-eq-value [idx val]
   (let [[tag idx-val] idx
@@ -574,9 +585,7 @@
          [:json_null_to_null :value]
          :value)
        (value->jsonb val)]
-      [:and
-       [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
-       [:is-distinct-from [(extract-value-fn data-type) :value] val]])))
+      (data-type-comparison :is-distinct-from :value val))))
 
 (defn- in-or-eq-value [idx v-set]
   (let [[tag idx-val] idx
@@ -593,9 +602,7 @@
                   (map value->jsonb v-set))
 
         (list* :or (map (fn [v]
-                          [:and
-                           [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]
-                           [:= [(extract-value-fn data-type) :value] v]])
+                          (data-type-comparison data-type := :value v))
                         v-set))))))
 
 (defn- constant->where-part [idx app-id component-type [_ v]]
@@ -663,24 +670,19 @@
                                                 :eav)
                                               (if-let [data-type (:indexed-checked-type val)]
                                                 [:ave
-                                                 [:=
-                                                  :checked_data_type
-                                                  [:cast [:inline (name data-type)] :checked_data_type]]
-                                                 [:not= [(extract-value-fn data-type) :t.value] nil]]
+                                                 (data-type-comparison data-type :not= :tvalue nil)]
                                                 [[:not= :t.value [:cast (->json nil) :jsonb]]]))})]]
                   :$comparator (let [{:keys [op value data-type]} val]
-                                 [[(case op
-                                     :$gt :>
-                                     :$gte :>=
-                                     :$lt :<
-                                     :$lte :<=
-                                     :$like :like
-                                     :$ilike :ilike)
-                                   [(extract-value-fn data-type)
-                                    :value]
-                                   value]
-                                  ;; Need this check so that postgres knows it can use the index
-                                  [:= :checked_data_type [:cast [:inline (name data-type)] :checked_data_type]]])
+                                 [(data-type-comparison data-type
+                                                        (case op
+                                                          :$gt :>
+                                                          :$gte :>=
+                                                          :$lt :<
+                                                          :$lte :<=
+                                                          :$like :like
+                                                          :$ilike :ilike)
+                                                        :value
+                                                        value)])
                   :$entityIdStartsWith
                   (let [prefix val]
                     [[:and
@@ -965,8 +967,18 @@
                                         (not= (:idx-key idx-config)
                                               (idx-key (:idx named-p))))
                                    (and (:data-type idx-config)
-                                        (not (= (:data-type idx-config)
-                                                (idx-data-type (:idx named-p))))))
+                                        (or (not (= (:data-type idx-config)
+                                                    (idx-data-type (:idx named-p))))
+                                            (and (= :string (:data-type idx-config))
+                                                 (not (and (= :function (-> named-p
+                                                                            :v
+                                                                            first))
+                                                           (contains? #{:$like :$ilike}
+                                                                      (-> named-p
+                                                                          :v
+                                                                          second
+                                                                          :$comparator
+                                                                          :op))))))))
                              -1
                              (+ (if (and (:idx-key idx-config)
                                          (= (:idx-key idx-config)
@@ -1295,13 +1307,16 @@
                      [:before :desc] :>
                      [:after :asc] :>
                      [:after :desc] :<)
-        order-col (if (= order-col-type :created-at-timestamp)
-                    order-col-name
-                    [(extract-value-fn order-col-type) order-col-name])
+        order-col-value-fn (when (not= order-col-type :created-at-timestamp)
+                             (extract-value-fn order-col-type comparison))
+        order-col (if order-col-value-fn
+                    [order-col-value-fn order-col-name]
+                    order-col-name)
         order-col-val [:cast
                        (cond (and (keyword? cursor-val)
-                                  (not= order-col-type :created-at-timestamp))
-                             [(extract-value-fn order-col-type) cursor-val]
+                                  (not= order-col-type :created-at-timestamp)
+                                  order-col-value-fn)
+                             [order-col-value-fn cursor-val]
 
                              (= :date order-col-type)
                              (triple-model/parse-date-value cursor-val)
@@ -1311,7 +1326,7 @@
                        (case order-col-type
                          :created-at-timestamp :bigint
                          :boolean :boolean
-                         :string :text
+                         :string :jsonb
                          :number :double-precision
                          :date :timestamp-with-time-zone)]]
 
@@ -1409,9 +1424,13 @@
                              (reverse-direction direction)
                              direction)
 
+        ;; Will be nil if we're sorting by serverCreatedAt or string
+        order-col-value-fn (when-not (= order-col-type :created-at-timestamp)
+                             (extract-value-fn order-col-type :>))
+
         query (-> query
                   (update :where (fn [wheres]
-                                   (if (= order-col-type :created-at-timestamp)
+                                   (if-not order-col-value-fn
                                      wheres
                                      ;; Make sure we use the index for ordering
                                      (list :and [:= :checked_data_type
@@ -1420,15 +1439,16 @@
                   (dissoc :select)
                   (assoc :select-distinct-on (list*
                                               [:order-val :order-eid]
-                                              [(if (= order-col-type :created-at-timestamp)
-                                                 [:cast order-col-name :bigint]
-                                                 [(extract-value-fn order-col-type) order-col-name])
+                                              [(if order-col-value-fn
+                                                 [order-col-value-fn  order-col-name]
+                                                 order-col-name)
                                                :order-val]
                                               [entity-id-col :order-eid]
                                               (:select query))))
 
         order-by [[:order-val
-                   (if (= order-col-type :created-at-timestamp)
+                   (if-not order-col-value-fn
+                     ;; No nulls in this case, so no need to specify null-first/last
                      order-by-direction
                      (if (= order-by-direction :desc)
                        (kw order-by-direction :-nulls-last)

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2356,8 +2356,6 @@
             run-query (fn [q]
                         (let [ctx (make-ctx)]
                           (->> (iq/permissioned-query ctx q)
-                               (tool/inspect)
-
                                (instaql-nodes->object-tree ctx)
                                (#(get % "etype"))
                                (map #(get % "label"))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2362,57 +2362,56 @@
                                (#(get % "etype"))
                                (map #(get % "label"))
                                set)))
-            tx-result (tx/transact! (aurora/conn-pool :write)
-                                    (attr-model/get-by-app-id (:id app))
-                                    (:id app)
-                                    (concat
-                                     [[:add-attr {:id id-attr-id
-                                                  :forward-identity [(random-uuid) "etype" "id"]
-                                                  :unique? true
-                                                  :index? true
-                                                  :value-type :blob
-                                                  :checked-data-type :string
-                                                  :cardinality :one}]
-                                      [:add-attr {:id label-attr-id
-                                                  :forward-identity [(random-uuid) "etype" "label"]
-                                                  :unique? true
-                                                  :index? true
-                                                  :value-type :blob
-                                                  :checked-data-type :string
-                                                  :cardinality :one}]]
-                                     (for [[t attr-id] attr-ids]
-                                       [:add-attr {:id attr-id
-                                                   :forward-identity [(random-uuid) "etype" (name t)]
-                                                   :unique? false
+            _tx-result (tx/transact! (aurora/conn-pool :write)
+                                     (attr-model/get-by-app-id (:id app))
+                                     (:id app)
+                                     (concat
+                                      [[:add-attr {:id id-attr-id
+                                                   :forward-identity [(random-uuid) "etype" "id"]
+                                                   :unique? true
                                                    :index? true
                                                    :value-type :blob
-                                                   :checked-data-type t
-                                                   :cardinality :one}])
+                                                   :checked-data-type :string
+                                                   :cardinality :one}]
+                                       [:add-attr {:id label-attr-id
+                                                   :forward-identity [(random-uuid) "etype" "label"]
+                                                   :unique? true
+                                                   :index? true
+                                                   :value-type :blob
+                                                   :checked-data-type :string
+                                                   :cardinality :one}]]
+                                      (for [[t attr-id] attr-ids]
+                                        [:add-attr {:id attr-id
+                                                    :forward-identity [(random-uuid) "etype" (name t)]
+                                                    :unique? false
+                                                    :index? true
+                                                    :value-type :blob
+                                                    :checked-data-type t
+                                                    :cardinality :one}])
 
-                                     (mapcat
-                                      (fn [i]
-                                        (let [id (random-uuid)]
-                                          [[:add-triple id id-attr-id (str id)]
-                                           [:add-triple id label-attr-id (nth labels i)]
-                                           [:add-triple id (:string attr-ids) (str i)]
-                                           [:add-triple id (:number attr-ids) i]
-                                           [:add-triple id (:date attr-ids) i]
-                                           [:add-triple id (:boolean attr-ids) (zero? (mod i 2))]]))
-                                      (range (count labels)))
-                                     ;; null
-                                     (let [id (random-uuid)]
-                                       [[:add-triple id id-attr-id (str id)]
-                                        [:add-triple id label-attr-id "null"]
-                                        [:add-triple id (:string attr-ids) nil]
-                                        [:add-triple id (:number attr-ids) nil]
-                                        [:add-triple id (:date attr-ids) nil]
-                                        [:add-triple id (:boolean attr-ids) nil]])
+                                      (mapcat
+                                       (fn [i]
+                                         (let [id (random-uuid)]
+                                           [[:add-triple id id-attr-id (str id)]
+                                            [:add-triple id label-attr-id (nth labels i)]
+                                            [:add-triple id (:string attr-ids) (str i)]
+                                            [:add-triple id (:number attr-ids) i]
+                                            [:add-triple id (:date attr-ids) i]
+                                            [:add-triple id (:boolean attr-ids) (zero? (mod i 2))]]))
+                                       (range (count labels)))
+                                      ;; null
+                                      (let [id (random-uuid)]
+                                        [[:add-triple id id-attr-id (str id)]
+                                         [:add-triple id label-attr-id "null"]
+                                         [:add-triple id (:string attr-ids) nil]
+                                         [:add-triple id (:number attr-ids) nil]
+                                         [:add-triple id (:date attr-ids) nil]
+                                         [:add-triple id (:boolean attr-ids) nil]])
 
-                                     ;; undefined
-                                     (let [id (random-uuid)]
-                                       [[:add-triple id id-attr-id (str id)]
-                                        [:add-triple id label-attr-id "undefined"]])))]
-        (tool/def-locals)
+                                      ;; undefined
+                                      (let [id (random-uuid)]
+                                        [[:add-triple id id-attr-id (str id)]
+                                         [:add-triple id label-attr-id "undefined"]])))]
 
         (testing "$isNull"
           (testing "string"

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2671,7 +2671,7 @@
             (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
 
             (testing "uses index"
-              (is (= "triples_string_trgm_gist_idx" (run-explain :string "2"))))
+              (is (= "ave_index" (run-explain :string "2"))))
 
             (testing "like uses index"
               (is (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa")))))


### PR DESCRIPTION
We use a gist index for strings so that `like` will be efficient, but it's not very good for exact matches, and it's not very good for ordering because it doesn't produce a sorted output ([according to the documentation](https://www.postgresql.org/docs/current/indexes-ordering.html), only B-Tree indexes produce sorted output).

We already have everything in the `ave` index and it sorts in the same order as strings do. We can use it for any index comparisons that don't use `like` or `ilike`.

This PR uses the `ave` index when we're sorting by strings, but still uses the gist index when comparing with `like` or `ilike`.