### PR TITLE
[core] Add configurable offline query cache size (#1362)

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -108,6 +108,8 @@ export type Config = {
   websocketURI?: string;
   apiURI?: string;
   devtool?: boolean | DevtoolConfig;
+  verbose?: boolean;
+  queryCacheLimit?: number;
 };
 
 export type InstantConfig<S extends InstantSchemaDef<any, any, any>> = {
@@ -117,6 +119,7 @@ export type InstantConfig<S extends InstantSchemaDef<any, any, any>> = {
   apiURI?: string;
   devtool?: boolean | DevtoolConfig;
   verbose?: boolean;
+  queryCacheLimit?: number;
 };
 
 export type ConfigWithSchema<S extends InstantGraph<any, any>> = Config & {

--- a/client/packages/react/src/useQuery.ts
+++ b/client/packages/react/src/useQuery.ts
@@ -56,6 +56,15 @@ export function useQueryInternal<
     stateForResult(_core._reactor.getPreviousResult(query)),
   );
 
+  // Update the ref when the query changes to avoid showing stale data
+  const previousQueryHash = useRef(queryHash);
+  if (previousQueryHash.current !== queryHash) {
+    resultCacheRef.current = stateForResult(
+      _core._reactor.getPreviousResult(query),
+    );
+    previousQueryHash.current = queryHash;
+  }
+
   // Similar to `resultCacheRef`, `useSyncExternalStore` will unsubscribe
   // if `subscribe` changes, so we use `useCallback` to memoize the function.
   const subscribe = useCallback(

--- a/client/sandbox/react-nextjs/lib/useIsHydrated.tsx
+++ b/client/sandbox/react-nextjs/lib/useIsHydrated.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export function useIsHydrated(): boolean {
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  return isHydrated;
+}

--- a/client/sandbox/react-nextjs/pages/play/query-cache-test.tsx
+++ b/client/sandbox/react-nextjs/pages/play/query-cache-test.tsx
@@ -1,0 +1,345 @@
+import { useRouter } from 'next/router';
+import { useState, useEffect } from 'react';
+import { i, id, InstantReactAbstractDatabase } from '@instantdb/react';
+import EphemeralAppPage, {
+  ResetButton,
+} from '../../components/EphemeralAppPage';
+import { useIsHydrated } from '../../lib/useIsHydrated';
+
+const schema = i.schema({
+  entities: {
+    todos: i.entity({
+      text: i.string(),
+      completed: i.boolean().optional(),
+      createdAt: i.number().optional(),
+    }),
+  },
+});
+
+const perms = {
+  todos: {
+    allow: {
+      view: 'true',
+      create: 'true',
+      update: 'true',
+      delete: 'true',
+    },
+  },
+};
+
+// Generate random todo text
+const randomTodoTexts = [
+  'Buy groceries',
+  'Walk the dog',
+  'Clean the house',
+  'Call mom',
+  'Finish project',
+  'Read a book',
+  'Go to gym',
+  'Cook dinner',
+  'Pay bills',
+  'Organize desk',
+  'Water plants',
+  'Schedule dentist appointment',
+  'Write blog post',
+  'Learn new skill',
+  'Plan vacation',
+];
+
+const defaultLimit = 3;
+
+function QueryCacheApp({
+  db,
+  appId,
+}: {
+  db: InstantReactAbstractDatabase<typeof schema>;
+  appId: string;
+}) {
+  const router = useRouter();
+  const [selectedTodoId, setSelectedTodoId] = useState<string | null>(null);
+
+  // Get cache limit from URL parameter for display purposes
+  const cacheLimit =
+    router.query.cacheLimit && typeof router.query.cacheLimit === 'string'
+      ? parseInt(router.query.cacheLimit, 10) || defaultLimit
+      : defaultLimit;
+
+  // Master query - all todos
+  const {
+    data: allTodos,
+    isLoading: todosLoading,
+    error: todosError,
+  } = db.useQuery({
+    todos: {},
+  });
+
+  // Detail query - specific todo if selected
+  console.log('Selected Todo ID:', selectedTodoId);
+  const { data: todoDetail, isLoading: detailLoading } = db.useQuery(
+    selectedTodoId
+      ? {
+          todos: {
+            $: { where: { id: selectedTodoId } },
+          },
+        }
+      : null,
+  );
+  console.log('Todo Detail Data:', todoDetail);
+  console.log('Todo Detail Loading:', detailLoading);
+
+  const generateRandomTodo = () => {
+    const randomText =
+      randomTodoTexts[Math.floor(Math.random() * randomTodoTexts.length)];
+    const todoId = id();
+
+    db.transact(
+      db.tx.todos[todoId].update({
+        text: `${randomText} - ${Math.floor(Math.random() * 100)}`,
+        completed: false,
+        createdAt: Date.now(),
+      }),
+    );
+  };
+
+  const deleteTodo = (todoId: string) => {
+    db.transact(db.tx.todos[todoId].delete());
+    if (selectedTodoId === todoId) {
+      setSelectedTodoId(null);
+    }
+  };
+
+  const toggleTodo = (todoId: string, completed: boolean) => {
+    db.transact(db.tx.todos[todoId].update({ completed: !completed }));
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-8">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8">Query Cache Test</h1>
+
+        {/* Controls */}
+        <div className="flex gap-4 items-center mb-6 pb-4 border-b">
+          <div className="flex flex-col">
+            <label className="text-sm font-medium">
+              Cache Limit:
+              <input
+                type="number"
+                min="1"
+                value={cacheLimit}
+                onChange={(e) => {
+                  const newLimit = parseInt(e.target.value, 10);
+                  if (!isNaN(newLimit) && newLimit > 0) {
+                    router.push(`?cacheLimit=${newLimit}`, undefined, {
+                      shallow: true,
+                    });
+                  }
+                }}
+                className="ml-2 px-3 py-1 border rounded w-20"
+              />
+            </label>
+            <span className="text-xs text-gray-500 mt-1">
+              Changing this will spawn a new app
+            </span>
+          </div>
+          <button
+            onClick={generateRandomTodo}
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            🎲 Spawn Random Todo
+          </button>
+          <span className="text-sm text-gray-600">
+            Current: <strong>{cacheLimit}</strong> queries
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Master View - All Todos */}
+          <div className="bg-white rounded-lg shadow p-6">
+            <h2 className="text-xl font-semibold mb-4">All Todos</h2>
+
+            {todosLoading ? (
+              <div className="text-gray-500">Loading todos...</div>
+            ) : todosError ? (
+              <div className="text-red-500">
+                Error loading todos: {todosError.message}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {allTodos?.todos?.map((todo) => (
+                  <div
+                    key={todo.id}
+                    className={`p-3 border rounded cursor-pointer transition-colors ${
+                      selectedTodoId === todo.id
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-gray-200 hover:border-gray-300'
+                    }`}
+                    onClick={() => setSelectedTodoId(todo.id)}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="checkbox"
+                          checked={todo.completed || false}
+                          onChange={(e) => {
+                            e.stopPropagation();
+                            toggleTodo(todo.id, todo.completed || false);
+                          }}
+                          className="w-4 h-4"
+                        />
+                        <span
+                          className={
+                            todo.completed ? 'line-through text-gray-500' : ''
+                          }
+                        >
+                          {todo.text}
+                        </span>
+                      </div>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteTodo(todo.id);
+                        }}
+                        className="text-red-500 hover:text-red-700 text-sm"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+
+                {(!allTodos?.todos || allTodos.todos.length === 0) && (
+                  <div className="text-gray-500 text-center py-8">
+                    No todos yet. Click "🎲 Spawn Random Todo" to create some!
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Detail View - Selected Todo */}
+          <div className="bg-white rounded-lg shadow p-6">
+            <h2 className="text-xl font-semibold mb-4">Todo Detail</h2>
+
+            {!selectedTodoId ? (
+              <div className="text-gray-500 text-center py-8">
+                Select a todo from the list to view details
+              </div>
+            ) : detailLoading ? (
+              <div className="text-gray-500">Loading todo details...</div>
+            ) : todoDetail?.todos?.[0] ? (
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    ID
+                  </label>
+                  <div className="text-sm text-gray-600 font-mono bg-gray-50 p-2 rounded">
+                    {todoDetail.todos[0].id}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Text
+                  </label>
+                  <div className="text-sm text-gray-900 bg-gray-50 p-2 rounded">
+                    {todoDetail.todos[0].text}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Status
+                  </label>
+                  <div className="text-sm text-gray-900 bg-gray-50 p-2 rounded">
+                    {todoDetail.todos[0].completed ? 'Completed' : 'Pending'}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Created At
+                  </label>
+                  <div className="text-sm text-gray-600 bg-gray-50 p-2 rounded">
+                    {todoDetail.todos[0].createdAt
+                      ? new Date(todoDetail.todos[0].createdAt).toLocaleString()
+                      : 'Unknown'}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="text-red-500 text-center py-8">
+                Todo not found or failed to load
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function QueryCacheTestPage() {
+  const router = useRouter();
+  const isHydrated = useIsHydrated();
+
+  // Get cache limit from URL parameter, only after hydration
+  const cacheLimit =
+    isHydrated &&
+    router.query.cacheLimit &&
+    typeof router.query.cacheLimit === 'string'
+      ? parseInt(router.query.cacheLimit, 10) || defaultLimit
+      : defaultLimit;
+
+  return (
+    <div className="max-w-6xl mx-auto p-4">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold mb-4">Query Cache Test</h1>
+
+        <div className="mb-6">
+          <h2 className="text-lg font-semibold mb-2">About Query Caching</h2>
+          <div className="text-sm text-gray-700 space-y-2 mb-4">
+            <p>
+              • Until we have single-store, we limit the number of queries we
+              cache for offline use
+            </p>
+            <p>• This tool helps verify the caching behavior works correctly</p>
+            <p>
+              • By default we cache 10 queries, but you can configure this by
+              passing{' '}
+              <code className="bg-gray-100 px-1 rounded">queryCacheLimit</code>{' '}
+              to <code className="bg-gray-100 px-1 rounded">init()</code>
+            </p>
+          </div>
+
+          <h3 className="font-medium mb-2">How to Test</h3>
+          <ol className="text-sm text-gray-700 space-y-1 list-decimal list-inside">
+            <li>
+              Create N+1 todos where N is the cache limit (current limit:{' '}
+              <strong>{cacheLimit}</strong>)
+            </li>
+            <li>View all the todos to load the data into IndexedDB</li>
+            <li>Turn off your dev server so you are now "offline"</li>
+            <li>Refresh the page</li>
+            <li>Verify that some todos will now show a loading state</li>
+          </ol>
+        </div>
+
+        <p className="text-sm text-gray-500 mb-2">
+          Cache limit: <strong>{cacheLimit}</strong> queries
+        </p>
+        {isHydrated && (
+          <ResetButton className="bg-gray-600 text-white px-4 py-2 rounded" />
+        )}
+      </div>
+      {isHydrated && (
+        <EphemeralAppPage
+          schema={schema}
+          perms={perms}
+          Component={QueryCacheApp}
+          addConfig={{ queryCacheLimit: cacheLimit }}
+        />
+      )}
+      {!isHydrated && <div className="text-center py-8">Loading...</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a new option to `init` to allow users to specify the number of queries they want to cache. The default it still 10, but now you can do ``init({ appId ..., schema, queryCacheLimit: 50 })` to persist the last 50 queries.

You can test this out in the sandbox app at `http://localhost:4000/play/query-cache-test`


https://github.com/user-attachments/assets/e3748b81-6aa0-46ce-85c5-21598d391d01


If this looks good can add docs in a follow-up PR!

--

In making the sandbox app I discovered two bugs

### 1. Stale data when switching todos

### Problem
- When switching between different todos (changing the query), the component would briefly show data from the previously selected todo
- This created a confusing UX where clicking Todo B, which was not cached, showed Todo A data

Looking at the `useQueryInternal` function in `/packages/react/src/useQuery.ts`, there was an issue in how `resultCacheRef` was being managed:

```typescript
// Line 56-58: This ref is only initialized ONCE on mount
const resultCacheRef = useRef<InstaQLLifecycleState<Schema, Q>>(
  stateForResult(_core._reactor.getPreviousResult(query)),
);
```
When the query changes (e.g., selecting a different todo), the `queryHash` changes and a new `subscribe` function is created, BUT the `resultCacheRef` still contains the data from the **previous query**.

### Fix
Updated the `useQuery.ts` file to properly handle query changes by tracking when the query hash changes and updating the result cache accordingly.

```typescript
// Added after resultCacheRef initialization:
// Update the ref when the query changes to avoid showing stale data
const previousQueryHash = useRef(queryHash);
if (previousQueryHash.current !== queryHash) {
  resultCacheRef.current = stateForResult(
    _core._reactor.getPreviousResult(query),
  );
  previousQueryHash.current = queryHash;
}
```

How it works now

1.`previousQueryHash` is now responsible for detecting when the query actually changes
2. When the query does changes, we update `resultCacheRef.current` to show previous data we had for the new query (if there was any)
This ensures you don't see Todo A's data when you click on Todo B

### 2. We were not persisting the last 10 queries.

### Problem
In the `_onMergeQuerySubs` method, when deciding which stored queries to restore from IndexedDB, the selection was based on:

```typescript
const storageKsToAdd = Object.keys(storageSubs)
  .filter((k) => !inMemorySubs[k])
  .slice(0, this.queryCacheLimit);
```

This approach had no consideration for which queries were most recently or frequently used.

### Fix
Added a timestamp so we can keep the most recently accessed queries:

1. **Track Access Time**: Added `lastAccessed` timestamp when creating/accessing query subscriptions in `_startQuerySub()`:

   ```typescript
   prev[hash].lastAccessed = Date.now();
   ```

2. **Sort by Recency**: Updated the selection logic to sort by `lastAccessed` before taking the first N queries:
   ```typescript
   const storageKsToAdd = Object.keys(storageSubs)
     .filter((k) => !inMemorySubs[k])
     .sort((a, b) => {
       // Sort by lastAccessed, newest first
       const aTime = storageSubs[a]?.lastAccessed || 0;
       const bTime = storageSubs[b]?.lastAccessed || 0;
       return bTime - aTime;
     })
     .slice(0, this.queryCacheLimit);
   ```
