### PR TITLE
Made sweeper compatible with clj-reload

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -28,7 +28,7 @@
         software.amazon.awssdk.crt/aws-crt {:mvn/version "0.33.11"}
 
         juji/editscript {:mvn/version "0.6.4"}
-        io.github.tonsky/clojure-plus {:mvn/version "1.6.1"}
+        io.github.tonsky/clojure-plus {:mvn/version "1.6.3"}
 
         org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
 

--- a/server/src/instant/dash/ephemeral_app.clj
+++ b/server/src/instant/dash/ephemeral_app.clj
@@ -132,6 +132,12 @@
   (stop)
   (start))
 
+(defn before-ns-unload []
+  (stop))
+
+(defn after-ns-reload []
+  (start))
+
 (comment
   (def res (http-post-handler {:body {:title "my-app"}}))
   (def ex-app (:app (:body res)))

--- a/server/src/instant/storage/sweeper.clj
+++ b/server/src/instant/storage/sweeper.clj
@@ -153,3 +153,9 @@
 (defn restart []
   (stop)
   (start))
+
+(defn before-ns-unload []
+  (stop))
+
+(defn after-ns-reload []
+  (start))


### PR DESCRIPTION
Minor. Fixes this exception on long-running sessions:

```
Error running scheduled fn
java.lang.IllegalArgumentException: No implementation of method: :get-connection of protocol: #'next.jdbc.protocols/Connectable found for class: nil
        at clojure.core$_cache_protocol_fn.invokeStatic(core_deftype.clj:585)
        at clojure.core$_cache_protocol_fn.invoke(core_deftype.clj:577)
        at next.jdbc.protocols$eval24451$fn__24452$G__24442__24459.invoke(protocols.clj:25)
        at next.jdbc$get_connection.invokeStatic(jdbc.clj:169)
        at next.jdbc$get_connection.invoke(jdbc.clj:148)
        at instant.jdbc.sql$execute_BANG_.invokeStatic(sql.clj:456)
        at instant.jdbc.sql$execute_BANG_.invoke(sql.clj:456)
        at instant.jdbc.sql$execute_BANG_.invokeStatic(sql.clj:456)
        at instant.jdbc.sql$execute_BANG_.invoke(sql.clj:456)
        at instant.storage.sweeper$claim_files_BANG_.invokeStatic(sweeper.clj:46)
        at instant.storage.sweeper$claim_files_BANG_.invoke(sweeper.clj:42)
        at instant.storage.sweeper$process_sweep_BANG_.invokeStatic(sweeper.clj:83)
        at instant.storage.sweeper$process_sweep_BANG_.invoke(sweeper.clj:78)
        at instant.storage.sweeper$handle_sweep_BANG_.invokeStatic(sweeper.clj:116)
        at instant.storage.sweeper$handle_sweep_BANG_.invoke(sweeper.clj:106)
        at instant.storage.sweeper$handle_sweep_BANG_.invokeStatic(sweeper.clj:107)
        at instant.storage.sweeper$handle_sweep_BANG_.invoke(sweeper.clj:106)
        at instant.storage.sweeper$start$fn__69461$fn__69462.invoke(sweeper.clj:146)
        at clojure.lang.AFn.applyToHelper(AFn.java:154)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1990)
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1990)
        at clojure.lang.RestFn.applyTo(RestFn.java:145)
        at clojure.core$apply.invokeStatic(core.clj:671)
        at clojure.core$bound_fn_STAR_$fn__5837.doInvoke(core.clj:2020)
        at clojure.lang.RestFn.invoke(RestFn.java:411)
        at chime.core$chime_at$schedule_loop__35007$task__35011$fn__35012.invoke(core.clj:100)
        at chime.core$chime_at$schedule_loop__35007$task__35011.invoke(core.clj:99)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1570)
        Suppressed: instant.SpanTrackException: 57bb218bab35cc6e
```