### PR TITLE
Add tracer/with-new-trace-root

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -233,7 +233,7 @@
      (tracer/record-info! {:name (format "init.start.%s" (name ~operation))})
      (tracer/with-span! {:name (format "init.finish.%s" (name ~operation))}
        ;; Don't let ourselves be the parent of any child spans
-       (binding [tracer/*span* nil]
+       (tracer/with-new-trace-root
          ~@body))))
 
 (defn -main [& _args]

--- a/server/src/instant/db/hint_testing.clj
+++ b/server/src/instant/db/hint_testing.clj
@@ -97,7 +97,7 @@
   (cache/ttl-cache-factory {} :ttl (* 1000 60)))
 
 (defn test-pg-hints-for-datalog-query [ctx patterns query query-hash]
-  (binding [tracer/*span* nil] ;; new root span
+  (tracer/with-new-trace-root
     (tracer/with-span! {:name "test-pg-hints-for-datalog"
                         :attributes {:query query
                                      :query-hash query-hash
@@ -138,7 +138,7 @@
   individually."
   [ctx permissioned-query-fn o query-hash]
   (cache/lookup-or-miss seen query-hash (constantly true))
-  (binding [tracer/*span* nil] ;; Create new root span
+  (tracer/with-new-trace-root
     (tracer/with-span! {:name "test-pg-hint-plan"
                         :attributes (merge {:query o
                                             :query-hash query-hash

--- a/server/src/instant/db/rule_where_testing.clj
+++ b/server/src/instant/db/rule_where_testing.clj
@@ -30,7 +30,7 @@
 
 (defn test-rule-wheres [ctx permissioned-query-fn o query-hash]
   (cache/lookup-or-miss seen query-hash (constantly true))
-  (binding [tracer/*span* nil] ;; Create new root span
+  (tracer/with-new-trace-root
     (tracer/with-span! {:name "test-pg-hint-plan"
                         :attributes (merge {:query o
                                             :app-id (:app-id ctx)

--- a/server/src/instant/util/e2e_tracer.clj
+++ b/server/src/instant/util/e2e_tracer.clj
@@ -40,7 +40,7 @@
 (def context-field ^Field (get-field SdkSpan "context"))
 
 (defn make-invalidator-tracking-span [^Long tx-id attrs]
-  (let [span (binding [tracer/*span* nil] ;; make sure this is a top-level span
+  (let [span (tracer/with-new-trace-root
                (tracer/new-span! {:name "e2e/invalidator/tracking-span"
                                   :attributes (merge {:tx-id tx-id}
                                                      attrs)}))

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -196,6 +196,12 @@
          (finally
            (end-span! *span*))))))
 
+(defmacro with-new-trace-root
+  "Creates a new root span, divorced from any parent spans."
+  [& body]
+  `(binding [*span* nil]
+     ~@body))
+
 (defn record-info!
   "Analogous to log/info.
 


### PR DESCRIPTION
Adds a nicer way to do `(binding [tracer/*span* nil]` to make it more obvious what we're doing.

Instead of:

```clojure
(binding [tracer/*span* nil]
  (do-thing))
```

You do:

```clojure
(tracer/with-new-span-root
  (do-thing))
```  