### PR TITLE
Better pg_hint_plan with counts

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -67,6 +67,8 @@
         com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.12.7.2"}
 
         lambdaisland/uri {:mvn/version "1.19.155"}
+        lambdaisland/deep-diff2 {:mvn/version "2.12.219"}
+
         com.auth0/java-jwt {:mvn/version "4.4.0"}
         com.auth0/jwks-rsa {:mvn/version "0.22.1"}
         com.stripe/stripe-java {:mvn/version "25.1.0"}

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -12,7 +12,7 @@
    [instant.dash.ephemeral-app :as ephemeral-app]
    [instant.dash.routes :as dash-routes]
    [instant.db.indexing-jobs :as indexing-jobs]
-   [instant.db.rule-where-testing :as rule-where-testing]
+   [instant.db.hint-testing :as hint-testing]
    [instant.storage.sweeper :as storage-sweeper]
    [instant.flags :as flags]
    [instant.flags-impl :as flags-impl]
@@ -300,8 +300,8 @@
       (with-log-init :welcome-email
         (welcome-email/start)))
 
-    (with-log-init :rule-where-testing
-      (rule-where-testing/start))
+    (with-log-init :hint-testing
+      (hint-testing/start))
     (with-log-init :web-server
       (start))
     (with-log-init :shutdown-hook

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1110,7 +1110,7 @@
                                    (when prev-table
                                      [prev-table]))
                             parent-froms)
-              :where (where-clause app-id named-p all-joins)}
+              :where (where-clause app-id triples-alias named-p all-joins)}
              (if (or
                   ;; only use `not materialized` when we're in the middle of an ordered
                   ;; query

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1241,7 +1241,7 @@
   (let [row-estimate (estimate-rows ctx pattern)
         pattern-symbol-map (pattern->symbol-map-placeholder pattern
                                                             row-estimate)]
-    {:symbol-map (update symbol-map (partial merge-with min) pattern-symbol-map)
+    {:symbol-map (merge-with min symbol-map pattern-symbol-map)
      :pattern (assoc pattern
                      :row-estimate row-estimate
                      :symbol-map symbol-map

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1020,6 +1020,7 @@
       (list* :or ors))))
 
 (def ^:dynamic *testing-pg-hints* false)
+(def ^:dynamic *debug* false)
 
 (defn test-pg-hints? []
   *testing-pg-hints*)
@@ -1415,8 +1416,6 @@
               (= #{[:e :v]} join-ctypes))
         (assoc named-p :idx [:keyword :eav])
         named-p))))
-
-(def ^:dynamic *debug* true)
 
 (defn- joining-with
   "Produces subsequent match tables. Each table joins on the previous

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -755,10 +755,6 @@
    {:name :triples_pkey
     :cols [:e :a]}
 
-   {:name :ave_index
-    :cols [:a :v]
-    :idx-key :ave}
-
    {:name :eav_uuid_index
     :cols [:e :a :v]
     :idx-key :eav}
@@ -767,6 +763,10 @@
     :cols [:a :v]
     :idx-key :ave
     :data-type :string}
+
+   {:name :ave_index
+    :cols [:a :v]
+    :idx-key :ave}
 
    {:name :vae_uuid_index
     :cols [:v :a :e]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1353,11 +1353,11 @@
   ([ctx nested-named-patterns]
    (let [counts-atom (atom (set {}))
          ;; Run annotate-with-hints to populate the counts atom
-         _ (with-out-str (annotate-with-hints (assoc ctx
-                                                     :phase :deps
-                                                     :counts counts-atom)
-                                              {}
-                                              nested-named-patterns))
+         _ (annotate-with-hints (assoc ctx
+                                       :phase :deps
+                                       :counts counts-atom)
+                                {}
+                                nested-named-patterns)
          count-queries @counts-atom
 
          ;; Fetch counts from the database. We should be able to store

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1324,7 +1324,7 @@
                                     (estimate-rows ctx page-info-pattern))
         {:keys [patterns symbol-map]}
         (annotate-patterns-with-hints ctx
-                                      (merge (if (and page-info-pattern (tool/inspect page-info-first?))
+                                      (merge (if (and page-info-pattern page-info-first?)
                                                (pattern->symbol-map-placeholder page-info-pattern
                                                                                 page-pattern-row-estimate)
                                                {})

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -810,7 +810,9 @@
           [:= :value [:cast \"25\" :jsonb]]]
   "
   [app-id triples-alias {:keys [idx] :as named-pattern} additional-clauses]
-  (let [attr-ids-where (constant->where-part idx app-id :a (:a named-pattern))
+  (let [attr-ids-where (when-let [a (:a named-pattern)]
+                         (when (named-constant? a)
+                           (constant->where-part idx app-id :a a)))
         rest-wheres (concat (->> (dissoc named-pattern :a)
                                  constant-components
                                  (map (fn [[component-type v]]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -755,6 +755,10 @@
    {:name :triples_pkey
     :cols [:e :a]}
 
+   {:name :ave_index
+    :cols [:a :v]
+    :idx-key :ave}
+
    {:name :eav_uuid_index
     :cols [:e :a :v]
     :idx-key :eav}
@@ -763,10 +767,6 @@
     :cols [:a :v]
     :idx-key :ave
     :data-type :string}
-
-   {:name :ave_index
-    :cols [:a :v]
-    :idx-key :ave}
 
    {:name :vae_uuid_index
     :cols [:v :a :e]
@@ -1197,18 +1197,8 @@
                               (:cols idx-config))
                       :matching-idx-key? (= (:idx-key idx-config)
                                             (idx-key (:idx named-p)))
-                      :matching-data-type? (and (= (:data-type idx-config)
-                                                   (idx-data-type (:idx named-p)))
-                                                (or (not= :string (idx-data-type (:idx named-p)))
-                                                    (not (and (= :function (-> named-p
-                                                                               :v
-                                                                               first))
-                                                              (contains? #{:$like :$ilike}
-                                                                         (-> named-p
-                                                                             :v
-                                                                             second
-                                                                             :$comparator
-                                                                             :op))))))))
+                      :matching-data-type? (= (:data-type idx-config)
+                                              (idx-data-type (:idx named-p)))))
              index-candidates)
 
         sorted-indexes (sort index-compare indexes-with-costs)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -747,37 +747,47 @@
          clauses)))
 
 (def index-configs
-  [{:name :triples_pkey
+  [{:name :ea_index
+    :cols [:e :a]
+    :idx-key :ea}
+
+   {:name :triples_pkey
     :cols [:e :a]}
+
    {:name :ave_index
     :cols [:a :v]
     :idx-key :ave}
-   {:name :ea_index
-    :cols [:e :a]
-    :idx-key :ea}
+
    {:name :eav_uuid_index
     :cols [:e :a :v]
     :idx-key :eav}
+
    {:name :triples_string_trgm_gist_idx
     :cols [:a :v]
     :idx-key :ave
     :data-type :string}
+
    {:name :vae_uuid_index
     :cols [:v :a :e]
     :idx-key :vae}
+
    {:name :triples_created_at_idx
     :cols [:a :created-at]}
+
    {:name :av_index
     :cols [:a :v :e]
     :idx-key :av}
+
    {:name :triples_number_type_idx
     :cols [:a :v]
     :idx-key :ave
     :data-type :number}
+
    {:name :triples_boolean_type_idx
     :cols [:a :v]
     :idx-key :ave
     :data-type :boolean}
+
    {:name :triples_date_type_idx
     :cols [:a :v]
     :idx-key :ave
@@ -930,6 +940,25 @@
                         paths)))))
        (apply concat)))
 
+(defn count-path [path]
+  (if (set? path)
+    (reduce (fn [acc path]
+              (+ acc (count-path path)))
+            0
+            path)
+    1))
+
+(defn join-cond-count [symbol-map named-p]
+  (reduce (fn [acc [ctype [_ sym]]]
+            (if-let [paths (get symbol-map sym)]
+              (+ acc (reduce (fn [acc path]
+                               (count-path path))
+                             0
+                             paths))
+              acc))
+          0
+          (variable-components named-p)))
+
 (defn- join-cond-for-or-gather
   "Generates a join condition for combining two or ctes. In contrast to join-cond,
    each column name needs to be fully qualified."
@@ -989,56 +1018,367 @@
 (defn test-pg-hints? []
   *testing-pg-hints*)
 
+(defn estimate-index-size [ctx symbol-map named-p component]
+  (let [filtered-p (select-keys named-p [:idx component :a])
+        wheres (where-clause (:app-id ctx) :t filtered-p nil)
+        count-info {:wheres wheres}]
+    (if (= (:phase ctx) :deps)
+      (do
+        (swap! (:counts ctx) conj count-info)
+        10000)
+      (get-in ctx [:counts count-info]))))
+
+(defn estimate-rows [ctx symbol-map named-p]
+  (let [count-info {:wheres (where-clause (:app-id ctx)
+                                          :t
+                                          named-p
+                                          nil)}]
+    (if (= :deps (:phase ctx))
+      (do
+        (swap! (:counts ctx) conj count-info)
+        10000)
+      (get-in ctx [:counts count-info]))))
+(defn index-compare [a b]
+  (cond (and (empty? (:known-remaining (:index-costs a)))
+             (not (empty? (:known-remaining (:index-costs b)))))
+        -1
+
+        (and (not (empty? (:known-remaining (:index-costs a))))
+             (empty? (:known-remaining (:index-costs b))))
+        1
+
+        (> (count (:path (:index-costs a)))
+           (count (:path (:index-costs b))))
+        -1
+
+        (> (count (:path (:index-costs b)))
+           (count (:path (:index-costs a))))
+        1
+
+        (and (< 0 (count (:path (:index-costs a))))
+             (< (/ (reduce + (map :cost (:path (:index-costs a))))
+                   (count (:path (:index-costs a))))
+                (/ (reduce + (map :cost (:path (:index-costs b))))
+                   (count (:path (:index-costs b))))))
+        -1
+
+        (and (< 0 (count (:path (:index-costs b))))
+             (< (/ (reduce + (map :cost (:path (:index-costs b))))
+                   (count (:path (:index-costs b))))
+                (/ (reduce + (map :cost (:path (:index-costs a))))
+                   (count (:path (:index-costs a))))))
+        1
+
+        ;; Prefer to put join conds in the index
+        (and (= (:known-remaining (:index-costs b))
+                (:join-components (:index-costs b)))
+             (not= (:known-remaining (:index-costs a))
+                   (:join-components (:index-costs a))))
+        -1
+
+        (and (= (:known-remaining (:index-costs a))
+                (:join-components (:index-costs a)))
+             (not= (:known-remaining (:index-costs b))
+                   (:join-components (:index-costs b))))
+        1
+
+        (and (:matching-idx-key? a)
+             (not (:matching-idx-key? b)))
+        -1
+
+        (and (not (:matching-idx-key? a))
+             (:matching-idx-key? b))
+        1
+
+        (and (:matching-data-type? a)
+             (not (:matching-data-type? b)))
+        -1
+
+        (and (not (:matching-data-type? a))
+             (:matching-data-type? b))
+        1
+
+        :else 0))
+
 (defn best-index
   "Determines the best index to use based on which components we know will be
    defined at this point in the query."
-  [named-p symbol-map]
-  (let [components [:e :a :v]
+  [ctx named-p symbol-map]
+  (let [index-candidates (filter (fn [idx-config]
+                                   (and (if (:idx-key idx-config)
+                                          (and (= (:idx-key idx-config)
+                                                  (idx-key (:idx named-p))))
+                                          true)
+
+                                        (if (:data-type idx-config)
+                                          (and (= (:data-type idx-config)
+                                                  (idx-data-type (:idx named-p)))
+                                               (or (not= :string (:data-type idx-config))
+                                                   (and (= :function (-> named-p
+                                                                         :v
+                                                                         first))
+                                                        (contains? #{:$like :$ilike}
+                                                                   (-> named-p
+                                                                       :v
+                                                                       second
+                                                                       :$comparator
+                                                                       :op)))))
+                                          true)))
+                                 index-configs)
 
         known-components
-        (set (filter (fn [c]
-                       (let [[tag value] (get named-p c)]
-                         (case tag
-                           :constant true
-                           :any false
-                           :function true
-                           :variable (contains? symbol-map value))))
-                     components))
+        (reduce (fn [acc c]
+                  (let [[tag value] (get named-p c)]
+                    (if-let [estimate
+                             (case tag
+                               :constant (case c
+                                           :a (count value)
+                                           :e (count value)
+                                           :v (estimate-index-size ctx symbol-map named-p :v))
+                               :any nil
+                               :function (estimate-index-size ctx symbol-map named-p c)
 
-        ;; it may be a good idea to give something a better score if it's a
-        ;; constant rather than in the symbol-map
-        scored-indexes
-        (map (fn [{:keys [cols] :as idx-config}]
-               (let [score (if (or (and (:idx-key idx-config)
-                                        (not= (:idx-key idx-config)
-                                              (idx-key (:idx named-p))))
-                                   (and (:data-type idx-config)
-                                        (or (not (= (:data-type idx-config)
-                                                    (idx-data-type (:idx named-p))))
-                                            (and (= :string (:data-type idx-config))
-                                                 (not (and (= :function (-> named-p
-                                                                            :v
-                                                                            first))
-                                                           (contains? #{:$like :$ilike}
-                                                                      (-> named-p
-                                                                          :v
-                                                                          second
-                                                                          :$comparator
-                                                                          :op))))))))
-                             -1
-                             (+ (if (and (:idx-key idx-config)
-                                         (= (:idx-key idx-config)
-                                            (idx-key (:idx named-p))))
-                                  0.5
-                                  0)
-                                (count (take-while (fn [col]
-                                                     (contains? known-components col))
-                                                   cols))))]
-                 (assoc idx-config :score score)))
-             index-configs)
+                               :variable (get symbol-map value))]
 
-        best-index (last (sort-by :score scored-indexes))]
-    best-index))
+                      (assoc acc
+                             ;; $isNull gets turned into a subquery that returns entity_ids,
+                             ;; and then we check in the cte if entity_id in (subquery).
+                             ;; So when we determine the index to use for the CTE, we shouldn't be
+                             ;; looking at the :v--that happens in the subquery.
+                             (if (and (= :v c)
+                                      (= :function tag)
+                                      (contains? #{:$isNull} (-> value keys first)))
+                               :e
+                               c)
+                             estimate)
+                      acc)))
+                {}
+                [:e :a :v :created-at])
+
+        join-components
+        (reduce (fn [acc c]
+                  (let [[tag value] (get named-p c)]
+                    (if (and (= :variable tag)
+                             (get symbol-map value))
+                      (assoc acc c (get symbol-map value))
+                      acc)))
+                {}
+                [:e :a :v :created-at])
+
+        needed-components (reduce (fn [acc c]
+                                    (let [[tag value] (get named-p c)]
+                                      (if (and (= tag :variable)
+                                               (not (contains? symbol-map value)))
+                                        (conj acc c)
+                                        acc)))
+                                  #{}
+                                  [:e :a :v :created-at])
+
+        indexes-with-costs
+        (map (fn [idx-config]
+               (assoc idx-config
+                      :index-costs
+                      (reduce (fn [acc col]
+                                (if-let [cost (get (:known-remaining acc) col)]
+                                  (-> acc
+                                      (update :known-remaining dissoc col)
+                                      (update :path conj {:cost cost
+                                                          :col col
+                                                          :type :index-lookup}))
+                                  (reduced acc)))
+                              ;; XXX: What do you do if you have multiple needed-components?
+                              ;;      Maybe that's when we should bust out the bitmapindex?
+                              {:known-remaining known-components
+                               :join-components join-components
+                               :needed-components needed-components
+                               :path []}
+                              (:cols idx-config))
+                      :matching-idx-key? (= (:idx-key idx-config)
+                                            (idx-key (:idx named-p)))
+                      :matching-data-type? (and (= (:data-type idx-config)
+                                                   (idx-data-type (:idx named-p)))
+                                                (or (not= :string (idx-data-type (:idx named-p)))
+                                                    (not (and (= :function (-> named-p
+                                                                               :v
+                                                                               first))
+                                                              (contains? #{:$like :$ilike}
+                                                                         (-> named-p
+                                                                             :v
+                                                                             second
+                                                                             :$comparator
+                                                                             :op))))))))
+             index-candidates)
+
+        sorted-indexes (sort index-compare indexes-with-costs)
+
+        best-index (first sorted-indexes)]
+     best-index))
+
+(defn pattern->symbol-map-placeholder [pattern row-estimate]
+  (reduce (fn [acc [ctype [_tag variable]]]
+            (case ctype
+              ;; This will be wrong for v, but it's the best we
+              ;; have at this point
+              (:e :v) (assoc acc variable row-estimate)
+              acc))
+          {}
+          (variable-components pattern)))
+
+(defn annotate-patterns-with-hints [ctx initial-symbol-map patterns]
+  (reduce (fn [{:keys [symbol-map] :as acc} [tag pattern]]
+            (case tag
+              :pattern (let [row-estimate (estimate-rows ctx symbol-map pattern)]
+                         (-> acc
+                             (update :symbol-map
+                                     (fn [m]
+                                       (merge-with min
+                                                   m
+                                                   (pattern->symbol-map-placeholder pattern row-estimate))))
+                             (update :patterns
+                                     conj
+                                     [tag (assoc pattern
+                                                 :row-estimate row-estimate
+                                                 :symbol-map symbol-map
+                                                 :best-index
+                                                 (best-index ctx
+                                                             (assoc pattern
+                                                                    :row-estimate row-estimate)
+                                                             symbol-map)
+                                                 :best-index-if-eav (when (= :vae (idx-key (:idx pattern)))
+                                                                      (best-index ctx
+                                                                                  (assoc pattern
+                                                                                         :row-estimate row-estimate
+                                                                                         :idx [:keyword :eav])
+                                                                                  symbol-map)))])))
+              :and (let [{:keys [patterns symbol-map]}
+                         (annotate-patterns-with-hints ctx symbol-map (:and pattern))]
+                     (-> acc
+                         (assoc :symbol-map symbol-map)
+                         (update :patterns conj [:and {:and patterns}])))
+              :or (let [{:keys [patterns symbol-map]}
+                        (reduce (fn [acc group]
+                                  (let [{:keys [patterns symbol-map]}
+                                        (annotate-patterns-with-hints ctx
+                                                                      {}
+                                                                      [group])]
+                                    (-> acc
+                                        (update :patterns (partial apply conj) patterns)
+                                        ;; It would be more accurate to do a merge-with
+                                        ;; max/+ here, but we don't capture contraints
+                                        ;; on the ors from previous CTEs, so min usually
+                                        ;; produces a better plan. If we pass symbol-map
+                                        ;; to the or instead of {} (both in accumulate-ctes
+                                        ;; and annotate-patterns-with-hints), then we could
+                                        ;; switch to max or +
+                                        (update :symbol-map (partial merge-with min) symbol-map))))
+                                {:patterns []
+                                 :symbol-map symbol-map}
+                                (:patterns (:or pattern)))]
+                    (-> acc
+                        (assoc :symbol-map symbol-map)
+                        (update :patterns conj [:or {:or (assoc (:or pattern) :patterns patterns)}])))
+
+              (update acc :patterns conj [tag pattern])))
+          {:symbol-map initial-symbol-map
+           :patterns []}
+          patterns))
+
+(defn pattern-count [patterns]
+  (reduce (fn [acc [tag pattern]]
+            (+ acc (case tag
+                     :pattern 1
+                     :or (pattern-count (:patterns (:or pattern)))
+                     :and (pattern-count (:and pattern)))))
+          0
+          patterns))
+
+(declare annotate-with-hints)
+
+(defn annotate-pattern-group-with-hints [ctx initial-symbol-map pattern-group]
+  (let [page-info-pattern (get-in pattern-group [:page-info :named-pattern 1])
+
+        page-info-first? false ;;(= 1 (pattern-count (:patterns pattern-group)))
+
+        page-pattern-row-estimate (when page-info-pattern
+                                    ;; XXX: We should do this later to get the symbol-map??
+                                    (estimate-rows ctx initial-symbol-map page-info-pattern))
+        {:keys [patterns symbol-map]}
+        (annotate-patterns-with-hints ctx
+                                      (merge (if (and page-info-pattern page-info-first?)
+                                               (pattern->symbol-map-placeholder page-info-pattern
+                                                                                page-pattern-row-estimate)
+                                               {})
+                                             initial-symbol-map)
+                                      (:patterns pattern-group))]
+    (cond-> pattern-group
+      true (assoc :patterns patterns)
+      page-info-pattern (update-in [:page-info :named-pattern 1]
+                                   (fn [p]
+                                     (assoc p
+                                            :best-index
+                                            (best-index ctx
+                                                        p
+                                                        (merge
+                                                         {(get-in pattern-group [:page-info :order-sym])
+                                                          page-pattern-row-estimate}
+                                                         (when (not page-info-first?)
+                                                           symbol-map))))))
+      (:children pattern-group) ((fn [pg]
+                                   (annotate-with-hints ctx symbol-map pg))))))
+
+(defn annotate-with-hints
+  "Annotates the named-patterns with the best index to use.  It uses
+  counts to choose better indexes than Postgres would choose on its
+  own.
+
+  Runs in two passes: In the first pass, we track the count queries
+  that we need to make so that we can fetch all of the counts in a
+  single go. Then we a second pass with the counts and it determines
+  the best index."
+  ([ctx nested-named-patterns]
+   (let [counts-atom (atom (set {}))
+         ;; Run annotate-with-hints to populate the counts atom
+         _ (with-out-str (annotate-with-hints (assoc ctx
+                                                     :phase :deps
+                                                     :counts counts-atom)
+                                              {}
+                                              nested-named-patterns))
+         count-queries @counts-atom
+
+         ;; Fetch counts from the database. We should be able to store
+         ;; a sketch that lets us do counts without talking to the db
+         query (when (seq count-queries)
+                 {:union-all (map-indexed (fn [i {:keys [wheres]}]
+                                            {:select [[i :i]
+                                                      [{:select [:%count.*]
+                                                        :from {:select :*
+                                                               :from :triples
+                                                               :where wheres
+                                                               :limit 10000}}
+                                                       :count]]})
+                                          count-queries)})
+         query-result (when query
+                        (sql/select ::resolve-counts
+                                    (:conn-pool (:db ctx))
+                                    (hsql/format query)))
+         resolved-counts (zipmap count-queries
+                                 (map :count query-result))]
+     ;; Run again with resolved counts
+     (annotate-with-hints (assoc ctx
+                                 :phase :choose
+                                 :counts resolved-counts)
+                          {}
+                          nested-named-patterns)))
+  ([ctx symbol-map nested-named-patterns]
+   (update-in nested-named-patterns
+              [:children :pattern-groups]
+              (fn [groups]
+                (mapv (fn [pattern-group]
+                        (annotate-pattern-group-with-hints ctx
+                                                           (when-let [join-sym (get-in nested-named-patterns [:children :join-sym])]
+                                                             {join-sym (get symbol-map join-sym 0)})
+                                                           pattern-group))
+                      groups)))))
 
 ;; ---
 ;; match-query
@@ -1074,6 +1414,8 @@
         (assoc named-p :idx [:keyword :eav])
         named-p))))
 
+(def ^:dynamic *debug* false)
+
 (defn- joining-with
   "Produces subsequent match tables. Each table joins on the previous
    table unless it is the first cte or the start of a new AND/OR
@@ -1107,7 +1449,12 @@
         cte [cur-table
              {:select (concat (when prev-table
                                 [(kw prev-table :.*)])
-                              (match-table-select cur-table))
+                              (match-table-select cur-table)
+                              (when *debug*
+                                [[(with-out-str (clojure.pprint/pprint named-p))
+                                  :named-p]
+                                 [(with-out-str (clojure.pprint/pprint symbol-map))
+                                  :symbol-map]]))
               :from (concat (list* [:triples triples-alias]
                                    (when prev-table
                                      [prev-table]))
@@ -1130,10 +1477,24 @@
                :materialized
                :not-materialized)]]
     {:cte cte
-     :pg-hints (if (test-pg-hints?)
-                 (let [best-idx (best-index named-p (merge symbol-map
-                                                           additional-joins))]
-                   [(pg-hint/index-scan triples-alias (:name best-idx))])
+     :pg-hints (if-let [best-idx (:best-index named-p)]
+                 (let [hint-fn (if (<= 2 (join-cond-count symbol-map named-p))
+                                 ;; This isn't a great hueristic--it
+                                 ;; catches too many cases where an index
+                                 ;; scan would be better. But it's usually
+                                 ;; much slower to use an index scan when
+                                 ;; you need a bitmap scan (unless you're
+                                 ;; sorting)
+                                 pg-hint/bitmap-scan
+                                 pg-hint/index-scan)
+                       idx (if (= (idx-key (:idx named-p))
+                                  :eav)
+                             (:name (:best-index-if-eav named-p))
+                             ;;:eav_uuid_index
+                             (:name best-idx))]
+                   (if idx
+                     [(hint-fn triples-alias idx)]
+                     []))
                  [])}))
 
 (defn symbol-fields-of-pattern
@@ -1672,7 +2033,7 @@
                           {:select [[[:exists has-previous-query]]]}
                           :not-materialized])
              :pg-hints (into (:pg-hints (:query match-query))
-                               pg-hints)
+                             pg-hints)
              :select (kw last-row-table :.*)
              :from last-table-name}
      :symbol-map symbol-map
@@ -2276,7 +2637,6 @@
                           [:qid
                            {:select [[[:inline app-id]]
                                      [[:inline query-hash]]]}]))
-
           sql-query (hsql/format query)
           postgres-config (flags/query-flags query-hash)
           sql-res (when query ;; we may not have a query if everything is missing attrs
@@ -2321,7 +2681,9 @@
            batch-data))))
 
 (defn query-nested [{:keys [app-id db] :as ctx} nested-patterns]
-  (let [nested-named-patterns (nested->named-patterns nested-patterns)]
+  (let [nested-named-patterns (cond->> nested-patterns
+                                true nested->named-patterns
+                                (test-pg-hints?) (annotate-with-hints ctx))]
     (throw-invalid-nested-patterns nested-named-patterns)
     (send-query-nested ctx (:conn-pool db) app-id nested-named-patterns)))
 
@@ -2330,16 +2692,20 @@
    the postgres query. Useful for testing and debugging."
   [ctx patterns]
   (assert (map? patterns) "explain only works with nested patterns.")
-  (let [nested-named-patterns (nested->named-patterns patterns)]
+  (let [nested-named-patterns (cond->> patterns
+                                true nested->named-patterns
+                                (test-pg-hints?) (annotate-with-hints ctx))]
     (throw-invalid-nested-patterns nested-named-patterns)
     (let [{:keys [query]} (nested-match-query ctx
                                               :m-
                                               (:app-id ctx)
                                               nested-named-patterns)
+
           sql-query (hsql/format
-                     (assoc query
-                            :raw
-                            "explain (analyze, verbose, buffers, timing, format json)"))]
+                     (cond-> query
+                       true (assoc :raw
+                                   "explain (analyze, verbose, buffers, timing, format json)")
+                       (not (test-pg-hints?)) (dissoc :pg-hints)))]
       (when query
         (sql/select-string-keys ::explain
                                 (-> ctx :db :conn-pool)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1070,6 +1070,7 @@
         1
 
         (and (< 0 (count (:path (:index-costs a))))
+             (< 0 (count (:path (:index-costs b))))
              (< (/ (reduce + (map :cost (:path (:index-costs a))))
                    (count (:path (:index-costs a))))
                 (/ (reduce + (map :cost (:path (:index-costs b))))
@@ -1077,6 +1078,7 @@
         -1
 
         (and (< 0 (count (:path (:index-costs b))))
+             (< 0 (count (:path (:index-costs a))))
              (< (/ (reduce + (map :cost (:path (:index-costs b))))
                    (count (:path (:index-costs b))))
                 (/ (reduce + (map :cost (:path (:index-costs a))))

--- a/server/src/instant/db/hint_testing.clj
+++ b/server/src/instant/db/hint_testing.clj
@@ -78,13 +78,17 @@
                                      :patterns (pr-str patterns)}}
       (let [old (tracer/with-span! {:name "test-pg-hints-for-datalog/without-hint-plan"}
                   (try
-                    (explain-datalog ctx patterns)
+                    (let [res (explain-datalog ctx patterns)]
+                      (tracer/add-data! {:attributes res})
+                      res)
                     (catch Exception e
                       e)))
             new (tracer/with-span! {:name "test-pg-hints-for-datalog/with-hint-plan"}
                   (binding [d/*testing-pg-hints* true]
                     (try
-                      (explain-datalog ctx patterns)
+                      (let [res (explain-datalog ctx patterns)]
+                        (tracer/add-data! {:attributes res})
+                        res)
                       (catch Exception e
                         e))))]
         (tracer/add-data! {:attributes {:without.ms (:time old)

--- a/server/src/instant/db/hint_testing.clj
+++ b/server/src/instant/db/hint_testing.clj
@@ -1,22 +1,15 @@
 (ns instant.db.hint-testing
   (:refer-clojure :exclude [test])
   (:require
-   [instant.util.json :refer [->json]]
    [clojure.core.async :as a]
    [clojure.core.cache.wrapped :as cache]
-   [clojure.walk :as walk]
    [instant.db.datalog :as d]
-   [instant.db.datalog :as d]
-   [instant.db.instaql :as instaql]
-   [instant.db.model.attr :as attr-model]
    [instant.flags :as flags]
-   [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
-   [instant.jdbc.sql :as sql]
-   [instant.util.instaql :refer [forms-hash instaql-nodes->object-tree]]
+   [instant.util.instaql :refer [forms-hash]]
+   [instant.util.json :refer [->json]]
    [instant.util.tracer :as tracer]
-   [lambdaisland.deep-diff2 :as ddiff]
-   [tool]))
+   [lambdaisland.deep-diff2 :as ddiff]))
 
 (def triples-alias-sorted-map
   (sorted-map-by (fn [a b]
@@ -128,7 +121,7 @@
               _ (tracer/with-span! {:name "test-pg-hint-plan/initialize"}
                   (try
                     (permissioned-query-fn ctx o)
-                    (catch Exception e
+                    (catch Exception _e
                       nil)))]
           (doseq [{:keys [ctx patterns]} @patterns-to-test]
             (test-pg-hints-for-datalog-query ctx patterns o query-hash)))))))

--- a/server/src/instant/db/hint_testing.clj
+++ b/server/src/instant/db/hint_testing.clj
@@ -1,0 +1,159 @@
+(ns instant.db.hint-testing
+  (:refer-clojure :exclude [test])
+  (:require
+   [instant.util.json :refer [->json]]
+   [clojure.core.async :as a]
+   [clojure.core.cache.wrapped :as cache]
+   [clojure.walk :as walk]
+   [instant.db.datalog :as d]
+   [instant.db.datalog :as d]
+   [instant.db.instaql :as instaql]
+   [instant.db.model.attr :as attr-model]
+   [instant.flags :as flags]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.jdbc.sql :as sql]
+   [instant.util.instaql :refer [forms-hash instaql-nodes->object-tree]]
+   [instant.util.tracer :as tracer]
+   [lambdaisland.deep-diff2 :as ddiff]
+   [tool]))
+
+(def triples-alias-sorted-map
+  (sorted-map-by (fn [a b]
+                   (let [a-num (some-> (re-find #"\d+" a)
+                                       (Long/parseLong))
+                         b-num (some-> (re-find #"\d+" b)
+                                       (Long/parseLong))
+                         res (compare a-num b-num)]
+                     (if (zero? res)
+                       (compare a b)
+                       res)))))
+
+(defn determine-indexes-used [plan]
+  (letfn [(step [node alias acc]
+            (cond
+              (map? node)
+              (let [alias' (or (get node "Alias")
+                               (get node "Relation Name")
+                               alias)
+
+                    acc' (if-let [idx (get node "Index Name")]
+                           (update acc alias' (fnil conj #{})
+                                   {:index idx
+                                    :node  (get node "Node Type")})
+                           acc)]
+
+                (reduce #(step %2 alias' %1) acc' (vals node)))
+
+              (sequential? node)
+              (reduce #(step %2 alias %1) acc node)
+
+              :else acc))]
+    (step plan nil triples-alias-sorted-map)))
+
+(defn explain-datalog [ctx patterns]
+  (let [explain-output (d/explain ctx patterns)
+        execution-time (-> explain-output
+                           (get-in [0 "QUERY PLAN"])
+                           first
+                           (get "Execution Time"))
+        planning-time (-> explain-output
+                          (get-in [0 "QUERY PLAN"])
+                          first
+                          (get "Planning Time"))]
+    {:time (+ execution-time planning-time)
+     :execution-time execution-time
+     :planning-time planning-time
+     :indexes (determine-indexes-used explain-output)}))
+
+(def seen (cache/ttl-cache-factory {} :ttl (* 1000 60)))
+
+(defn test-pg-hints-for-datalog-query [ctx patterns query query-hash]
+  (binding [tracer/*span* nil] ;; new root span for each patterns
+    (tracer/with-span! {:name "test-pg-hints-for-datalog"
+                        :attributes {:query query
+                                     :query-hash query-hash
+                                     :app-id (:app-id ctx)
+                                     :current-user-id (-> ctx :current-user :id)
+                                     :patterns (pr-str patterns)}}
+      (let [old (tracer/with-span! {:name "test-pg-hints-for-datalog/without-hint-plan"}
+                  (try
+                    (explain-datalog ctx patterns)
+                    (catch Exception e
+                      e)))
+            new (tracer/with-span! {:name "test-pg-hints-for-datalog/with-hint-plan"}
+                  (binding [d/*testing-pg-hints* true]
+                    (try
+                      (explain-datalog ctx patterns)
+                      (catch Exception e
+                        e))))]
+        (tracer/add-data! {:attributes {:without.ms (:time old)
+                                        :with.ms (:time new)
+                                        :without.error (instance? Exception old)
+                                        :with.error (instance? Exception new)
+                                        :improvement (- (or (:time old)
+                                                            (* 1000 10))
+                                                        (or (:time new)
+                                                            (* 1000 10)))
+                                        :index-diff (when (and (:indexes old)
+                                                               (:indexes new))
+                                                      (->json (into triples-alias-sorted-map
+                                                                    (ddiff/minimize (ddiff/diff (:indexes old)
+                                                                                                (:indexes new))))))}})))))
+
+(defn test-pg-hints [ctx permissioned-query-fn o query-hash]
+  (cache/lookup-or-miss seen query-hash (constantly true))
+  (binding [tracer/*span* nil] ;; Create new root span
+    (tracer/with-span! {:name "test-pg-hint-plan"
+                        :attributes (merge {:query o
+                                            :query-hash query-hash
+                                            :app-id (:app-id ctx)
+                                            :current-user-id (-> ctx :current-user :id)}
+                                           (flags/pg-hint-testing-toggles))}
+      (binding [sql/*query-timeout-seconds* 5]
+        (let [patterns-to-test (atom [])
+              ctx (assoc ctx
+                         :datalog-query-fn (fn [c p]
+                                             (swap! patterns-to-test conj {:ctx c
+                                                                           :patterns p})
+                                             (d/query c p))
+                         ;; Prevent infinite cycle
+                         :testing-rule-wheres true)
+
+              ;; First, get the datalog query patterns for the query and rules
+              _ (tracer/with-span! {:name "test-pg-hint-plan/initialize"}
+                  (try
+                    (permissioned-query-fn ctx o)
+                    (catch Exception e
+                      nil)))]
+          (doseq [{:keys [ctx patterns]} @patterns-to-test]
+            (test-pg-hints-for-datalog-query ctx patterns o query-hash)))))))
+
+(defn worth-testing? [_ctx _o query-hash]
+  (and (flags/test-rule-wheres?)
+       (not (cache/lookup seen query-hash))))
+
+(defonce process-chan (atom (a/chan (a/sliding-buffer 10))))
+
+(defn queue-for-testing [ctx permissioned-query-fn o]
+  (let [query-hash (forms-hash o)]
+    (when (worth-testing? ctx o query-hash)
+      (a/put! @process-chan [ctx permissioned-query-fn o query-hash]))))
+
+(defn start []
+  (reset! process-chan (a/chan (a/sliding-buffer 10)))
+  (a/go
+    (loop []
+      (when-let [args (a/<! @process-chan)]
+        (try (apply test-pg-hints args)
+             (catch Exception e
+               (def -e e)
+               nil)))
+      (recur))))
+
+(defn stop []
+  (a/close! @process-chan))
+
+(defn restart []
+  (stop)
+  (start))

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -11,7 +11,7 @@
    [instant.db.model.attr-pat :as attr-pat]
    [instant.db.model.entity :as entity-model]
    [instant.db.model.triple :as triple-model]
-   [instant.db.rule-where-testing :as rule-where-testing]
+   [instant.db.hint-testing :as hint-testing]
    [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
@@ -2099,7 +2099,7 @@
                                    :admin? admin?
                                    :query (pr-str o)}}
     (when-not (:testing-rule-wheres ctx) ;; Prevent infinite cycle
-      (rule-where-testing/queue-for-testing ctx permissioned-query o))
+      (hint-testing/queue-for-testing ctx permissioned-query o))
     (if admin?
       (query ctx (dissoc o :$$ruleParams))
       (let [ctx (assoc ctx :preloaded-refs (cel/create-preloaded-refs-cache))

--- a/server/src/instant/util/pg_hint_plan.clj
+++ b/server/src/instant/util/pg_hint_plan.clj
@@ -76,7 +76,7 @@
 (defn bitmap-scan
   "Forces bitmap scan on the table. Restricts to specified indexes if any."
   [tbl & indexes]
-  (into [:'BitMapScan tbl] indexes))
+  (into [:'BitmapScan tbl] indexes))
 
 (defn no-seq-scan
   "Forces to not do sequential scan on the table."


### PR DESCRIPTION
Uses counts from the database to choose better hints.

This is an experiment to see how good we can be at generating query plans if we have count information from the database. Right now it does an actual query like `count * from triples where attr_id = :attr-id and value = :value`. But if this works, then we should be able to replace that database query with a lookup in a [count-min sketch](https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch) that we maintain for each attr.

**How it works**

If the *testing-pg-hints* flag is on, we'll walk the `nested-named-patterns` to determine the best index to use for each pattern and update each pattern with the index to use. We walk it in two phases--in phase 1, we collect all of the count queries we will need to make. Then we fetch all of the counts in one go. In phase 2, we make index decisions based on the counts.

As we go through the patterns, we keep track of the information we've gathered in each previous pattern to get the best hints. For example, if we know the `e` from a previous pattern returns a very small number, then we might look at indexes that have the e first.

To keep the count queries from getting too out of control, we do a `select count(*) from (select * from x limit 10000))`.