### PR TITLE
[docs] fix docs/schema

### DIFF
--- a/client/packages/core/src/schema.ts
+++ b/client/packages/core/src/schema.ts
@@ -25,7 +25,7 @@ import {
  * i.schema({ entities, links, rooms })
  *
  * @see
- * https://instantdb.com/docs/schema
+ * https://instantdb.com/docs/modeling-data
  */
 function graph<
   EntitiesWithoutLinks extends EntitiesDef,
@@ -46,7 +46,7 @@ function graph<
 /**
  * Creates an entity definition, to be used in conjunction with `i.graph`.
  *
- * @see https://instantdb.com/docs/schema
+ * @see https://instantdb.com/docs/modeling-data
  * @example
  *   {
  *     posts: i.entity({
@@ -144,7 +144,7 @@ type LinksIndex = Record<
  * You can push this schema to your database with the CLI,
  * or use it inside `init`, to get typesafety and autocompletion.
  *
- * @see https://instantdb.com/docs/schema
+ * @see https://instantdb.com/docs/modeling-data
  * @example
  *   i.schema({
  *     entities: { },

--- a/client/sandbox/react-native-expo/instant.schema.ts
+++ b/client/sandbox/react-native-expo/instant.schema.ts
@@ -1,11 +1,9 @@
-// Docs: https://www.instantdb.com/docs/schema
+// Docs: https://www.instantdb.com/docs/modeling-data
 
 import { i } from '@instantdb/react-native';
 
 const _schema = i.schema({
   // This section lets you define entities: think `posts`, `comments`, etc
-  // Take a look at the docs to learn more:
-  // https://www.instantdb.com/docs/schema#defining-entities
   entities: {
     $users: i.entity({
       email: i.string().unique().indexed(),
@@ -13,11 +11,8 @@ const _schema = i.schema({
   },
   // You can define links here.
   // For example, if `posts` should have many `comments`.
-  // More in the docs:
-  // https://www.instantdb.com/docs/schema#defining-links
   links: {},
   // If you use presence, you can define a room schema here
-  // https://www.instantdb.com/docs/schema#defining-rooms
   rooms: {},
 });
 

--- a/client/sandbox/strong-init-vite/instant.schema.ts
+++ b/client/sandbox/strong-init-vite/instant.schema.ts
@@ -1,11 +1,8 @@
-// Docs: https://www.instantdb.com/docs/schema
+// Docs: https://www.instantdb.com/docs/modeling-data
 
 import { i } from '@instantdb/react';
 
 const _schema = i.schema({
-  // This section lets you define entities: think `posts`, `comments`, etc
-  // Take a look at the docs to learn more:
-  // https://www.instantdb.com/docs/schema#defining-entities
   entities: {
     $users: i.entity({
       email: i.string().unique().indexed(),
@@ -18,10 +15,6 @@ const _schema = i.schema({
       content: i.string(),
     }),
   },
-  // You can define links here.
-  // For example, if `posts` should have many `comments`.
-  // More in the docs:
-  // https://www.instantdb.com/docs/schema#defining-links
   links: {
     postsOwner: {
       forward: {


### PR DESCRIPTION
Goes over all the places where we linked to /docs/schema, and link to /docs/modeling-data instead. 

I tried to be a bit more general about the link (rather then linking to subsections), so the links have a higher chance of standing the test of time. 

@dwwoelfel @nezaj @tonsky @drew-harris 