### PR TITLE
Tweak create namespace input

### DIFF
--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -1626,8 +1626,8 @@ function NewNamespaceDialog({
       </h5>
 
       <TextInput
-        label="Name"
         value={name}
+        placeholder="Name your namespace"
         onChange={(n) => setName(n)}
         autoFocus
       />


### PR DESCRIPTION
In #1418 added `autofocus` to the create namespace input which triggers password managers. Interestingly we don't have this problem for the new app modal which also auto-focuses.

The only difference is the new app modal doesn't provide a label for the `TextInput`. Looking at `TextInput`, we wrap the whole input inside a `label` tag regardless of whether a value for label was provided. If a value was provided though, we add a div before the input with the label text.

I'm not too familiar with how password managers detect and autofill fields, but from some sleuthing on stack overflow and talking with claude removing the "Name" text from inside the <label> eliminates detection.

Another alternative was to remove the `label` tag and instead wrap the whole input in a `div` -- but this seems worse for accessibility and would affect all uses of `TextInput`