### PR TITLE
Remove old vae and eav indexes

### DIFF
--- a/server/resources/migrations/74_drop_old_vae_eav_indexes.down.sql
+++ b/server/resources/migrations/74_drop_old_vae_eav_indexes.down.sql
@@ -1,0 +1,5 @@
+-- Run this concurrently first
+create unique index eav_index on triples(app_id, entity_id, attr_id, value) where eav;
+
+-- Run this concurrently first
+create index vae_index on triples(app_id, value, attr_id, entity_id) where vae;

--- a/server/resources/migrations/74_drop_old_vae_eav_indexes.down.sql
+++ b/server/resources/migrations/74_drop_old_vae_eav_indexes.down.sql
@@ -1,5 +1,5 @@
 -- Run this concurrently first
-create unique index eav_index on triples(app_id, entity_id, attr_id, value) where eav;
+create unique index if not exists eav_index on triples(app_id, entity_id, attr_id, value) where eav;
 
 -- Run this concurrently first
-create index vae_index on triples(app_id, value, attr_id, entity_id) where vae;
+create index if not exists vae_index on triples(app_id, value, attr_id, entity_id) where vae;

--- a/server/resources/migrations/74_drop_old_vae_eav_indexes.up.sql
+++ b/server/resources/migrations/74_drop_old_vae_eav_indexes.up.sql
@@ -1,0 +1,5 @@
+-- run this concurrently first
+drop index vae_index;
+
+-- run this concurrently first
+drop index eav_index;

--- a/server/resources/migrations/74_drop_old_vae_eav_indexes.up.sql
+++ b/server/resources/migrations/74_drop_old_vae_eav_indexes.up.sql
@@ -1,5 +1,5 @@
 -- run this concurrently first
-drop index vae_index;
+drop index if exists vae_index;
 
 -- run this concurrently first
-drop index eav_index;
+drop index if exists eav_index;


### PR DESCRIPTION
Removes the indexes that were replaced in https://github.com/instantdb/instant/pull/1326

I'll delay merging and check the autoexplain to be sure we don't still have queries relying on these indexes.

## Deployment plan

- [ ] Merge to main
- [ ] Drop the indexes concurrently
```sql
drop index concurrently if exists vae_index;

drop index concurrently if exists eav_index;
```
- [ ] Run the migrations