### PR TITLE
Adds support for postgres copy out

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources" "data" "target/classes"]
- :deps {cheshire/cheshire {:mvn/version "5.10.0"}
+ :deps {cheshire/cheshire {:mvn/version "6.0.0"}
         clj-http/clj-http {:mvn/version "3.12.3"}
 
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.981"}
@@ -60,11 +60,11 @@
         com.github.steffan-westcott/clj-otel-api {:mvn/version "0.2.4"}
 
         dev.cel/cel {:mvn/version "0.9.1"}
-        com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.6"}
+        com.fasterxml.jackson.core/jackson-core {:mvn/version "2.18.3"}
         com.google.crypto.tink/tink {:mvn/version "1.12.0"}
         com.google.crypto.tink/tink-awskms {:mvn/version "1.9.1"}
         ;; Version required by aws kms library pulled in by tink
-        com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.12.7.2"}
+        com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.18.3"}
 
         lambdaisland/uri {:mvn/version "1.19.155"}
         lambdaisland/deep-diff2 {:mvn/version "2.12.219"

--- a/server/src/instant/jdbc/copy.clj
+++ b/server/src/instant/jdbc/copy.clj
@@ -1,0 +1,181 @@
+(ns instant.jdbc.copy
+  (:require
+   [instant.util.json :as json])
+  (:import
+   (java.nio ByteBuffer)
+   (java.time Duration Instant LocalDate ZoneOffset)
+   (java.util UUID)
+   (org.postgresql.jdbc PgConnection)))
+
+;; ------------------
+;; Decoders for types
+
+;; binary decoders that consume the input
+
+(defn- advance-buf [^ByteBuffer bb ^Integer len]
+  (.position bb (int (+ (.position bb) len))))
+
+(defn- bin-decode-uuid [^ByteBuffer bb ^Integer byte-len]
+  (when (not= byte-len 16)
+    (throw (ex-info "Invalid byte length for uuid" {:byte-len byte-len})))
+  (UUID. (.getLong bb) (.getLong bb)))
+
+(defn- bin-decode-text [^ByteBuffer bb ^Integer byte-len]
+  (let [res (String. (.array bb) (.position bb) byte-len "UTF-8")]
+    (advance-buf bb byte-len)
+    res))
+
+(defn- bin-decode-json [^ByteBuffer bb ^Integer byte-len]
+  (let [res (json/parse-bytes (.array bb) (.position bb) byte-len)]
+    (advance-buf bb byte-len)
+    res))
+
+(defn- bin-decode-jsonb [^ByteBuffer bb ^Integer byte-len]
+  ;; jsonb starts with a version byte, then the data comes after
+  (let [version (.get bb)]
+    (when (not= 1 version)
+      (throw (ex-info "Invalid version byte for jsonb" {:version version}))))
+  (bin-decode-json bb (dec byte-len)))
+
+(def pg-diff (Duration/between Instant/EPOCH
+                               (.atStartOfDay (LocalDate/of 2000 1 1)
+                                              ZoneOffset/UTC)))
+
+(def pg-diff-seconds (.toSeconds ^Duration pg-diff))
+
+(defn- bin-decode-timestamptz [^ByteBuffer bb ^Integer byte-len]
+  (when (not= byte-len 8)
+    (throw (ex-info "Invalid byte length for timestamptz" {:byte-len byte-len})))
+  (let [secs-and-micros (.getLong bb)
+        secs (+ (/ secs-and-micros 1000000) pg-diff-seconds)
+        nanos (* (mod secs-and-micros 1000000) 1000)]
+    (Instant/ofEpochSecond secs nanos)))
+
+(defn- bin-decode-boolean [^ByteBuffer bb ^Integer byte-len]
+  (when (not= byte-len 1)
+    (throw (ex-info "Invalid byte length for boolean" {:byte-len byte-len})))
+  (case (.get bb)
+    0 false
+    1 true))
+
+(defn- bin-decode-integer [^ByteBuffer bb ^Integer byte-len]
+  (when (not= byte-len 4)
+    (throw (ex-info "Invalid byte length for integer" {:byte-len byte-len})))
+  (.getInt bb))
+
+(defn- bin-decode-bigint [^ByteBuffer bb ^Integer byte-len]
+  (when (not= byte-len 8)
+    (throw (ex-info "Invalid byte length for bigint" {:byte-len byte-len})))
+  (.getLong bb))
+
+(defn- bin-decode-checked-data-type [^ByteBuffer bb ^Integer byte-len]
+  (keyword (bin-decode-text bb byte-len)))
+
+;; Check https://github.com/igrishaev/pg2/tree/master/pg-core/src/java/org/pg/processor
+;; for the format when adding a new decoder.
+(defn- bin-decode [^ByteBuffer bb pgtype ^Integer byte-len]
+  (case pgtype
+    "uuid" (bin-decode-uuid bb byte-len)
+    "text" (bin-decode-text bb byte-len)
+    "json" (bin-decode-json bb byte-len)
+    "jsonb" (bin-decode-jsonb bb byte-len)
+    "timestamptz" (bin-decode-timestamptz bb byte-len)
+    "boolean" (bin-decode-boolean bb byte-len)
+    "integer" (bin-decode-integer bb byte-len)
+    "bigint" (bin-decode-bigint bb byte-len)
+    "checked_data_type" (bin-decode-checked-data-type bb byte-len)))
+
+;; ------------
+;; Row decoding
+
+(def signature-bytes (byte-array [(byte \P)
+                                  (byte \G)
+                                  (byte \C)
+                                  (byte \O)
+                                  (byte \P)
+                                  (byte \Y)
+                                  (byte \newline)
+                                  -1
+                                  (byte \return)
+                                  (byte \newline)
+                                  0]))
+
+(defn- advance-header [^ByteBuffer bb]
+  (doseq [expected signature-bytes
+          :let [actual (.get bb)]]
+    (when (not= expected actual)
+      (throw (ex-info "Invalid signature byte" {:expected expected
+                                                :actual actual}))))
+
+  (let [flags (.getInt bb)]
+    (when (not= 0 flags)
+      (throw (ex-info "Invalid flags field" {:expected 0
+                                             :actual flags}))))
+
+  (let [extension-length (.getInt bb)]
+    (.position bb (+ (.position bb) extension-length))))
+
+(defn- decode-row [^ByteBuffer bb columns]
+  (let [field-count (.getShort bb)]
+    (if (= -1 field-count)
+      nil
+      (do (when-not (= (count columns) field-count)
+            (throw (ex-info "Invalid number of columns" {:field-count field-count
+                                                         :column-count (count columns)})))
+          (persistent!
+            (reduce (fn [m {:keys [name pgtype]}]
+                      (let [field-length (.getInt bb)]
+                        (if (= -1 field-length)
+                          (assoc! m name nil)
+                          (assoc! m name (bin-decode bb pgtype field-length)))))
+                    (transient {})
+                    columns))))))
+
+;; -------
+;; Reducer
+
+(defn- copy-reduce [^PgConnection conn copy-query columns f init]
+  (let [out (.copyOut (.getCopyAPI conn) copy-query)
+        format (.getFormat out)]
+    (when (not= 1 format)
+      (throw (ex-info "Expected copy query to be in binary format." {:format format})))
+    ;; Docs on binary format
+    ;; https://www.postgresql.org/docs/current/sql-copy.html#id-1.9.3.55.9.4
+    ;; First row includes a header and the first row of data
+    (let [bb (ByteBuffer/wrap (.readFromCopy out))]
+      (advance-header bb)
+      (loop [init' init
+             bb bb]
+        (if-let [row (decode-row bb columns)]
+          (let [result (f init' row)]
+            (if (reduced? result)
+              @result
+              (if-let [next-read (.readFromCopy out)]
+                (recur result (ByteBuffer/wrap next-read))
+                result)))
+          ;; We got -1 to indicate end of stream,
+          ;; next-read should be nil
+          (if-let [next-read (.readFromCopy out)]
+            (recur init' (ByteBuffer/wrap next-read))
+            init'))))))
+
+(defn copy-reducer
+  "Modeleted after next-jdbc/plan, returns a reducer.
+
+   copy-query must be in format:
+     `copy table to stdout with (format binary)`
+   You can do a select with:
+     `copy (select id, field from table) to stdout with (format binary)`
+
+   Columns should be a list of {:name, :pgtype} maps and must be in the same
+   order as the data that the query returns.
+   See bin-decode for the list of supported types.
+
+   Open a new connection to be used with copy and close it afterwards.
+   Don't use one from the Hikari pool. The connection might be left in
+   an invalid state if the copy operation ends prematurely."
+  [^PgConnection conn copy-query columns]
+  (reify
+    clojure.lang.IReduceInit
+    (reduce [_ f init]
+      (copy-reduce conn copy-query columns f init))))

--- a/server/src/instant/util/json.clj
+++ b/server/src/instant/util/json.clj
@@ -1,9 +1,11 @@
 (ns instant.util.json
   (:require [cheshire.core :as cheshire]
-            [cheshire.generate :refer [add-encoder encode-nil encode-str]])
+            [cheshire.generate :refer [add-encoder encode-nil encode-str]]
+            [cheshire.factory :as factory]
+            [cheshire.parse :as parse])
   (:import (com.google.protobuf NullValue)
            (dev.cel.expr Value)
-           (com.fasterxml.jackson.core JsonGenerator)
+           (com.fasterxml.jackson.core JsonGenerator JsonFactory)
            (com.google.protobuf.util JsonFormat)
            (java.time Instant)))
 
@@ -28,6 +30,16 @@
 (def <-json
   "Converts a JSON string to a Clojure data structure."
   cheshire/parse-string)
+
+(defn parse-bytes [^bytes bytes ^Integer offset ^Integer len]
+  (parse/parse
+   (.createParser ^JsonFactory (or factory/*json-factory*
+                                   factory/json-factory)
+                  bytes
+                  offset
+                  len)
+   nil nil nil))
+
 
 (defn json-type-of-clj [v]
   (cond (string? v)

--- a/server/test/instant/jdbc/copy_test.clj
+++ b/server/test/instant/jdbc/copy_test.clj
@@ -1,0 +1,149 @@
+(ns instant.jdbc.copy-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [honey.sql :as hsql]
+   [instant.config :as config]
+   [instant.fixtures :refer [with-zeneca-app]]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.copy :as copy]
+   [instant.jdbc.sql :as sql]
+   [instant.jdbc.wal :refer [jdbc-password jdbc-username]]
+   [next.jdbc.connection :refer [jdbc-url]])
+  (:import
+   (java.sql DriverManager)
+   (java.util Properties)
+   (org.postgresql PGProperty)
+   (org.postgresql.jdbc PgConnection)))
+
+(defn get-copy-conn
+  "Creates a disposable connection for testing copy"
+  ^PgConnection []
+  (let [db-spec (config/get-aurora-config)
+        props (Properties.)
+        _ (do (.set PGProperty/USER props (jdbc-username db-spec))
+              (.set PGProperty/PASSWORD props (jdbc-password db-spec))
+              (.set PGProperty/REPLICATION props "database")
+              (.set PGProperty/ASSUME_MIN_SERVER_VERSION props "9.4")
+              (.set PGProperty/PREFER_QUERY_MODE props "simple"))
+        conn (DriverManager/getConnection (jdbc-url (-> db-spec
+                                                        (dissoc :user :password)))
+                                          props)]
+    (.unwrap conn PgConnection)))
+
+(deftest copy-works-with-triples
+  (with-zeneca-app
+    (fn [app _r]
+      (with-open [conn (get-copy-conn)]
+        (let [reducer (copy/copy-reducer conn
+                                         (format "copy (select app_id, entity_id, attr_id, value, value_md5, ea, eav, av, ave, vae, created_at, checked_data_type from triples where app_id = '%s') to stdout with (format binary)"
+                                                 (:id app))
+                                         [{:name :app_id
+                                           :pgtype "uuid"}
+                                          {:name :entity_id
+                                           :pgtype "uuid"}
+                                          {:name :attr_id
+                                           :pgtype "uuid"}
+                                          {:name :value
+                                           :pgtype "jsonb"}
+                                          {:name :value_md5
+                                           :pgtype "text"}
+                                          {:name :ea
+                                           :pgtype "boolean"}
+                                          {:name :eav
+                                           :pgtype "boolean"}
+                                          {:name :av
+                                           :pgtype "boolean"}
+                                          {:name :ave
+                                           :pgtype "boolean"}
+                                          {:name :vae
+                                           :pgtype "boolean"}
+                                          {:name :created_at
+                                           :pgtype "bigint"}
+                                          {:name :checked_data_type
+                                           :pgtype "checked_data_type"}])
+              copy-rows (time (persistent!
+                                (reduce (fn [rows row]
+                                          (conj! rows row))
+                                        (transient [])
+                                        reducer)))
+              select-rows (mapv (fn [row]
+                                  (update row :checked_data_type keyword))
+                                (sql/select (aurora/conn-pool :read)
+                                            (hsql/format {:select [:app_id
+                                                                   :entity_id
+                                                                   :attr_id
+                                                                   :value
+                                                                   :value_md5
+                                                                   :ea
+                                                                   :eav
+                                                                   :av
+                                                                   :ave
+                                                                   :vae
+                                                                   :created_at
+                                                                   :checked_data_type]
+                                                          :from :triples
+                                                          :where [:= :app-id :?app_id]}
+                                                         {:params {:app_id (:id app)}})))]
+          (is (= (set select-rows)
+                 (set copy-rows))))))))
+
+(deftest throws-on-invalid-query
+  (with-open [conn (get-copy-conn)]
+    (is (thrown-with-msg? Exception
+                          #"binary format"
+                          (reduce (fn [x _row]
+                                    x)
+                                  0
+                                  (copy/copy-reducer conn
+                                                     "copy config to stdout"
+                                                     []))))))
+
+(deftest handles-all-of-the-types
+  (with-open [conn (get-copy-conn)]
+    (let [query "copy (select 'ab3f1923-f604-49c2-bfa0-b30e062db84c'::uuid as uuid,
+                              'text'::text as text,
+                              '{\"json\": [null, 1, true, 5.0]}'::json as json,
+                              '{\"json\": [null, 1, true, 5.0]}'::jsonb as jsonb,
+                              '123456'::jsonb as jsonb_number,
+                              '123456'::json as json_number,
+                              triples_extract_date_value('0'::jsonb)::timestamptz as timestamptz,
+                              true::boolean as boolean,
+                              1::int as integer,
+                              99999999999999999::bigint as bigint,
+                              'date'::checked_data_type as checked_data_type) to stdout (format binary)"
+          result (reduce (fn [_ row]
+                           row)
+                         nil
+                         (copy/copy-reducer conn query [{:name :uuid
+                                                         :pgtype "uuid"}
+                                                        {:name :text
+                                                         :pgtype "text"}
+                                                        {:name :json
+                                                         :pgtype "json"}
+                                                        {:name :jsonb
+                                                         :pgtype "jsonb"}
+                                                        {:name :jsonb_number
+                                                         :pgtype "jsonb"}
+                                                        {:name :json_number
+                                                         :pgtype "json"}
+                                                        {:name :timestamptz
+                                                         :pgtype "timestamptz"}
+                                                        {:name :boolean
+                                                         :pgtype "boolean"}
+                                                        {:name :integer
+                                                         :pgtype "integer"}
+                                                        {:name :bigint
+                                                         :pgtype "bigint"}
+                                                        {:name :checked_data_type
+                                                         :pgtype "checked_data_type"}]))]
+      (is (= result {:uuid #uuid "ab3f1923-f604-49c2-bfa0-b30e062db84c"
+                     :text "text"
+                     :json {"json" [nil 1 true 5.0]}
+                     :jsonb {"json" [nil 1 true 5.0]}
+                     :json_number 123456
+                     :jsonb_number 123456
+                     :timestamptz #instant "1970-01-01T00:00:00Z"
+                     :boolean true
+                     :integer 1
+                     :bigint 99999999999999999
+                     :checked_data_type :date})))))

--- a/server/test/instant/jdbc/copy_test.clj
+++ b/server/test/instant/jdbc/copy_test.clj
@@ -11,6 +11,7 @@
    [next.jdbc.connection :refer [jdbc-url]])
   (:import
    (java.sql DriverManager)
+   (java.time Instant)
    (java.util Properties)
    (org.postgresql PGProperty)
    (org.postgresql.jdbc PgConnection)))
@@ -142,7 +143,7 @@
                      :jsonb {"json" [nil 1 true 5.0]}
                      :json_number 123456
                      :jsonb_number 123456
-                     :timestamptz #instant "1970-01-01T00:00:00Z"
+                     :timestamptz (Instant/parse "1970-01-01T00:00:00Z")
                      :boolean true
                      :integer 1
                      :bigint 99999999999999999


### PR DESCRIPTION
This adds support for postgres copy. We'll use this to populate the attr sketches when we first create the new logical replication slot for the aggregator.

It also upgrades cheshire and jackson to fix a bug with parsing bytes. I looked through the change history and didn't see any breaking changes in the documentation that would affect us.

When we create the replication slot, postgres will give us a snapshot identifier. We can use that snapshot identifier to call `set transaction snapshot :snapshot-id` and get a view into the database as of the time that the snapshot was created. Then we can call `copy` on that connection to fetch all of the triples and build up the attr sketches. Once the sketches are saved, we can start listening to changes on the new slot. This will give us a consistent view of the database without any missing data in the sketches.

In the future, we may also be able to use copy for things like exports, but I've found it to be a bit flaky. You can't used it with the conn-pool, because if it's not closed properly (if there is an error, there doesn't seem to be a way to close it properly without closing the underlying connection), then it will cause subsequent queries to fail.