### PR TITLE
[Explorer] Better error for failed delete

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -848,8 +848,11 @@ export function Explorer({
                       ),
                     );
                   }
-                } catch (error) {
-                  errorToast(`Failed to delete ${rowText}`);
+                } catch (error: any) {
+                  const errorMessage = error.message;
+                  errorToast(
+                    `Failed to delete ${rowText}${errorMessage ? `: ${errorMessage}` : ''}`,
+                  );
                   return;
                 }
 


### PR DESCRIPTION
I noticed when we fail to delete rows in the explorer we don't give a helpful error to our users. This is especially confusing in the following scenario

```typescript
// instant.schema.ts
const _schema = i.schema({
  entities: {
    $users: i.entity({
      email: i.string().unique().indexed().optional(),
    }),
    profiles: i.entity({
      handle: i.string(),
    }),
    posts: i.entity({
      title: i.string(),
      content: i.string(),
      createdAt: i.number().indexed(),
    }),
  },
  links: {
    userProfiles: {
      forward: { on: "profiles", has: "one", label: "user" },
      reverse: { on: "$users", has: "one", label: "profile" },
    },
    postAuthors: {
      forward: { on: "posts", has: "one", label: "author", required: true },
      reverse: { on: "profiles", has: "many", label: "posts" },
    },
  },
});
```

Now if you create some users/profiles/posts and then try to delete a profile in the explorer it will fail due to the required attribute on posts.

**Before**

https://github.com/user-attachments/assets/593556bc-5705-44e8-a0d1-5418e82213d6

**After**

https://github.com/user-attachments/assets/461266e1-70fa-450d-addf-38be2a437788

Also works for things like timeouts

https://github.com/user-attachments/assets/ef22a7a3-9f95-41e0-bbd3-f49c5f657ba4
