### PR TITLE
Tweak header and footer navs

### DIFF
--- a/client/www/components/marketingUi.tsx
+++ b/client/www/components/marketingUi.tsx
@@ -203,9 +203,6 @@ export function LandingFooter() {
               <div>Engineered in San Francisco</div>
             </div>
             <div className="flex flex-wrap gap-x-4 gap-y-2">
-              <NavLink href="/examples">Examples</NavLink>
-              <NavLink href="/essays">Essays</NavLink>
-              <NavLink href="/docs">Docs</NavLink>
               <NavLink href="/hiring">Hiring</NavLink>
               <NavLink href="https://discord.com/invite/VU53p7uQcE">
                 Discord
@@ -215,10 +212,6 @@ export function LandingFooter() {
               </NavLink>
               <NavLink href="/privacy">Privacy Policy</NavLink>
               <NavLink href="/terms">Terms</NavLink>
-              <NavLink href="/dash">Login</NavLink>
-              <div className="text-orange-500">
-                <NavLink href="/dash">Signup</NavLink>
-              </div>
             </div>
           </div>
         </div>

--- a/client/www/components/marketingUi.tsx
+++ b/client/www/components/marketingUi.tsx
@@ -83,6 +83,7 @@ function NavItems() {
     <>
       <NavLink href="/pricing">Pricing</NavLink>
       <NavLink href="/examples">Examples</NavLink>
+      <NavLink href="/tutorial">Tutorial</NavLink>
       <NavLink href="/essays">Essays</NavLink>
       <NavLink href="/docs">Docs</NavLink>
       <NavLink href="/hiring">Hiring</NavLink>

--- a/client/www/pages/index.tsx
+++ b/client/www/pages/index.tsx
@@ -104,7 +104,7 @@ function LandingHero() {
                       size="large"
                       href="/tutorial"
                     >
-                      Try the demo
+                      Try the tutorial
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
I realize the only links we have to the tutorial at the moment are the button in the hero unit and in the home tab of the dashboard. Thought it would be nice to also add it into the header nav and be more explicit in the CTA.

Also removed some links in the footer which I thought was a little crowded