### PR TITLE
allow backspace to empty field when editing json

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -666,6 +666,13 @@ export function EditRowDialog({
     setUpdatedBlobValues((prev) => {
       const current = prev[field] || {};
 
+      if (value === '') {
+        return {
+          ...prev,
+          [field]: { type: 'json', value: undefined, error: 'Invalid JSON' },
+        };
+      }
+
       return {
         ...prev,
         [field]: isValidJson(value)


### PR DESCRIPTION
<img width="173" height="95" alt="image" src="https://github.com/user-attachments/assets/19869336-5eb2-4990-aa79-d0e2bbd336d0" />
pressing backspace at this state would previously do nothing and you would be stuck with a single quote you couldn't remove. this pr allows the text field to be empty