### PR TITLE
Update intern page now that /paid is fixed

### DIFF
--- a/client/www/pages/intern/index.tsx
+++ b/client/www/pages/intern/index.tsx
@@ -38,7 +38,7 @@ const tools: ToolCard[] = [
     title: 'Paid Subscriptions',
     href: '/intern/paid',
     description:
-      'Shows data about our paid apps. (Currently this is failing to fetch, we should fix?)',
+      'Shows data about our paid apps.',
     category: 'Analytics',
   },
   {


### PR DESCRIPTION
Updates intern page to remove the note about `/intern/paid` being broken now that it's fixed.