### PR TITLE
Add created date to feedback app

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -43,17 +43,3 @@ text-email:
 html-email:
 	echo "Generating HTML version email..."
 	pandoc -f markdown -t html www/_emails/markdown/$(slug).md -o www/_emails/html/$(slug).html
-
-feedback-app-push:
-	cd www && \
-		FEEDBACK_APP_ID=$$(grep NEXT_PUBLIC_FEEDBACK_APP_ID .env | cut -d '=' -f2) \
-		INSTANT_SCHEMA_FILE_PATH=./lib/intern/docs-feedback/instant.schema.ts \
-		INSTANT_PERMS_FILE_PATH=./lib/intern/docs-feedback/instant.perms.ts \
-		pnpm exec instant-cli push --app=$$FEEDBACK_APP_ID
-
-feedback-app-pull:
-	cd www && \
-	FEEDBACK_APP_ID=$$(grep NEXT_PUBLIC_FEEDBACK_APP_ID .env | cut -d '=' -f2) \
-	INSTANT_SCHEMA_FILE_PATH=./lib/intern/docs-feedback/instant.schema.ts \
-	INSTANT_PERMS_FILE_PATH=./lib/intern/docs-feedback/instant.perms.ts \
-	pnpm exec instant-cli pull --app=$$FEEDBACK_APP_ID

--- a/client/www/components/docs/RatingBox.tsx
+++ b/client/www/components/docs/RatingBox.tsx
@@ -76,6 +76,7 @@ function RatingBox({
                     localId,
                     key: `${localId}_${pageId}`,
                     wasHelpful: 'yes' === item.id,
+                    createdAt: Date.now(),
                   }),
               );
             }}

--- a/client/www/components/intern/docs-feedback/analytics-dashboard.tsx
+++ b/client/www/components/intern/docs-feedback/analytics-dashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { MetricsOverview } from './metrics-overview';
 import { ProblemPages } from './problem-pages';
 import { PageDrilldown } from './page-drilldown';
@@ -10,26 +11,54 @@ import db from '@/lib/intern/docs-feedback/db';
 type View = 'overview' | 'drilldown' | 'comments';
 
 export function AnalyticsDashboard() {
-  const [currentView, setCurrentView] = useState<View>('overview');
-  const [selectedPageId, setSelectedPageId] = useState<string>('');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Initialize state from URL params
+  const viewParam = (searchParams.get('view') as View) || 'overview';
+  const pageIdParam = searchParams.get('pageId') || '';
+
+  const [currentView, setCurrentView] = useState<View>(viewParam);
+  const [selectedPageId, setSelectedPageId] = useState<string>(pageIdParam);
+
+  const updateURL = (view: View, pageId?: string) => {
+    const params = new URLSearchParams();
+    params.set('view', view);
+    if (pageId) {
+      params.set('pageId', pageId);
+    }
+    router.push(`?${params.toString()}`);
+  };
 
   const handlePageClick = (pageId: string) => {
     setSelectedPageId(pageId);
     setCurrentView('drilldown');
+    updateURL('drilldown', pageId);
   };
 
   const handleBackToOverview = () => {
     setCurrentView('overview');
     setSelectedPageId('');
+    updateURL('overview');
   };
 
   const handleViewComments = () => {
     setCurrentView('comments');
+    updateURL('comments');
   };
 
   const handleSignOut = () => {
     db.auth.signOut();
   };
+
+  // Sync URL changes with component state
+  useEffect(() => {
+    const view = (searchParams.get('view') as View) || 'overview';
+    const pageId = searchParams.get('pageId') || '';
+
+    setCurrentView(view);
+    setSelectedPageId(pageId);
+  }, [searchParams]);
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/client/www/components/intern/docs-feedback/comments-view.tsx
+++ b/client/www/components/intern/docs-feedback/comments-view.tsx
@@ -191,7 +191,15 @@ function CommentCard({ comment }: { comment: Rating }) {
             <div className="font-medium text-gray-900 text-sm">
               {comment.pageId}
             </div>
-            <div className="text-xs text-gray-500">ID: {comment.localId}</div>
+            {comment.createdAt && (
+              <span className="text-xs text-gray-500">
+                {new Date(comment.createdAt).toLocaleDateString('en-US', {
+                  month: '2-digit',
+                  day: '2-digit',
+                  year: 'numeric',
+                })}
+              </span>
+            )}
           </div>
         </div>
         <span

--- a/client/www/components/intern/docs-feedback/page-drilldown.tsx
+++ b/client/www/components/intern/docs-feedback/page-drilldown.tsx
@@ -197,7 +197,15 @@ function FeedbackItem({ feedback }: { feedback: Rating }) {
             {feedback.wasHelpful ? '👍 Helpful' : '👎 Not Helpful'}
           </span>
         </div>
-        <span className="text-xs text-gray-500">ID: {feedback.localId}</span>
+        {feedback.createdAt && (
+          <span className="text-xs text-gray-500">
+            {new Date(feedback.createdAt).toLocaleDateString('en-US', {
+              month: '2-digit',
+              day: '2-digit',
+              year: 'numeric',
+            })}
+          </span>
+        )}
       </div>
 
       {feedback.extraComment && (

--- a/client/www/lib/intern/docs-feedback/README.md
+++ b/client/www/lib/intern/docs-feedback/README.md
@@ -8,12 +8,25 @@ You can see the tool at `/intern/docs-feedback`.
 
 You'll need to auth with an @instantdb.com email to see the data
 
-## Updating schema/perms
+## Export the app locally
+
+To get the docs feedback app data locally, run our export script from the server
+repo
 
 ```
-# Pull latest schema and permissions (from client root)
-make feedback-app-pull
+scripts/export.sh --email 'your-email-address' --app-id 5d9c6277-e6ac-42d6-8e51-2354b4870c05
+```
 
-# Push latest schema and permissions (from client root)
-make feedback-app-push
+## Updating schema/perms
+
+First update locally to test changes
+
+```
+INSTANT_CLI_DEV=1 pnpx instant-cli@latest push --app 5d9c6277-e6ac-42d6-8e51-2354b4870c05
+```
+
+Once everything looks good you can push to prod
+
+```
+pnpx instant-cli@latest push --app 5d9c6277-e6ac-42d6-8e51-2354b4870c05
 ```

--- a/client/www/lib/intern/docs-feedback/analytics.ts
+++ b/client/www/lib/intern/docs-feedback/analytics.ts
@@ -21,7 +21,11 @@ export type OverallMetrics = {
 
 export function useRatings() {
   const { data, isLoading, error } = db.useQuery({
-    ratings: {},
+    ratings: {
+      $: {
+        order: { serverCreatedAt: 'desc' },
+      },
+    },
   });
 
   const ratings = data?.ratings || [];

--- a/client/www/lib/intern/docs-feedback/analytics.ts
+++ b/client/www/lib/intern/docs-feedback/analytics.ts
@@ -1,14 +1,9 @@
 import { useMemo } from 'react';
+import { InstaQLEntity } from '@instantdb/react';
 import db from './db';
+import schema from './instant.schema';
 
-export type Rating = {
-  id: string;
-  pageId: string;
-  wasHelpful: boolean;
-  extraComment?: string;
-  key: string;
-  localId: string;
-};
+export type Rating = InstaQLEntity<typeof schema, 'ratings', {}>;
 
 export type PageMetrics = {
   pageId: string;

--- a/client/www/lib/intern/docs-feedback/instant.schema.ts
+++ b/client/www/lib/intern/docs-feedback/instant.schema.ts
@@ -17,6 +17,7 @@ const _schema = i.schema({
       localId: i.string(),
       pageId: i.string().indexed(),
       wasHelpful: i.boolean(),
+      createdAt: i.date().indexed().optional(),
     }),
   },
   links: {},


### PR DESCRIPTION
Main change is adding `createdAt` to the feedback app so we can show when someone gave us feedback about our docs.

<img width="1188" height="998" alt="CleanShot 2025-07-17 at 17 33 58@2x" src="https://github.com/user-attachments/assets/7273c3ab-c3da-4bcf-9ef9-f82d22f0aeb2" />


Also changed the following:

* Added deep-linking so when you refresh you don't go back to the index
* Updated docs / removed the makefile command for updating the feedback app

I had trouble with the Makefile command not being able to pick up the schema/perms, it always wanted to create a new app. Figured instead of having those commands would be nicer to just be explicit on how to update the app 