### PR TITLE
fix lookup strings being tested as uuids

### DIFF
--- a/client/packages/core/__tests__/src/transactionValidation.test.ts
+++ b/client/packages/core/__tests__/src/transactionValidation.test.ts
@@ -1,6 +1,6 @@
 import { i } from '../../src/schema';
 import { validateTransactions } from '../../src/transactionValidation.ts';
-import { tx as originalTx, TxChunk } from '../../src/instatx.ts';
+import { lookup, tx as originalTx, TxChunk } from '../../src/instatx.ts';
 import id from '../../src/utils/uuid.ts';
 import { expect, test } from 'vitest';
 import { InstantSchemaDef } from '../../src';
@@ -385,4 +385,11 @@ test('validates UUID format for entity IDs', () => {
   // Test for links
   beValid(tx.users[validUuid].link({ posts: id() }));
   beWrong(tx.users[validUuid].link({ posts: 'not-a-uuid' }));
+});
+
+test('allows lookup values in square bracket', () => {
+  beValid(
+    tx.users[lookup('email', 'john@example.net')].update({ name: 'John' }),
+  );
+  beValid(tx.users[lookup('email', 'john@example.net')].link({ posts: id() }));
 });

--- a/client/packages/core/__tests__/src/transactionValidation.test.ts
+++ b/client/packages/core/__tests__/src/transactionValidation.test.ts
@@ -393,3 +393,8 @@ test('allows lookup values in square bracket', () => {
   );
   beValid(tx.users[lookup('email', 'john@example.net')].link({ posts: id() }));
 });
+
+test('allows lookup values in link', () => {
+  beValid(tx.users[id()].link({ posts: lookup('title', 'Hello') }));
+  beWrong(tx.users[id()].link({ posts: 'non lookup or uuid' }));
+});

--- a/client/packages/core/src/queryValidation.ts
+++ b/client/packages/core/src/queryValidation.ts
@@ -3,7 +3,7 @@ import {
   DataAttrDef,
   ValueTypes,
 } from './schemaTypes.ts';
-import { validateUUIDOrLink } from './transactionValidation.ts';
+import { isValidEntityId } from './transactionValidation.ts';
 
 export class QueryValidationError extends Error {
   constructor(message: string, path?: string) {
@@ -225,7 +225,7 @@ const validateDotNotationAttribute = (
 
   // Handle 'id' field specially - every entity has an id field
   if (finalAttrName === 'id') {
-    if (!validateUUIDOrLink(value)) {
+    if (!isValidEntityId(value)) {
       throw new QueryValidationError(
         `Invalid value for id field in entity '${currentEntityName}'. Expected a UUID, but received: ${value}`,
         path,
@@ -244,7 +244,7 @@ const validateDotNotationAttribute = (
   const attrDef = finalEntity.attrs[finalAttrName];
 
   if (Object.keys(finalEntity.links).includes(finalAttrName)) {
-    if (!validateUUIDOrLink(value)) {
+    if (!isValidEntityId(value)) {
       throw new QueryValidationError(
         `Invalid value for link '${finalAttrName}' in entity '${currentEntityName}'. Expected a UUID, but received: ${value}`,
         path,
@@ -344,7 +344,7 @@ const validateWhereClause = (
     } else if (linkDef) {
       // For links, we expect the value to be a string (ID of the linked entity)
       // Create a synthetic string attribute definition for validation
-      if (!validateUUIDOrLink(value)) {
+      if (!isValidEntityId(value)) {
         throw new QueryValidationError(
           `Invalid value for link '${key}' in entity '${entityName}'. Expected a UUID, but received: ${value}`,
           `${path}.${key}`,

--- a/client/packages/core/src/queryValidation.ts
+++ b/client/packages/core/src/queryValidation.ts
@@ -3,7 +3,7 @@ import {
   DataAttrDef,
   ValueTypes,
 } from './schemaTypes.ts';
-import { isValidEntityId } from './transactionValidation.ts';
+import { validate as validateUUID } from 'uuid';
 
 export class QueryValidationError extends Error {
   constructor(message: string, path?: string) {
@@ -225,7 +225,7 @@ const validateDotNotationAttribute = (
 
   // Handle 'id' field specially - every entity has an id field
   if (finalAttrName === 'id') {
-    if (!isValidEntityId(value)) {
+    if (!validateUUID(value)) {
       throw new QueryValidationError(
         `Invalid value for id field in entity '${currentEntityName}'. Expected a UUID, but received: ${value}`,
         path,
@@ -244,7 +244,7 @@ const validateDotNotationAttribute = (
   const attrDef = finalEntity.attrs[finalAttrName];
 
   if (Object.keys(finalEntity.links).includes(finalAttrName)) {
-    if (!isValidEntityId(value)) {
+    if (!validateUUID(value)) {
       throw new QueryValidationError(
         `Invalid value for link '${finalAttrName}' in entity '${currentEntityName}'. Expected a UUID, but received: ${value}`,
         path,
@@ -344,7 +344,7 @@ const validateWhereClause = (
     } else if (linkDef) {
       // For links, we expect the value to be a string (ID of the linked entity)
       // Create a synthetic string attribute definition for validation
-      if (!isValidEntityId(value)) {
+      if (!validateUUID(value)) {
         throw new QueryValidationError(
           `Invalid value for link '${key}' in entity '${entityName}'. Expected a UUID, but received: ${value}`,
           `${path}.${key}`,

--- a/client/packages/core/src/queryValidation.ts
+++ b/client/packages/core/src/queryValidation.ts
@@ -3,8 +3,7 @@ import {
   DataAttrDef,
   ValueTypes,
 } from './schemaTypes.ts';
-
-import { validate as validateUUID } from 'uuid';
+import { validateUUIDOrLink } from './transactionValidation.ts';
 
 export class QueryValidationError extends Error {
   constructor(message: string, path?: string) {
@@ -226,7 +225,7 @@ const validateDotNotationAttribute = (
 
   // Handle 'id' field specially - every entity has an id field
   if (finalAttrName === 'id') {
-    if (!validateUUID(value)) {
+    if (!validateUUIDOrLink(value)) {
       throw new QueryValidationError(
         `Invalid value for id field in entity '${currentEntityName}'. Expected a UUID, but received: ${value}`,
         path,
@@ -245,7 +244,7 @@ const validateDotNotationAttribute = (
   const attrDef = finalEntity.attrs[finalAttrName];
 
   if (Object.keys(finalEntity.links).includes(finalAttrName)) {
-    if (!validateUUID(value)) {
+    if (!validateUUIDOrLink(value)) {
       throw new QueryValidationError(
         `Invalid value for link '${finalAttrName}' in entity '${currentEntityName}'. Expected a UUID, but received: ${value}`,
         path,
@@ -345,7 +344,7 @@ const validateWhereClause = (
     } else if (linkDef) {
       // For links, we expect the value to be a string (ID of the linked entity)
       // Create a synthetic string attribute definition for validation
-      if (!validateUUID(value)) {
+      if (!validateUUIDOrLink(value)) {
         throw new QueryValidationError(
           `Invalid value for link '${key}' in entity '${entityName}'. Expected a UUID, but received: ${value}`,
           `${path}.${key}`,

--- a/client/packages/core/src/transactionValidation.ts
+++ b/client/packages/core/src/transactionValidation.ts
@@ -122,7 +122,7 @@ const validateLinkOperation = (
         }
       } else {
         // Handle single UUID
-        if (typeof linkValue === 'string' && !isValidEntityId(linkValue)) {
+        if (!isValidEntityId(linkValue)) {
           throw new TransactionValidationError(
             `Invalid UUID in link '${linkName}' for entity '${entityName}'. Expected a UUID, but received: ${linkValue}`,
           );
@@ -151,7 +151,7 @@ const validateOp = (
 
   // _id should be a uuid
   if (!Array.isArray(_id)) {
-    const isUuid = isValidEntityId(_id);
+    const isUuid = validateUUID(_id);
     if (!isUuid) {
       throw new TransactionValidationError(
         `Invalid id for entity '${entityName}'. Expected a UUID, but received: ${_id}`,

--- a/client/packages/core/src/transactionValidation.ts
+++ b/client/packages/core/src/transactionValidation.ts
@@ -113,10 +113,10 @@ const validateLinkOperation = (
     if (linkValue !== null && linkValue !== undefined) {
       if (Array.isArray(linkValue)) {
         // Handle array of UUIDs
-        for (const uuid of linkValue) {
-          if (!isValidEntityId(uuid)) {
+        for (const linkReference of linkValue) {
+          if (!isValidEntityId(linkReference)) {
             throw new TransactionValidationError(
-              `Invalid UUID in link '${linkName}' for entity '${entityName}'. Expected a UUID, but received: ${uuid}`,
+              `Invalid entity ID in link '${linkName}' for entity '${entityName}'. Expected a UUID or a lookup, but received: ${linkReference}`,
             );
           }
         }

--- a/client/packages/core/src/transactionValidation.ts
+++ b/client/packages/core/src/transactionValidation.ts
@@ -2,7 +2,7 @@ import { TransactionChunk, Op, isLookup } from './instatx.ts';
 import { IContainEntitiesAndLinks, DataAttrDef } from './schemaTypes.ts';
 import { validate as validateUUID } from 'uuid';
 
-export const validateUUIDOrLink = (value: unknown): boolean => {
+export const isValidEntityId = (value: unknown): boolean => {
   if (typeof value !== 'string') {
     return false;
   }
@@ -114,7 +114,7 @@ const validateLinkOperation = (
       if (Array.isArray(linkValue)) {
         // Handle array of UUIDs
         for (const uuid of linkValue) {
-          if (!validateUUIDOrLink(uuid)) {
+          if (!isValidEntityId(uuid)) {
             throw new TransactionValidationError(
               `Invalid UUID in link '${linkName}' for entity '${entityName}'. Expected a UUID, but received: ${uuid}`,
             );
@@ -122,7 +122,7 @@ const validateLinkOperation = (
         }
       } else {
         // Handle single UUID
-        if (typeof linkValue === 'string' && !validateUUIDOrLink(linkValue)) {
+        if (typeof linkValue === 'string' && !isValidEntityId(linkValue)) {
           throw new TransactionValidationError(
             `Invalid UUID in link '${linkName}' for entity '${entityName}'. Expected a UUID, but received: ${linkValue}`,
           );
@@ -151,7 +151,7 @@ const validateOp = (
 
   // _id should be a uuid
   if (!Array.isArray(_id)) {
-    const isUuid = validateUUIDOrLink(_id);
+    const isUuid = isValidEntityId(_id);
     if (!isUuid) {
       throw new TransactionValidationError(
         `Invalid id for entity '${entityName}'. Expected a UUID, but received: ${_id}`,

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.20.22';
+const version = 'v0.20.23';
 
 export { version };

--- a/client/sandbox/admin-sdk-express/package.json
+++ b/client/sandbox/admin-sdk-express/package.json
@@ -4,7 +4,8 @@
   "description": "Test script for admin SDK",
   "type": "module",
   "scripts": {
-    "dev": "node --watch --watch-preserve-output -r ts-node/register ./src/index.ts"
+    "dev": "node --watch --watch-preserve-output -r ts-node/register ./src/index.ts",
+    "dev:schema": "node --watch --watch-preserve-output --loader ts-node/esm ./src/with-schema.ts"
   },
   "dependencies": {
     "@instantdb/admin": "workspace:*",

--- a/client/sandbox/admin-sdk-express/src/index.ts
+++ b/client/sandbox/admin-sdk-express/src/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors'; // Import cors module
-import { init, tx, id } from '@instantdb/admin';
+import { init, tx, id, lookup } from '@instantdb/admin';
 import { assert } from 'console';
 import dotenv from 'dotenv';
 import fs from 'fs';
@@ -70,6 +70,27 @@ async function testTransact() {
       })
       .link({ todos: todoAId })
       .link({ todos: todoBId }),
+  ]);
+  console.log(JSON.stringify(res, null, 2));
+}
+
+async function testTransactWithLookup() {
+  const todoAId = id();
+  const todoBId = id();
+  const user = { id: '3c32701d-f4a2-40e8-b83c-077dd4cb5cec' };
+  const res = await transact([
+    tx.todos[lookup('title', 'Drink a protein shake')].update({
+      title: 'Drink a protein shake',
+      creatorId: user.id,
+    }),
+    tx.goals[id()]
+      .update({
+        title: 'Get six pack abs',
+        priority6: 1,
+        creatorId: user.id,
+      })
+      .link({ todos: lookup('title', 'Go on a run') })
+      .link({ todos: lookup('title', 'Drink a protein shake') }),
   ]);
   console.log(JSON.stringify(res, null, 2));
 }

--- a/client/sandbox/admin-sdk-express/src/index.ts
+++ b/client/sandbox/admin-sdk-express/src/index.ts
@@ -74,27 +74,6 @@ async function testTransact() {
   console.log(JSON.stringify(res, null, 2));
 }
 
-async function testTransactWithLookup() {
-  const todoAId = id();
-  const todoBId = id();
-  const user = { id: '3c32701d-f4a2-40e8-b83c-077dd4cb5cec' };
-  const res = await transact([
-    tx.todos[lookup('title', 'Drink a protein shake')].update({
-      title: 'Drink a protein shake',
-      creatorId: user.id,
-    }),
-    tx.goals[id()]
-      .update({
-        title: 'Get six pack abs',
-        priority6: 1,
-        creatorId: user.id,
-      })
-      .link({ todos: lookup('title', 'Go on a run') })
-      .link({ todos: lookup('title', 'Drink a protein shake') }),
-  ]);
-  console.log(JSON.stringify(res, null, 2));
-}
-
 async function testCreateToken() {
   const token = await auth.createToken('stopa@instantdb.com');
   console.log('custom token!', token);

--- a/client/sandbox/admin-sdk-express/src/with-schema.ts
+++ b/client/sandbox/admin-sdk-express/src/with-schema.ts
@@ -97,20 +97,37 @@ async function testTransact() {
 
 async function testTransactWithLookup() {
   const user = { id: '3c32701d-f4a2-40e8-b83c-077dd4cb5cec' };
+  const pushupId = id();
   const res = await transact([
-    tx.todos[lookup('title', 'Drink a protein shake')].update({
-      title: 'Drink a protein shake',
+    tx.todos[pushupId].create({
+      title: 'Do a pushup',
       creatorId: user.id,
     }),
-    tx.goals[id()]
-      .update({
-        title: 'Get six pack abs',
-        creatorId: user.id,
-      })
-      .link({ todos: lookup('title', 'Go on a run') })
-      .link({ todos: lookup('title', 'Drink a protein shake') }),
   ]);
+
+  await transact([
+    tx.todos[lookup('title', 'Do a pushup')].update({
+      title: 'Do a pushup',
+      creatorId: 'random id',
+    }),
+  ]);
+
   console.log(JSON.stringify(res, null, 2));
+
+  const result = await query({
+    todos: {
+      $: {
+        where: {
+          title: 'Do a pushup',
+        },
+      },
+    },
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+
+  // Delete the todo
+  await transact([tx.todos[lookup('title', 'Do a pushup')].delete()]);
 }
 
 async function testCreateToken() {

--- a/client/sandbox/admin-sdk-express/src/with-schema.ts
+++ b/client/sandbox/admin-sdk-express/src/with-schema.ts
@@ -64,8 +64,6 @@ process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);
 });
 
-testTransactWithLookup();
-
 // ----------------------------
 // Some handy tester functions
 
@@ -98,8 +96,6 @@ async function testTransact() {
 }
 
 async function testTransactWithLookup() {
-  const todoAId = id();
-  const todoBId = id();
   const user = { id: '3c32701d-f4a2-40e8-b83c-077dd4cb5cec' };
   const res = await transact([
     tx.todos[lookup('title', 'Drink a protein shake')].update({

--- a/client/sandbox/admin-sdk-express/src/with-schema.ts
+++ b/client/sandbox/admin-sdk-express/src/with-schema.ts
@@ -227,6 +227,7 @@ async function testAdminStorageBulkDelete(keyword: string) {
 // testCreateToken();
 // testQuery();
 // testTransact();
+// testTransactWithLookup();
 // testScoped();
 // testSignOut();
 // testFetchUser();


### PR DESCRIPTION
This PR fixes the issue of lookup attributes being tested as UUIDs and throwing errors for valid transactions