### PR TITLE
fix subscribe query typing with useDates

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -482,7 +482,7 @@ function coerceQuery(o: any) {
 
 class InstantCoreDatabase<
   Schema extends InstantSchemaDef<any, any, any>,
-  UseDates extends boolean,
+  UseDates extends boolean = false,
 > implements IInstantDatabase<Schema>
 {
   public _reactor: Reactor<RoomsOf<Schema>>;
@@ -554,9 +554,12 @@ class InstantCoreDatabase<
    *    console.log(resp.data.goals)
    *  });
    */
-  subscribeQuery<Q extends InstaQLParams<Schema>, UseDates extends boolean>(
+  subscribeQuery<
+    Q extends InstaQLParams<Schema>,
+    UseDatesLocal extends boolean = UseDates,
+  >(
     query: Q,
-    cb: (resp: InstaQLSubscriptionState<Schema, Q, UseDates>) => void,
+    cb: (resp: InstaQLSubscriptionState<Schema, Q, UseDatesLocal>) => void,
     opts?: InstaQLOptions,
   ) {
     return this._reactor.subscribeQuery(query, cb, opts);
@@ -741,7 +744,7 @@ function init<
   Storage?: any,
   NetworkListener?: any,
   versions?: { [key: string]: string },
-): InstantCoreDatabase<Schema, Config['useDateObjects']> {
+): InstantCoreDatabase<Schema, UseDates> {
   const existingClient = globalInstantCoreStore[
     reactorKey(config)
   ] as InstantCoreDatabase<any, Config['useDateObjects']>;

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.20.26';
+const version = 'v0.20.27';
 
 export { version };


### PR DESCRIPTION
```ts
const schema = i.schema({
  entities: {
    todos: i.entity({
      text: i.string(),
      done: i.boolean(),
      createdAt: i.date(),
    }),
  },
});

type Todo = InstaQLEntity<typeof schema, "todos", {}, undefined, true>;

// Initialize the database
// ---------
const db = init({ appId: APP_ID, schema, useDateObjects: true });

// Subscribe to data
// ---------
db.subscribeQuery({ todos: {} }, (resp) => {
  if (resp.error) {
    renderError(resp.error.message); // Pro-tip: Check you have the right appId!
    return;
  }
  if (resp.data) {
    render(resp.data);
  }
});
```

Type of resp.data is 
```typescript
(property) data: {
    todos: {
        id: string;
        text: string;
        done: boolean;
        createdAt: string | number | Date;
    }[];
}
```

it should be
```typescript
(property) data: {
    todos: {
        id: string;
        text: string;
        done: boolean;
        createdAt: Date;
    }[];
}
```

This pr fixes that