### PR TITLE
Destructure error in the docs

### DIFF
--- a/client/packages/react/src/InstantReactAbstractDatabase.ts
+++ b/client/packages/react/src/InstantReactAbstractDatabase.ts
@@ -179,17 +179,23 @@ export default abstract class InstantReactAbstractDatabase<
    * @see https://instantdb.com/docs/instaql
    *
    * @example
-   *  // listen to all goals
-   *  db.useQuery({ goals: {} })
+   *   // listen to all goals
+   *   const { isLoading, error, data } = db.useQuery({ goals: {} });
    *
-   *  // goals where the title is "Get Fit"
-   *  db.useQuery({ goals: { $: { where: { title: "Get Fit" } } } })
+   *   // goals where the title is "Get Fit"
+   *   const { isLoading, error, data } = db.useQuery({
+   *     goals: { $: { where: { title: 'Get Fit' } } },
+   *   });
    *
-   *  // all goals, _alongside_ their todos
-   *  db.useQuery({ goals: { todos: {} } })
+   *   // all goals, _alongside_ their todos
+   *   const { isLoading, error, data } = db.useQuery({
+   *     goals: { todos: {} },
+   *   });
    *
-   *  // skip if `user` is not logged in
-   *  db.useQuery(auth.user ? { goals: {} } : null)
+   *   // skip if `user` is not logged in
+   *   const { isLoading, error, data } = db.useQuery(
+   *     auth.user ? { goals: {} } : null,
+   *   );
    */
   useQuery = <Q extends InstaQLParams<Schema>>(
     query: null | Q,

--- a/client/www/pages/docs/patterns.md
+++ b/client/www/pages/docs/patterns.md
@@ -45,7 +45,7 @@ query filter. For example, if you want to find all posts that are not linked to
 an author you can do
 
 ```javascript
-db.useQuery({
+const { isLoading, error, data } = db.useQuery({
   posts: {
     $: {
       where: {

--- a/client/www/public/rules.txt
+++ b/client/www/public/rules.txt
@@ -861,7 +861,7 @@ Must use `$user` prefix.
 ```typescript
 // app/page.tsx
 const docId = new URLSearchParams(window.location.search).get("docId");
-const { data } = db.useQuery({ docs: {} }, { ruleParams: { docId } });
+const { isLoading, error, data } = db.useQuery({ docs: {} }, { ruleParams: { docId } });
 
 db.transact(
   db.tx.docs[docId].ruleParams({ docId }).update({ title: 'eat' })


### PR DESCRIPTION
Updates the docs in a few places to destructure `error` when using `db.useQuery`. 

I noticed that claude didn't destructure the error and it made it harder to debug the failing query. Hopefully giving it more examples will clue it in that it needs to handle query errors.