### PR TITLE
fix table overflow for explorer files view

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -1302,6 +1302,9 @@ export function Explorer({
                                 attr.name === 'id')),
                           'cursor-pointer': attr.sortable || attr.name === 'id',
                         },
+                        selectedNamespace.name === '$files' &&
+                          attr.name === 'url' &&
+                          'w-32',
                       )}
                       onClick={
                         attr.sortable


### PR DESCRIPTION
BEFORE:
<img width="971" height="221" alt="image" src="https://github.com/user-attachments/assets/8a58fbc0-bcc5-4644-af08-8b9556deb7b0" />


AFTER: 
<img width="949" height="197" alt="image" src="https://github.com/user-attachments/assets/ae4a855c-9168-4bea-beea-8c63928f1b6a" />
