### PR TITLE
Fix standalone packaging for core

### DIFF
--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -41,6 +41,7 @@
     "build": "rm -rf dist; npm run build:tshy && npm run build:standalone && npm run check-exports",
     "build:tshy": "tshy",
     "build:standalone": "vite build",
+    "prepublishOnly": "npm run build:standalone",
     "publish-package": "pnpm publish --access public --no-git-checks"
   },
   "devDependencies": {

--- a/client/www/pages/docs/patterns.md
+++ b/client/www/pages/docs/patterns.md
@@ -168,7 +168,7 @@ via a CDN through [unpkg](https://www.unpkg.com/@instantdb/core/).
 
 ```jsx
 <!-- Load Instant via unpkg. Consider replacing `@latest` with current version  -->
-<script src="https://www.unpkg.com/@instantdb/core@latest/dist/standalone/index.umd.js"></script>
+<script src="https://www.unpkg.com/@instantdb/core@latest/dist/standalone/index.umd.cjs"></script>
 
 <!-- Use Instant like normal -->
 <script>


### PR DESCRIPTION
@instantdb/core's standalone files were sometimes missing from unpkg. Seemed like an intermittement issue

I think what was happening was when publishing, npm would sometimes pack the package before vite finished writing the standalone files to disk.

Talking it through with claude it suggested it only affected the core package because it publishes immediately after building, while react and platform packages have a natural delay (they build after core, giving core's files time to fully write).

The fix here adds a `prepublishOnly` script to ensure the standalone build completes right before npm creates the package:

This should ensure the dist/standalone directory exists when npm packs the files

I was able to get this working 3x in a row w/ `pnpm run dev` running as well

* [v.20.9-experimental.j3](https://www.unpkg.com/@instantdb/core@0.20.9-experimental.j3/dist/standalone/index.umd.cjs), 
* [v.20.9-experimental.j4](https://www.unpkg.com/@instantdb/core@0.20.9-experimental.j4/dist/standalone/index.umd.cjs)
* [v.20.9-experimental.j5](https://www.unpkg.com/@instantdb/core@0.20.9-experimental.j5/dist/standalone/index.umd.cjs)

