### PR TITLE
Faster add-attr when not indexed

### DIFF
--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -406,19 +406,11 @@
                            :where [:and
                                    [:= :attr-inserts.value-type [:inline "blob"]]
                                    :attr-inserts.is-indexed]
-                           :join [[:attr-idents :ident]
-                                  [:= :attr-inserts.forward-ident :ident.id]
-
-                                  [:idents :id-ident]
-                                  [:and
-                                   [:= :id-ident.app-id app-id]
-                                   [:= :id-ident.label [:inline "id"]]
-                                   [:= :id-ident.etype :ident.etype]]
-
-                                  [:attrs :id-attr]
+                           :join [[:attrs :id-attr]
                                   [:and
                                    [:= :id-attr.app-id app-id]
-                                   [:= :id-attr.forward-ident :id-ident.id]]
+                                   [:= :id-attr.label "id"]
+                                   [:= :id-attr.etype :attr-inserts.etype]]
 
                                   [:triples :needs-null-triple]
                                   [:and
@@ -429,7 +421,6 @@
                                    [:not [:exists {:select :1
                                                    :from :triples
                                                    :where [:and
-                                                           :triples.ave
                                                            [:= :triples.app-id app-id]
                                                            [:= :triples.attr-id :attr-inserts.id]
                                                            [:= :triples.entity-id :needs-null-triple.entity-id]]}]]]]}]


### PR DESCRIPTION
Makes add-attr fast when you're adding a new non-indexed attr on a large table.

If the attr is indexed, we have to add nulls to every entity in the triples table. Postgres was getting confused and trying to check which entities needed nulls even when you added an unindexed attr. 

Removing the joins to the idents table allowed postgres to build a better query plan that skipped the whole check when you weren't adding an indexed attr.

Adding indexed attrs to an existing table is still slow. I'll follow-up with a PR that does that in two steps: 1. adds the attr without indexing it, 2. creates a background job to index it.