### PR TITLE
Hack to improve some slow queries

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1504,6 +1504,12 @@
         (assoc named-p :idx [:keyword :eav])
         named-p))))
 
+(defn always-materialize? [named-p]
+  (and (uspec/tagged-as? :constant (:a named-p))
+       (= 1 (count (uspec/tagged-unwrap (:a named-p))))
+       (contains? (flags/flag :always-materialize-attr-ids)
+                  (first (uspec/tagged-unwrap (:a named-p))))))
+
 (defn- joining-with
   "Produces subsequent match tables. Each table joins on the previous
    table unless it is the first cte or the start of a new AND/OR
@@ -1552,6 +1558,7 @@
                                     :additional-clauses all-joins}
                                    named-p)}
              (if (or
+                  (always-materialize? named-p)
                   ;; only use `not materialized` when we're in the middle of an ordered
                   ;; query
                   (not page-info)

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -170,6 +170,8 @@
                             (assoc acc (keyword setting) value))
                           {}
                           (get result "flags"))
+                  (update :always-materialize-attr-ids (fn [vs]
+                                                         (set (map parse-uuid vs))))
                   (update :tika-enabled-apps (fn [vs]
                                                (set (map parse-uuid vs)))))
 


### PR DESCRIPTION
This adds support for `always-materialize-attr-ids` in the flags instant-config field.

Quick hack to make some queries more efficient while we work on improving join orders with the attr sketches.