### PR TITLE
[docs] quickfix: broken link in reading data

### DIFF
--- a/client/www/pages/docs/instaql.md
+++ b/client/www/pages/docs/instaql.md
@@ -567,7 +567,7 @@ The `serverCreatedAt` field is a reserved key that orders by the time that the o
 You can also order by any attribute that is indexed and has a checked type.
 
 {% callout %}
-Add indexes and checked types to your attributes from the [Explorer on the Instant dashboard](/dash?t=explorer) or from the [cli with Schema-as-code](/docs/schema).
+Add indexes and checked types to your attributes from the [Explorer on the Instant dashboard](/dash?t=explorer) or from the [cli](/docs/cli).
 {% /callout %}
 
 ```typescript


### PR DESCRIPTION
A user pointed out a broken link in the 'reading data' section. Went ahead and fixed it. 

Note: I saw some other places where we use /docs/schema. I will push up a separate PR fixing those -- wanted to action fast on the pertinent feedback.

@nezaj @dwwoelfel @tonsky @drew-harris 