### PR TITLE
Skip child order

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -24,7 +24,7 @@
    [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util]
    [instant.system-catalog :as system-catalog]
-   [medley.core :refer [update-existing-in dissoc-in]]
+   [medley.core :refer [update-existing-in]]
    [instant.storage.s3 :as instant-s3]
    [instant.comment :as c])
   (:import
@@ -867,7 +867,7 @@
     ;; everything. We only need to order if there is pagination.
     ;; The client is just going to get a set of triples anyway, so it can handle
     ;; ordering on the frontend.
-    (when (or limit first last offset before after order)
+    (when (or limit first last offset before after)
       (let [{:keys [k direction]} (or order default-order)
             eid-sym (attr-pat/default-level-sym etype level)
             order-sym (if (= "serverCreatedAt" k)
@@ -976,13 +976,7 @@
           form' (-> form
                     (assoc :etype next-etype)
                     (assoc :level next-level)
-                    (assoc :join-attr-pat join-attr-pat)
-                    ;; We don't support limiting on child queries, so
-                    ;; there's no reason to do the extra work to order
-                    ;; by on the postgres side for child queries. When
-                    ;; we add limits on children, we will need to
-                    ;; update this.
-                    (dissoc-in [:option-map :order]))]
+                    (assoc :join-attr-pat join-attr-pat))]
       form')))
 
 (defn find-row-by-aid [rows aid]

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -867,7 +867,8 @@
     ;; everything. We only need to order if there is pagination.
     ;; The client is just going to get a set of triples anyway, so it can handle
     ;; ordering on the frontend.
-    (when (or limit first last offset before after)
+    (when (and (= level 0)
+               (or limit first last offset before after order))
       (let [{:keys [k direction]} (or order default-order)
             eid-sym (attr-pat/default-level-sym etype level)
             order-sym (if (= "serverCreatedAt" k)

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -863,11 +863,7 @@
 (defn page-info-of-form [{:keys [state] :as ctx}
                          {:keys [etype level option-map] :as _form}]
   (let [{:keys [order limit first last offset before after]} option-map]
-    ;; We don't need to do extra work to order the results if we're returning
-    ;; everything. We only need to order if there is pagination.
-    ;; The client is just going to get a set of triples anyway, so it can handle
-    ;; ordering on the frontend.
-    (when (and (= level 0)
+    (when (and (= level 0) ;; Don't bother ordering child forms since you can't paginate them
                (or limit first last offset before after order))
       (let [{:keys [k direction]} (or order default-order)
             eid-sym (attr-pat/default-level-sym etype level)

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -24,7 +24,7 @@
    [instant.util.tracer :as tracer]
    [instant.util.uuid :as uuid-util]
    [instant.system-catalog :as system-catalog]
-   [medley.core :refer [update-existing-in]]
+   [medley.core :refer [update-existing-in dissoc-in]]
    [instant.storage.s3 :as instant-s3]
    [instant.comment :as c])
   (:import
@@ -976,7 +976,13 @@
           form' (-> form
                     (assoc :etype next-etype)
                     (assoc :level next-level)
-                    (assoc :join-attr-pat join-attr-pat))]
+                    (assoc :join-attr-pat join-attr-pat)
+                    ;; We don't support limiting on child queries, so
+                    ;; there's no reason to do the extra work to order
+                    ;; by on the postgres side for child queries. When
+                    ;; we add limits on children, we will need to
+                    ;; update this.
+                    (dissoc-in [:option-map :order]))]
       form')))
 
 (defn find-row-by-aid [rows aid]


### PR DESCRIPTION
This ignores ordering for child forms on the postgres side. We'll still give the user the data in the right order when they get it from the client or the admin query. 

We don't support pagination on child forms and we don't rely on the order of the triples from postgres to apply the order-by on the client (or in admin query). So any ordering we do in postgres for child forms is just wasted cycles.

In this query:

```clj
{:users {:$ {:where {:email {:$ilike "%org.com"}, :order {createdAt "desc"}
             :comments: {:$ {:order {:createdAt "desc"}}}}}
```

We'll order the users in the database so that we can get cursors, but we'll treat the comments query as if it was written without the order by.

I'd also like to skip the ordering when you don't provide a `first`, `last`, `before`, or `after` param, but we already return cursors in that case and it might be considered a breaking change to stop.
