### PR TITLE
Log info from hazelcast's jmx metrics to gauges

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -93,7 +93,8 @@
         dev.weavejester/medley {:mvn/version "1.8.1"}
         com.hazelcast/hazelcast {:mvn/version "5.5.0"}
         net.openhft/zero-allocation-hashing {:mvn/version "0.27ea1"}
-        com.github.luben/zstd-jni {:mvn/version "1.5.7-4"}}
+        com.github.luben/zstd-jni {:mvn/version "1.5.7-4"}
+        org.clojure/java.jmx {:mvn/version "1.1.0"}}
  :aliases {:dev {:extra-paths ["dev" "test" "dev-resources"]
                  :extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "3.10.0"}
                               criterium/criterium           {:mvn/version "0.4.6"}

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -183,8 +183,9 @@
                                                               (every? (fn [x] (instance? Instant x)) v))))
                                                  (format "'%s'%s"
                                                          (->pg-stringable-array v)
-                                                         (when-let [pgtype (-> v meta :pgtype)]
-                                                           (str "::" pgtype)))
+                                                         (if-let [pgtype (-> v meta :pgtype)]
+                                                           (str "::" pgtype)
+                                                           ""))
 
                                                  (= "bigint[][]" (-> v meta :pgtype))
                                                  (format "'%s'::bigint[][]"


### PR DESCRIPTION
Gets properties that hazelcast publishes to jmx and sends them to honeycomb with our gauges.

Adds a dependency on https://github.com/clojure/java.jmx, which provides a nicer interface to jmx info.