### PR TITLE
Detect Bun in cli for newer versions of Bun.

### DIFF
--- a/client/packages/cli/src/util/packageManager.js
+++ b/client/packages/cli/src/util/packageManager.js
@@ -11,6 +11,7 @@ async function detectPackageManager(destPath) {
     'package-lock.json': 'npm',
     'pnpm-lock.yaml': 'pnpm',
     'bun.lockb': 'bun',
+    'bun.lock': 'bun',
   };
 
   for (const dir of traverseUpDirectories(destPath)) {


### PR DESCRIPTION
Bun recently switched to a non-binary lockfile format for new projects. If that is in use, this will detect it. 