### PR TITLE
[sm] fix __esModule showing up in perms

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -17,7 +17,7 @@ import chalk from 'chalk';
 import { program, Option } from 'commander';
 import { input, select } from '@inquirer/prompts';
 import envPaths from 'env-paths';
-import { loadConfig } from 'unconfig';
+import { loadConfig } from './util/loadConfig.js';
 import { packageDirectory } from 'pkg-dir';
 import openInBrowser from 'open';
 import ora from 'ora';

--- a/client/packages/cli/src/util/loadConfig.ts
+++ b/client/packages/cli/src/util/loadConfig.ts
@@ -1,0 +1,17 @@
+import {
+  loadConfig as _loadConfig,
+  LoadConfigOptions,
+  LoadConfigResult,
+} from 'unconfig';
+
+export async function loadConfig<T>(
+  opts: LoadConfigOptions<T>,
+): Promise<LoadConfigResult<T>> {
+  const res = await _loadConfig(opts);
+  // Unconfig seems to add an __esModule property to the config object
+  // Removing it.
+  if (typeof res.config === 'object' && '__esModule' in res.config) {
+    delete res.config.__esModule;
+  }
+  return res;
+}


### PR DESCRIPTION
We got some reports that if we pushed perms, we would get __esModule: true in the result. 

I wasn't able to repro this on my machine, but we saw in the `unconfig` library, that in their tests they explictly delete __esModule: 

https://github.com/antfu-collective/unconfig/blob/845a3ad811cc41954b467ef2a528ace7fd09a63f/test/run.test.ts#L44 

I went ahead and wrapped loadConfig, and deleted __esModule. 

I am not 100% sure this will do the trick, but I think we should be good.

@dwwoelfel @nezaj @tonsky @drew-harris 
