### PR TITLE
Validate pagination params are only used at top level

### DIFF
--- a/client/packages/core/__tests__/src/queryValidation.test.ts
+++ b/client/packages/core/__tests__/src/queryValidation.test.ts
@@ -824,3 +824,162 @@ test('where clause dot notation validation', () => {
     users: { $: { where: { 'posts.comments': 'not-a-uuid' } } },
   });
 });
+
+test('pagination parameters can only be used at top-level namespaces', () => {
+  const cursor = ['cursor', 'data', 'value', 1];
+
+  beValid({
+    posts: {
+      $: {
+        limit: 10,
+      },
+    },
+  });
+
+  beValid({
+    posts: {
+      $: {
+        offset: 20,
+      },
+    },
+  });
+
+  beValid({
+    posts: {
+      $: {
+        before: cursor,
+      },
+    },
+  });
+
+  beValid({
+    posts: {
+      $: {
+        after: cursor,
+      },
+    },
+  });
+
+  beValid({
+    posts: {
+      $: {
+        first: 5,
+      },
+    },
+  });
+
+  beValid({
+    posts: {
+      $: {
+        last: 5,
+      },
+    },
+  });
+
+  // Valid - multiple pagination params at top-level
+  beValid({
+    users: {
+      $: {
+        limit: 5,
+        offset: 10,
+      },
+      posts: {
+        $: {
+          where: { title: 'Test' },
+        },
+      },
+    },
+  });
+
+  // Invalid - pagination params in nested namespace
+  beWrong({
+    users: {
+      posts: {
+        $: {
+          limit: 10,
+        },
+      },
+    },
+  });
+
+  beWrong({
+    users: {
+      posts: {
+        $: {
+          offset: 10,
+        },
+      },
+    },
+  });
+
+  beWrong({
+    users: {
+      posts: {
+        $: {
+          before: cursor,
+        },
+      },
+    },
+  });
+
+  beWrong({
+    users: {
+      posts: {
+        $: {
+          after: cursor,
+        },
+      },
+    },
+  });
+
+  beWrong({
+    users: {
+      posts: {
+        $: {
+          first: 5,
+        },
+      },
+    },
+  });
+
+  beWrong({
+    users: {
+      posts: {
+        $: {
+          last: 5,
+        },
+      },
+    },
+  });
+
+  // Invalid - multiple pagination params in deeply nested namespace
+  beWrong({
+    users: {
+      posts: {
+        comments: {
+          $: {
+            limit: 5,
+            offset: 10,
+            first: 3,
+          },
+        },
+      },
+    },
+  });
+
+  // Valid - multiple top-level entities with different pagination params
+  beValid({
+    posts: {
+      $: {
+        limit: 10,
+        offset: 5,
+      },
+    },
+    users: {
+      $: {
+        first: 20,
+        after: cursor,
+      },
+    },
+  });
+});

--- a/client/packages/core/src/queryValidation.ts
+++ b/client/packages/core/src/queryValidation.ts
@@ -391,7 +391,7 @@ const validateDollarObject = (
   for (const param of paginationParams) {
     if (dollarObj[param] !== undefined && !isTopLevel) {
       throw new QueryValidationError(
-        `'${param}' can only be used on top-level namespaces. It cannot be used in nested queries at path: ${path}`,
+        `'${param}' can only be used on top-level namespaces. It cannot be used in nested queries.`,
         path,
       );
     }

--- a/client/packages/core/src/queryValidation.ts
+++ b/client/packages/core/src/queryValidation.ts
@@ -368,7 +368,7 @@ const validateDollarObject = (
   entityName: string,
   schema?: IContainEntitiesAndLinks<any, any>,
   path?: string,
-  isTopLevel: boolean = false,
+  depth: number = 0,
 ): void => {
   for (const key of Object.keys(dollarObj)) {
     if (!dollarSignKeys.includes(key)) {
@@ -389,7 +389,7 @@ const validateDollarObject = (
     'last',
   ];
   for (const param of paginationParams) {
-    if (dollarObj[param] !== undefined && !isTopLevel) {
+    if (dollarObj[param] !== undefined && depth > 0) {
       throw new QueryValidationError(
         `'${param}' can only be used on top-level namespaces. It cannot be used in nested queries.`,
         path,
@@ -418,7 +418,7 @@ const validateEntityInQuery = (
   entityName: string,
   schema: IContainEntitiesAndLinks<any, any>,
   path: string,
-  isTopLevel: boolean = false,
+  depth: number = 0,
 ): void => {
   if (!queryPart || typeof queryPart !== 'object') {
     throw new QueryValidationError(
@@ -449,7 +449,7 @@ const validateEntityInQuery = (
             linkedEntityName,
             schema,
             `${path}.${key}`,
-            false, // nested queries are never top-level
+            depth + 1,
           );
         }
       }
@@ -468,7 +468,7 @@ const validateEntityInQuery = (
         entityName,
         schema,
         `${path}.$`,
-        isTopLevel,
+        depth,
       );
     }
   }
@@ -527,7 +527,7 @@ export const validateQuery = (
       topLevelKey,
       schema,
       topLevelKey,
-      true, // This is a top-level entity
+      0, // Start at depth 0 for top-level entities
     );
   }
 };

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.20.19';
+const version = 'v0.20.20';
 
 export { version };


### PR DESCRIPTION
What it says on the tin!

For the query

```typescript
const todosQuery = {
  todos: {
    owner: { $: { limit: 1 } },
  },
} satisfies InstaQLParams<AppSchema>;
```

<img width="1926" height="1574" alt="CleanShot 2025-08-06 at 14 13 23@2x" src="https://github.com/user-attachments/assets/0a9db602-07e6-44c5-a815-e24f313037cd" />

