### PR TITLE
Enable auth.ref for storage rules

### DIFF
--- a/server/test/instant/storage/coordinator_test.clj
+++ b/server/test/instant/storage/coordinator_test.clj
@@ -1,0 +1,147 @@
+(ns instant.storage.coordinator-test
+  (:require [clojure.test :as test :refer [deftest is testing]]
+            [instant.storage.coordinator :as coordinator]
+            [instant.fixtures :refer [with-empty-app]]
+            [instant.model.app-user :as app-user-model]
+            [instant.model.rule :as rule-model]
+            [instant.db.model.attr :as attr-model]
+            [instant.db.instaql :as i]
+            [instant.db.transaction :as tx]
+            [instant.util.test :as test-util :refer [perm-err?]]
+            [instant.jdbc.aurora :as aurora]))
+
+(defn make-ctx [app-id]
+  {:db {:conn-pool (aurora/conn-pool :read)}
+   :app-id app-id
+   :attrs (attr-model/get-by-app-id app-id)})
+
+(deftest assert-storage-permission-test
+  (with-empty-app
+    (fn [{app-id :id}]
+      ;; Set up attributes for $user.authorization.role
+      (let [conn (aurora/conn-pool :write)
+            auth-etype-attr-id (random-uuid)
+            auth-role-attr-id (random-uuid)
+            user-auth-link-attr-id (random-uuid)]
+
+        ;; Create attributes
+        (tx/transact! conn
+                      (attr-model/get-by-app-id app-id)
+                      app-id
+                      [[:add-attr {:id auth-etype-attr-id
+                                   :forward-identity [(random-uuid) "authorization" "id"]
+                                   :unique? true
+                                   :index? false
+                                   :value-type :blob
+                                   :cardinality :one}]
+                       [:add-attr {:id auth-role-attr-id
+                                   :forward-identity [(random-uuid) "authorization" "role"]
+                                   :unique? false
+                                   :index? false
+                                   :value-type :blob
+                                   :cardinality :one}]
+                       [:add-attr {:id user-auth-link-attr-id
+                                   :forward-identity [(random-uuid) "authorization" "$user"]
+                                   :reverse-identity [(random-uuid) "$users" "authorization"]
+                                   :unique? false
+                                   :index? false
+                                   :value-type :ref
+                                   :cardinality :one}]])
+
+        ;; Create users
+        (let [pass-user-id (random-uuid)
+              fail-user-id (random-uuid)
+              pass-user (app-user-model/create! conn
+                                                {:app-id app-id
+                                                 :id pass-user-id
+                                                 :email "pass@example.com"})
+              fail-user (app-user-model/create! conn
+                                                {:app-id app-id
+                                                 :id fail-user-id
+                                                 :email "fail@example.com"})
+              pass-auth-id (random-uuid)
+              fail-auth-id (random-uuid)]
+
+          ;; Add authorization data
+          (tx/transact! conn
+                        (attr-model/get-by-app-id app-id)
+                        app-id
+                        [;; Create authorization entities
+                         [:add-triple pass-auth-id auth-etype-attr-id (str pass-auth-id)]
+                         [:add-triple pass-auth-id auth-role-attr-id "authorized"]
+                         [:add-triple fail-auth-id auth-etype-attr-id (str fail-auth-id)]
+                         [:add-triple fail-auth-id auth-role-attr-id "pending"]
+                         ;; Link authorization to users
+                         [:add-triple pass-auth-id user-auth-link-attr-id (:id pass-user)]
+                         [:add-triple fail-auth-id user-auth-link-attr-id (:id fail-user)]])
+
+          ;; Set up permissions
+          (let [rules {"$files" {"allow" {"view" "'authorized' in auth.ref('$user.authorization.role')"
+                                          "create" "'authorized' in auth.ref('$user.authorization.role')"
+                                          "delete" "'authorized' in auth.ref('$user.authorization.role')"}}}]
+            (rule-model/put! conn {:app-id app-id :code rules})
+
+            (testing "create permission"
+              (testing "pass@example.com should have create permission"
+                (is (= true
+                       (coordinator/assert-storage-permission!
+                        "create"
+                        {:app-id app-id
+                         :path "/test/file.txt"
+                         :current-user pass-user}))))
+
+              (testing "fail@example.com should not have create permission"
+                (is (perm-err?
+                     (coordinator/assert-storage-permission!
+                      "create"
+                      {:app-id app-id
+                       :path "/test/file.txt"
+                       :current-user fail-user})))))
+
+            (testing "delete permission"
+              (testing "pass@example.com should have delete permission"
+                (is (= true
+                       (coordinator/assert-storage-permission!
+                        "delete"
+                        {:app-id app-id
+                         :path "/test/file.txt"
+                         :current-user pass-user}))))
+
+              (testing "fail@example.com should not have delete permission"
+                (is (perm-err?
+                     (coordinator/assert-storage-permission!
+                      "delete"
+                      {:app-id app-id
+                       :path "/test/file.txt"
+                       :current-user fail-user})))))
+
+            (testing "view permission"
+              (testing "pass@example.com should have view permission"
+                (is (= true
+                       (coordinator/assert-storage-permission!
+                        "view"
+                        {:app-id app-id
+                         :path "/test/file.txt"
+                         :current-user pass-user}))))
+
+              (testing "fail@example.com should not have view permission"
+                (is (perm-err?
+                     (coordinator/assert-storage-permission!
+                      "view"
+                      {:app-id app-id
+                       :path "/test/file.txt"
+                       :current-user fail-user})))))
+
+            (testing "no permissions set should deny by default"
+              (rule-model/put! conn {:app-id app-id :code {}})
+
+              (testing "should deny create when no permissions are set"
+                (is (perm-err?
+                     (coordinator/assert-storage-permission!
+                      "create"
+                      {:app-id app-id
+                       :path "/test/file.txt"
+                       :current-user pass-user})))))))))))
+
+(comment
+  (test/run-tests *ns*))


### PR DESCRIPTION
Folks weren't able to use `auth.ref` for `create` and `delete` permissions in storage (also for `view` for those who go through the deprecated `create-download-url`). This was because we missing some params for context to enable traversing refs.

Added some tests for this too!