### PR TITLE
Drop some logging events in prod

### DIFF
--- a/server/src/instant/util/logging_exporter.clj
+++ b/server/src/instant/util/logging_exporter.clj
@@ -171,9 +171,18 @@
            "store/swap-datalog-cache!"
            "store/bump-instaql-version!"
            "store/add-instaql-query!"
+           "store/mark-datalog-queries-stale!"
+           "store/remove-query!"
+           "store/assoc-session!"
+           "store/remove-session!"
+           "store/remove-session-data!"
+           "store/upsert-datalog-loader!"
            "instaql/get-eid-check-result!"
            "extract-permission-helpers"
-           "instaql/map-permissioned-node") true
+           "instaql/map-permissioned-node"
+           "datalog-query-reactive!"
+           "instaql/preload-entity-maps"
+           "datalog/send-query-nested") true
 
           ("receive-worker/handle-event"
            "receive-worker/handle-receive")


### PR DESCRIPTION
Drops a few logging events in prod that aren't very useful for debugging via the logs.

Chosen [based on this query](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'parse*20*40message*20*22*5b*2a*5d*20*2ams*20*5b*2a*5d*20*2a*22*20as*20trace_id*2c*20duration*2c*20span_name*2c*20rest*20*0a*7c*20stats*20sum*28strlen*28*40message*29*29*20as*20total_length*20by*20span_name*20*0a*7c*20sort*20total_length*20desc~queryId~'0af4912b-bb7e-45e7-b549-bdde6ef091b6~source~(~'*2faws*2felasticbeanstalk*2fInstant-docker-prod-env-2*2fvar*2flog*2feb-docker*2fcontainers*2feb-current-app*2fstdouterr.log)~lang~'CWLI)), which shows the span names that generate the most log volume: 