### PR TITLE
Fix Sign In with Apple with Invertase lib

### DIFF
--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -136,6 +136,11 @@
                           (= jwt-nonce nonce)
                           nil
 
+                          ;; For some reason invertase replaces nonce with SHA256 of nonce
+                          ;; https://github.com/invertase/react-native-apple-authentication/blob/cadd7cad1c8c2c59505959850affaa758328f1a3/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java#L139-L146
+                          (and jwt-nonce nonce (= jwt-nonce (-> nonce crypt-util/str->sha256 crypt-util/bytes->hex-string)))
+                          nil
+
                           (and (string/blank? jwt-nonce)
                                (not (string/blank? nonce)))
                           "The id_token is missing a nonce."


### PR DESCRIPTION
Report: https://discord.com/channels/1031957483243188235/1384530339354906654

Reason: apparently Invertase converts `nonce` to SHA256 of `nonce` before sending it to Apple. During `signInWithIdToken` we compare nonce from `id_token` returned by Apple and nonce user provides, and that check was failing

https://github.com/invertase/react-native-apple-authentication/blob/cadd7cad1c8c2c59505959850affaa758328f1a3/android/src/main/java/com/RNAppleAuthentication/AppleAuthenticationAndroidModule.java#L139-L146

Kicker: Comment in invertase codebase:

```
// SHA256 of the nonce to keep in line with the iOS library (and avoid confusion)
```

Avoid confusion 🥴
