### PR TITLE
Fix inflection on schema operations

### DIFF
--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -964,7 +964,7 @@ function stepSummary(
   return {
     friendlyDescription: inProgress.length
       ? `Completing ${inProgress.length} of ${steps.length} schema operations.`
-      : `Finished ${steps.length} schema operation${
+      : `Finished ${steps.length} schema operation${steps.length === 1 ? '' : 's'}${
           errored.length
             ? `, with ${errored.length} error${errored.length > 1 ? 's' : ''}`
             : '.'


### PR DESCRIPTION
Fixes a bug where it used the wrong inflection, now it will say "Finished 1 schema operation" or "Finished 10 schema operations".