### PR TITLE
Delete stale ephemeral apps in agents essay demo

### DIFF
--- a/client/www/components/essays/agents_essay_demo_section.tsx
+++ b/client/www/components/essays/agents_essay_demo_section.tsx
@@ -3,10 +3,11 @@ import config, { getLocal, isDev } from '@/lib/config';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 import confetti from 'canvas-confetti';
 import * as ephemeral from '@/lib/ephemeral';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PlatformApi } from '@instantdb/platform';
 import { i } from '@instantdb/core';
 import useLocalStorage from '@/lib/hooks/useLocalStorage';
+import differenceInDays from 'date-fns/differenceInDays';
 
 type InitState = {
   step: 'init';
@@ -14,6 +15,7 @@ type InitState = {
   adminToken: undefined;
   timeTaken: undefined;
   askedForDemoApp: undefined;
+  expiresMs: undefined;
 };
 
 type SchemaPushedState = {
@@ -31,6 +33,7 @@ type AppCreatedState = {
   timeTaken: number;
   askedForDemoApp: boolean;
   claimed: boolean;
+  expiresMs: number;
   schema?: SchemaPushedState;
   perms?: PermsPushedState;
 };
@@ -38,16 +41,28 @@ type AppCreatedState = {
 type InteractionState = InitState | AppCreatedState;
 
 export default function AgentsEssayDemoSection() {
+  const init = {
+    step: 'init',
+    appId: undefined,
+    adminToken: undefined,
+    timeTaken: undefined,
+    askedForDemoApp: undefined,
+    expiresMs: undefined,
+  } as const;
   const [state, setState] = useLocalStorage<InteractionState>(
     'agents-essay-demo',
-    {
-      step: 'init',
-      appId: undefined,
-      adminToken: undefined,
-      timeTaken: undefined,
-      askedForDemoApp: undefined,
-    },
+    init,
   );
+  useEffect(() => {
+    if (state.step !== 'app-created') return;
+    if (state.claimed) return;
+    if (
+      !state.expiresMs ||
+      differenceInDays(new Date(state.expiresMs), new Date()) < 2
+    ) {
+      setState(init);
+    }
+  }, [state.expiresMs]);
 
   return (
     <div>
@@ -98,9 +113,11 @@ export default function AgentsEssayDemoSection() {
         }
         onClick={async () => {
           const start = Date.now();
-          const { app } = await ephemeral.provisionApp({
+          const res = await ephemeral.provisionApp({
             title: 'agents-essay-demo',
           });
+
+          const { app, expires_ms } = res;
           const end = Date.now();
 
           const appId = app.id;
@@ -112,6 +129,7 @@ export default function AgentsEssayDemoSection() {
             timeTaken: end - start,
             askedForDemoApp: false,
             claimed: false,
+            expiresMs: expires_ms,
           });
           confetti({
             angle: randomInRange(55, 125),

--- a/client/www/lib/ephemeral.tsx
+++ b/client/www/lib/ephemeral.tsx
@@ -5,7 +5,10 @@ export async function provisionApp({
   title,
 }: {
   title: string;
-}): Promise<{ app: { id: string; 'admin-token': string } }> {
+}): Promise<{
+  app: { id: string; 'admin-token': string };
+  expires_ms: number;
+}> {
   return await jsonFetch(`${config.apiURI}/dash/apps/ephemeral`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
In agents essay demo, we didn't handle the case where an ephemeral app expires. I went ahead and added some logic to handle this. 

Now: 
If the app isn't claimed, we compare it's `expires_ms` to the current date. If we are within 2 days of expiring, we abandon this app and start the tutorial from scratch

Note:
We also provision apps for the examples page. I think there's some shared abstractions we can create that would work in both places. I am not 100% sure what that shared abstraction should look like though. Examples is a bit different in that (a) it also takes app id from params, and (b) it does not want to 'transfer' ownership. Punting the right abstraction for now. 

@dwwoelfel @nezaj @tonsky @drew-harris 