### PR TITLE
Single query for create-app

### DIFF
--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -7,7 +7,6 @@
    [instant.db.model.transaction :as transaction-model]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
-   [instant.model.app-admin-token :as app-admin-token-model]
    [instant.model.instant-user :as instant-user-model]
    [instant.model.rule :as rule-model]
    [instant.system-catalog-ops :refer [query-op]]


### PR DESCRIPTION
This makes creating an app a little bit faster because we don't have to do two round trips to the database. 

Inserts both the app and the admin token with a CTE instead of two queries inside of a transaction.