### PR TITLE
fix cursor link

### DIFF
--- a/client/packages/mcp/src/index.html.ts
+++ b/client/packages/mcp/src/index.html.ts
@@ -6,7 +6,7 @@ const html = (serverOrigin: string): string => {
     'utf-8',
   ).toString('base64');
 
-  const cursorUrl = `https://cursor.com/install-mcp?name=InstantDB${dev ? '%20Dev' : ''}&config=${cursorConfig}`;
+  const cursorUrl = `https://cursor.com/en/install-mcp?name=InstantDB${dev ? '%20Dev' : ''}&config=${cursorConfig}`;
   return /* HTML */ `<!doctype html>
     <html lang="en">
       <head>

--- a/client/www/pages/docs/using-llms.md
+++ b/client/www/pages/docs/using-llms.md
@@ -28,7 +28,7 @@ When you add the MCP server, you'll be sent through an OAuth flow to grant acces
 
 ### Cursor
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=InstantDB&config=eyJ1cmwiOiJodHRwczovL21jcC5pbnN0YW50ZGIuY29tL21jcCJ9)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=InstantDB&config=eyJ1cmwiOiJodHRwczovL21jcC5pbnN0YW50ZGIuY29tL21jcCJ9)
 
 Or edit your `~/.cursor/mcp.json` directly:
 

--- a/client/www/pages/tutorial.tsx
+++ b/client/www/pages/tutorial.tsx
@@ -392,7 +392,7 @@ export default function McpTutorial({ files }: MarkdownContent) {
           <p>Click this button to install the Instant MCP server in Cursor:</p>
           <div className="flex">
             <a
-              href="https://cursor.com/install-mcp?name=InstantDB&config=eyJ1cmwiOiJodHRwczovL21jcC5pbnN0YW50ZGIuY29tL21jcCJ9"
+              href="https://cursor.com/en/install-mcp?name=InstantDB&config=eyJ1cmwiOiJodHRwczovL21jcC5pbnN0YW50ZGIuY29tL21jcCJ9"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
looks like cursor added a `/en` to their install-mcp link 

@nezaj @dwwoelfel @tonsky @drew-harris 