### PR TITLE
Remove exactly

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -742,7 +742,7 @@ class InstantAdminDatabase<Schema extends InstantSchemaDef<any, any, any>> {
    *  await db.query({ goals: { todos: {} } })
    */
   query = <Q extends InstaQLParams<Schema>>(
-    query: Exactly<InstaQLParams<Schema>, Q>,
+    query: Q,
     opts: AdminQueryOpts = {},
   ): Promise<InstaQLResponse<Schema, Q>> => {
     if (query && opts && 'ruleParams' in opts) {

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -532,7 +532,7 @@ class InstantCoreDatabase<Schema extends InstantSchemaDef<any, any, any>>
    *  });
    */
   subscribeQuery<Q extends InstaQLParams<Schema>>(
-    query: Exactly<InstaQLParams<Schema>, Q>,
+    query: Q,
     cb: (resp: InstaQLSubscriptionState<Schema, Q>) => void,
     opts?: InstaQLOptions,
   ) {

--- a/client/packages/react/src/InstantReactAbstractDatabase.ts
+++ b/client/packages/react/src/InstantReactAbstractDatabase.ts
@@ -21,7 +21,6 @@ import {
   RoomsOf,
   InstantSchemaDef,
   IInstantDatabase,
-  Exactly,
 } from '@instantdb/core';
 import {
   KeyboardEvent,
@@ -199,7 +198,7 @@ export default abstract class InstantReactAbstractDatabase<
    *   );
    */
   useQuery = <Q extends InstaQLParams<Schema>>(
-    query: null | Exactly<InstaQLParams<Schema>, Q>,
+    query: null | Q,
     opts?: InstaQLOptions,
   ): InstaQLLifecycleState<Schema, Q> => {
     return useQueryInternal<Q, Schema>(this._core, query, opts).state;

--- a/client/www/lib/hooks/explorer.tsx
+++ b/client/www/lib/hooks/explorer.tsx
@@ -75,7 +75,6 @@ export function useNamespacesQuery(
       ? {
           [selectedNs.name]: {
             $: {
-              // @ts-ignore: unreleased aggregate feature (only works with admin queries)
               aggregate: 'count',
               ...(where ? { where: where } : {}),
             },


### PR DESCRIPTION
Removing `Exactly`, because it might be creating some type errors for people. 