### PR TITLE
[mcp] Fix rate limit in remote server

### DIFF
--- a/client/packages/mcp/package.json
+++ b/client/packages/mcp/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "vitest",
-    "dev": "tsx watch --preserveWatchOutput src/index.ts | pino-pretty --colorize",
+    "dev": "tsx watch src/index.ts | pino-pretty --colorize",
     "build": "rm -rf dist && tsc",
     "prepublishOnly": "npm run build",
     "publish-package": "pnpm publish --access public --no-git-checks",

--- a/client/packages/mcp/package.json
+++ b/client/packages/mcp/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "vitest",
-    "dev": "tsx watch src/index.ts | pino-pretty --colorize",
+    "dev": "tsx watch --clear-screen=false src/index.ts | pino-pretty --colorize",
     "build": "rm -rf dist && tsc",
     "prepublishOnly": "npm run build",
     "publish-package": "pnpm publish --access public --no-git-checks",

--- a/client/packages/mcp/src/db/instant.schema.ts
+++ b/client/packages/mcp/src/db/instant.schema.ts
@@ -42,12 +42,12 @@ const _schema = i.schema({
     }),
     mcpRefreshTokens: i.entity({
       scope: i.string(),
-      tokenHash: i.string(),
+      tokenHash: i.string().unique(),
     }),
     mcpTokens: i.entity({
       expiresAt: i.date(),
       scope: i.string(),
-      tokenHash: i.string(),
+      tokenHash: i.string().unique(),
     }),
     redirects: i.entity({
       authParams: i.json(),

--- a/client/packages/mcp/src/index.ts
+++ b/client/packages/mcp/src/index.ts
@@ -447,6 +447,11 @@ async function startSse() {
   app.use(
     pinoHttp({
       logger,
+      autoLogging: {
+        ignore(req) {
+          return req.url === '/health';
+        },
+      },
     }),
   );
   app.use(express.json());
@@ -601,7 +606,7 @@ async function startSse() {
   const host = process.env.IN_FLY ? '0.0.0.0' : 'localhost';
 
   if (process.env.IN_FLY) {
-    app.set('trust proxy', true);
+    app.set('trust proxy', 2);
   }
 
   app.listen(port, host, () => console.log(`listening on port ${port}`));


### PR DESCRIPTION
Fixes the rate limit from a global limit to an IP-based limit. `express-rate-limiter` didn't like that we were setting `trust proxy` to true, instead we have to set it to 2.

Other minor changes:

1. Replaces `--preserveWatchOutput` with `--clear-screen=false` in the `dev` alias (`--preserveWatchOutput` isn't a supported flag for tsx)
2. Marks the tokenHashes as unique to fix deleting tokens
3. Stops logging health checks to make the logs easier to parse