### PR TITLE
Sort strings lexicographically on the client

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -1027,6 +1027,45 @@ test('arbitrary ordering with dates', () => {
   expect(numAscRes).toEqual(ascExpected);
 });
 
+test('arbitrary ordering with strings', () => {
+  const schema = i.schema({
+    entities: {
+      tests: i.entity({
+        string: i.string().indexed(),
+      }),
+    },
+  });
+
+  const txSteps = [];
+  const vs = ['10', '2', 'a0', 'Zz'];
+  for (const v of vs) {
+    txSteps.push(
+      tx.tests[randomUUID()].update({
+        string: v,
+      }),
+    );
+  }
+
+  const newStore = transact(
+    store,
+    instaml.transform({ attrs: store.attrs, schema: schema }, txSteps),
+  );
+
+  const ascRes = query(
+    { store: newStore },
+    { tests: { $: { order: { string: 'asc' } } } },
+  ).data.tests.map((x) => x.string);
+
+  expect(ascRes).toEqual(vs);
+
+  const descRes = query(
+    { store: newStore },
+    { tests: { $: { order: { string: 'desc' } } } },
+  ).data.tests.map((x) => x.string);
+
+  expect(descRes).toEqual(vs.toReversed());
+});
+
 test('$isNull', () => {
   const q = { books: { $: { where: { title: { $isNull: true } } } } };
   expect(query({ store }, q).data.books.length).toEqual(0);

--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -1,5 +1,6 @@
 import { query as datalogQuery } from './datalog.js';
 import { uuidCompare } from './utils/uuid.ts';
+import { stringCompare } from './utils/strings.ts';
 import * as s from './store.js';
 
 // Pattern variables
@@ -477,7 +478,20 @@ function shouldIgnoreAttr(attrs, id) {
   return attr['value-type'] === 'ref' && attr['forward-identity'][2] !== 'id';
 }
 
-function compareOrder([id_a, v_a], [id_b, v_b]) {
+// Compares values where we already know that the two values are distinct
+// and not null.
+// Takes into account the data type.
+function compareDisparateValues(a, b, dataType) {
+  if (dataType === 'string') {
+    return stringCompare(a, b);
+  }
+  if (a > b) {
+    return 1;
+  }
+  return -1;
+}
+
+function compareOrder([id_a, v_a], [id_b, v_b], dataType) {
   if (v_a === v_b || (v_a == null && v_b == null)) {
     return uuidCompare(id_a, id_b);
   }
@@ -488,10 +502,8 @@ function compareOrder([id_a, v_a], [id_b, v_b]) {
   if (v_a == null) {
     return -1;
   }
-  if (v_a > v_b) {
-    return 1;
-  }
-  return -1;
+
+  return compareDisparateValues(v_a, v_b, dataType);
 }
 
 function comparableDate(x) {
@@ -505,14 +517,14 @@ function isBefore(startCursor, orderAttr, direction, idVec) {
   const [c_e, _c_a, c_v, c_t] = startCursor;
   const compareVal = direction === 'desc' ? 1 : -1;
   if (orderAttr['forward-identity']?.[2] === 'id') {
-    return compareOrder(idVec, [c_e, c_t]) === compareVal;
+    return compareOrder(idVec, [c_e, c_t], null) === compareVal;
   }
   const [e, v] = idVec;
-  const v_new =
-    orderAttr['checked-data-type'] === 'date' ? comparableDate(v) : v;
-  const c_v_new =
-    orderAttr['checked-data-type'] === 'date' ? comparableDate(c_v) : c_v;
-  return compareOrder([e, v_new], [c_e, c_v_new]) === compareVal;
+  const dataType = orderAttr['checked-data-type'];
+  const v_new = dataType === 'date' ? comparableDate(v) : v;
+  const c_v_new = dataType === 'date' ? comparableDate(c_v) : c_v;
+
+  return compareOrder([e, v_new], [c_e, c_v_new], dataType) === compareVal;
 }
 
 function orderAttrFromCursor(store, cursor) {
@@ -590,10 +602,10 @@ function runDataloadAndReturnObjects(
   idVecs.sort(
     direction === 'asc'
       ? function compareIdVecs(a, b) {
-          return compareOrder(a, b);
+          return compareOrder(a, b, orderAttr?.['checked-data-type']);
         }
       : function compareIdVecs(a, b) {
-          return compareOrder(b, a);
+          return compareOrder(b, a, orderAttr?.['checked-data-type']);
         },
   );
 

--- a/client/packages/core/src/utils/strings.ts
+++ b/client/packages/core/src/utils/strings.ts
@@ -1,0 +1,19 @@
+function fallbackCompareStrings(a: string, b: string) {
+  return a.localeCompare(b);
+}
+
+function makeCompareStringsFn(): (a: string, b: string) => number {
+  let compareStrings = fallbackCompareStrings;
+
+  if (typeof Intl === 'object' && Intl.hasOwnProperty('Collator')) {
+    try {
+      const collator = Intl.Collator('en-US');
+
+      compareStrings = collator.compare;
+    } catch (_e) {}
+  }
+
+  return compareStrings;
+}
+
+export const stringCompare = makeCompareStringsFn();

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.20.23';
+const version = 'v0.20.24';
 
 export { version };


### PR DESCRIPTION
Sorts strings lexicographically using `Intl.Collator('en-US')`, with a fallback to `String.localeCompare`.

This will fix some issues with pagination where items get cut out due to incompatible sorting. 

More info in this paper doc: https://www.dropbox.com/scl/fi/zcoagghpaztcrz388d2jo/How-should-we-sort-strings_.paper?rlkey=n7btkf1hxxcym2z9ssdct30kj&st=we5c28dh&dl=0