### PR TITLE
Use the same cache key for docs and dash selected app

### DIFF
--- a/client/www/components/docs/Layout.jsx
+++ b/client/www/components/docs/Layout.jsx
@@ -14,9 +14,9 @@ import { BareNav } from '@/components/marketingUi';
 import navigation from '@/data/docsNavigation';
 import { createdAtComparator } from '@/lib/app';
 import RatingBox from './RatingBox';
+import { getLocallySavedApp, setLocallySavedApp } from '@/lib/locallySavedApp';
 
 function useSelectedApp(apps = []) {
-  const cacheKey = 'docs-appId';
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
   const [selectedAppData, setSelectedAppData] = useState(null);
@@ -24,7 +24,7 @@ function useSelectedApp(apps = []) {
   useEffect(() => {
     if (!router.isReady) return;
 
-    const cachedAppData = getLocal(cacheKey);
+    const cachedAppData = getLocallySavedApp();
     const { app: queryAppId, ...remainingQueryParams } = router.query;
 
     const fromParams = queryAppId && apps.find((a) => a.id === queryAppId);
@@ -38,7 +38,7 @@ function useSelectedApp(apps = []) {
         title: fromParams.title,
       };
       setSelectedAppData(data);
-      setLocal(cacheKey, data);
+      setLocallySavedApp(data);
       // Removes query param after caching
       router.replace(
         {
@@ -66,7 +66,7 @@ function useSelectedApp(apps = []) {
       const data = { id: app.id, title: app.title };
 
       setSelectedAppData(data);
-      setLocal(cacheKey, data);
+      setLocallySavedApp(data);
     },
     [apps.length],
   );

--- a/client/www/lib/locallySavedApp.tsx
+++ b/client/www/lib/locallySavedApp.tsx
@@ -1,0 +1,13 @@
+import { getLocal, setLocal } from './config';
+
+export type LocallySavedApp = {
+  id: string;
+};
+
+export function getLocallySavedApp(): LocallySavedApp | undefined {
+  return getLocal('locally-saved-app');
+}
+
+export function setLocallySavedApp(app: LocallySavedApp) {
+  setLocal('locally-saved-app', app);
+}

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -1,4 +1,4 @@
-import { init, InstantReactWebDatabase } from '@instantdb/react';
+import { init } from '@instantdb/react';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { v4 } from 'uuid';
 import produce from 'immer';
@@ -76,6 +76,7 @@ import OAuthApps from '@/components/dash/OAuthApps';
 import clsx from 'clsx';
 import AuthorizedOAuthAppsScreen from '@/components/dash/AuthorizedOAuthAppsScreen';
 import { useNamespacesQuery, useSchemaQuery } from '@/lib/hooks/explorer';
+import { getLocallySavedApp, setLocallySavedApp } from '@/lib/locallySavedApp';
 
 // (XXX): we may want to expose this underlying type
 type InstantReactClient = ReturnType<typeof init>;
@@ -373,10 +374,11 @@ function Dashboard() {
     const firstApp = apps?.[0];
     if (!firstApp) return;
 
-    const _lastAppId = getLocal('dash_app_id');
-    const lastAppId = Boolean(apps.find((a) => a.id === _lastAppId))
-      ? _lastAppId
-      : null;
+    const lastApp = getLocallySavedApp();
+    const lastAppId =
+      lastApp && Boolean(apps.find((a) => a.id === lastApp.id))
+        ? lastApp.id
+        : null;
 
     const defaultAppId = lastAppId ?? firstApp.id;
     if (!defaultAppId) return;
@@ -389,7 +391,7 @@ function Dashboard() {
       },
     });
 
-    setLocal('dash_app_id', defaultAppId);
+    setLocallySavedApp({ id: defaultAppId });
   }, [dashResponse.data]);
 
   useEffect(() => {
@@ -411,7 +413,7 @@ function Dashboard() {
   }, [app?.id, app?.admin_token]);
 
   function nav(q: { s: string; app?: string; t?: string }, cb?: () => void) {
-    if (q.app) setLocal('dash_app_id', q.app);
+    if (q.app) setLocallySavedApp({ id: q.app });
 
     router
       .push({


### PR DESCRIPTION
In one of our user sessions, a user mentioned how he was surprised that the selected app across dash and docs weren't in sync.

I went ahead and made it so both the docs and the dash use the same local storage key to store the app id. 

Hence, they now stay in sync!

**Note: you may be wondering, why keep using getLocal and setLocal, instead of useLocalStorage?** 

If we switch to `useLocalStorage`, we can't quite keep the useEffect logic as it currently is, since setting our cached item will trigger a re-render. I wanted to keep this change incremental. 

@nezaj @dwwoelfel @tonsky @drew-harris 