### PR TITLE
Add a schema page to the dashboard where you can see the full schema

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       '@instantdb/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@instantdb/platform':
+        specifier: workspace:*
+        version: link:../packages/platform
       '@instantdb/react':
         specifier: workspace:*
         version: link:../packages/react

--- a/client/www/components/dash/Schema.tsx
+++ b/client/www/components/dash/Schema.tsx
@@ -7,7 +7,14 @@ import {
 import { Monaco } from '@monaco-editor/react';
 import { useState } from 'react';
 import { DBAttr } from '@/lib/types';
-import { CodeEditor, Content, Label, SectionHeading, Select } from '../ui';
+import {
+  CodeEditor,
+  Content,
+  Fence,
+  Label,
+  SectionHeading,
+  Select,
+} from '@/components/ui';
 
 import { attrsToSchema } from '@/lib/schema';
 
@@ -103,7 +110,16 @@ export function Schema({ db }: { db: InstantReactClient }) {
           <p>This is the schema for your app in code form.</p>
           <p>
             We recommend you use the <code>instant-cli</code> to push and pull
-            changes to your schema.
+            changes to your schema:
+          </p>
+          <p>
+            <div className="border rounded text-sm overflow-auto">
+              <Fence
+                copyable
+                code={`npx instant-cli@latest pull`}
+                language="bash"
+              />
+            </div>
           </p>
           <p>
             <a href="https://www.instantdb.com/docs/modeling-data#schema-as-code">

--- a/client/www/components/dash/Schema.tsx
+++ b/client/www/components/dash/Schema.tsx
@@ -1,0 +1,153 @@
+import { useSchemaQuery } from '@/lib/hooks/explorer';
+import { init } from '@instantdb/react';
+import {
+  apiSchemaToInstantSchemaDef,
+  generateSchemaTypescriptFile,
+} from '@instantdb/platform';
+import { Monaco } from '@monaco-editor/react';
+import { useState } from 'react';
+import { DBAttr } from '@/lib/types';
+import { CodeEditor, Content, Label, SectionHeading, Select } from '../ui';
+
+import { attrsToSchema } from '@/lib/schema';
+
+type InstantReactClient = ReturnType<typeof init>;
+
+async function addInstantLibs(monaco: Monaco) {
+  const files = [
+    'index.d.ts',
+    'schema.d.ts',
+    'schemaTypes.d.ts',
+    'presence.d.ts',
+  ];
+
+  const fileContents = await Promise.all(
+    files.map(async (file) => {
+      const content = await fetch(
+        `https://unpkg.com/@instantdb/core@latest/dist/esm/${file}`,
+      ).then((r) => r.text());
+      return { file, content };
+    }),
+  );
+
+  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    target: monaco.languages.typescript.ScriptTarget.ESNext,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs, // Node-style lookup
+    baseUrl: 'file:///', // virtual project root
+    ...monaco.languages.typescript.typescriptDefaults.getCompilerOptions(),
+
+    paths: {
+      '@instantdb/core': ['file:///node_modules/@instantdb/core/index.d.ts'],
+      '@instantdb/admin': ['file:///node_modules/@instantdb/admin/index.d.ts'],
+      '@instantdb/react': ['file:///node_modules/@instantdb/react/index.d.ts'],
+      '@instantdb/react-native': [
+        'file:///node_modules/@instantdb/react-native/index.d.ts',
+      ],
+    },
+  });
+
+  for (const { file, content } of fileContents) {
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/core/${file}`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/admin/${file}`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/react/${file}`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/react-native/${file}`,
+    );
+  }
+}
+
+type Pkg =
+  | '@instantdb/core'
+  | '@instantdb/react'
+  | '@instantdb/react-native'
+  | '@instantdb/admin';
+
+function attrsToTsFile(attrs: Record<string, DBAttr>, pkg: Pkg) {
+  const schema = apiSchemaToInstantSchemaDef(
+    attrsToSchema(Object.values(attrs)),
+  );
+
+  return generateSchemaTypescriptFile(schema, schema, pkg);
+}
+
+export function Schema({ db }: { db: InstantReactClient }) {
+  const { attrs } = useSchemaQuery(db);
+
+  const [pkg, setPkg] = useState<
+    | '@instantdb/core'
+    | '@instantdb/admin'
+    | '@instantdb/react'
+    | '@instantdb/react-native'
+  >('@instantdb/core');
+
+  const onMount = (_editor: any, monaco: Monaco) => {
+    addInstantLibs(monaco);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col md:flex-row min-h-0">
+      <div className="flex flex-col gap-4 border-r p-4 text-sm md:basis-96 md:text-base min-h-0">
+        <SectionHeading>Schema</SectionHeading>
+        <Content>
+          <p>This is the schema for your app in code form.</p>
+          <p>
+            We recommend you use the <code>instant-cli</code> to push and pull
+            changes to your schema.
+          </p>
+          <p>
+            <a href="https://www.instantdb.com/docs/modeling-data#schema-as-code">
+              Learn more in the docs.
+            </a>
+          </p>
+        </Content>
+      </div>
+      <div className="flex w-full flex-1 flex-col justify-start">
+        <div className="flex flex-col gap-2 h-full min-h-0">
+          <div className="flex items-center gap-4 border-b px-4 py-2">
+            <div className="font-mono">instant.schema.ts</div>
+
+            <Label>Package</Label>
+            <Select<Pkg>
+              options={[
+                { label: '@instantdb/core', value: '@instantdb/core' },
+                { label: '@instantdb/react', value: '@instantdb/react' },
+                {
+                  label: '@instantdb/react-native',
+                  value: '@instantdb/react-native',
+                },
+                { label: '@instantdb/admin', value: '@instantdb/admin' },
+              ]}
+              onChange={(o) => {
+                if (o) {
+                  setPkg(o.value);
+                }
+              }}
+            />
+          </div>
+          <div className="flex-grow min-h-0">
+            <CodeEditor
+              readOnly={true}
+              onChange={() => null}
+              language="typescript"
+              value={
+                attrs ? attrsToTsFile(attrs, pkg) : '/* Loading schema... */'
+              }
+              onMount={onMount}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -387,7 +387,7 @@ function AddAttrForm({
           <div className="flex flex-col gap-2">
             <h6 className="text-md font-bold">Enforce type</h6>
             <div className="flex gap-2">
-              <Select
+              <Select<CheckedDataType | 'none'>
                 value={checkedDataType || 'none'}
                 onChange={(v) => {
                   if (!v) {
@@ -402,7 +402,7 @@ function AddAttrForm({
                 options={[
                   {
                     label: 'Any (not enforced)',
-                    value: '',
+                    value: 'none',
                   },
                   {
                     label: 'String',

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -370,7 +370,9 @@ export function Checkbox({
   );
 }
 
-export function Select({
+export function Select<
+  Value extends string | number | readonly string[] = string,
+>({
   value,
   options,
   className,
@@ -381,9 +383,9 @@ export function Select({
   title,
 }: {
   value?: string;
-  options: { label: string; value: string }[];
+  options: { label: string; value: Value }[];
   className?: string;
-  onChange: (option?: { label: string; value: string }) => void;
+  onChange: (option?: { label: string; value: Value }) => void;
   disabled?: boolean;
   emptyLabel?: string;
   tabIndex?: number;
@@ -407,7 +409,7 @@ export function Select({
     >
       {options.length ? (
         options.map((option) => (
-          <option key={option.value} value={option.value}>
+          <option key={option.label} value={option.value}>
             {option.label}
           </option>
         ))
@@ -873,6 +875,7 @@ export function CodeEditor(props: {
   path?: string;
   tabIndex?: number;
   loading?: boolean;
+  readOnly?: boolean;
 }) {
   return (
     <Editor
@@ -888,6 +891,7 @@ export function CodeEditor(props: {
         minimap: { enabled: false },
         automaticLayout: true,
         tabIndex: props.tabIndex,
+        readOnly: props.readOnly,
       }}
       onChange={(value) => {
         props.onChange(value || '');

--- a/client/www/lib/hooks/explorer.tsx
+++ b/client/www/lib/hooks/explorer.tsx
@@ -93,7 +93,14 @@ export function useNamespacesQuery(
   };
 }
 export function useSchemaQuery(db: InstantReactWebDatabase<any>) {
-  const [namespaces, setNamespaces] = useState<SchemaNamespace[] | null>(null);
+  const [state, setState] = useState<
+    | {
+        namespaces: SchemaNamespace[];
+        attrs: Record<string, DBAttr>;
+      }
+    | { namespaces: null; attrs: null }
+  >({ namespaces: null, attrs: null });
+
   // (XXX)
   // This is a hack so we can listen to all attr changes
   //
@@ -107,10 +114,13 @@ export function useSchemaQuery(db: InstantReactWebDatabase<any>) {
 
   useEffect(() => {
     function onAttrs(_oAttrs: Record<string, DBAttr>) {
-      setNamespaces(dbAttrsToExplorerSchema(_oAttrs));
+      setState({
+        attrs: _oAttrs,
+        namespaces: dbAttrsToExplorerSchema(_oAttrs),
+      });
     }
     return db._core._reactor.subscribeAttrs(onAttrs);
   }, [db]);
 
-  return { namespaces };
+  return state;
 }

--- a/client/www/lib/schema.tsx
+++ b/client/www/lib/schema.tsx
@@ -204,14 +204,11 @@ function removeHidden(attrs: DBAttr[]) {
   });
 }
 
-// Helper functions
 function getFwdEtype(attr: DBAttr) {
-  // Given an attr, return its forward etype
   return attr['forward-identity'][1];
 }
 
 function getFwdLabel(attr: DBAttr) {
-  // Given an attr, return its forward label
   return attr['forward-identity'][2];
 }
 

--- a/client/www/package.json
+++ b/client/www/package.json
@@ -18,6 +18,7 @@
     "@instantdb/admin": "workspace:*",
     "@instantdb/core": "workspace:*",
     "@instantdb/react": "workspace:*",
+    "@instantdb/platform": "workspace:*",
     "@markdoc/markdoc": "0.1.13",
     "@markdoc/next.js": "^0.3.7",
     "@monaco-editor/react": "^4.6.0",

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -21,6 +21,10 @@ import {
   ComboboxOption,
   ComboboxOptions,
 } from '@headlessui/react';
+import {
+  apiSchemaToInstantSchemaDef,
+  generateSchemaTypescriptFile,
+} from '@instantdb/platform';
 
 import { StyledToastContainer, errorToast, successToast } from '@/lib/toast';
 import config, { cliOauthParamName, getLocal, setLocal } from '@/lib/config';
@@ -33,9 +37,10 @@ import {
   voidTicket,
 } from '@/lib/auth';
 import { TokenContext } from '@/lib/contexts';
-import { DashResponse, InstantApp, InstantMember } from '@/lib/types';
+import { DashResponse, DBAttr, InstantApp, InstantMember } from '@/lib/types';
 
 import { Perms } from '@/components/dash/Perms';
+import { Schema } from '@/components/dash/Schema';
 import Auth from '@/components/dash/Auth';
 import { Explorer } from '@/components/dash/explorer/Explorer';
 import { Onboarding } from '@/components/dash/Onboarding';
@@ -45,6 +50,7 @@ import {
   ActionForm,
   Button,
   Checkbox,
+  CodeEditor,
   Content,
   Copyable,
   Dialog,
@@ -74,6 +80,7 @@ import { createdAtComparator } from '@/lib/app';
 import OAuthApps from '@/components/dash/OAuthApps';
 import clsx from 'clsx';
 import AuthorizedOAuthAppsScreen from '@/components/dash/AuthorizedOAuthAppsScreen';
+import { useNamespacesQuery, useSchemaQuery } from '@/lib/hooks/explorer';
 
 // (XXX): we may want to expose this underlying type
 type InstantReactClient = ReturnType<typeof init>;
@@ -85,6 +92,7 @@ const roleOrder = ['collaborator', 'admin', 'owner'] as const;
 type MainTabId =
   | 'home'
   | 'explorer'
+  | 'schema'
   | 'repl'
   | 'sandbox'
   | 'perms'
@@ -125,6 +133,7 @@ interface Tab<TabId> {
 const mainTabs: Tab<MainTabId>[] = [
   { id: 'home', title: 'Home' },
   { id: 'explorer', title: 'Explorer' },
+  { id: 'schema', title: 'Schema' },
   { id: 'perms', title: 'Permissions' },
   { id: 'auth', title: 'Auth' },
   { id: 'repl', title: 'Query Inspector' },
@@ -575,6 +584,8 @@ function Dashboard() {
                   <Home />
                 ) : tab === 'explorer' ? (
                   <ExplorerTab appId={appId} db={connection.db} />
+                ) : tab === 'schema' ? (
+                  <Schema db={connection.db} />
                 ) : tab === 'repl' ? (
                   <QueryInspector
                     className="flex-1 w-full"

--- a/server/src/instant/model/schema.clj
+++ b/server/src/instant/model/schema.clj
@@ -144,16 +144,18 @@
 (def $files-url-aid (system-catalog/get-attr-id "$files" "url"))
 
 (defn transform-$files-url-attr
-  "$files.url is a derived attribute that we always return from queries. 
-  It does not exist inside our database, so it's marked as optional. 
+  "$files.url is a derived attribute that we always return from queries.
+  It does not exist inside our database, so it's marked as optional.
 
-  However, to our users, it's seen as a required attribute, since we always 
+  However, to our users, it's seen as a required attribute, since we always
   provide it."
   [{:keys [id] :as a}]
   (if (= $files-url-aid id)
     (assoc a :required? true)
     a))
 
+;; Any edits to attrs->schema should be
+;; replicated in attrsToSchema at www/lib/schema.tsx
 (defn attrs->schema [attrs]
   (let [filtered-attrs (map transform-$files-url-attr (attr-model/remove-hidden attrs))
         {blobs :blob refs :ref} (group-by :value-type filtered-attrs)


### PR DESCRIPTION
This adds a `Schema` tab to the dashboard where you can see the full schema for an app in `instant.schema.ts` form.

I've found it very useful for debugging query issues that people report. 

Opening as an RFC because I'm not 100% sure it's a good fit for the dashboard. It's read-only and people might expect you could do a bit more on the schema tab besides just view your `instant.schema.ts`. If we're worried that users will get confused, we could just leave it off the sidebar. Then we could still use it for debugging by adding `t=schema` manually.

Here is what it looks like:

<img width="1239" height="1163" alt="image" src="https://github.com/user-attachments/assets/56ca1570-6793-40d6-9e03-edc551975dbd" />
