### PR TITLE
Tweak llm rules

### DIFF
--- a/client/www/lib/intern/llm-example/app/page.tsx
+++ b/client/www/lib/intern/llm-example/app/page.tsx
@@ -528,7 +528,7 @@ function PostList({ posts }: { posts: PostsWithProfile[] }) {
 
 function App() {
   return (
-    <>
+    <div>
       <db.SignedIn>
         <EnsureProfile>
           <Main />
@@ -537,7 +537,7 @@ function App() {
       <db.SignedOut>
         <Login />
       </db.SignedOut>
-    </>
+    </div>
   );
 }
 

--- a/client/www/lib/intern/llm-example/llm-rules-template.md
+++ b/client/www/lib/intern/llm-example/llm-rules-template.md
@@ -34,7 +34,9 @@ Sections:
 ═══════════════════════════════════════════════════════════════════════════════
 -->
 
-## <!-- SECTION: CURSOR_FRONTMATTER -->
+<!-- SECTION: CURSOR_FRONTMATTER -->
+
+---
 
 description:
 globs:
@@ -42,7 +44,9 @@ alwaysApply: true
 
 ---
 
-## <!-- SECTION: WINDSURF_FRONTMATTER -->
+<!-- SECTION: WINDSURF_FRONTMATTER -->
+
+---
 
 trigger: always_on
 description: How to use InstantDB

--- a/client/www/pages/intern/llm-example.tsx
+++ b/client/www/pages/intern/llm-example.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import App from '@/lib/intern/llm-example/app/page';
+import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
 import { useAdmin } from '@/lib/auth';
 
 function Page() {
   const { isAdmin, isLoading, error } = useAdmin();
+  const isHydrated = useIsHydrated();
 
-  if (isLoading) {
-    return null;
+  if (!isHydrated || isLoading) {
+    return <div></div>;
   }
 
   if (error || !isAdmin) {

--- a/client/www/pages/tutorial.tsx
+++ b/client/www/pages/tutorial.tsx
@@ -421,8 +421,8 @@ export default function McpTutorial({ files }: MarkdownContent) {
           <FileContentCard
             title="Instant Rules for Cursor"
             content={cursorRulesContent}
-            filename=".cursor/rules/instant.md"
-            description="Click the button below to copy the rules for Instant and paste them into .cursor/rules/instant.md in the root of your project."
+            filename=".cursor/rules/instant.mdc"
+            description="Click the button below to copy the rules for Instant and paste them into .cursor/rules/instant.mdc in the root of your project."
           />
         </div>
       ),


### PR DESCRIPTION
Did a pass on the live tutorial and noticed a few fixes

* The frontmatter was off for cursor and windsurf
* Updated instructions for cursor to specify `.mdc` format
* Used `<div></div>` instead of `<></>` in App component.
* Fixed SSR issue for `intern/llm-example`