### PR TITLE
Fix formatting for apple docs conditionals

### DIFF
--- a/client/www/components/docs/NavButton.jsx
+++ b/client/www/components/docs/NavButton.jsx
@@ -18,6 +18,13 @@
  * {% conditional param="choice" value="bar" %}
  *   Content for Bar
  * {% /conditional %}
+ *
+ * {% conditional param="choice" value="bar" %}
+ *   Content for bar
+ *   {% else %}
+ *     Content for not bar
+ *   {% /else %}
+ * {% /conditional %}
  */
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -100,7 +107,7 @@ export function NavButton({
   return <div>{href ? <Link href={href}>{Component}</Link> : Component}</div>;
 }
 
-export function ConditionalContent({ param, value, children }) {
+export function ConditionalContent({ param, value, children, elseChildren }) {
   const selected = Array.isArray(value)
     ? value.some((v) => isSelected(param, v))
     : isSelected(param, value);
@@ -109,5 +116,8 @@ export function ConditionalContent({ param, value, children }) {
     return <>{children}</>;
   }
 
+  if (elseChildren) {
+    return <>{elseChildren}</>;
+  }
   return null;
 }

--- a/client/www/markdoc/tags.js
+++ b/client/www/markdoc/tags.js
@@ -6,6 +6,7 @@ import {
   NavButton,
   ConditionalContent,
 } from '@/components/docs/NavButton';
+import { Tag, transformer } from '@markdoc/markdoc';
 
 function CustomDiv({ className, children }) {
   return <div className={className}>{children}</div>;
@@ -87,7 +88,23 @@ const tags = {
       param: { type: String, required: true },
       value: { type: [String, Array], required: true },
     },
+    transform(node, config) {
+      // Supports an else tag inside of the conditional.
+      const attrs = node.transformAttributes(config);
+      const kids = node.children ?? [];
+
+      const idx = kids.findIndex((c) => c?.type === 'tag' && c?.tag === 'else');
+
+      const thenNodes = idx === -1 ? kids : kids.slice(0, idx);
+      const elseNodes = idx === -1 ? [] : kids.slice(idx);
+
+      const thenChildren = thenNodes.map((c) => transformer.node(c, config));
+      const elseChildren = elseNodes.map((c) => transformer.node(c, config));
+
+      return new Tag(this.render, { ...attrs, elseChildren }, thenChildren);
+    },
   },
+
   'blank-link': {
     selfClosing: true,
     attributes: {

--- a/client/www/pages/docs/auth/apple.md
+++ b/client/www/pages/docs/auth/apple.md
@@ -79,16 +79,27 @@ This step is not needed for Expo.
 
 ## Step 4: Register your OAuth client with Instant
 
+{% conditional param="method" value="web-redirect" %}
+
 - Go to the Instant dashboard and select _Auth_ tab.
 - Select _Add Apple Client_
 - Select unique _clientName_ (`apple` by default, will be used in `db.auth` calls)
 - Fill in _Services ID_ from Step 2
-  {% conditional param="method" value="web-redirect" %}
 - Fill in _Team ID_ from [Membership details](https://developer.apple.com/account#MembershipDetailsCard)
 - Fill in _Key ID_ from Step 3.5
 - Fill in _Private Key_ by copying file content from Step 3.5
-  {% /conditional %}
 - Click `Add Apple Client`
+
+{% else %}
+
+- Go to the Instant dashboard and select _Auth_ tab.
+- Select _Add Apple Client_
+- Select unique _clientName_ (`apple` by default, will be used in `db.auth` calls)
+- Fill in _Services ID_ from Step 2
+- Click `Add Apple Client`
+
+{% /else %}
+{% /conditional %}
 
 {% conditional param="method" value="web-redirect" %}
 


### PR DESCRIPTION
Two changes:

1. Adds an else branch to the nav `{% conditional %}` tags
2. Uses the else branch in the apple doc. We copy the shared elements from the list into the else branch so that we don't have to put a conditional in between list items. The conditional inside of the items gives us weird gaps.

Before:

<img width="717" height="940" alt="image" src="https://github.com/user-attachments/assets/b1cc4c0a-db73-4703-b635-2f7269fae7a0" />


After:

<img width="662" height="927" alt="image" src="https://github.com/user-attachments/assets/e15aa6fe-3a87-432c-95f9-36521cb15fd6" />
