### PR TITLE
[docs] Fix reference to step 3.5 in Sign in with Apple

### DIFF
--- a/client/www/pages/docs/auth/apple.md
+++ b/client/www/pages/docs/auth/apple.md
@@ -83,11 +83,11 @@ This step is not needed for Expo.
 - Select _Add Apple Client_
 - Select unique _clientName_ (`apple` by default, will be used in `db.auth` calls)
 - Fill in _Services ID_ from Step 2
-<!-- prettier-ignore -->{% conditional param="method" value="web-redirect" %}
+  {% conditional param="method" value="web-redirect" %}
 - Fill in _Team ID_ from [Membership details](https://developer.apple.com/account#MembershipDetailsCard)
 - Fill in _Key ID_ from Step 3.5
 - Fill in _Private Key_ by copying file content from Step 3.5
-<!-- prettier-ignore -->{% /conditional %}
+  {% /conditional %}
 - Click `Add Apple Client`
 
 {% conditional param="method" value="web-redirect" %}


### PR DESCRIPTION
A user pointed out that in one of our steps for sign in with apple, we were talking about a "step 3.5", which was non-existent for their flow. 

Ref: https://x.com/maxrusakovic/status/1944073418204119395

This is because our conditional param was not working, when we included `<!-- prettier-ignore -->` beside it. 

I went ahead and removed the prettier-ignore, and the conditional now works. 

@nezaj @dwwoelfel @tonsky @drew-harris 
