### PR TITLE
[Dash] Fix namespace updates no propagating

### DIFF
--- a/client/www/components/dash/Perms.tsx
+++ b/client/www/components/dash/Perms.tsx
@@ -10,16 +10,17 @@ import { InstantApp, DashResponse, SchemaNamespace } from '@/lib/types';
 import { Button, Content, JSONEditor, SectionHeading } from '@/components/ui';
 import { HomeButton } from '@/pages/dash';
 import { InstantReactWebDatabase } from '@instantdb/react';
-import { useSchemaQuery } from '@/lib/hooks/explorer';
 
 export function Perms({
   app,
   db,
   dashResponse,
+  namespaces,
 }: {
   app: InstantApp;
   db: InstantReactWebDatabase<any>;
   dashResponse: SWRResponse<DashResponse>;
+  namespaces: SchemaNamespace[] | null;
 }) {
   const [errorRes, setErrorRes] = useState<{
     message: string;
@@ -29,8 +30,6 @@ export function Perms({
   const value = useMemo(() => {
     return app.rules ? JSON.stringify(app.rules, null, 2) : '';
   }, [app]);
-
-  const { namespaces } = useSchemaQuery(db);
 
   const schema = rulesSchema(namespaces);
 

--- a/client/www/components/dash/Schema.tsx
+++ b/client/www/components/dash/Schema.tsx
@@ -1,4 +1,3 @@
-import { useSchemaQuery } from '@/lib/hooks/explorer';
 import { init } from '@instantdb/react';
 import {
   apiSchemaToInstantSchemaDef,
@@ -6,7 +5,7 @@ import {
 } from '@instantdb/platform';
 import { Monaco } from '@monaco-editor/react';
 import { useState } from 'react';
-import { DBAttr } from '@/lib/types';
+import { DBAttr, SchemaNamespace } from '@/lib/types';
 import {
   CodeEditor,
   Content,
@@ -88,9 +87,15 @@ function attrsToTsFile(attrs: Record<string, DBAttr>, pkg: Pkg) {
   return generateSchemaTypescriptFile(schema, schema, pkg);
 }
 
-export function Schema({ db }: { db: InstantReactClient }) {
-  const { attrs } = useSchemaQuery(db);
-
+export function Schema({
+  db,
+  namespaces,
+  attrs,
+}: {
+  db: InstantReactClient;
+  namespaces: SchemaNamespace[] | null;
+  attrs: Record<string, DBAttr> | null;
+}) {
   const [pkg, setPkg] = useState<
     | '@instantdb/core'
     | '@instantdb/admin'

--- a/client/www/components/dash/explorer/Explorer.tsx
+++ b/client/www/components/dash/explorer/Explorer.tsx
@@ -50,11 +50,7 @@ import { DBAttr, SchemaAttr, SchemaNamespace } from '@/lib/types';
 import { useIsOverflow } from '@/lib/hooks/useIsOverflow';
 import { useClickOutside } from '@/lib/hooks/useClickOutside';
 import { isTouchDevice } from '@/lib/config';
-import {
-  useSchemaQuery,
-  useNamespacesQuery,
-  SearchFilter,
-} from '@/lib/hooks/explorer';
+import { useNamespacesQuery, SearchFilter } from '@/lib/hooks/explorer';
 import { TokenContext } from '@/lib/contexts';
 import { EditNamespaceDialog } from '@/components/dash/explorer/EditNamespaceDialog';
 import { EditRowDialog } from '@/components/dash/explorer/EditRowDialog';
@@ -421,9 +417,11 @@ function SearchInput({
 export function Explorer({
   db,
   appId,
+  namespaces,
 }: {
   db: InstantReactWebDatabase<any>;
   appId: string;
+  namespaces: SchemaNamespace[] | null;
 }) {
   // DEV
   _dev(db);
@@ -566,7 +564,6 @@ export function Explorer({
   }
 
   // data
-  const { namespaces } = useSchemaQuery(db);
   const { selectedNamespace } = useMemo(
     () => ({
       selectedNamespace: namespaces?.find(

--- a/client/www/components/dash/explorer/QueryInspector.tsx
+++ b/client/www/components/dash/explorer/QueryInspector.tsx
@@ -5,9 +5,9 @@ import { StarIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 
 import { Button, CodeEditor, cn } from '@/components/ui';
-import { useSchemaQuery } from '@/lib/hooks/explorer';
 import { errorToast, infoToast } from '@/lib/toast';
 import { InstantReactWebDatabase } from '@instantdb/react';
+import { SchemaNamespace } from '@/lib/types';
 
 const SAVED_QUERIES_CACHE_KEY = '__instant:explorer-saved-queries';
 const QUERY_HISTORY_CACHE_KEY = '__instant:explorer-query-history';
@@ -58,17 +58,18 @@ export function QueryInspector({
   className,
   appId,
   db,
+  namespaces,
 }: {
   className?: string;
   appId: string;
   db: InstantReactWebDatabase<any>;
+  namespaces: SchemaNamespace[] | null;
 }) {
   const cache = new QueryInspectorCache(appId);
   const [query, setQuery] = useState<Record<string, any>>({});
   const [draft, setQueryDraft] = useState('{}');
   const [history, setQueryHistory] = useState<CachedQueryItem[]>([]);
   const [saved, setSavedQueries] = useState<CachedQueryItem[]>([]);
-  const { namespaces } = useSchemaQuery(db);
   const { data, isLoading, error } = db.useQuery(query);
 
   useEffect(() => {

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -2,6 +2,7 @@ import { TokenContext } from '@/lib/contexts';
 import { successToast } from '@/lib/toast';
 import { DashResponse, InstantApp } from '@/lib/types';
 import config from '@/lib/config';
+import { useSchemaQuery } from '@/lib/hooks/explorer';
 import { jsonFetch } from '@/lib/fetch';
 import { APIResponse, signOut, useAuthToken, useTokenFetch } from '@/lib/auth';
 import { Sandbox } from '@/components/dash/Sandbox';
@@ -337,30 +338,13 @@ function DevtoolWithData({
           }}
         />
         <div className="flex w-full flex-1 overflow-auto">
-          {tab === 'explorer' ? (
-            <Explorer db={connection.db} appId={appId} />
-          ) : tab === 'sandbox' ? (
-            <div className="min-w-[960px] w-full">
-              <Sandbox app={app} db={connection.db} />
-            </div>
-          ) : tab === 'admin' ? (
-            <div className="min-w-[960px] w-full p-4">
-              <Admin dashResponse={dashResponse} app={app} />
-            </div>
-          ) : tab === 'help' ? (
-            <div className="min-w-[960px] w-full p-4 space-y-4">
-              <Help />
-              <Button
-                size="mini"
-                variant="secondary"
-                onClick={() => {
-                  signOut();
-                }}
-              >
-                Sign out
-              </Button>
-            </div>
-          ) : null}
+          <DevtoolContent
+            connection={connection}
+            app={app}
+            appId={appId}
+            tab={tab}
+            dashResponse={dashResponse}
+          />
         </div>
       </div>
     </DevtoolWindow>
@@ -424,6 +408,56 @@ function AppIdLabel({ appId }: { appId: string }) {
         {appId}
       </code>
     </div>
+  );
+}
+
+// Component that manages schema subscription for devtool
+function DevtoolContent({
+  connection,
+  app,
+  appId,
+  tab,
+  dashResponse,
+}: {
+  connection: { state: 'ready'; db: InstantReactClient };
+  app: InstantApp;
+  appId: string;
+  tab: string;
+  dashResponse: APIResponse<DashResponse>;
+}) {
+  const schemaData = useSchemaQuery(connection.db);
+
+  return (
+    <>
+      {tab === 'explorer' ? (
+        <Explorer
+          db={connection.db}
+          appId={appId}
+          namespaces={schemaData.namespaces}
+        />
+      ) : tab === 'sandbox' ? (
+        <div className="min-w-[960px] w-full">
+          <Sandbox app={app} db={connection.db} />
+        </div>
+      ) : tab === 'admin' ? (
+        <div className="min-w-[960px] w-full p-4">
+          <Admin dashResponse={dashResponse} app={app} />
+        </div>
+      ) : tab === 'help' ? (
+        <div className="min-w-[960px] w-full p-4 space-y-4">
+          <Help />
+          <Button
+            size="mini"
+            variant="secondary"
+            onClick={() => {
+              signOut();
+            }}
+          >
+            Sign out
+          </Button>
+        </div>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
We got a repro in https://github.com/instantdb/instant/issues/790 which shows that shows when users created a new namespace in the Sandbox tab, it wouldn't appear in the Explorer tab until they refreshed the page.

### Solution

Moved the schema subscription to the dashboard level to capture all namespace changes, eliminating the issue where newly mounted tabs wouldn't receive the current namespace state

### Changes:

1. Created `DashboardContent` component in `/www/pages/dash/index.tsx` that:

   - Calls `useSchemaQuery` at the dashboard level
   - Passes namespace data as props to child components
   - Ensures namespace updates are always being listened to

2. Created `DevtoolContent` component in `/www/pages/_devtool/index.tsx` with the same pattern

Thought it was also nicer to encapsulate these into their own components -- `Dashboard` and `DevtoolWithData` were kinda big

### Testing

- Create a namespace in Sandbox tab → immediately visible in Explorer tab
- Do the same and see the devtool also sees the update
- Schema, Perms, and Query Inspector tabs all receive live updates

**Before**

https://github.com/user-attachments/assets/c5bb62e0-a7a5-48a2-9fd3-d5017d4b3093

**After**

https://github.com/user-attachments/assets/62f21064-553a-42ec-bbeb-b330a684efa7
