### PR TITLE
Cache preflight options requests

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -45,7 +45,7 @@
    [instant.util.tracer :as tracer]
    [instant.app-deletion-sweeper :as app-deletion-sweeper]
    [ring.middleware.cookies :refer [CookieDateTime]]
-   [ring.middleware.cors :refer [wrap-cors]]
+   [ring.middleware.cors :refer [wrap-cors preflight?]]
    [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
    [ring.middleware.keyword-params :refer [wrap-keyword-params]]
    [ring.middleware.multipart-params :refer [wrap-multipart-params]]
@@ -105,6 +105,19 @@
 
     true))
 
+(defn wrap-options-cache-control [handler]
+  (fn [request]
+    (let [response (handler request)]
+      (if (or (not (preflight? request))
+              (not (allow-cors-origin? request))
+              (flags/toggled? :disable-preflight-caching))
+        response
+        ;; If we allowed the CORs origin, add 5 minute cache control headers
+        (update response :headers merge {"Vary" "origin"
+                                         "Access-Control-Max-Age" "300"
+                                         "Cache-Control" "public, max-age=300"})))))
+
+
 (defn not-found [_req]
   (response/not-found {:message "Oops! We couldn't match this route."}))
 
@@ -138,6 +151,7 @@
               wrap-json-response
               (wrap-cors :access-control-allow-origin allow-cors-origin?
                          :access-control-allow-methods [:get :put :post :delete])
+              wrap-options-cache-control
               (http-util/tracer-wrap-span))
           (wrap-json-response not-found)))
 


### PR DESCRIPTION
Adds caching to our cors preflight requests.

If the cors origin is allowed, then we will tell the browser and CDN to cache it for 5 minutes. If it's not allowed, we don't add any caching headers. If everything works well, we could increase the cache duration to something like a day.

This will make things like initializing a session or creating an ephemeral app faster. If the user makes two requests within 5 minutes, their browser will cache and they won't have to make a second options request. And if other people have made requests in the last 5 minutes, then they can get the response directly from the CDN instead of going all the way back to the origin.

There is an instant-config toggles setting to turn off caching globally. I've set the toggle to disable it until we get it in production so that we can monitor it as soon as we turn it on.

This website has a good overview on caching options requests: https://httptoolkit.com/blog/cache-your-cors/