### PR TITLE
Adds a count-min-sketch implementation

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -88,7 +88,8 @@
 
         djblue/portal {:mvn/version "0.58.5"}
         dev.weavejester/medley {:mvn/version "1.8.1"}
-        com.hazelcast/hazelcast {:mvn/version "5.5.0"}}
+        com.hazelcast/hazelcast {:mvn/version "5.5.0"}
+        net.openhft/zero-allocation-hashing {:mvn/version "0.27ea1"}}
  :aliases {:dev {:extra-paths ["dev" "test" "dev-resources"]
                  :extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}
                               criterium/criterium           {:mvn/version "0.4.6"}

--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -1,0 +1,141 @@
+(ns instant.db.attr-sketch
+  (:require
+   [clojure.pprint]
+   [instant.db.model.triple :as triple])
+  (:import
+   (java.nio ByteBuffer)
+   (net.openhft.hashing LongHashFunction)))
+
+(set! *warn-on-reflection* true)
+
+(defrecord Sketch [width
+                   depth
+                   bins
+                   total
+                   total-not-binned])
+
+;; Update printer so that it doesn't print a ton numbers for the bins
+(defmethod clojure.pprint/simple-dispatch Sketch [x]
+  (let [bin-display (symbol (format "<bins %d>" (count (:bins x))))]
+    (#'clojure.pprint/pprint-map (into {} (assoc x :bins bin-display)))))
+
+(def ln2 (Math/log 2))
+
+(defn make-sketch
+  ([] (make-sketch {}))
+  ([{:keys [confidence error-rate]
+     :or {confidence 0.998
+          error-rate 0.001}}]
+   (let [width (int (Math/ceil (/ 2 error-rate)))
+         depth (int (Math/ceil (/ (* -1 (Math/log (- 1 confidence)))
+                                  ln2)))]
+     (map->Sketch {:width width
+                   :depth depth
+                   :bins (vec (repeat (* width depth) 0))
+                   :total 0
+                   :total-not-binned 0}))))
+
+(defn data-type-for-hash [checked-data-type x]
+  (case checked-data-type
+    :number (condp instance? x
+              java.lang.Long [:long x]
+              java.lang.Integer [:integer x]
+              java.lang.Double [:double x])
+    :string [:string x]
+    :boolean [:boolean x]
+    :date [:long (.toEpochMilli (triple/parse-date-value x))]
+
+    (condp instance? x
+      java.lang.Long [:long x]
+      java.lang.Integer [:integer x]
+      java.lang.String [:string x]
+      java.lang.Boolean [:boolean x]
+      ;; Use string as the universal format for uuids for the purpose of
+      ;; the sketch. We could use bytes, but this will still work if the
+      ;; uuid gets passed to us as a string somehow
+      java.util.UUID [:string (str x)]
+      nil)))
+
+(defn hash-val [^Long seed ^Long hash-idx data-type val]
+  (let [xx (LongHashFunction/xx3 (+ seed hash-idx))]
+    (case data-type
+      :long (.hashLong xx val)
+      :integer (.hashInt xx val)
+      :double (.hashBytes xx (.. (ByteBuffer/allocate 8)
+                                 (putDouble val)
+                                 (array)))
+      :string (.hashChars xx ^String val)
+      :boolean (.hashBoolean xx val))))
+
+(defn add
+  ([^Sketch sketch checked-data-type v]
+   (add sketch checked-data-type v 1))
+  ([^Sketch sketch checked-data-type v_ n]
+   (if-let [[data-type v] (data-type-for-hash checked-data-type v_)]
+     ;; Only track counts for the items that you can query for
+     (let [seed (hash-val 0 -1 data-type v)
+           bins (persistent!
+                  (reduce (fn [bins i]
+                            (let [hash (hash-val seed i data-type v)
+                                  bin-idx (int (+ (Long/remainderUnsigned hash
+                                                                          (:width sketch))
+                                                  (* i (:width sketch))))]
+                              (assoc! bins bin-idx (+ (get bins bin-idx)
+                                                      n))))
+                          (transient (:bins sketch))
+                          (range (:depth sketch))))]
+       (-> sketch
+           (update :total + n)
+           (assoc :bins bins)))
+     ;; Track totals even if you can't query for the item
+     (-> sketch
+         (update :total + n)
+         (update :total-not-binned + n)))))
+
+(defn add-batch
+  "Expects items to be a map of {:value, :checked-data-type} => n, will add all
+   items to the sketch in a single batch."
+  ([^Sketch sketch items]
+   (let [{:keys [bins item-count not-binned-count]}
+         (persistent!
+           (reduce-kv (fn [acc {:keys [value checked-data-type]} n]
+                        (if-let [[data-type v] (data-type-for-hash checked-data-type value)]
+                          (let [seed (hash-val 0 -1 data-type v)
+                                bins (reduce (fn [bins i]
+                                               (let [hash (hash-val seed i data-type v)
+                                                     bin-idx (int (+ (Long/remainderUnsigned hash
+                                                                                             (:width sketch))
+                                                                     (* i (:width sketch))))]
+                                                 (assoc! bins bin-idx (+ n (get bins bin-idx)))))
+                                             (:bins acc)
+                                             (range (:depth sketch)))]
+                            (-> acc
+                                (assoc! :bins bins)
+                                (assoc! :item-count (+ (:item-count acc) n))))
+                          (-> acc
+                              (assoc! :item-count (+ (:item-count acc) n))
+                              (assoc! :not-binned-count (+ (:not-binned-count acc) n)))))
+                      (transient {:bins (transient (:bins sketch))
+                                  :item-count 0
+                                  :not-binned-count 0})
+                      items))]
+     (-> sketch
+         (update :total + item-count)
+         (update :total-not-binned + not-binned-count)
+         (assoc :bins (persistent! bins))))))
+
+(defn check [^Sketch sketch checked-data-type val_]
+  (let [[data-type val] (data-type-for-hash checked-data-type val_)
+        _ (assert data-type (format "Unknown data for sketch %s" val))
+        seed (hash-val 0 -1 data-type val)]
+    (reduce (fn [m i]
+              (let [hash (hash-val seed i data-type val)
+                    bin-idx (int (+ (Long/remainderUnsigned hash
+                                                            (:width sketch))
+                                    (* i (:width sketch))))
+                    bin-val (nth (:bins sketch) bin-idx)]
+                (if m
+                  (min bin-val m)
+                  bin-val)))
+            nil
+            (range (:depth sketch)))))

--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -39,15 +39,18 @@
   (case checked-data-type
     :number (condp instance? x
               java.lang.Long [:long x]
-              java.lang.Integer [:integer x]
+              java.lang.Integer [:long (long x)]
               java.lang.Double [:double x])
-    :string [:string x]
-    :boolean [:boolean x]
+    :string (do (assert (string? x))
+                [:string x])
+    :boolean (do (assert (boolean? x))
+                 [:boolean x])
     :date [:long (.toEpochMilli (triple/parse-date-value x))]
 
     (condp instance? x
       java.lang.Long [:long x]
-      java.lang.Integer [:integer x]
+      java.lang.Integer [:long (long x)]
+      java.lang.Double [:double x]
       java.lang.String [:string x]
       java.lang.Boolean [:boolean x]
       ;; Use string as the universal format for uuids for the purpose of
@@ -60,7 +63,6 @@
   (let [xx (LongHashFunction/xx3 (+ seed hash-idx))]
     (case data-type
       :long (.hashLong xx val)
-      :integer (.hashInt xx val)
       :double (.hashBytes xx (.. (ByteBuffer/allocate 8)
                                  (putDouble val)
                                  (array)))

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1074,9 +1074,10 @@
         join-cost (reduce + 0 (vals (:join-remaining costs)))
         filter-cost (reduce + 0 (vals (select-keys (:known-remaining costs)
                                                    (:filter-components costs))))]
-    (* 1.0 (* (+ path-cost
-                 (* 2 filter-cost))
-              (max 1 join-cost)))))
+    (* 1.0
+       (+ path-cost
+          (* 2 filter-cost))
+       (max 1 join-cost))))
 
 (defn index-compare
   "Compares the indexes pairwise to try to pick the best one.

--- a/server/test/instant/db/attr_sketch_test.clj
+++ b/server/test/instant/db/attr_sketch_test.clj
@@ -66,3 +66,21 @@
     (is (= 10 (cms/check sketch :string "hi")))
 
     (is (= 10 (cms/check sketch nil "hi")))))
+
+(deftest the-sketch-hash-is-stable
+  (let [sketch (-> (cms/make-sketch {:confidence 0.8
+                                     :error-rate 0.1})
+                   (cms/add nil 1)
+                   (cms/add nil "1")
+                   (cms/add :date 0)
+                   (cms/add nil true)
+                   (cms/add nil #uuid "c8ae4358-8da2-49c4-b93d-0f294e817383")
+                   (cms/add nil (int 2))
+                   (cms/add nil 1.8)
+                   (cms/add nil {:json :value}))]
+    (is (= 8 (:total sketch)))
+    (is (= 1 (:total-not-binned sketch)))
+    (is (= [0 1 1 0 0 0 0 0 2 0 0 0 0 0 0 1 0 1 0 1
+            1 0 1 0 0 1 0 1 0 1 0 0 1 0 0 1 0 0 0 0
+            0 0 0 1 2 0 0 0 0 0 0 0 1 1 0 0 0 0 1 1]
+           (:bins sketch)))))

--- a/server/test/instant/db/attr_sketch_test.clj
+++ b/server/test/instant/db/attr_sketch_test.clj
@@ -1,0 +1,68 @@
+(ns instant.db.attr-sketch-test
+  (:require [clojure.test :as test :refer [deftest is]]
+            [instant.db.attr-sketch :as cms]))
+
+(deftest sketch-returns-counts
+  (let [sketch (cms/make-sketch)
+        ;; Adds 0 zeroes, 1 ones, 2 twos, etc. up to 100
+        populated-sketch (reduce (fn [sketch i]
+                                   (cms/add sketch nil i i))
+                                 sketch
+                                 (range 100))]
+    (doseq [i (range 100)]
+      (is (= i (cms/check populated-sketch nil i))))
+    (is (= 0 (cms/check populated-sketch nil -1)))))
+
+(deftest sketch-normalizes-dates
+  (let [sketch (-> (cms/make-sketch)
+                   (cms/add :date 0))]
+    (is (= 1
+           (cms/check sketch :date "1970-01-01T00:00:00Z")))
+    (is (= 0
+           (cms/check sketch :date 1)))))
+
+(deftest sanity-check
+  (let [sketch (cms/make-sketch {:confidence 0.9
+                                 :error-rate 0.1})]
+    (is (= 20 (:width sketch)))
+    (is (= 4 (:depth sketch)))
+    (is (= 80 (count (:bins sketch))))
+    (is (= 0 (:total sketch)))
+    (is (every? zero? (:bins sketch)))
+
+    (is (= 1 (:total (cms/add sketch nil "val"))))))
+
+(deftest ignores-values-we-cant-match-on
+  (let [sketch (-> (cms/make-sketch)
+                   (cms/add nil 1)
+                   (cms/add nil {:json :data}))]
+    (is (= 2 (:total sketch)))
+    (is (thrown-with-msg? AssertionError
+                          #"Unknown data"
+                          (cms/check sketch nil {:json :data})))
+    (is (= 1 (:total-not-binned sketch)))))
+
+(deftest add-batch
+  (let [sketch (-> (cms/make-sketch)
+                   (cms/add-batch {{:value 1
+                                    :checked-data-type nil} 5
+
+                                   {:value {:json :data}
+                                    :checked-data-type nil} 2
+
+                                   {:value 0
+                                    :checked-data-type :date} 4
+
+                                   {:value "hi"
+                                    :checked-data-type :string} 10}))]
+    (is (= 21 (:total sketch)))
+
+    (is (= 5 (cms/check sketch nil 1)))
+
+    (is (= 2 (:total-not-binned sketch)))
+
+    (is (= 4 (cms/check sketch :date 0)))
+
+    (is (= 10 (cms/check sketch :string "hi")))
+
+    (is (= 10 (cms/check sketch nil "hi")))))


### PR DESCRIPTION
I'm pulling apart this PR into smaller pieces to make it easier to review: https://github.com/instantdb/instant/pull/1458

This PR adds a [count-min-sketch](https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch) implementation with some tests.

It uses [xxhash](https://xxhash.com/) for hashing the inputs, which seems to be a popular choice because it is fast and it's easy to create a bunch of pairwise-independent hashes by incrementing the seed.

When we put items in the sketch, we use the `checked-data-type` to let us normalize dates. If we didn't do that then we would return the wrong result if a user put 0 in the db, but then queried for "1970-01-01T00:00:00Z". When you add a checked-data-type to an existing column, we'll see that change in the wal listener. We'll remove the old value from the sketch and add the new value with the new type.

