### PR TITLE
Add more debugging data

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -533,7 +533,9 @@
     (assoc (merge metadata event-attrs)
            :socket-origin (rs/socket-origin socket)
            :socket-ip (rs/socket-ip socket)
-           :session-id sess-id)))
+           :session-id sess-id
+           :x-amzn-trace-id (rs/socket-x-amzn-trace-id socket)
+           :x-amzn-cf-id (rs/socket-x-amz-cf-id socket))))
 
 (defn handle-receive [store session event metadata]
   (tracer/with-exceptions-silencer [silence-exceptions]

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -141,6 +141,18 @@
           last
           string/trim))
 
+(defn socket-x-amzn-trace-id
+  "Load balancer trace id"
+  [{:keys [^WebSocketHttpExchange http-req]}]
+  (some-> http-req
+          (.getRequestHeader "x-amzn-trace-id")))
+
+(defn socket-x-amz-cf-id
+  "Cloudfront tracking id"
+  [{:keys [^WebSocketHttpExchange http-req]}]
+  (some-> http-req
+          (.getRequestHeader "x-amz-cf-id")))
+
 (defn report-active-sessions [store]
   (let [db @(:sessions store)]
     (for [datom (d/datoms db :aevt :session/id)

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -75,13 +75,14 @@
   "Wraps standard http requests within a span."
   [handler]
   (fn [request]
-    (if (or (:websocket? request)
-            (cors/preflight? request))
+    (if (cors/preflight? request)
       ;; We skip websocket requests;
       ;; Because websockets are long-lived,
       ;; a parent-span doesn't make sense.
       (handler request)
-      (tracer/with-span! {:name "http-req"}
+      (tracer/with-span! {:name "http-req"
+                          :attributes (when (:websocket? request)
+                                        {:websocket? true})}
         (let [{:keys [status] :as response}  (handler request)]
           (tracer/add-data! {:attributes {:status status}})
           response)))))

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -76,9 +76,6 @@
   [handler]
   (fn [request]
     (if (cors/preflight? request)
-      ;; We skip websocket requests;
-      ;; Because websockets are long-lived,
-      ;; a parent-span doesn't make sense.
       (handler request)
       (tracer/with-span! {:name "http-req"
                           :attributes (when (:websocket? request)


### PR DESCRIPTION
Various debugging improvements:

1. Adds a tag to sql query in indexing-jobs
2. Moves the tracer around the try-catch in indexing jobs so that we can see what caused the errors in honeycomb
3. Adds `x-amzn-trace-id` and `x-amzn-cf-id` to `handle-receive`'s tracer attrs to make it easier to trace the connection back to the load balancer and cdn
4. Doesn't skip the websocket request in the tracer. The idea was that we shouldn't wrap a span around the websocket handler because it's long-running and all of its children would be attached to the trace. I was expecting to have to use [`tracer/with-new-trace-root`](https://github.com/instantdb/instant/pull/1511) on it, but it turns out not to be necessary. The handler completes immediately and just gets handed off to an internal undertow handler.