### PR TITLE
fix query typo in docs

### DIFF
--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -299,7 +299,7 @@ const query = {
     todos: {
       $: {
         where: {
-          'todos.title': 'Go on a run',
+          title: 'Go on a run',
         },
       },
     },


### PR DESCRIPTION
Changes
```ts
const query = {
  goals: {
    todos: {
      $: {
        where: {
          'todos.title': 'Go on a run',
        },
      },
    },
  },
};
const { isLoading, error, data } = db.useQuery(query);
```
TO 

```ts
const query = {
  goals: {
    todos: {
      $: {
        where: {
          title: 'Go on a run',
        },
      },
    },
  },
};
const { isLoading, error, data } = db.useQuery(query);
```

in the docs