### PR TITLE
Enable pg hint plan by default (gated behind a feature flag)

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -2922,15 +2922,16 @@
            batch-data))))
 
 (defn query-nested [{:keys [app-id db query-hash] :as ctx} nested-patterns]
-  (let [disable-pg-hint? (or (flags/toggled? :disable-pg-hints)
-                             (contains? (flags/flag :disable-hint-query-hashes)
-                                        query-hash))
-        enable-pg-hints? (or (flags/toggled? :pg-hints-by-default)
-                             (contains? (flags/flag :use-hint-query-hashes)
-                                        query-hash))]
-    (tracer/add-data! {:use-pg-hint (and enable-pg-hints?
-                                         (not disable-pg-hint?))})
-    (binding [*enable-pg-hints* (not disable-pg-hint?)]
+  (let [disable-hints? (or (flags/toggled? :disable-pg-hints)
+                           (contains? (flags/flag :disable-hint-query-hashes)
+                                      query-hash))
+        enable-hints? (or (flags/toggled? :pg-hints-by-default)
+                          (contains? (flags/flag :use-hint-query-hashes)
+                                     query-hash))]
+    (tracer/add-data! {:use-pg-hint (and enable-hints?
+                                         (not disable-hints?))})
+    (binding [*enable-pg-hints* (and enable-hints?
+                                     (not disable-hints?))]
       (let [nested-named-patterns (cond->> nested-patterns
                                     true nested->named-patterns
                                     (enable-pg-hints?) (annotate-with-hints ctx))]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -2928,8 +2928,9 @@
         enable-hints? (or (flags/toggled? :pg-hints-by-default)
                           (contains? (flags/flag :use-hint-query-hashes)
                                      query-hash))]
-    (tracer/add-data! {:use-pg-hint (and enable-hints?
-                                         (not disable-hints?))})
+    (tracer/add-data! {:attributes {:use-pg-hint (and enable-hints?
+                                                      (not disable-hints?))
+                                    :query-hash query-hash}})
     (binding [*enable-pg-hints* (and enable-hints?
                                      (not disable-hints?))]
       (let [nested-named-patterns (cond->> nested-patterns

--- a/server/src/instant/db/hint_testing.clj
+++ b/server/src/instant/db/hint_testing.clj
@@ -112,6 +112,7 @@
                         (tracer/add-data! {:attributes res})
                         res)
                       (catch Exception e
+                        (tracer/add-exception! e {:escaping? false})
                         e))))
             new (tracer/with-span! {:name "test-pg-hints-for-datalog/with-hint-plan"}
                   (binding [d/*enable-pg-hints* true
@@ -121,6 +122,7 @@
                         (tracer/add-data! {:attributes res})
                         res)
                       (catch Exception e
+                        (tracer/add-exception! e {:escaping? false})
                         e))))
             sketches (tracer/with-span! {:name "test-pg-hints-for-datalog/with-sketches"}
                        (binding [d/*enable-pg-hints* true
@@ -130,6 +132,7 @@
                              (tracer/add-data! {:attributes res})
                              res)
                            (catch Exception e
+                             (tracer/add-exception! e {:escaping? false})
                              e))))]
         (tracer/add-data! {:attributes {:without.ms (:time old)
                                         :with.ms (:time new)

--- a/server/src/instant/db/rule_where_testing.clj
+++ b/server/src/instant/db/rule_where_testing.clj
@@ -4,16 +4,11 @@
             [instant.db.datalog :as d]
             [instant.flags :as flags]
             [instant.jdbc.sql :as sql]
-            ;; [instant.model.rule :as rule-model]
-            ;; [instant.util.coll :as ucoll]
+            [instant.model.rule :as rule-model]
+            [instant.util.coll :as ucoll]
             [instant.util.cache :refer [lookup-or-miss]]
             [instant.util.tracer :as tracer]
             [instant.util.instaql :refer [instaql-nodes->object-tree forms-hash]]))
-
-;; DWW: Temporarily hijacking this ns to test out pg_hint_plan
-;;      Add a new row to `toggles` in the instant-config app with
-;;      setting="pg-hint-test/postgres-index-name" (e.g. pg-hint-test/av_index), value=true
-;;      to test with that index enabled.
 
 (def seen (cache/ttl-cache-factory {} :ttl (* 1000 60)))
 
@@ -32,26 +27,23 @@
 (defn test-rule-wheres [ctx permissioned-query-fn o query-hash]
   (lookup-or-miss seen query-hash (constantly true))
   (tracer/with-new-trace-root
-    (tracer/with-span! {:name "test-pg-hint-plan"
+    (tracer/with-span! {:name "test-rule-wheres"
                         :attributes (merge {:query o
                                             :app-id (:app-id ctx)
-                                            :current-user-id (-> ctx :current-user :id)}
-                                           (flags/pg-hint-testing-toggles))}
+                                            :current-user-id (-> ctx :current-user :id)})}
       (binding [sql/*query-timeout-seconds* 5]
         (let [ctx (assoc ctx :datalog-query-fn d/query)
               without-rule-wheres-fut
               (future
-                (tracer/with-span! {:name "test-pg-hint-plan/without-hint-plan"}
-                  (binding [d/*testing-pg-hints* false]
-                    (run-test ctx ;;(assoc ctx :use-rule-wheres? false)
-                              permissioned-query-fn o))))
+                (tracer/with-span! {:name "test-rule-wheres/without-rule-wheres"}
+                  (run-test (assoc ctx :use-rule-wheres? false)
+                            permissioned-query-fn o)))
 
               with-rule-wheres-fut
               (future
-                (tracer/with-span! {:name "test-pg-hint-plan/with-hint-plan"}
-                  (binding [d/*testing-pg-hints* true]
-                    (run-test ctx ;;(assoc ctx :use-rule-wheres? true)
-                              permissioned-query-fn o))))
+                (tracer/with-span! {:name "test-rule-wheres/with-rule-wheres"}
+                  (run-test (assoc ctx :use-rule-wheres? true)
+                            permissioned-query-fn o)))
 
               without-rule-wheres @without-rule-wheres-fut
               with-rule-wheres @with-rule-wheres-fut
@@ -75,17 +67,14 @@
           (tracer/add-data! {:attributes attrs})
           attrs)))))
 
-#_(defn worth-testing? [ctx o]
+(defn worth-testing? [ctx o query-hash]
   (and (flags/test-rule-wheres?)
+       (not (cache/lookup seen query-hash))
        (let [rules (rule-model/get-by-app-id {:app-id (:app-id ctx)})]
          (and rules
               (ucoll/exists? (fn [field]
                                (rule-model/get-program! rules (name field) "view"))
                              (keys o))))))
-
-(defn worth-testing? [_ctx _o query-hash]
-  (and (flags/test-rule-wheres?)
-       (not (cache/lookup seen query-hash))))
 
 (defonce process-chan (atom (a/chan (a/sliding-buffer 10))))
 

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -3,7 +3,8 @@
 ;; and can be required from anywhere.
 (ns instant.flags
   (:require
-   [clojure.walk :as w]))
+   [clojure.walk :as w]
+   [instant.config :as config]))
 
 ;; Map of query to {:result {result-tree}
 ;;                  :tx-id int}
@@ -33,6 +34,8 @@
             :toggles {}
             :flags {}
             :handle-receive-timeout {}})
+
+(def toggle-defaults {:pg-hints-by-default (= :test (config/get-env))})
 
 (defn transform-query-result
   "Function that is called on the query result before it is stored in the
@@ -164,7 +167,7 @@
                             (get result "query-flags"))
         toggles (reduce (fn [acc {:strs [setting toggled]}]
                           (assoc acc (keyword setting) toggled))
-                        {}
+                        toggle-defaults
                         (get result "toggles"))
         flags (-> (reduce (fn [acc {:strs [setting value]}]
                             (assoc acc (keyword setting) value))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -174,8 +174,8 @@
                                                          (set (map parse-uuid vs))))
                   (update :tika-enabled-apps (fn [vs]
                                                (set (map parse-uuid vs))))
-                  (update :use-hint-query-hashes (fn [vs]
-                                                   (set vs))))
+                  (update :disable-hint-query-hashes (fn [vs]
+                                                       (set vs))))
 
         handle-receive-timeout (reduce (fn [acc {:strs [appId timeoutMs]}]
                                          (assoc acc (parse-uuid appId) timeoutMs))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -386,4 +386,3 @@
 
 (defn hard-deletion-sweeper-disabled? []
   (toggled? :hard-deletion-sweeper-disabled?))
-

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.set :as set]
    [clojure+.walk :as walk]
+   [instant.config :as config]
+   [instant.db.attr-sketch :as cms]
    [instant.db.datalog :as d]
    [instant.db.instaql :as iq]
    [instant.db.model.attr :as attr-model]
@@ -9,8 +11,10 @@
    [instant.db.transaction :as tx]
    [instant.jdbc.aurora :as aurora]
    [instant.model.rule :as rule-model]
+   [instant.reactive.aggregator :as aggregator]
    [instant.util.exception :as ex]
-   [instant.util.instaql :refer [instaql-nodes->object-tree]])
+   [instant.util.instaql :refer [instaql-nodes->object-tree]]
+   [next.jdbc])
   (:import
    (java.time Duration Instant)))
 
@@ -186,3 +190,38 @@
          (if (= ::ex/validation-failed (::ex/type (ex-data instant-ex#)))
            instant-ex#
            (throw e#))))))
+
+(defn in-memory-sketches-for-app [app-id]
+  (with-open [conn (next.jdbc/get-connection (config/get-aurora-config))]
+    (reduce (fn [acc sketch]
+              (assoc acc (select-keys sketch [:app-id :attr-id]) sketch))
+            (aggregator/initial-sketch-seq conn
+                                           (format "copy (select app_id, attr_id, entity_id, value, checked_data_type, created_at, eav, ea from triples where app_id = '%s'::uuid order by app_id, attr_id) to stdout with (format binary)"
+                                                   app-id)))))
+
+(defn lookup-with-in-memory-sketches
+  ([original-lookup in-memory-sketches keys]
+   (lookup-with-in-memory-sketches original-lookup
+                                   in-memory-sketches
+                                   (aurora/conn-pool :read)
+                                   keys))
+  ([original-lookup in-memory-sketches conn keys]
+   (let [{:keys [results missing]}
+         (reduce (fn [acc k]
+                   (if-let [ours (get in-memory-sketches k)]
+                     (assoc-in acc [:results k] ours)
+                     (update acc :missing conj k)))
+                 {:results {}
+                  :missing #{}}
+                 keys)]
+     (merge results (original-lookup conn missing)))))
+
+(defmacro with-sketches
+  "Calculates the sketches for the app and returns them from calls to `attr-sketch/lookup`.
+   Used when we need to have the sketches for a test, but the aggregator isn't running or
+   we don't want to wait for the aggregator to catch up."
+  [app & body]
+  `(let [sketches# (in-memory-sketches-for-app (:id ~app))
+         original-lookup# (var-get #'cms/lookup)]
+     (with-redefs [cms/lookup (partial lookup-with-in-memory-sketches original-lookup# sketches#)]
+       ~@body)))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as string]
    [clojure.test :as test :refer [are deftest is testing]]
-   [instant.config :as config]
    [instant.data.bootstrap :as bootstrap]
    [instant.data.constants :as constants]
    [instant.data.resolvers :as resolvers]
@@ -27,7 +26,7 @@
    [instant.util.coll :as ucoll]
    [instant.util.exception :as ex]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
-   [instant.util.test :refer [instant-ex-data pretty-perm-q]]
+   [instant.util.test :refer [instant-ex-data pretty-perm-q with-sketches]]
    [next.jdbc :as next-jdbc]
    [rewrite-clj.zip :as z]
    [zprint.core :as zprint])
@@ -2768,132 +2767,132 @@
              ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))}))))))
 
 (deftest comparators
-  (binding [d/*testing-pg-hints* true]
+  (binding [d/*enable-pg-hints* true
+            d/*estimate-with-sketch* true]
     (with-zeneca-checked-data-app
       (fn [app _r]
-        (let [attr-ids {:string (random-uuid)
-                        :number (random-uuid)
-                        :boolean (random-uuid)
-                        :date (random-uuid)}
-              label-attr-id (random-uuid)
-              labels ["a" "b" "c" "d" "e"]
-              make-ctx (fn []
-                         (let [attrs (attr-model/get-by-app-id (:id app))]
-                           {:db {:conn-pool (aurora/conn-pool :write)}
-                            :app-id (:id app)
-                            :attrs attrs}))
-              run-query (fn [return-field q]
-                          (let [ctx (make-ctx)]
-                            (->> (iq/permissioned-query ctx q)
-                                 (instaql-nodes->object-tree ctx)
-                                 (#(get % "etype"))
-                                 (map #(get % (name return-field)))
-                                 set)))
-              run-explain (fn run-explain
-                            ([data-type value]
-                             (run-explain :$gt data-type value))
-                            ([op data-type value]
-                             (let [explain
-                                   (d/explain (make-ctx)
-                                              {:children
-                                               {:pattern-groups
-                                                [{:patterns
-                                                  [[{:idx-key :ave, :data-type data-type}
-                                                    '?etype-0
-                                                    (get attr-ids data-type)
-                                                    {:$comparator {:op op, :value value, :data-type data-type}}]]}]}})]
-                               (-> explain
-                                   first
-                                   (get "QUERY PLAN")
-                                   first
-                                   (get-in ["Plan" "Plans" 0 "Index Name"])))))]
-          (tx/transact! (aurora/conn-pool :write)
-                        (attr-model/get-by-app-id (:id app))
-                        (:id app)
-                        (concat
-                         [[:add-attr {:id (random-uuid)
-                                      :forward-identity [(random-uuid) "etype" "id"]
-                                      :unique? true
-                                      :index? true
-                                      :value-type :blob
-                                      :checked-data-type :string
-                                      :cardinality :one}]
-                          [:add-attr {:id label-attr-id
-                                      :forward-identity [(random-uuid) "etype" "label"]
-                                      :unique? true
-                                      :index? true
-                                      :value-type :blob
-                                      :checked-data-type :string
-                                      :cardinality :one}]]
-                         (for [[t attr-id] attr-ids]
-                           [:add-attr {:id attr-id
-                                       :forward-identity [(random-uuid) "etype" (name t)]
-                                       :unique? false
-                                       :index? true
-                                       :value-type :blob
-                                       :checked-data-type t
-                                       :cardinality :one}])
+        (with-sketches app
+          (let [attr-ids {:string (random-uuid)
+                          :number (random-uuid)
+                          :boolean (random-uuid)
+                          :date (random-uuid)}
+                label-attr-id (random-uuid)
+                labels ["a" "b" "c" "d" "e"]
+                make-ctx (fn []
+                           (let [attrs (attr-model/get-by-app-id (:id app))]
+                             {:db {:conn-pool (aurora/conn-pool :write)}
+                              :app-id (:id app)
+                              :attrs attrs}))
+                run-query (fn [return-field q]
+                            (let [ctx (make-ctx)]
+                              (->> (iq/permissioned-query ctx q)
+                                   (instaql-nodes->object-tree ctx)
+                                   (#(get % "etype"))
+                                   (map #(get % (name return-field)))
+                                   set)))
+                run-explain (fn run-explain
+                              ([data-type value]
+                               (run-explain :$gt data-type value))
+                              ([op data-type value]
+                               (let [explain
+                                     (d/explain (make-ctx)
+                                                {:children
+                                                 {:pattern-groups
+                                                  [{:patterns
+                                                    [[{:idx-key :ave, :data-type data-type}
+                                                      '?etype-0
+                                                      (get attr-ids data-type)
+                                                      {:$comparator {:op op, :value value, :data-type data-type}}]]}]}})]
+                                 (-> explain
+                                     first
+                                     (get "QUERY PLAN")
+                                     first
+                                     (get-in ["Plan" "Plans" 0 "Index Name"])))))]
+            (tx/transact! (aurora/conn-pool :write)
+                          (attr-model/get-by-app-id (:id app))
+                          (:id app)
+                          (concat
+                           [[:add-attr {:id (random-uuid)
+                                        :forward-identity [(random-uuid) "etype" "id"]
+                                        :unique? true
+                                        :index? true
+                                        :value-type :blob
+                                        :checked-data-type :string
+                                        :cardinality :one}]
+                            [:add-attr {:id label-attr-id
+                                        :forward-identity [(random-uuid) "etype" "label"]
+                                        :unique? true
+                                        :index? true
+                                        :value-type :blob
+                                        :checked-data-type :string
+                                        :cardinality :one}]]
+                           (for [[t attr-id] attr-ids]
+                             [:add-attr {:id attr-id
+                                         :forward-identity [(random-uuid) "etype" (name t)]
+                                         :unique? false
+                                         :index? true
+                                         :value-type :blob
+                                         :checked-data-type t
+                                         :cardinality :one}])
 
-                         (mapcat
-                          (fn [i]
-                            (let [id (random-uuid)]
-                              [[:add-triple id label-attr-id (nth labels i)]
-                               [:add-triple id (:string attr-ids) (str i)]
-                               [:add-triple id (:number attr-ids) i]
-                               [:add-triple id (:date attr-ids) i]
-                               [:add-triple id (:boolean attr-ids) (zero? (mod i 2))]]))
-                          (range (count labels)))))
-          (when (= :test (config/get-env))
-            (sql/select (aurora/conn-pool :write) ["ANALYZE triples"]))
-          (testing "string"
-            (is (= #{"3" "4"}  (run-query :string {:etype {:$ {:where {:string {:$gt "2"}}}}})))
-            (is (= #{"2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$gte "2"}}}}})))
-            (is (= #{"0" "1"} (run-query :string {:etype {:$ {:where {:string {:$lt "2"}}}}})))
-            (is (= #{"0" "1" "2"} (run-query :string {:etype {:$ {:where {:string {:$lte "2"}}}}})))
-            (is (= #{"1"} (run-query :string {:etype {:$ {:where {:string "1"}}}})))
-            (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
+                           (mapcat
+                            (fn [i]
+                              (let [id (random-uuid)]
+                                [[:add-triple id label-attr-id (nth labels i)]
+                                 [:add-triple id (:string attr-ids) (str i)]
+                                 [:add-triple id (:number attr-ids) i]
+                                 [:add-triple id (:date attr-ids) i]
+                                 [:add-triple id (:boolean attr-ids) (zero? (mod i 2))]]))
+                            (range (count labels)))))
+            (testing "string"
+              (is (= #{"3" "4"}  (run-query :string {:etype {:$ {:where {:string {:$gt "2"}}}}})))
+              (is (= #{"2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$gte "2"}}}}})))
+              (is (= #{"0" "1"} (run-query :string {:etype {:$ {:where {:string {:$lt "2"}}}}})))
+              (is (= #{"0" "1" "2"} (run-query :string {:etype {:$ {:where {:string {:$lte "2"}}}}})))
+              (is (= #{"1"} (run-query :string {:etype {:$ {:where {:string "1"}}}})))
+              (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
 
-            (testing "uses index"
-              (is (= "ave_index" (run-explain :string "2"))))
+              (testing "uses index"
+                (is (= "ave_index" (run-explain :string "2"))))
 
-            (testing "like uses index"
-              (is (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa")))))
+              (testing "like uses index"
+                (is (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa")))))
 
-          (testing "number"
-            (is (= #{3 4} (run-query :number {:etype {:$ {:where {:number {:$gt 2}}}}})))
-            (is (= #{2 3 4} (run-query :number {:etype {:$ {:where {:number {:$gte 2}}}}})))
-            (is (= #{0 1} (run-query :number {:etype {:$ {:where {:number {:$lt 2}}}}})))
-            (is (= #{0 1 2} (run-query :number {:etype {:$ {:where {:number {:$lte 2}}}}})))
-            (is (= #{1} (run-query :number {:etype {:$ {:where {:number 1}}}})))
-            (is (= #{0 2 3 4} (run-query :number {:etype {:$ {:where {:number {:$not 1}}}}})))
+            (testing "number"
+              (is (= #{3 4} (run-query :number {:etype {:$ {:where {:number {:$gt 2}}}}})))
+              (is (= #{2 3 4} (run-query :number {:etype {:$ {:where {:number {:$gte 2}}}}})))
+              (is (= #{0 1} (run-query :number {:etype {:$ {:where {:number {:$lt 2}}}}})))
+              (is (= #{0 1 2} (run-query :number {:etype {:$ {:where {:number {:$lte 2}}}}})))
+              (is (= #{1} (run-query :number {:etype {:$ {:where {:number 1}}}})))
+              (is (= #{0 2 3 4} (run-query :number {:etype {:$ {:where {:number {:$not 1}}}}})))
 
-            (testing "uses index"
-              (is (= "triples_number_type_idx" (run-explain :number 2)))))
+              (testing "uses index"
+                (is (= "triples_number_type_idx" (run-explain :number 2)))))
 
-          (testing "date"
-            (is (= #{3 4} (run-query :date {:etype {:$ {:where {:date {:$gt 2}}}}})))
-            (is (= #{2 3 4} (run-query :date {:etype {:$ {:where {:date {:$gte 2}}}}})))
-            (is (= #{0 1} (run-query :date {:etype {:$ {:where {:date {:$lt 2}}}}})))
-            (is (= #{0 1 2} (run-query :date {:etype {:$ {:where {:date {:$lte 2}}}}})))
-            (is (= #{1} (run-query :date {:etype {:$ {:where {:date 1}}}})))
-            (is (= #{1} (run-query :date {:etype {:$ {:where {:date (.toString (Instant/ofEpochMilli 1))}}}})))
-            (is (= #{0 2 3 4} (run-query :date {:etype {:$ {:where {:date {:$not 1}}}}})))
+            (testing "date"
+              (is (= #{3 4} (run-query :date {:etype {:$ {:where {:date {:$gt 2}}}}})))
+              (is (= #{2 3 4} (run-query :date {:etype {:$ {:where {:date {:$gte 2}}}}})))
+              (is (= #{0 1} (run-query :date {:etype {:$ {:where {:date {:$lt 2}}}}})))
+              (is (= #{0 1 2} (run-query :date {:etype {:$ {:where {:date {:$lte 2}}}}})))
+              (is (= #{1} (run-query :date {:etype {:$ {:where {:date 1}}}})))
+              (is (= #{1} (run-query :date {:etype {:$ {:where {:date (.toString (Instant/ofEpochMilli 1))}}}})))
+              (is (= #{0 2 3 4} (run-query :date {:etype {:$ {:where {:date {:$not 1}}}}})))
 
-            (testing "uses index"
-              (is (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2))))))
+              (testing "uses index"
+                (is (= "triples_date_type_idx" (run-explain :date (Instant/ofEpochMilli 2))))))
 
-          (testing "boolean"
-            (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt true}}}}})))
-            (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt false}}}}})))
-            (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gte true}}}}})))
-            (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt false}}}}})))
-            (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt true}}}}})))
-            (is (= #{false true} (run-query :boolean {:etype {:$ {:where {:boolean {:$lte true}}}}})))
-            (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean true}}}})))
-            (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$not true}}}}})))
+            (testing "boolean"
+              (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt true}}}}})))
+              (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gt false}}}}})))
+              (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean {:$gte true}}}}})))
+              (is (= #{} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt false}}}}})))
+              (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$lt true}}}}})))
+              (is (= #{false true} (run-query :boolean {:etype {:$ {:where {:boolean {:$lte true}}}}})))
+              (is (= #{true} (run-query :boolean {:etype {:$ {:where {:boolean true}}}})))
+              (is (= #{false} (run-query :boolean {:etype {:$ {:where {:boolean {:$not true}}}}})))
 
-            (testing "uses index"
-              (is (= "triples_boolean_type_idx" (run-explain :boolean true))))))))))
+              (testing "uses index"
+                (is (= "triples_boolean_type_idx" (run-explain :boolean true)))))))))))
 
 (deftest in-with-types
   (with-zeneca-checked-data-app
@@ -3015,7 +3014,8 @@
                                     ("eid-nonfiction" :bookshelves/order 1))}))))))
 
 (deftest lookup-unique-uses-the-av-index
-  (binding [d/*testing-pg-hints* true]
+  (binding [d/*enable-pg-hints* true
+            d/*estimate-with-sketch* true]
     (with-zeneca-app
       (fn [app _r]
         (let [attr-ids {:id (random-uuid)
@@ -3045,51 +3045,45 @@
                                          [:add-triple id (:handle attr-ids) "a"]])
                                       (let [id (random-uuid)]
                                         [[:add-triple id (:id attr-ids) (str id)]
-                                         [:add-triple id (:handle attr-ids) "b"]])
-                                      (mapcat (fn [i]
-                                                (let [id (random-uuid)]
-                                                  [[:add-triple id (:id attr-ids) (str id)]
-                                                   [:add-triple id (:handle attr-ids) (str i)]]))
-                                              (range 5000))))]
-          (when (= :test (config/get-env))
-            (sql/select (aurora/conn-pool :write) ["ANALYZE triples"]))
-          (testing "query on unique attr"
-            (let [{:keys [patterns]} (iq/instaql-query->patterns
-                                      (make-ctx)
-                                      {:user {:$ {:where {:handle "a"}}}})
-                  explain (d/explain (make-ctx) patterns)
-                  plan (-> explain
-                           first
-                           (get "QUERY PLAN")
-                           first
-                           (get-in ["Plan" "Plans" 0]))
-                  ;; Make sure it's using the full index
-                  expected-index-cond (format "((t0.app_id = '%s'::uuid) AND (t0.attr_id = '%s'::uuid) AND (CASE WHEN (t0.value = 'null'::jsonb) THEN NULL::jsonb ELSE t0.value END = '\"a\"'::jsonb))"
-                                              (:id app)
-                                              (:handle attr-ids))]
-              (is (= expected-index-cond (get plan "Index Cond")))
-              (is (= "av_index" (get plan "Index Name")))))
+                                         [:add-triple id (:handle attr-ids) "b"]])))]
+          (with-sketches app
+            (testing "query on unique attr"
+              (let [{:keys [patterns]} (iq/instaql-query->patterns
+                                        (make-ctx)
+                                        {:user {:$ {:where {:handle "a"}}}})
+                    explain (d/explain (make-ctx) patterns)
+                    plan (-> explain
+                             first
+                             (get "QUERY PLAN")
+                             first
+                             (get-in ["Plan" "Plans" 0]))
+                    ;; Make sure it's using the full index
+                    expected-index-cond (format "((t0.app_id = '%s'::uuid) AND (t0.attr_id = '%s'::uuid) AND (CASE WHEN (t0.value = 'null'::jsonb) THEN NULL::jsonb ELSE t0.value END = '\"a\"'::jsonb))"
+                                                (:id app)
+                                                (:handle attr-ids))]
+                (is (= expected-index-cond (get plan "Index Cond")))
+                (is (= "av_index" (get plan "Index Name")))))
 
-          (testing "query with lookup"
-            (let [explain (d/explain (make-ctx) {:children
-                                                 {:pattern-groups
-                                                  [{:patterns
-                                                    [[:ea [(:handle attr-ids) "a"]]]}]}})
-                  plan (-> explain
-                           first
-                           (get "QUERY PLAN")
-                           first
-                           (get-in ["Plan" "Plans"])
-                           first
-                           (get "Plans")
-                           first)
-                  ;; Make sure it's using the full index
-                  expected-index-cond (format "((triples.app_id = '%s'::uuid) AND (triples.attr_id = '%s'::uuid) AND (CASE WHEN (triples.value = 'null'::jsonb) THEN NULL::jsonb ELSE triples.value END = '\"a\"'::jsonb))"
-                                              (:id app)
-                                              (:handle attr-ids))]
+            (testing "query with lookup"
+              (let [explain (d/explain (make-ctx) {:children
+                                                   {:pattern-groups
+                                                    [{:patterns
+                                                      [[:ea [(:handle attr-ids) "a"]]]}]}})
+                    plan (-> explain
+                             first
+                             (get "QUERY PLAN")
+                             first
+                             (get-in ["Plan" "Plans"])
+                             first
+                             (get "Plans")
+                             first)
+                    ;; Make sure it's using the full index
+                    expected-index-cond (format "((t0_lookup.app_id = '%s'::uuid) AND (t0_lookup.attr_id = '%s'::uuid) AND (CASE WHEN (t0_lookup.value = 'null'::jsonb) THEN NULL::jsonb ELSE t0_lookup.value END = '\"a\"'::jsonb))"
+                                                (:id app)
+                                                (:handle attr-ids))]
 
-              (is (= expected-index-cond (get plan "Index Cond")))
-              (is (= "av_index" (get plan "Index Name"))))))))))
+                (is (= expected-index-cond (get plan "Index Cond")))
+                (is (= "av_index" (get plan "Index Name")))))))))))
 
 (deftest arbitrary-order-by-all-types
   (with-empty-app
@@ -4736,27 +4730,29 @@
 (deftest pg-hint-plan-is-working
   (with-zeneca-app
     (fn [app _r]
-      (binding [d/*testing-pg-hints* true]
-        (next-jdbc/with-transaction [conn (aurora/conn-pool :read)]
-          (next-jdbc/execute! conn ["select set_config('pg_hint_plan.debug_print', 'verbose', true)"])
-          (next-jdbc/execute! conn ["select set_config('pg_hint_plan.message_level', 'warning', true)"])
-          (let [ctx {:db {:conn-pool conn}
-                     :app-id (:id app)
-                     :attrs (attr-model/get-by-app-id (:id app))}
-                {:keys [patterns]} (iq/instaql-query->patterns ctx
-                                                               {:users {:$ {:where {:handle "a"}}}})
-                explain (d/explain ctx patterns)
-                warnings (loop [msgs []
-                                ^PSQLWarning warnings (:warnings (meta explain))]
-                           (if warnings
-                             (recur (conj msgs (.getMessage warnings))
-                                    (.getNextWarning warnings))
-                             msgs))
-                hint-state-dump (ucoll/seek (fn [msg]
-                                              (string/includes? msg "HintStateDump"))
-                                            warnings)]
-            (is (not (nil? hint-state-dump)))
-            (is (string/includes? hint-state-dump "used hints:IndexScan(t0 av_index)IndexScan(t2 ea_index)"))))))))
+      (with-sketches app
+        (binding [d/*enable-pg-hints* true
+                  d/*estimate-with-sketch* true]
+          (next-jdbc/with-transaction [conn (aurora/conn-pool :read)]
+            (next-jdbc/execute! conn ["select set_config('pg_hint_plan.debug_print', 'verbose', true)"])
+            (next-jdbc/execute! conn ["select set_config('pg_hint_plan.message_level', 'warning', true)"])
+            (let [ctx {:db {:conn-pool conn}
+                       :app-id (:id app)
+                       :attrs (attr-model/get-by-app-id (:id app))}
+                  {:keys [patterns]} (iq/instaql-query->patterns ctx
+                                                                 {:users {:$ {:where {:handle "a"}}}})
+                  explain (d/explain ctx patterns)
+                  warnings (loop [msgs []
+                                  ^PSQLWarning warnings (:warnings (meta explain))]
+                             (if warnings
+                               (recur (conj msgs (.getMessage warnings))
+                                      (.getNextWarning warnings))
+                               msgs))
+                  hint-state-dump (ucoll/seek (fn [msg]
+                                                (string/includes? msg "HintStateDump"))
+                                              warnings)]
+              (is (not (nil? hint-state-dump)))
+              (is (string/includes? hint-state-dump "used hints:IndexScan(t0 av_index)IndexScan(t2 ea_index)")))))))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Adds a new instant-config toggle to enable pg_hint_plan by default, with an instant-config flag to disable hints for individual queries by their hashes.

The testing is looking good and I've already enabled it for the 20 best queries.

Changes in this PR:
1. Enables hints for the lookup subqueries in datalog queries.

When you do a lookup, we do something like:

```sql
where entity_id = (select entity_id from triples where attr_id = :lookup-attr-id and value = :lookup-value)
```

Lookups are unique, so we know that should be an `av_index` lookup. It complicated the `where-clause` function a bit because now it needs to pass pg-hints back up. There are other subqueries that we'll want to add hints to also.

2. Uses hints during tests and adds some helpers to get the sketches during tests, since they update incrementally in the background.

Easier to review with whitespace turned off: https://github.com/instantdb/instant/pull/1545/files?w=1
