### PR TITLE
Fix cors

### DIFF
--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -3,13 +3,13 @@
 import { i } from "@instantdb/core";
 
 const _schema = i.schema({
-  // We inferred 7 attributes!
+  // We inferred 8 attributes!
   // Take a look at this schema, and if everything looks good,
   // run `push schema` again to enforce the types.
   entities: {
     $files: i.entity({
-      path: i.string().unique().indexed().optional(),
-      url: i.any().optional(),
+      path: i.string().unique().indexed(),
+      url: i.string(),
     }),
     $users: i.entity({
       email: i.string().unique().indexed().optional(),
@@ -28,6 +28,10 @@ const _schema = i.schema({
     }),
     "e2e-logging": i.entity({
       "invalidator-rate": i.number(),
+    }),
+    flags: i.entity({
+      setting: i.string().unique(),
+      value: i.json(),
     }),
     "friend-emails": i.entity({
       email: i.string().unique(),
@@ -57,6 +61,12 @@ const _schema = i.schema({
     "rate-limited-apps": i.entity({
       appId: i.string().unique(),
     }),
+    "refresh-skip-attrs": i.entity({
+      "default-value": i.boolean().optional(),
+      disabled: i.boolean().optional(),
+      "disabled-apps": i.json().optional(),
+      "enabled-apps": i.any().optional(),
+    }),
     "rule-where-testing": i.entity({
       enabled: i.boolean(),
     }),
@@ -74,10 +84,6 @@ const _schema = i.schema({
       "dualWrite?": i.boolean().optional(),
       "useLocationId?": i.boolean(),
     }),
-    "log-sampled-apps": i.entity({
-      appId: i.string().unique(),
-      sampleRate: i.number(),
-    }),
     "storage-whitelist": i.entity({
       appId: i.string().unique().indexed(),
       email: i.string().optional(),
@@ -93,8 +99,8 @@ const _schema = i.schema({
       "use-vfutures": i.boolean(),
     }),
     toggles: i.entity({
-      setting: i.string(),
-      toggled: i.boolean()
+      setting: i.string().unique(),
+      toggled: i.boolean(),
     }),
     "use-patch-presence": i.entity({
       "default-value": i.boolean(),

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -115,7 +115,7 @@
         ;; If we allowed the CORs origin, add cache control headers
         (let [max-age (or (str (flags/flag :cors-max-age))
                           "600")]
-          (update response :headers merge {"Vary" "origin"
+          (update response :headers merge {"Vary" "origin, Access-Control-Allow-Headers"
                                            "Access-Control-Max-Age" max-age
                                            "Cache-Control" (str "public, max-age=" max-age)}))))))
 

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -112,10 +112,12 @@
               (not (allow-cors-origin? request))
               (flags/toggled? :disable-preflight-caching))
         response
-        ;; If we allowed the CORs origin, add 1 day cache control headers
-        (update response :headers merge {"Vary" "origin"
-                                         "Access-Control-Max-Age" "86400"
-                                         "Cache-Control" "public, max-age=86400"})))))
+        ;; If we allowed the CORs origin, add cache control headers
+        (let [max-age (or (str (flags/flag :cors-max-age))
+                          "600")]
+          (update response :headers merge {"Vary" "origin"
+                                           "Access-Control-Max-Age" max-age
+                                           "Cache-Control" (str "public, max-age=" max-age)}))))))
 
 
 (defn not-found [_req]

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -115,7 +115,7 @@
         ;; If we allowed the CORs origin, add cache control headers
         (let [max-age (or (str (flags/flag :cors-max-age))
                           "600")]
-          (update response :headers merge {"Vary" "origin, Access-Control-Allow-Headers"
+          (update response :headers merge {"Vary" "origin, Access-Control-Request-Headers"
                                            "Access-Control-Max-Age" max-age
                                            "Cache-Control" (str "public, max-age=" max-age)}))))))
 

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -29,7 +29,8 @@
             :app-deletion-sweeper {}
             :rule-wheres {}
             :rule-where-testing {}
-            :toggles {}})
+            :toggles {}
+            :flags {}})
 
 (defn transform-query-result
   "Function that is called on the query result before it is stored in the
@@ -145,6 +146,10 @@
                           (assoc acc (keyword setting) toggled))
                         {}
                         (get result "toggles"))
+        flags (reduce (fn [acc {:strs [setting value]}]
+                          (assoc acc (keyword setting) value))
+                        {}
+                        (get result "flags"))
         rule-wheres (if-let [rule-where-ent (-> result
                                                 (get "rule-wheres")
                                                 first)]
@@ -178,7 +183,8 @@
      :app-deletion-sweeper app-deletion-sweeper
      :rule-wheres rule-wheres
      :rule-where-testing rule-where-testing
-     :toggles toggles}))
+     :toggles toggles
+     :flags flags}))
 
 (def queries [{:query query :transform #'transform-query-result}])
 
@@ -313,6 +319,9 @@
 
 (defn toggled? [key]
   (get-in (query-result) [:toggles key]))
+
+(defn flag [key]
+  (get-in (query-result) [:flags key]))
 
 (defn pg-hint-testing-toggles []
   (reduce-kv (fn [acc k v]


### PR DESCRIPTION
We weren't varying the response based on the headers we return in `Access-Control-Allow-Headers`, which was causing signup to fail. Now we add `Access-Control-Request-Headers` to the `vary` header, which will force the cdn to send the request back to the origin when it needs new headers.

Also puts the max-age in a new `flags` field in `instant-config`.