### PR TITLE
[Dash] Add pop-out icon for Docs link

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -13,6 +13,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from '@heroicons/react/24/solid';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import {
   Combobox,
   ComboboxButton,
@@ -1081,8 +1082,11 @@ function Nav({
           items={availableTabs.map((t) => ({
             ...t,
             label: (
-              <div className="flex gap-2">
+              <div className="flex gap-2 items-center">
                 <span>{t.label}</span>
+                {t.id === 'docs' && (
+                  <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                )}
               </div>
             ),
           }))}


### PR DESCRIPTION
James mentioned he was surprised the Docs link on the dashboard opened a new tab, he thought it would be nicer if we added a pop out icon to indicate that.

<img width="326" height="878" alt="CleanShot 2025-07-12 at 09 07 52@2x" src="https://github.com/user-attachments/assets/8660113d-b97a-4028-b287-47092a00674e" />
