### PR TITLE
Copy hooks to confighooks

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -284,7 +284,7 @@ jobs:
       uses: "./.github/actions/elastic-beanstalk"
       with:
         working-directory: "server"
-        files: '["docker-compose.yml", ".ebextensions/resources.config", ".ebextensions/sysctl.config", ".platform/hooks/prebuild/prebuild.sh", ".platform/hooks/postdeploy/cloudwatch.sh"]'
+        files: '["docker-compose.yml", ".ebextensions/resources.config", ".ebextensions/sysctl.config", ".platform/hooks/prebuild/prebuild.sh", ".platform/hooks/postdeploy/cloudwatch.sh", ".platform/confighooks/prebuild/prebuild.sh", ".platform/confighooks/postdeploy/cloudwatch.sh"]'
         aws-region: "us-east-1"
         bucket: "elasticbeanstalk-us-east-1-597134865416"
         application-name: "instant-docker-prod"

--- a/server/.platform/confighooks/postdeploy/cloudwatch.sh
+++ b/server/.platform/confighooks/postdeploy/cloudwatch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+
+# We log the container logs directly from docker container with the
+# awslogs driver in the docker-compose.yml.
+
+sed -i 's/\*stdouterr.log/nonexistent.log/g' /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_beanstalk.json
+
+systemctl restart amazon-cloudwatch-agent.service

--- a/server/.platform/confighooks/prebuild/prebuild.sh
+++ b/server/.platform/confighooks/prebuild/prebuild.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -x
+
+# Rotate Hazelcast port on every deploy
+
+file="/etc/deploy_count.txt"
+
+touch "$file"
+if [ ! -f "$file" ]; then
+  echo "0" > "$file"
+fi
+
+read -r current_count < "$file"
+new_count=$((current_count + 1))
+echo "$new_count" > "$file"
+
+hz_port=$((5701 + (new_count % 8)))
+
+echo "HZ_PORT=$hz_port" > hazelcast.env
+
+# Update EB_ENV_NAME in the docker-compose.yml
+
+sed -i "s/EB_ENV_NAME/$(/opt/elasticbeanstalk/bin/get-config container -k environment_name)/g" docker-compose.yml


### PR DESCRIPTION
Copies the files in `.platform/hook` to `.platform/confighooks` so that elastic beanstalk can do configuration updates.