### PR TITLE
Add font-mono back to the blog

### DIFF
--- a/client/www/pages/essays/[slug].tsx
+++ b/client/www/pages/essays/[slug].tsx
@@ -44,7 +44,9 @@ const Post = ({ post }: { post: Post }) => {
       <MainNav />
       <div className="mt-6 p-4 space-y-4">
         <div className="mb-4 py-4 max-w-prose mx-auto">
-          <h1 className="text-4xl font-medium mb-2">{title}</h1>
+          <h1 className="text-4xl font-mono font-bold leading-snug mb-2">
+            {title}
+          </h1>
           <div className="flex text-sm text-gray-500">
             <span>
               {authors.map((author, idx) => {
@@ -71,7 +73,7 @@ const Post = ({ post }: { post: Post }) => {
             <img src={hero} className="w-full rounded" />
           </div>
         )}
-        <div className="prose prose-headings:font-medium prose-h1:mt-8 prose-h1:mb-4 prose-h2:mt-4 prose-h2:mb-2 prose-pre:bg-gray-100 mx-auto">
+        <div className="prose prose-headings:font-mono prose-headings:leading-snug prose-headings:font-bold prose-h1:mt-8 prose-h1:mb-4 prose-h2:mt-4 prose-h2:mb-2 prose-pre:bg-gray-100 mx-auto">
           <ReactMarkdown
             rehypePlugins={[rehypeRaw]}
             remarkPlugins={[remarkGfm]}

--- a/client/www/pages/essays/index.tsx
+++ b/client/www/pages/essays/index.tsx
@@ -41,7 +41,7 @@ export default function Page({ posts }: { posts: Post[] }) {
                       href={`/essays/${slug}`}
                       className="hover:text-blue-500"
                     >
-                      <h2 className="text-2xl font-bold font-mono leading-normal mb-2">
+                      <h2 className="text-2xl font-bold font-mono leading-snug mb-2">
                         {title}
                       </h2>
                     </NextLink>

--- a/client/www/pages/essays/index.tsx
+++ b/client/www/pages/essays/index.tsx
@@ -41,7 +41,9 @@ export default function Page({ posts }: { posts: Post[] }) {
                       href={`/essays/${slug}`}
                       className="hover:text-blue-500"
                     >
-                      <h2 className="text-3xl font-medium mb-2">{title}</h2>
+                      <h2 className="text-2xl font-bold font-mono leading-normal mb-2">
+                        {title}
+                      </h2>
                     </NextLink>
                     <div className="flex text-sm text-gray-500">
                       <span>


### PR DESCRIPTION
The whole blog being Sans-serif felt a bit bland. Thought we could spruce it up a bit. Added back font-mono to headings: 

<img width="3456" height="1918" alt="image" src="https://github.com/user-attachments/assets/bc43506c-7412-402f-a6e3-0f70d22a9f95" />

<img width="3456" height="1938" alt="image" src="https://github.com/user-attachments/assets/b3a39601-05d3-4bc3-bd16-c885250a6aeb" />

@nezaj @dwwoelfel @tonsky @drew-harris 