### PR TITLE
Clarify nested order

### DIFF
--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -570,7 +570,7 @@ You can also order by any attribute that is indexed and has a checked type.
 Add indexes and checked types to your attributes from the [Explorer on the Instant dashboard](/dash?t=explorer) or from the [cli with Schema-as-code](/docs/schema).
 {% /callout %}
 
-```javascript
+```typescript
 // Get the todos that are due next
 const query = {
   todos: {
@@ -581,6 +581,34 @@ const query = {
       },
       order: {
         dueDate: 'asc',
+      },
+    },
+  },
+};
+```
+
+Order is not supported on nested attributes. So if todos had an owner you could
+not order todos by "owner.name". This behavior is different from `where`,
+which supports filtering on nested attributes.
+
+```typescript
+// ❌ Order does not support nested attributes
+const query = {
+  todos: {
+    $: {
+      order: {
+        'owner.name': 'asc', // Cannot order by nested attributes
+      },
+    },
+  },
+};
+
+// ✅ Where does support filtering on nested attributes
+const query = {
+  todos: {
+    $: {
+      where: {
+        'owner.name': 'alyssa.p.hacker@instantdb.com',
       },
     },
   },


### PR DESCRIPTION
A user was surprised that they could use nested attributes for `where` but not for `order` -- clarifying that in the docs!

<img width="1298" height="1076" alt="CleanShot 2025-08-04 at 09 53 09@2x" src="https://github.com/user-attachments/assets/acd8c8ba-1ed8-4258-b490-d6db7095e317" />
