### PR TITLE
Add a reverse sketch for storing reverse links

### DIFF
--- a/server/resources/migrations/78_add_reverse_bins_to_sketch.down.sql
+++ b/server/resources/migrations/78_add_reverse_bins_to_sketch.down.sql
@@ -1,0 +1,4 @@
+alter table attr_sketches drop column reverse_width;
+alter table attr_sketches drop column reverse_depth;
+alter table attr_sketches drop column reverse_total;
+alter table attr_sketches drop column reverse_bins;

--- a/server/resources/migrations/78_add_reverse_bins_to_sketch.up.sql
+++ b/server/resources/migrations/78_add_reverse_bins_to_sketch.up.sql
@@ -1,0 +1,4 @@
+alter table attr_sketches add column reverse_width integer;
+alter table attr_sketches add column reverse_depth integer;
+alter table attr_sketches add column reverse_total bigint;
+alter table attr_sketches add column reverse_bins bytea;


### PR DESCRIPTION
This lets us use the sketch to get counts for patterns like:

```
[:vae :some-eid :some-aid ?v]
```

In this case, we can use the reverse sketch to look up how many of the triples have entity_id = `:some-eid`. 

We only store the reverse sketch when we have a cardinality-many ref attr. If it's not cardinality-many, then the count is either 0 or 1 and we don't need the sketch to look that up.

The reverse sketch lives on the same row as the current forward sketch. That seemed to be the easiest path forward. I also considered creating a `reverse` field on the `attr_sketch` and making the sketch unique by `(app_id, attr_id, reverse)`, but that makes querying for the sketches more difficult. Another idea was to just jam the entity ids into the existing sketch, but then our totals are doubled and it makes it difficult to grow the sketches when they start to get full later.

### Deployment plan

I'll just wipe out all of the existing sketches and start from scratch again.

- [ ] Turn off the flags: `disable-aggregator` -> `true`, `skip-aggregator-initialization` -> `false`
- [ ] Merge this PR
- [ ] Run the db migration
- [ ] Deploy this PR
- [ ] Truncate the attr_sketches and wal_aggregator_status tables
- [ ] Drop the aggregator slot
- [ ] Follow this deployment procedure from the last PR https://github.com/instantdb/instant/pull/1513