### PR TITLE
Type fix for aggregate in admin query

### DIFF
--- a/client/www/lib/hooks/explorer.tsx
+++ b/client/www/lib/hooks/explorer.tsx
@@ -75,6 +75,7 @@ export function useNamespacesQuery(
       ? {
           [selectedNs.name]: {
             $: {
+              // @ts-ignore: unreleased aggregate feature (only works with admin queries)
               aggregate: 'count',
               ...(where ? { where: where } : {}),
             },


### PR DESCRIPTION
Fixes the type error when we use `aggregate: 'count'` in our admin query on the dashboard.

We don't put that in the types because it only works if you're on the dashboard. The type changes in https://github.com/instantdb/instant/pull/1335 must have added stricter type checking of the useQuery query somehow.