### PR TITLE
[Metrics] Increase daily job metrics timeout to 6 minutes

### DIFF
--- a/server/src/instant/scripts/daily_metrics.clj
+++ b/server/src/instant/scripts/daily_metrics.clj
@@ -58,7 +58,7 @@
   This is intended to run daily to speed up monthly metrics generation."
   ([] (insert-new-activity (aurora/conn-pool :write)))
   ([conn]
-   (binding [sql/*query-timeout-seconds* 180]
+   (binding [sql/*query-timeout-seconds* 360]
      (sql/do-execute! conn
                       ["WITH date_range AS (
                     SELECT


### PR DESCRIPTION
Previously the timeout for the metrics job was 3 minutes.

Saw the metrics job didn't run again today -- looks like it takes just over 3 minutes to run query for one day of data. Doubling the timeout time to unblock the jobs.

The main culprit is the size of our transactions table. It's almost ~1bil records! (which in itself is a fun fact -- we've almost processed a billion transactions on instant!)