### PR TITLE
[Sandbox] Prevent double running

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -52,6 +52,7 @@ export function Sandbox({
   );
   const [output, setOutput] = useState<any[]>([]);
   const [showRunning, setShowRunning] = useState(false);
+  const [isExecuting, setIsExecuting] = useState(false);
 
   function out(
     type: 'log' | 'error' | 'query' | 'transaction' | 'eval',
@@ -86,6 +87,9 @@ export function Sandbox({
   }, [output]);
 
   const exec = async () => {
+    if (isExecuting) return;
+
+    setIsExecuting(true);
     const timer = setTimeout(() => setShowRunning(true), 200);
 
     if (!appendResults) {
@@ -182,6 +186,7 @@ export function Sandbox({
     } finally {
       clearTimeout(timer);
       setShowRunning(false);
+      setIsExecuting(false);
     }
   };
 


### PR DESCRIPTION
A user reported an edge case where we could accidentally double-run in the sandbox. This makes it so we can only run one exec at a time