### PR TITLE
[Docs] Clarify order can be used in nested namespace

### DIFF
--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -546,7 +546,7 @@ const loadPreviousPage = () => {
 
 ### Ordering
 
-The default ordering is by the time the objects were created, in ascending order. You can change the order with the `order` key in the option map for top-level namespaces:
+The default ordering is by the time the objects were created, in ascending order. You can change the order with the `order` key in the option map for namespaces:
 
 ```javascript
 const query = {
@@ -581,6 +581,23 @@ const query = {
       },
       order: {
         dueDate: 'asc',
+      },
+    },
+  },
+};
+```
+
+You can use order in nested namespaces as well:
+
+```typescript
+// Get goals with their associated todos ordered by due date
+const query = {
+  goals: {
+    todos: {
+      $: {
+        order: {
+          dueDate: 'asc',
+        },
       },
     },
   },


### PR DESCRIPTION
The docs said order can only be used in top-level namespaces but it can be used in nested namespaces. Clarifying that here!