### PR TITLE
[Explorer] Fix link/unlink crash

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -707,7 +707,7 @@ export function EditRowDialog({
 
   const handleUnlinkRef = (attr: SchemaAttr, id: string) => {
     setRefUpdates((v) => {
-      const existing = item[attr.name].find((x: any) => x.id === id);
+      const existing = item[attr.name]?.find((x: any) => x.id === id);
       if (existing) {
         return {
           ...v,


### PR DESCRIPTION
Noticed Explorer would crash if someone added and then deleted a link. Pushing up fix here

Repro steps:
1. Click Add a row for an entity with schema for a link
2. Add a link
3. Click delete
4. See crash

**Before**
https://github.com/user-attachments/assets/5661dc51-c401-438a-bc39-ffe05d491306

**After**
https://github.com/user-attachments/assets/91f7c70e-b829-489f-b080-c46b60225804

