### PR TITLE
Update using-llms.md: fix the not-found link

### DIFF
--- a/client/www/pages/docs/using-llms.md
+++ b/client/www/pages/docs/using-llms.md
@@ -9,7 +9,7 @@ results we recommend doing two things:
 - Use the Instant MCP server to enable LLMs to create and update your apps
 - Add rules or context to your LLM to help it understand how Instant works
 
-To get set up quickly, check out our [whirlwind tutorial](/labs/mcp-tutorial).
+To get set up quickly, check out our [whirlwind tutorial](https://instantdb.com/tutorial).
 Otherwise read on for more detailed setup instructions.
 
 ## Instant MCP Server


### PR DESCRIPTION
### Current behavior
After clicking the `whirlwind tutorial` link, it redirected to the home page `instantdb.com` as the link is not found.
<img width="2098" height="1094" alt="image" src="https://github.com/user-attachments/assets/fd6cef6d-9b3d-42d1-8faf-c128323e6564" />
<img width="1724" height="1332" alt="image" src="https://github.com/user-attachments/assets/e85a9f1b-3f65-4b07-a9ce-40437c2e9b3e" />

### Expected behavior and the fix
Use the right link to the tutorial and it should navigate to it.