### PR TITLE
Set default scopes for the MCP server if they're not provided

### DIFF
--- a/client/packages/mcp/src/oauth-service-provider.ts
+++ b/client/packages/mcp/src/oauth-service-provider.ts
@@ -108,10 +108,15 @@ export function makeApiAuth(
 
 // https://github.com/modelcontextprotocol/modelcontextprotocol/issues/653
 // Anthropic says it's fixed, but it doesn't seem like it
-function patchClientForClaude(
+function patchClientForScopes(
   client: OAuthClientInformationFull,
 ): OAuthClientInformationFull {
-  if (client.scope?.includes('claudeai')) {
+  if (
+    !client.scope ||
+    // https://github.com/modelcontextprotocol/modelcontextprotocol/issues/653
+    // Anthropic says it's fixed, but it doesn't seem like it
+    client.scope?.includes('claudeai')
+  ) {
     return { ...client, scope: 'apps-read apps-write' };
   }
   return client;
@@ -159,7 +164,7 @@ export class ServiceProvider implements OAuthServerProvider {
 
       registerClient: async (rawClient: OAuthClientInformationFull) => {
         const client = {
-          ...patchClientForClaude(rawClient),
+          ...patchClientForScopes(rawClient),
         };
 
         await this.#db.transact(


### PR DESCRIPTION
Fixes a bug with VSCode, where it will generate the client without any scopes, then fail to go through the OAuth flow because the client doesn't have the requested scope.