### PR TITLE
set idle_in_transaction_session_timeout for each connection

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -370,8 +370,9 @@
 (defn toggled? [key]
   (get-in (query-result) [:toggles key]))
 
-(defn flag [key]
-  (get-in (query-result) [:flags key]))
+(defn flag
+  ([key] (get-in (query-result) [:flags key]))
+  ([key not-found] (get-in (query-result) [:flags key] not-found)))
 
 (defn handle-receive-timeout [app-id]
   (get-in (query-result) [:handle-receive-timeout app-id]))

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -2,6 +2,7 @@
   (:require
    [instant.aurora-config :refer [rds-cluster-id->db-config secret-arn->db-creds]]
    [instant.config :as config]
+   [instant.flags :as flags]
    [instant.util.async :as ua]
    [instant.util.lang :as lang]
    [instant.util.tracer :as tracer]
@@ -186,6 +187,12 @@
                       (catch Exception _e nil)))
      :get-config (fn [] @current-config)}))
 
+(defn get-connection [config]
+  (let [conn (next-jdbc/get-connection config)]
+    (next-jdbc/execute! conn ["select set_config('idle_in_transaction_session_timeout', ?::text, false)"
+                              (flags/flag :idle-in-transaction-session-timeout (* 1000 45))])
+    conn))
+
 (defn aurora-cluster-datasource
   "Creates a datasource that is resilent to password rotations and failover in aurora"
   [add-conn-to-tracker get-config]
@@ -201,7 +208,7 @@
                   (get-creds {:failed-credentials failed-credentials
                               :attempts 3})
                   config (get-config)
-                  conn (try (next-jdbc/get-connection config user password)
+                  conn (try (get-connection (assoc config :user user :password password))
                             (catch Exception e
                               (let [throwing? (>= attempt 3)]
                                 (tracer/record-info! {:name "aurora/get-conn-error"
@@ -217,10 +224,23 @@
                 (recur (inc attempt)
                        creds))))))
       (getConnection [_ user pass]
-        (next-jdbc/get-connection (get-config) user pass))
+        (get-connection (assoc (get-config) :user user :password pass)))
       (getLoginTimeout [_] (or @login-timeout 0))
       (setLoginTimeout [_ seconds] (reset! login-timeout seconds))
       (toString [_] (connection/jdbc-url (get-config))))))
+
+(defn dev-datasource [config]
+  (let [login-timeout (atom nil)]
+    (reify DataSource
+      (getConnection [_]
+        (tracer/with-span! {:name "dev/get-connection"}
+          (get-connection config)))
+      (getConnection [_ user pass]
+        (tracer/with-span! {:name "dev/get-connection"}
+          (get-connection (assoc config :user user :password pass))))
+      (getLoginTimeout [_] (or @login-timeout 0))
+      (setLoginTimeout [_ seconds] (reset! login-timeout seconds))
+      (toString [_] (connection/jdbc-url config)))))
 
 (defonce -conn-pool nil)
 
@@ -273,8 +293,7 @@
                 (doto hikari-config
                   (.setUsername (:user config))
                   (.setPassword (:password config))
-                  (.setJdbcUrl (connection/jdbc-url (dissoc config
-                                                            :user :password))))))]
+                  (.setDataSource (dev-datasource config)))))]
     ;; Check that the pool is working
     (.close (next-jdbc/get-connection pool))
     pool))

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -559,10 +559,14 @@
 
       ;; This could be other things besides a timeout,
       ;; but we don't have any way to check :/
-      (:query-canceled
-       :idle-in-transaction-session-timeout)
+      :query-canceled
       (throw+ {::type ::timeout
                ::message "The query took too long to complete."}
+              e)
+
+      :idle-in-transaction-session-timeout
+      (throw+ {::type ::timeout
+               ::message "The transaction took too long to complete."}
               e)
 
       :invalid-parameter-value

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -559,7 +559,8 @@
 
       ;; This could be other things besides a timeout,
       ;; but we don't have any way to check :/
-      :query-canceled
+      (:query-canceled
+       :idle-in-transaction-session-timeout)
       (throw+ {::type ::timeout
                ::message "The query took too long to complete."}
               e)
@@ -605,5 +606,7 @@
   (loop [cause e]
     (cond
       (::type (ex-data cause)) cause
+      ;; Unwrap errors from next-jdbc/with-transaction
+      (:handling (ex-data cause)) (:handling (ex-data cause))
       (nil? (.getCause cause)) nil
       :else (recur (.getCause cause)))))

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -191,6 +191,16 @@
            instant-ex#
            (throw e#))))))
 
+(defmacro timeout-err? [& body]
+  `(try
+     ~@body
+     false
+     (catch Exception e#
+       (let [instant-ex# (ex/find-instant-exception e#)]
+         (if (= ::ex/timeout (::ex/type (ex-data instant-ex#)))
+           instant-ex#
+           (throw e#))))))
+
 (defn in-memory-sketches-for-app [app-id]
   (with-open [conn (next.jdbc/get-connection (config/get-aurora-config))]
     (reduce (fn [acc sketch]


### PR DESCRIPTION
Sets the `idle_in_transaction_session_timeout` setting to 1 minute. This should contain the havoc that long-running transactions can wreak on the the system.

If it turns out that 1 minute was much too low, we can change it live with a feature flag, but it will only apply to newly-created connections.