### PR TITLE
Remove another usage of the vae index

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -693,7 +693,6 @@
                   SELECT
                     cast(elem ->> 0 AS uuid) AS entity_id,
                     cast(elem ->> 1 AS text) AS etype,
-                    TO_JSONB(cast(elem ->> 0 AS uuid)) AS entity_id_jsonb
                   FROM
                     jsonb_array_elements(cast(?id+etypes AS jsonb)) AS elem
                 ),
@@ -714,7 +713,7 @@
                     triples.ctid
                   FROM
                     triples
-                    JOIN id_etypes ON triples.value = entity_id_jsonb
+                    JOIN id_etypes ON json_uuid_to_uuid(triples.value) = id_etypes.entity_id
                     JOIN attrs ON triples.attr_id = attrs.id
                   WHERE
                     triples.vae

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -692,7 +692,7 @@
                 id_etypes AS (
                   SELECT
                     cast(elem ->> 0 AS uuid) AS entity_id,
-                    cast(elem ->> 1 AS text) AS etype,
+                    cast(elem ->> 1 AS text) AS etype
                   FROM
                     jsonb_array_elements(cast(?id+etypes AS jsonb)) AS elem
                 ),


### PR DESCRIPTION
Found one more use of the vae_index in the auto_explain.

This makes us do the comparison with `json_uuid_to_uuid(value)` so that we can look it up directly in the vae_uuid_index without doing the conversion.