### PR TITLE
[tempfix] disable validation for mcp

### DIFF
--- a/client/packages/mcp/src/index.ts
+++ b/client/packages/mcp/src/index.ts
@@ -432,6 +432,7 @@ async function startSse() {
     adminToken: ensureEnv('INSTANT_ADMIN_TOKEN'),
     appId: ensureEnv('INSTANT_APP_ID'),
     schema,
+    disableValidation: true,
   });
 
   const oauthConfig: OAuthConfig = {


### PR DESCRIPTION
It looks like we are getting some errors authenticated with MCP. It looks like the reason is because of a validation failure when we give the admin sdk lookups. Disabling validation for now to see if that fixes things. 

@nezaj @dwwoelfel @tonsky @drew-harris 