### PR TITLE
Use `= any(values)` instead of `in values`

### DIFF
--- a/server/resources/data_readers.clj
+++ b/server/resources/data_readers.clj
@@ -1,0 +1,1 @@
+{instant instant.util.date/parse-instant}

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -579,6 +579,17 @@
 (defn- value->jsonb [x]
   [:cast (->json x) :jsonb])
 
+(defn- in-any [col vs pgtype]
+  (case (count vs)
+    0 [:= 0 1]
+    1 [:= col [:cast
+               (case pgtype
+                 :jsonb (->json (first vs))
+                 (first vs))
+               pgtype]]
+    [:= col [:any (with-meta (set vs)
+                    {:pgtype (str (name pgtype) "[]")})]]))
+
 (defn extract-value-fn [data-type op]
   (case data-type
     :date  :triples_extract_date_value
@@ -588,14 +599,25 @@
               nil)
     :boolean :triples_extract_boolean_value))
 
+(def data-type->pg-type {:date :timestamptz
+                         :number :float8
+                         :string :text
+                         :boolean :boolean})
+
 (defn data-type-comparison [data-type op col val]
   (if-let [f (extract-value-fn data-type op)]
     [:and
-     [op [f col] val]
+     (if (and (= op :=)
+              (set? val))
+       (in-any [f col] val (data-type->pg-type data-type))
+       [op [f col] val])
      [:=
       :checked_data_type
       [:cast [:inline (name data-type)] :checked_data_type]]]
-    [op col (value->jsonb val)]))
+    (if (and (= op :=)
+             (set? val))
+      (in-any col val :jsonb)
+      [op col (value->jsonb val)])))
 
 (defn- not-eq-value [idx val]
   (let [[tag idx-val] idx
@@ -619,30 +641,26 @@
     (if (empty? v-set)
       [:= 0 1]
       (if-not data-type
-        (in-or-eq (case idx-val
+        (let [col (case idx-val
                     ;; Make sure av uses the av_index
                     :av [:json_null_to_null :value]
                     ;; Make sure vae uses the vae_uuid_index
                     ;; and eav uses the eav_uuid_index
                     (:eav :vae) [:json_uuid_to_uuid :value]
 
-                    :value)
-                  (if (or (= :vae idx-val)
-                          (= :eav idx-val))
-                    v-set
-                    (map value->jsonb v-set)))
-
-        (list* :or (map (fn [v]
-                          (data-type-comparison data-type := :value v))
-                        v-set))))))
+                    :value)]
+          (if (or (= :vae idx-val)
+                  (= :eav idx-val))
+            (in-any col v-set (if (every? uuid? v-set)
+                                :uuid
+                                :jsonb))
+            (in-any col v-set :jsonb)))
+        (data-type-comparison data-type := :value v-set)))))
 
 (defn- constant->where-part [idx app-id component-type [_ v]]
   (condp = component-type
     :e (if (every? uuid? v)
-         (case (count v)
-           0 [:= 0 1]
-           1 [:= :entity-id (first v)]
-           [:= :entity-id [:any (with-meta v {:pgtype "uuid[]"})]])
+         (in-any :entity-id v :uuid)
          (list* :or
                 (for [lookup v]
                   (if (uuid? lookup)

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -567,19 +567,13 @@
 ;; -----
 ;; where
 
-(defn- in-or-eq
-  "If the set has only one element,
-   return an = clause. Otherwise, return an :in clause."
-  [k v-set]
-  (case (count v-set)
-    0 [:= 0 1]
-    1 [:= k (first v-set)]
-    [:in k v-set]))
-
 (defn- value->jsonb [x]
   [:cast (->json x) :jsonb])
 
-(defn- in-any [col vs pgtype]
+(defn- in-any
+  "If the set has only one element,
+   return an = clause. Otherwise, return an `= ANY(vs)` clause."
+  [col vs pgtype]
   (case (count vs)
     0 [:= 0 1]
     1 [:= col [:cast

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -21,7 +21,6 @@
    (java.time Instant LocalDate LocalDateTime)
    (java.util UUID)
    (javax.sql DataSource)
-   (org.postgresql.jdbc PgArray)
    (org.postgresql.util PGobject PSQLException)))
 
 (set! *warn-on-reflection* true)
@@ -60,7 +59,7 @@
         "bit" (Long/parseLong value 2)
         value))))
 
-(defn <-pgarray [^PgArray a]
+(defn <-array [^Array a]
   (let [type (.getBaseTypeName a)
         vs (.getArray a)]
     (case type
@@ -87,9 +86,9 @@
 
 
 (extend-protocol rs/ReadableColumn
-  PgArray
-  (read-column-by-label [^PgArray v _] (<-pgarray v))
-  (read-column-by-index [^PgArray v _2 _3] (<-pgarray v))
+  Array
+  (read-column-by-label [^Array v _] (<-array v))
+  (read-column-by-index [^Array v _2 _3] (<-array v))
 
   PGobject
   (read-column-by-label [^PGobject v _] (<-pgobject v))

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -19,34 +19,10 @@
    (com.zaxxer.hikari HikariDataSource)
    (java.sql Array Connection PreparedStatement ResultSet ResultSetMetaData)
    (java.time Instant LocalDate LocalDateTime)
-   (java.util UUID)
    (javax.sql DataSource)
    (org.postgresql.util PGobject PSQLException)))
 
 (set! *warn-on-reflection* true)
-
-(defn ->pg-text-array
-  "Formats as text[] in pg, i.e. {item-1, item-2, item3}"
-  [col]
-  (clojure.core/format
-   "{%s}"
-   (string/join
-    ","
-    (map (fn [s] (clojure.core/format "\"%s\""
-                                      ;; Escape quotes (but don't double esc)
-                                      (string/replace s #"(?<!\\)\"" "\\\"")))
-         col))))
-
-(defn ->pg-uuid-array
-  "Formats as uuid[] in pg, i.e. {item-1, item-2, item3}"
-  [uuids]
-  (let [s (StringBuilder. "{")]
-    (doseq [^UUID uuid uuids]
-      (when (not= 1 (.length s))
-        (.append s \,))
-      (.append s (.toString uuid)))
-    (.append s "}")
-    (.toString s)))
 
 (defn <-pgobject
   "Transform PGobject containing `json` or `jsonb` value to Clojure data"

--- a/server/src/instant/util/date.clj
+++ b/server/src/instant/util/date.clj
@@ -1,6 +1,7 @@
 (ns instant.util.date
   (:import
-   (java.time ZoneId ZonedDateTime ZoneRegion LocalDate)
+   (java.io Writer)
+   (java.time Instant ZoneId ZonedDateTime ZoneRegion LocalDate)
    (java.time.format DateTimeFormatter)
    (java.time.temporal TemporalAdjusters)))
 
@@ -34,6 +35,12 @@
         first-of-next-month (.with (LocalDate/from today) (TemporalAdjusters/firstDayOfNextMonth))
         start-of-day (.atStartOfDay first-of-next-month est-zone)]
     start-of-day))
+
+(defmethod print-method Instant [o ^Writer w]
+  (.write w (str "#instant \"" (.toString o) "\"")))
+
+(defn parse-instant [x]
+  (Instant/parse x))
 
 (comment
   (first-of-next-month-est))

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -7,6 +7,7 @@
    [clojure.test :refer [deftest testing is]])
   (:import
    (java.time Instant)
+   (java.sql Timestamp)
    (clojure.lang ExceptionInfo)))
 
 (deftest in-progress-stmts
@@ -69,10 +70,10 @@
           vs-res (:v (sql/select-one (aurora/conn-pool :read)
                                      ["select ? as v" (with-meta vs {:pgtype "timestamptz[]"})]))]
       (is (= 2 (count vs-res)))
-      (is (= (first vs)
-             (.toInstant (first vs-res))))
-      (is (= (second vs)
-             (.toInstant (second vs-res))))))
+      (is (= (Timestamp/from ^Instant (first vs))
+             (first vs-res)))
+      (is (= (Timestamp/from ^Instant (second vs))
+             (second vs-res)))))
 
   (testing "float8[]"
     (let [vs [1.0 0.5 -10.0]]

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -73,14 +73,18 @@
       (is (= 2 (count vs-res)))
       (is (= (-> vs
                  ^Instant first
-                 (.truncatedTo ChronoUnit/MICROS)
-                 (Timestamp/from))
-             (first vs-res)))
+                 (.truncatedTo ChronoUnit/MICROS))
+             (-> vs-res
+                 ^Timestamp first
+                 (.toInstant)
+                 (.truncatedTo ChronoUnit/MICROS))))
       (is (= (-> vs
                  ^Instant second
-                 (.truncatedTo ChronoUnit/MICROS)
-                 (Timestamp/from))
-             (second vs-res)))))
+                 (.truncatedTo ChronoUnit/MICROS))
+             (-> vs-res
+                 ^Timestamp second
+                 (.toInstant)
+                 (.truncatedTo ChronoUnit/MICROS))))))
 
   (testing "float8[]"
     (let [vs [1.0 0.5 -10.0]]

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -73,18 +73,18 @@
       (is (= 2 (count vs-res)))
       (is (= (-> vs
                  ^Instant first
-                 (.truncatedTo ChronoUnit/MICROS))
+                 (.truncatedTo ChronoUnit/SECONDS))
              (-> vs-res
                  ^Timestamp first
                  (.toInstant)
-                 (.truncatedTo ChronoUnit/MICROS))))
+                 (.truncatedTo ChronoUnit/SECONDS))))
       (is (= (-> vs
                  ^Instant second
-                 (.truncatedTo ChronoUnit/MICROS))
+                 (.truncatedTo ChronoUnit/SECONDS))
              (-> vs-res
                  ^Timestamp second
                  (.toInstant)
-                 (.truncatedTo ChronoUnit/MICROS))))))
+                 (.truncatedTo ChronoUnit/SECONDS))))))
 
   (testing "float8[]"
     (let [vs [1.0 0.5 -10.0]]

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -4,9 +4,11 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.util.test :refer [wait-for]]
+   [instant.util.json :as json]
    [clojure.test :refer [deftest testing is are]])
   (:import
-   [clojure.lang ExceptionInfo]))
+   (java.time Instant)
+   (clojure.lang ExceptionInfo)))
 
 (deftest ->pgobject
   (testing "formats text[]"
@@ -43,6 +45,54 @@
                         #"read-only-sql-transaction"
                         (sql/execute! (aurora/conn-pool :read)
                                       ["insert into config (k, v) values ('a', '\"b\"'::jsonb)"]))))
+
+(deftest coercion
+  (testing "text[]"
+    (is (= {:v ["hello" "world"]}
+           (sql/select-one (aurora/conn-pool :read)
+                           ["select ? as v" (with-meta ["hello" "world"] {:pgtype "text[]"})]))))
+
+  (testing "uuid[]"
+    (let [ids [#uuid "c94c255f-9f2f-4484-9868-54a41786b613"
+               #uuid "6454f319-e532-4955-b93a-654e6baedde7"]]
+      (is (= {:v ids}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" (with-meta ids {:pgtype "uuid[]"})])))))
+
+  (testing "jsonb[]"
+    (let [vs [{"a" 1} nil [{"b" 2}]]]
+      (is (= {:v vs}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" (with-meta vs {:pgtype "jsonb[]"})])))))
+
+  (testing "jsonb[]"
+    (let [vs [{"a" 1} nil [{"b" 2}]]]
+      (is (= {:v vs}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" (with-meta vs {:pgtype "jsonb[]"})])))))
+
+  (testing "timestamptz[]"
+    (let [vs [(Instant/now)
+              (Instant/now)]
+          vs-res (:v (sql/select-one (aurora/conn-pool :read)
+                                     ["select ? as v" (with-meta vs {:pgtype "timestamptz[]"})]))]
+      (is (= 2 (count vs-res)))
+      (is (= (first vs)
+             (.toInstant (first vs-res))))
+      (is (= (second vs)
+             (.toInstant (second vs-res))))))
+
+  (testing "float8[]"
+    (let [vs [1.0 0.5 -10.0]]
+      (is (= {:v vs}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" (with-meta vs {:pgtype "float8[]"})])))))
+
+  (testing "boolean[]"
+    (let [vs [true false true]]
+      (is (= {:v vs}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" (with-meta vs {:pgtype "boolean[]"})]))))))
 
 (deftest elementset-test
   (let [xs [1 2 3]

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -7,6 +7,7 @@
    [clojure.test :refer [deftest testing is]])
   (:import
    (java.time Instant)
+   (java.time.temporal ChronoUnit)
    (java.sql Timestamp)
    (clojure.lang ExceptionInfo)))
 
@@ -70,9 +71,15 @@
           vs-res (:v (sql/select-one (aurora/conn-pool :read)
                                      ["select ? as v" (with-meta vs {:pgtype "timestamptz[]"})]))]
       (is (= 2 (count vs-res)))
-      (is (= (Timestamp/from ^Instant (first vs))
+      (is (= (-> vs
+                 ^Instant first
+                 (.truncatedTo ChronoUnit/MICROS)
+                 (Timestamp/from))
              (first vs-res)))
-      (is (= (Timestamp/from ^Instant (second vs))
+      (is (= (-> vs
+                 ^Instant second
+                 (.truncatedTo ChronoUnit/MICROS)
+                 (Timestamp/from))
              (second vs-res)))))
 
   (testing "float8[]"

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -4,18 +4,10 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.util.test :refer [wait-for]]
-   [instant.util.json :as json]
-   [clojure.test :refer [deftest testing is are]])
+   [clojure.test :refer [deftest testing is]])
   (:import
    (java.time Instant)
    (clojure.lang ExceptionInfo)))
-
-(deftest ->pgobject
-  (testing "formats text[]"
-    (are [input result] (= (.getValue (sql/->pgobject (with-meta input {:pgtype "text[]"})))
-                           result)
-      ["a" "b" "c"] "{\"a\",\"b\",\"c\"}"
-      ["a\"b"] "{\"a\"b\"}")))
 
 (deftest in-progress-stmts
   (let [in-progress (sql/make-statement-tracker)]


### PR DESCRIPTION
Updates our datalog queries to use `= ANY` instead of `IN` or multiple `OR`s, e.g. `value = ANY '{"a","b"}' instead of `value in ("a", "b")` or `value = "a" OR value = "b"`. 

We did this in a previous PR for matching the attr ids: https://github.com/instantdb/instant/pull/973

The benefits are:
1. Fewer parameters
2. Less data over the wire
3. Better query plans for `$in` queries

If you do a query with `$in`, we'll create a big list of ORs and postgres will do a big bitmap-or scan on all of the individual values. 

For this query:

```js
{$files: {$: {where: {paths: {$in: list-of-paths}}}
```
The query plan before looks like:

```
    ->  Bitmap Heap Scan on triples t0  (cost=36.06..37.22 rows=1 width=88) (actual time=1.736..2.089 rows=20 loops=1)
          Recheck Cond: (((app_id = :app-id) AND (attr_id = :attr-id) AND (value = :v1) AND ave) OR ((app_id = :app-id) AND (attr_id = :attr-id) AND (value = :v2) AND ave) ...
          Heap Blocks: exact=20
          ->  BitmapOr  (cost=36.06..36.06 rows=1 width=0) (actual time=1.712..1.717 rows=0 loops=1)
                ->  Bitmap Index Scan on ave_index  (cost=0.00..1.80 rows=1 width=0) (actual time=0.328..0.328 rows=1 loops=1)
                      Index Cond: ((app_id = :app-id) AND (attr_id = :attr-id) AND (value = :v1))
                ->  Bitmap Index Scan on ave_index  (cost=0.00..1.80 rows=1 width=0) (actual time=0.031..0.031 rows=1 loops=1)
                      Index Cond: ((app_id = :app-id) AND (attr_id = :attr-id) AND (value = :v2))
                ...
```                

The query plan using `= any` can just use a single index condition

```
    ->  Index Scan using ave_index on triples t0  (cost=0.69..37.16 rows=1 width=88) (actual time=0.095..0.496 rows=20 loops=1)
          Index Cond: ((app_id = :app-id) AND (attr_id = :attr-id) AND (value = ANY ('{"v1, "v1",...}')))
```