### PR TITLE
Use github as the source of truth for prod migrations

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -30,6 +30,12 @@ dev-down:
 	@echo "Migrating dev db up down by 1"
 	migrate -database "postgresql://localhost:5432/instant?sslmode=disable" -path resources/migrations down 1
 
+## Generates the blank up/down files for the migration
+# Update -digits to 3 when we hit migration 100
+create-migration:
+	@read -p "Enter the migration name: " name; \
+	migrate create -dir resources/migrations -ext sql -digits 2 -seq "$$name"
+
 compile-java:
 	clojure -T:build compile-java
 


### PR DESCRIPTION
This change will make gomigrate fetch the migrations from the main branch of GitHub instead of looking at your local filesystem.

This will prevent any incidents where someone was working on a migration locally and forgot to checkout main and stash their changes before running the migrations.

Only affects `make prod-up`, `make prod-down` and `make prod-version`.

gomigrate docs: https://github.com/golang-migrate/migrate/tree/master/source/github

Also adds a `make create-migration` that will generate the two blank up/down files for you.