### PR TITLE
[wip] count-min-sketch for attrs

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -58,11 +58,6 @@ restart:
 	@echo "Restarting beanstalk..."
 	aws elasticbeanstalk restart-app-server --environment-name Instant-prod-env
 
-dev-with-prod-db:
-	@DATABASE_URL=$$(./scripts/prod_connection_string.sh); \
-	echo "[IMPORTANT] Booting up backend w/ prod db..." && \
-	DATABASE_URL="$${DATABASE_URL}" clj -T:build dev
-
 prod-ssh:
 	./scripts/prod_ssh.sh
 

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -88,7 +88,8 @@
 
         djblue/portal {:mvn/version "0.58.5"}
         dev.weavejester/medley {:mvn/version "1.8.1"}
-        com.hazelcast/hazelcast {:mvn/version "5.5.0"}}
+        com.hazelcast/hazelcast {:mvn/version "5.5.0"}
+        net.openhft/zero-allocation-hashing {:mvn/version "0.27ea1"}}
  :aliases {:dev {:extra-paths ["dev" "test" "dev-resources"]
                  :extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}
                               criterium/criterium           {:mvn/version "0.4.6"}

--- a/server/resources/migrations/75_add_sketch.down.sql
+++ b/server/resources/migrations/75_add_sketch.down.sql
@@ -1,0 +1,4 @@
+drop table attr_sketches;
+drop table wal_aggregator_status;
+
+alter table triples replica identity default;

--- a/server/resources/migrations/75_add_sketch.up.sql
+++ b/server/resources/migrations/75_add_sketch.up.sql
@@ -6,6 +6,8 @@ create table attr_sketches (
   depth integer not null,
   total bigint not null,
   total_not_binned bigint not null,
+  -- maybe we should make bins nullable so that we can avoid storing
+  -- zeroes
   bins bigint[] not null,
   max_lsn pg_lsn,
   created_at timestamp with time zone not null default now(),
@@ -16,8 +18,6 @@ create table attr_sketches (
 -- unique constraint creates index we can use for cascade deletes on app
 -- add index for cascade deletes on attr
 create index on attr_sketches (attr_id);
-
-
 
 create trigger update_updated_at_trigger
 before update on attr_sketches

--- a/server/resources/migrations/75_add_sketch.up.sql
+++ b/server/resources/migrations/75_add_sketch.up.sql
@@ -1,0 +1,48 @@
+create table attr_sketches (
+  id uuid primary key,
+  app_id uuid not null references apps (id) on delete cascade,
+  attr_id uuid not null references attrs (id) on delete cascade,
+  width integer not null,
+  depth integer not null,
+  total bigint not null,
+  total_not_binned bigint not null,
+  bins bigint[] not null,
+  max_lsn pg_lsn,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  unique (app_id, attr_id)
+);
+
+-- unique constraint creates index we can use for cascade deletes on app
+-- add index for cascade deletes on attr
+create index on attr_sketches (attr_id);
+
+
+
+create trigger update_updated_at_trigger
+before update on attr_sketches
+for each row
+execute function update_updated_at_column();
+
+-- This acts as a singleton table where we keep track of which lsn
+-- we've completed processing. The updates to the attr_sketches will
+-- happen in the same transaction where we update the wal_aggregator
+-- Then on a crash, we can restart the wal from the lsn in the
+-- aggregator status
+create table wal_aggregator_status (
+  id int primary key,
+  lsn pg_lsn,
+  process_id text,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now()
+);
+
+create trigger update_updated_at_trigger
+before update on wal_aggregator_status
+for each row
+execute function update_updated_at_column();
+
+-- Insert the singleton we use to store the lsn we've flushed
+insert into wal_aggregator_status (id) values (1);
+
+alter table triples replica identity full;

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1074,9 +1074,10 @@
         join-cost (reduce + 0 (vals (:join-remaining costs)))
         filter-cost (reduce + 0 (vals (select-keys (:known-remaining costs)
                                                    (:filter-components costs))))]
-    (* 1.0 (* (+ path-cost
-                 (* 2 filter-cost))
-              (max 1 join-cost)))))
+    (* 1.0
+       (+ path-cost
+          (* 2 filter-cost))
+       (max 1 join-cost))))
 
 (defn index-compare
   "Compares the indexes pairwise to try to pick the best one.

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -205,7 +205,7 @@
                     (.logical)
                     (.withSlotOption "include-lsn" true)
                     (.withSlotOption "format-version" version)
-                    (.withStartPosition (LogSequenceNumber/valueOf start-lsn))
+                    (.withStartPosition start-lsn)
                     (.withSlotName slot-name)
                     (.withStatusInterval 1 TimeUnit/SECONDS))]
     (.start ^ChainedLogicalStreamBuilder builder)))

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -1,0 +1,220 @@
+(ns instant.reactive.aggregator
+  (:require
+   [clojure.core.async :as a]
+   [instant.config :as config]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.wal :as wal]
+   ;; XXX: Should move this out of util
+   [instant.util.count-min-sketch :as cms]
+   [instant.util.async :as ua]
+   [instant.util.json :refer [<-json]]
+   [instant.util.tracer :as tracer])
+  (:import
+   (org.postgresql.replication LogSequenceNumber)))
+
+(declare wal-opts)
+
+(declare aggregator-q)
+
+;; ------
+;; wal record xf
+
+(defn get-triples-data [columns]
+  (reduce (fn [data {:keys [name value]}]
+            (case name
+              "app_id" (assoc data :app-id (parse-uuid value))
+              "attr_id" (assoc data :attr-id (parse-uuid value))
+              "value" (assoc data :value (<-json value))
+              "checked_data_type" (assoc data :checked-data-type (keyword value))
+              data))
+          {}
+          columns))
+
+(defn transform-wal-record [{:keys [changes lsn] :as _record}]
+  (let [sketch-changes (reduce (fn [acc change]
+                                 (if (not= "triples" (:table change))
+                                   acc
+                                   (case (:action change)
+                                     :insert
+                                     (conj acc {:incr 1
+                                                :lsn lsn
+                                                :triples-data (get-triples-data (:columns change))})
+
+                                     :delete
+                                     (conj acc {:incr -1
+                                                :lsn lsn
+                                                :triples-data (get-triples-data (:identity change))})
+
+                                     :update
+                                     (conj acc
+                                           ;; Remove the old
+                                           {:incr -1
+                                            :lsn lsn
+                                            :triples-data (get-triples-data (:identity change))}
+                                           ;; Add the new
+                                           {:incr 1
+                                            :lsn lsn
+                                            :triples-data (get-triples-data (:columns change))}))))
+                               []
+                               changes)]
+    (when (seq sketch-changes)
+      {:sketch-changes sketch-changes})))
+
+(defn wal-record-xf
+  "Filters wal records for supported changes. Returns [app-id changes]"
+  []
+  (keep #'transform-wal-record))
+
+;; ------
+;; invalidator
+
+(defn max-lsn [^LogSequenceNumber a ^LogSequenceNumber b]
+  (cond (not a)
+        b
+
+        (not b)
+        a
+
+        :else
+        (case (compare a b)
+          0 a
+          -1 b
+          1 a)))
+
+(defn collect-sketch-changes [sketch-changes]
+  (reduce (fn [acc {:keys [incr triples-data lsn]}]
+            (let [key {:app-id (:app-id triples-data)
+                       :attr-id (:attr-id triples-data)}
+                  record {:value (:value triples-data)
+                          :checked-data-type (:checked-data-type triples-data)}]
+              (-> acc
+                  (update-in [:changes key :records record] (fnil + 0) incr)
+                  (update-in [:changes key :max-lsn] max-lsn lsn)
+                  (update :max-lsn max-lsn lsn))))
+          {:changes {}
+           :max-lsn nil}
+          sketch-changes))
+
+(defn process-sketch-changes [conn sketch-changes]
+  (tool/def-locals)
+  (tracer/with-span! {:name "aggregator/process-sketch-changes"
+                      :attributes {:change-count (:count sketch-changes)}}
+    (let [{:keys [changes max-lsn]} (collect-sketch-changes sketch-changes)]
+      (assert max-lsn "max-lsn was nil, we can't apply changes")
+      (tracer/add-data! {:attributes {:max-lsn max-lsn}})
+      ;; XXX: Get sketches all in one go
+      (let [sketches (reduce-kv
+                      (fn [acc k {:keys [records max-lsn]}]
+                        ;; TODO: Handle case where attr is deleted in the interim
+                        (let [record (cms/find-or-create-sketch! conn k)]
+                          (conj acc (-> record
+                                        (update :sketch cms/add-batch records)
+                                        (assoc :max-lsn max-lsn)))))
+                      []
+                      changes)]
+        (cms/save-sketches! conn {:sketches sketches
+                                  ;; :previous-lsn ??
+                                  :lsn max-lsn})))))
+
+;; XXXX: pass start-lsn in here
+;;       Have to reconfigure things a bit so that we start this after we get a lock on the slot
+(defn start-worker [wal-chan process-chan]
+  ;; XXX: If anything fails here, we should make some noise and
+  ;;      shut down our worker so that someone else can try
+  (tracer/record-info! {:name "aggregator-worker/start"})
+  ;; sketch cache should live here
+
+  ;; Shuffles items from the wal-chan to the process-chan
+  (a/go
+    (loop []
+      (when-some [{:keys [sketch-changes]} (a/<! wal-chan)]
+        (a/>! (:in process-chan) sketch-changes)
+        (recur)))
+    (tracer/record-info! {:name "aggregator-worker/shutdown"}))
+
+  ;; Processes the items every N seconds in a batch
+  (a/go
+    (loop [_previous-lsn nil] ;; Get previous lsn when we start up
+      (when-some [sketch-changes (a/<! (:out process-chan))]
+        (let [{:keys [lsn]} (process-sketch-changes (aurora/conn-pool :write)
+                                                    sketch-changes)]
+          (recur lsn))))
+    (tracer/record-info! {:name "aggregator-worker/shutdown"})))
+
+;; ------
+;; orchestration
+
+(defn wal-ex-handler [e]
+  (tracer/record-exception-span! e {:name "aggregator/wal-ex-handler"
+                                    :escaping? false})
+  (wal/shutdown! wal-opts))
+
+(defn create-wal-chans []
+  (let [chan (a/chan 1 (wal-record-xf))]
+    {:wal-chan chan
+     :close-signal-chan (a/chan)
+     :worker-chan chan}))
+
+;; XXX: Need some way to test.
+(defn start
+  "Entry point for the agggregator.
+
+  Creates the aggregator wal slot if it does not already exist.
+
+  If the wal slot is already active, waits in the background
+  for it to become inactive and subscribes to it.
+
+  When we subscribe to the wal slot, we aggregate counts for all of
+  the attrs."
+  ([]
+   (start nil))
+  ([slot-name-for-testing]
+   (let [{:keys [wal-chan worker-chan close-signal-chan]}
+         (create-wal-chans)
+
+         wal-opts (wal/make-wal-opts {:wal-chan wal-chan
+                                      :close-signal-chan close-signal-chan
+                                      :ex-handler wal-ex-handler
+                                      :get-conn-config (fn []
+                                                         (or (config/get-next-aurora-config)
+                                                             ;; Use the next db so that we don't
+                                                             ;; have to worry about restarting the
+                                                             ;; invalidator when failing over to a
+                                                             ;; new blue/green deployment
+                                                             (config/get-aurora-config)))
+                                      :slot-name (or slot-name-for-testing
+                                                     (name (config/get-env)))
+                                      :slot-type :aggregator})
+         process-chan (ua/chunked-chan {:flush-ms 10000
+                                        :max-items 10000})]
+     (ua/fut-bg
+       (wal/start-worker wal-opts))
+
+     ;; XXX: Probably needs to change
+     @(:started-promise wal-opts)
+
+     (def aggregator-q
+       (start-worker worker-chan process-chan))
+
+     wal-opts)))
+
+(defn start-global []
+  (def wal-opts (start)))
+
+(defn stop [wal-opts]
+  (let [shutdown-future (future (wal/shutdown! wal-opts))]
+    (loop []
+      (when-not (realized? shutdown-future)
+        (wal/kick-wal (aurora/conn-pool :write))
+        (Thread/sleep 100)
+        (recur))))
+  (a/close! (:to wal-opts))
+  (a/close! (:close-signal-chan wal-opts)))
+
+(defn stop-global []
+  (when (bound? #'wal-opts)
+    (stop wal-opts)))
+
+(defn restart []
+  (stop-global)
+  (start-global))

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -3,7 +3,6 @@
    [clojure.core.async :as a]
    [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
-   [instant.jdbc.sql :as sql]
    [instant.jdbc.wal :as wal]
    [instant.util.async :as ua]
    [instant.db.attr-sketch :as cms]
@@ -104,7 +103,7 @@
       (assert max-lsn "max-lsn was nil, we can't apply changes")
       (tracer/add-data! {:attributes {:max-lsn max-lsn}})
       ;; XXX: Get sketches all in one go
-      (let [sketches (cms/find-or-create-sketches! (keys changes))
+      (let [sketches (cms/find-or-create-sketches! conn (keys changes))
             sketches (reduce-kv
                       (fn [acc k {:keys [records max-lsn]}]
                         ;; TODO: Handle case where attr is deleted in the interim

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -484,7 +484,8 @@
                                                              ;; invalidator when failing over to a
                                                              ;; new blue/green deployment
                                                              (config/get-aurora-config)))
-                                      :slot-name process-id})]
+                                      :slot-name process-id
+                                      :slot-type :invalidator})]
      (ua/fut-bg
       (wal/start-worker wal-opts))
 

--- a/server/src/instant/util/count_min_sketch.clj
+++ b/server/src/instant/util/count_min_sketch.clj
@@ -1,0 +1,287 @@
+(ns instant.util.count-min-sketch
+  (:require
+   [clojure.pprint]
+   [honey.sql :as hsql]
+   [instant.config :as config]
+   [instant.jdbc.sql :as sql]
+   [instant.db.model.triple :as triple])
+  (:import
+   (java.nio ByteBuffer)
+   (net.openhft.hashing LongHashFunction)))
+
+(set! *warn-on-reflection* true)
+
+(defrecord Sketch [width
+                   depth
+                   bins
+                   total
+                   total-not-binned])
+
+(defmethod clojure.pprint/simple-dispatch Sketch [x]
+  (#'clojure.pprint/pprint-map (into {} (assoc x :bins '<bins>))))
+
+(def ln2 (Math/log 2))
+
+(defn make-sketch
+  ([] (make-sketch {}))
+  ([{:keys [confidence error-rate]
+     :or {confidence 0.998
+          error-rate 0.001}}]
+   (let [width (Math/ceil (/ 2 error-rate))
+         depth (Math/ceil (/ (* -1 (Math/log (- 1 confidence)))
+                             ln2))]
+     (map->Sketch {:width width
+                   :depth depth
+                   :bins (vec (repeat (* width depth) 0))
+                   :total 0
+                   :total-not-binned 0}))))
+
+(defn data-type-for-hash [checked-data-type x]
+  (case checked-data-type
+    :number (condp instance? x
+              java.lang.Long [:long x]
+              java.lang.Integer [:integer x]
+              java.lang.Double [:double x])
+    :string [:string x]
+    :boolean [:boolean x]
+    :date [:long (.toEpochMilli (triple/parse-date-value x))]
+
+    (condp instance? x
+      java.lang.Long [:long x]
+      java.lang.Integer [:integer x]
+      java.lang.String [:string x]
+      java.lang.Boolean [:boolean x]
+      ;; Use string as the universal format for uuids for the purpose of
+      ;; the sketch. We could use bytes, but this will still work if the
+      ;; uuid gets passed to us as a string somehow
+      java.util.UUID [:string (str x)]
+      nil)))
+
+(defn hash-val [^Long seed ^Long hash-idx data-type val]
+  (let [xx (LongHashFunction/xx3 (+ seed hash-idx))]
+    (case data-type
+      :long (.hashLong xx val)
+      :integer (.hashInt xx val)
+      :double (.hashBytes xx (.. (ByteBuffer/allocate 8)
+                                 (putDouble val)
+                                 (array)))
+      :string (.hashChars xx ^String val)
+      :boolean (.hashBoolean xx val))))
+
+(defn add
+  ([^Sketch sketch checked-data-type v]
+   (add sketch checked-data-type v 1))
+  ([^Sketch sketch checked-data-type v_ n]
+   (if-let [[data-type v] (data-type-for-hash checked-data-type v_)]
+     ;; Only track counts for the items that you can query for
+     (let [seed (hash-val 0 -1 data-type v)
+           bins (persistent!
+                 (reduce (fn [bins i]
+                           (let [hash (hash-val seed i data-type v)
+                                 bin-idx (int (+ (Long/remainderUnsigned hash
+                                                                         (:width sketch))
+                                                 (* i (:width sketch))))]
+                             (assoc! bins bin-idx (+ (get bins bin-idx)
+                                                     n))))
+                         (transient (:bins sketch))
+                         (range (:depth sketch))))]
+       (-> sketch
+           (update :total + n)
+           (assoc :bins bins)))
+     ;; Track totals even if you can't query for the item
+     (-> sketch
+         (update sketch :total + n)
+         (update sketch :total-not-binned + n)))))
+
+
+(defn add-batch
+  "Expects items to be a map of {:value, :checked-data-type} => n, will add all
+   items to the sketch in a single batch."
+  ([^Sketch sketch items]
+   (let [{:keys [bins item-count not-binned-count]}
+         (persistent!
+          (reduce-kv (fn [acc {:keys [value checked-data-type]} n]
+                       (if-let [[data-type v] (data-type-for-hash checked-data-type value)]
+                         (let [seed (hash-val 0 -1 data-type v)
+                               bins (reduce (fn [bins i]
+                                              (let [hash (hash-val seed i data-type v)
+                                                    bin-idx (int (+ (Long/remainderUnsigned hash
+                                                                                            (:width sketch))
+                                                                    (* i (:width sketch))))]
+                                                (assoc! bins bin-idx (+ n (get bins bin-idx)))))
+                                            (:bins acc)
+                                            (range (:depth sketch)))]
+                           (-> acc
+                               (assoc! :bins bins)
+                               (assoc! :item-count (+ (:item-count acc) n))))
+                         (-> acc
+                             (assoc! :item-count (+ (:item-count acc) n))
+                             (assoc! :not-binned-count (+ (:not-binned-count acc) n)))))
+                     (transient {:bins (transient (:bins sketch))
+                                 :item-count 0
+                                 :not-binned-count 0})
+                     items))]
+     (-> sketch
+         (update :total + item-count)
+         (update :total-not-binned + not-binned-count)
+         (assoc :bins (persistent! bins))))))
+
+(defn check [^Sketch sketch checked-data-type val_]
+  (let [[data-type val] (data-type-for-hash checked-data-type val_)
+        _ (assert data-type (format "Unknown data for sketch %s" val))
+        seed (hash-val 0 -1 data-type val)]
+    (reduce (fn [m i]
+              (let [hash (hash-val seed i data-type val)
+                    bin-idx (int (+ (Long/remainderUnsigned hash
+                                                            (:width sketch))
+                                    (* i (:width sketch))))
+                    bin-val (nth (:bins sketch) bin-idx)]
+                (if m
+                  (min bin-val m)
+                  bin-val)))
+            nil
+            (range (:depth sketch)))))
+
+(defn check-mean-min [^Sketch sketch checked-data-type val_]
+  (let [[data-type val] (data-type-for-hash checked-data-type val_)
+        _ (assert data-type (format "Unknown data for sketch %s" val))
+        seed (hash-val 0 -1 data-type val)
+        total (reduce (fn [total i]
+                        (let [hash (hash-val seed i data-type val)
+                              bin-idx (int (+ (Long/remainderUnsigned hash
+                                                                      (:width sketch))
+                                              (* i (:width sketch))))
+                              bin-val (nth (:bins sketch) bin-idx)
+                              diff (- (:total sketch) bin-val)]
+                          (+ total (- bin-val
+                                      (quot diff
+                                            (dec (:width sketch)))))))
+                      0
+                      (range (:depth sketch)))]
+    (quot total (:depth sketch))))
+
+(defn check-mean [^Sketch sketch checked-data-type val_]
+  (let [[data-type val] (data-type-for-hash checked-data-type val_)
+        _ (assert data-type (format "Unknown data for sketch %s" val))
+        seed (hash-val 0 -1 data-type val)
+        total (reduce (fn [total i]
+                        (let [hash (hash-val seed i data-type val)
+                              bin-idx (int (+ (Long/remainderUnsigned hash
+                                                                      (:width sketch))
+                                              (* i (:width sketch))))
+                              bin-val (nth (:bins sketch) bin-idx)]
+                          (+ total bin-val)))
+                      0
+                      (range (:depth sketch)))]
+    (quot total (:depth sketch))))
+
+;; XXX: Testing ints
+;; Deciding not to use ints for these reasons
+;;  1. Somehow postgres is able to compress the bigints better
+;;  2. Less chance of an overflow error, but if the counts get that high,
+;;     then the sketch probably won't work that well anyway?
+;;  3. It's hard to get clojure to stick to ints and will probably create bugs
+;; It would be nice to use ints because they're smaller and faster
+
+;; How the process can work:
+;; 1. Fetch all of the triples for an attr
+;; 2. Start listening to the wal for that attr and queue up any changes
+;; We might miss some data, maybe we could take a lock on the triples table
+;; while we're fetching the triples for that attr?
+;; Alternatively, we could keep track of every primary key?
+
+;; Process for watching the wal
+;; 1. update comes in
+;; 2. if the triple is created, deleted, or has a value change, we put it in a queue of
+;;    items to process
+;; 3. Every so often, we flush the writes and update a record that to the lastapplied lsn
+;; 4. When the transaction comes back, then we tell the server what we've applied
+;; 5. If there is an error, then we can restart from the value in the db
+
+;; We could have one instance that talks to the persistant wal log and whoever gets subscribed
+;; to that one is the one that updates the counts
+;;
+
+(defn record->Sketch [record]
+  {:sketch (map->Sketch {:width (:width record)
+                         :depth (:depth record)
+                         :bins (:bins record)
+                         :total (:total record)
+                         :total-not-binned (:total_not_binned record)})
+   :id (:id record)
+   :app-id (:app_id record)
+   :attr-id (:attr_id record)
+   :max-lsn (:max_lsn record)})
+
+(defn find-or-create-sketch! [conn {:keys [app-id attr-id]}]
+  (if-let [existing (sql/select-one ::find-sketch
+                                    conn
+                                    (hsql/format {:select :*
+                                                  :from :attr-sketches
+                                                  :where [:and
+                                                          [:= :app-id app-id]
+                                                          [:= :attr-id attr-id]]}))]
+    (record->Sketch existing)
+    (let [sketch (make-sketch)
+          new (sql/execute-one! ::create-sketch
+                                conn
+                                (hsql/format {:insert-into :attr-sketches
+                                              :values [{:id (random-uuid)
+                                                        :app-id app-id
+                                                        :attr-id attr-id
+                                                        :width (:width sketch)
+                                                        :depth (:depth sketch)
+                                                        :total (:total sketch)
+                                                        :total-not-binned (:total-not-binned sketch)
+                                                        :bins :?bins}]}
+                                             {:params {:bins (with-meta (:bins sketch)
+                                                               {:pgtype "bigint[]"})}}))]
+      (record->Sketch new))))
+
+(def wal-aggregator-status-id :1)
+
+(defn save-sketches! [conn {:keys [sketches
+                                   ;;previous-lsn ;; XXX: need to keep track of last lsn so that we are sure we don't overwrite
+                                   lsn]}]
+  (let [q {:with [[[:data
+                    {:columns [:id :total :total-not-binned :max-lsn :bins]}]
+                   {:values (map-indexed
+                             (fn [i {:keys [id sketch] :as record}]
+                               [id
+                                (:total sketch)
+                                (:total-not-binned sketch)
+                                (:max-lsn record)
+                                (keyword (str "?bins-" i))])
+                             sketches)}]
+                  [:update-sketches
+                   {:update :attr_sketches
+                    :from :data
+                    :set {:total :data.total
+                          :total-not-binned :data.total-not-binned
+                          :max-lsn :data.max-lsn
+                          :bins :data.bins}
+                    :where [:= :attr_sketches.id :data.id]}]
+                  [:update-wal-aggregator-status
+                   {:update :wal-aggregator-status
+                    :set {:lsn lsn
+                          :process-id @config/process-id}
+                    :where [:and
+                            ;; XXX
+                            ;; [:= :max-lsn last-lsn]
+                            [:= :id wal-aggregator-status-id]]
+                    :returning :*}]]
+           ;; XXX: Need to throw if this is null
+           ;; [:raise_exception_message [:inline "lsn is not what we expected, did someone else steal our slot?"]]
+           :select :*
+           :from :update-wal-aggregator-status}
+        params (reduce-kv (fn [params i {:keys [sketch]}]
+                            (assoc params
+                                   (keyword (str "bins-" i))
+                                   (with-meta (:bins sketch)
+                                     {:pgtype "bigint[]"})))
+                          {}
+                          sketches)]
+    (sql/execute-one! ::save-sketches!
+                      conn
+                      (time (hsql/format q {:params params}))
+                      {:skip-log-params true})))

--- a/server/src/instant/util/date.clj
+++ b/server/src/instant/util/date.clj
@@ -36,7 +36,7 @@
         start-of-day (.atStartOfDay first-of-next-month est-zone)]
     start-of-day))
 
-(defmethod print-method Instant [o ^Writer w]
+(defmethod print-method Instant [^Instant o ^Writer w]
   (.write w (str "#instant \"" (.toString o) "\"")))
 
 (defn parse-instant [x]

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -310,7 +310,7 @@
        result#)))
 
 (defmacro profile [options? & body]
-  `(prof/profile ~options? ~body))
+  `(prof/profile ~options? ~@body))
 
 (def prof-serve-ui prof/serve-ui)
 


### PR DESCRIPTION
Adds count-min sketch for attrs to keep track of attr counts.

Still TODO
- [ ] Lots of small todos in the code
- [ ] Define the migrations for populating the initial sketches
- [ ] Set up the process for claiming the aggregation slot and monitoring it to claim once it is dropped by another machine

Stretch goal
- [ ] Keep track of data usage at the same time (tricky because we don't know how postgres defines the size)

