### PR TITLE
Remove schema and perms from get-apps

### DIFF
--- a/client/packages/mcp/src/index.ts
+++ b/client/packages/mcp/src/index.ts
@@ -195,20 +195,9 @@ function registerTools(server: McpServer, api: PlatformApi) {
   server.tool(
     'get-apps',
     'List all apps owned by the authenticated user',
-    {
-      includeSchema: z
-        .boolean()
-        .optional()
-        .describe('Include schema in response'),
-      includePerms: z
-        .boolean()
-        .optional()
-        .describe('Include permissions in response'),
-    },
-    async ({ includeSchema, includePerms }) => {
+    async () => {
       try {
-        const opts = { includeSchema, includePerms };
-        const result = await api.getApps(opts);
+        const result = await api.getApps();
 
         return {
           content: [

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.20.27';
+const version = 'v0.20.28';
 
 export { version };


### PR DESCRIPTION
It's very easy to return a lot of data from `get-apps`. We likely don't need the schema and perms but just the app name. Verified this works as expected in the MCP inspector

<img width="2806" height="1192" alt="CleanShot 2025-08-15 at 16 15 17@2x" src="https://github.com/user-attachments/assets/57c462ba-0ab8-45fa-94b0-54567420259f" />
