### PR TITLE
Use the eav index when it's better

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -622,6 +622,7 @@
                     ;; Make sure av uses the av_index
                     :av [:json_null_to_null :value]
                     ;; Make sure vae uses the vae_uuid_index
+                    ;; and eav uses the eav_uuid_index
                     (:eav :vae) [:json_uuid_to_uuid :value]
 
                     :value)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1034,10 +1034,12 @@
 ;; ---
 ;; match-query
 
-(defn flatten-symbol-map-values [values]
-  (if (set? values)
-    (mapcat flatten-symbol-map-values values)
-    values))
+(defn flatten-symbol-map-values [vs]
+  (mapcat (fn [v]
+            (if (set? v)
+              (mapcat flatten-symbol-map-values v)
+              [v]))
+          vs))
 
 (defn transform-named-p-for-ref-joins
   "If we're joining e -> e or e -> v, it's better to use the eav index
@@ -1446,13 +1448,6 @@
 
 (defn has-prev-tbl [table]
   (kw table :-has-prev))
-
-(defn flatten-symbol-map-values [vs]
-  (mapcat (fn [v]
-            (if (set? v)
-              (mapcat flatten-symbol-map-values v)
-              [v]))
-          vs))
 
 (defn add-page-info
   "Updates the cte with pagination constraints."

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -622,10 +622,11 @@
                     ;; Make sure av uses the av_index
                     :av [:json_null_to_null :value]
                     ;; Make sure vae uses the vae_uuid_index
-                    :vae [:json_uuid_to_uuid :value]
+                    (:eav :vae) [:json_uuid_to_uuid :value]
 
                     :value)
-                  (if (= :vae idx-val)
+                  (if (or (= :vae idx-val)
+                          (= :eav idx-val))
                     v-set
                     (map value->jsonb v-set)))
 

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1034,6 +1034,35 @@
 ;; ---
 ;; match-query
 
+(defn flatten-symbol-map-values [values]
+  (if (set? values)
+    (mapcat flatten-symbol-map-values values)
+    values))
+
+(defn transform-named-p-for-ref-joins
+  "If we're joining e -> e or e -> v, it's better to use the eav index
+  instead of the vae index. It would be cleaner to make this choice in
+  attr-pat.clj, but at that point we don't know what we're going to be
+  joining to since the patterns might be reordered in
+  optimize-attr-pats."
+  [symbol-map named-p]
+  (if (not= :vae (idx-key (:idx named-p)))
+    named-p
+    (let [join-ctypes (reduce (fn [acc [ctype [_ sym]]]
+                                (if-let [paths (some-> (get symbol-map sym)
+                                                       flatten-symbol-map-values)]
+                                  (into acc (map (fn [path]
+                                                   [ctype (:ctype path)])
+                                                 paths))
+                                  acc)
+                                )
+                              #{}
+                              (variable-components named-p))]
+      (if (or (= #{[:e :e]} join-ctypes)
+              (= #{[:e :v]} join-ctypes))
+        (assoc named-p :idx [:keyword :eav])
+        named-p))))
+
 (defn- joining-with
   "Produces subsequent match tables. Each table joins on the previous
    table unless it is the first cte or the start of a new AND/OR
@@ -1042,7 +1071,8 @@
    matches the structure of the symbol-map. It allows us to connect the
    cte to the parent cte if this is a child pattern in a nested query."
   [prefix app-id additional-joins symbol-map prev-idx start-of-group? named-p {:keys [page-info]}]
-  (let [cur-idx (inc prev-idx)
+  (let [named-p (transform-named-p-for-ref-joins symbol-map named-p)
+        cur-idx (inc prev-idx)
         cur-table (kw prefix cur-idx)
         triples-alias (kw :t cur-idx)
         prev-table (when-not (or start-of-group? (neg? prev-idx))


### PR DESCRIPTION
Sometimes it's better to use the eav index, for example in the zeneca query:

### Examples
```clj
{:books {:$ {:where {:bookshelves.users.handle "stopa"}}
```

We send patterns to datalog that look like:

```clj
[[:av ?users-2 :user-aid "stopa"]
 [:vae ?users-2 :bookshelves-aid ?bookshelves-1]
 [:vae ?bookshelves-1 :books-aid ?books-0]]
```

Since we've resolved `?users-2` as an entity-id in the first pattern and it's in the e position in the second pattern, using the eav index will hit the `e` and the `a`, which will usually make a good plan for postgres.

On the other hand, if we went the other way through the links:

```clj
{:users {:$ {:where {:bookshelves.books.title "The Count of Monte Cristo"}}}}
```

We'll create patterns:

```clj
[[:ave ?books-2 :title-eid "The Count of Monte Cristo"]
 [:vae ?bookshelves-1 :book-eid ?books-2]
 [:vae ?users-0 :bookshelf-eid ?bookshelves-1]]
 ```
 
Since we've resolved `?books-2` as an entity-id in the first pattern and it's in the v position in the second pattern, using the vae index will hit the v and the a.

### Explanation

You may be wondering why we put `vae` as the index in the first example, when it should obviously be `eav`. That's because the patterns were reversed in `optimize-attr-pats` after we chose the index to use. It was the right index when we chose it.

That's why we rewrite the `named-pattern` in the datalog.clj. It's just the easiest place to figure out what we're joininig to. In the future, attr-pat shouldn't have any say in the index we use, it should just give us the properties of the attr. Then we can decide which index in datalog.clj based on the full query.