### PR TITLE
Fix delete cascade that goes into system namespaces

### DIFF
--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -33,7 +33,12 @@
           :when (#{:add-triple :deep-merge-triple :retract-triple :delete-entity} op)
           :when (and etype
                      (string/starts-with? etype "$")
-                     (not (and admin? (= etype "$users")))
+                     (not (and admin?
+                               (#{"$users"
+                                  "$userRefreshTokens"
+                                  "$magicCodes"
+                                  "$oauthUserLinks"
+                                  "$oauthCodes"} etype)))
                      ;; checking admin? is not enough for $files so we handle
                      ;; validations later
                      (not (string/starts-with? etype "$files")))]

--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -31,14 +31,8 @@
   [{:keys [admin?]} tx-step-maps]
   (doseq [{:keys [op etype] :as tx-step} tx-step-maps
           :when (#{:add-triple :deep-merge-triple :retract-triple :delete-entity} op)
-          :when (and etype
-                     (string/starts-with? etype "$")
-                     (not (and admin?
-                               (#{"$users"
-                                  "$userRefreshTokens"
-                                  "$magicCodes"
-                                  "$oauthUserLinks"
-                                  "$oauthCodes"} etype)))
+          :when (and (string/starts-with? etype "$")
+                     (not admin?)
                      ;; checking admin? is not enough for $files so we handle
                      ;; validations later
                      (not (string/starts-with? etype "$files")))]


### PR DESCRIPTION
Report: https://discord.com/channels/1031957483243188235/1407291069015785522

Issue is that we validate reserve names after cascade delete expansion (which is more correct, as we actually check what we are deleting). In the old version we were only checking it before expansion (so technically you can delete from any namespace that is cascade linked to e.g. users)