### PR TITLE
[RULES] Tweak seed rules

### DIFF
--- a/client/www/lib/intern/llm-example/app/page.tsx
+++ b/client/www/lib/intern/llm-example/app/page.tsx
@@ -108,6 +108,7 @@ function addShout({
 // Instant query Hooks
 // ---------
 function useProfile() {
+  // CRITICAL: useUser can only be used inside a db.SignedIn component
   const user = db.useUser();
   const { data, isLoading, error } = db.useQuery({
     profiles: {
@@ -259,7 +260,6 @@ function CodeStep({ sentEmail }: { sentEmail: string }) {
 }
 
 function EnsureProfile({ children }: { children: React.ReactNode }) {
-  // IMPORTANT: useUser can only be used inside a db.SignedIn component
   const user = db.useUser();
 
   const { isLoading, profile, error } = useProfile();
@@ -526,6 +526,7 @@ function PostList({ posts }: { posts: PostsWithProfile[] }) {
   );
 }
 
+// CRITICAL: Use db.SignedIn and db.SignedOut to handle authentication state
 function App() {
   return (
     <div>

--- a/client/www/lib/intern/llm-example/app/page.tsx
+++ b/client/www/lib/intern/llm-example/app/page.tsx
@@ -26,7 +26,7 @@ function randomHandle() {
 // Write Data
 // ---------
 async function createProfile(userId: string) {
-  // IMPORTANT: transact is how you write data to the database
+  // CRITICAL: transact is how you write data to the database
   // We want to block until the profile is created, so we use await
   await db.transact(
     db.tx.profiles[userId]
@@ -39,7 +39,7 @@ async function createProfile(userId: string) {
 
 function addPost(text: string, authorId: string | undefined) {
   db.transact(
-    // IMPORTANT: ids must be a valid UUID, so we use `id()` to generate one
+    // CRITICAL: ids must be a valid UUID, so we use `id()` to generate one
     db.tx.posts[id()]
       .update({
         text,

--- a/client/www/lib/intern/llm-example/llm-rules-template.md
+++ b/client/www/lib/intern/llm-example/llm-rules-template.md
@@ -76,10 +76,16 @@ and react native. Instant also offers a javascript admin SDK that can be used on
 the backend.
 
 If you want to use Instant with react you should only use `@instantdb/react`. For react-native you should
-only use `@instantdb/react-native`. For the admin SDK you should only use
+only use `@instantdb/react-native`. For scripts or server environments you should only use the admin SDK
 `@instantdb/admin`. For other client-side frameworks or vanilla js you should only use `@instantdb/core`
 
-You cannot use Instant on the backend outside of the admin SDK at the moment.
+CRITICAL: To use the admin SDK you MUST get an admin token for the app. You can
+get the admin token with the MCP tool via `create-app` or `get-app`. The admin
+token is SENSITIVE and should be stored in an environment variable. Do not
+hardcode it in your script.
+
+CRITICAL: If you want to create seed data YOU MUST write a script that uses the admin SDK.
+DO NOT try to seed data on the client.
 
 <!-- SECTION: APP_DESCRIPTION -->
 

--- a/client/www/lib/intern/llm-example/llm-rules-template.md
+++ b/client/www/lib/intern/llm-example/llm-rules-template.md
@@ -80,7 +80,7 @@ only use `@instantdb/react-native`. For scripts or server environments you shoul
 `@instantdb/admin`. For other client-side frameworks or vanilla js you should only use `@instantdb/core`
 
 CRITICAL: To use the admin SDK you MUST get an admin token for the app. You can
-get the admin token with the MCP tool via `create-app` or `get-app`. The admin
+get the admin token with the MCP tool via `create-app`. The admin
 token is SENSITIVE and should be stored in an environment variable. Do not
 hardcode it in your script.
 


### PR DESCRIPTION
Made a few more tweaks. To address these issues I've been seeing

* Sometimes `useProfile` is used outside of `db.SignedIn`
* Seeding data on the client can lead to infinite loops due to permission failures.
* Standardize on using `CRITICAL` instead of `IMPORTANT` for hints