### PR TITLE
Add support for uploading streams to admin sdk

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -405,6 +405,7 @@ class Auth {
 type FileOpts = {
   contentType?: string;
   contentDisposition?: string;
+  fileSize?: number; // Required for streaming uploads
 };
 
 /**

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.3';
+const version = 'v0.21.4';
 
 export { version };

--- a/client/sandbox/admin-sdk-express/src/index.ts
+++ b/client/sandbox/admin-sdk-express/src/index.ts
@@ -169,6 +169,21 @@ async function testUploadFile(src: string, dest: string, contentType?: string) {
   console.log('Uploaded:', data);
 }
 
+async function testUploadFileStream(
+  src: string,
+  dest: string,
+  contentType?: string,
+) {
+  const fp = path.join(__dirname, src);
+  const stream = fs.createReadStream(fp);
+  const fileSize = fs.statSync(fp).size;
+  const data = await db.storage.uploadFile(dest, stream, {
+    contentType: contentType,
+    fileSize,
+  });
+  console.log('Uploaded with stream:', data);
+}
+
 async function testQueryFiles() {
   const res = await query({ $files: {} });
   console.log(JSON.stringify(res, null, 2));
@@ -261,6 +276,7 @@ async function testDeleteAllowedInTx(
 
 // testUploadFile('circle_blue.jpg', 'circle_blue.jpg', 'image/jpeg');
 // testUploadFile("circle_blue.jpg", "circle_blue2.jpg", "image/jpeg");
+// testUploadFileStream("circle_blue.jpg", "circle_blue.jpg", "image/jpeg");
 // testQueryFiles()
 // testDeleteSingleFile("circle_blue.jpg");
 // testDeleteBulkFile(["circle_blue.jpg", "circle_blue2.jpg"]);

--- a/client/sandbox/admin-sdk-express/src/index.ts
+++ b/client/sandbox/admin-sdk-express/src/index.ts
@@ -5,9 +5,13 @@ import { init, tx, id, lookup } from '@instantdb/admin';
 import { assert } from 'console';
 import dotenv from 'dotenv';
 import fs from 'fs';
-import path from 'path';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const config = {
   apiURI: 'http://localhost:8888',


### PR DESCRIPTION
As part of stress testing uploads, noticed we don't support uploading streams from the admin sdk but we do support it via API. With this PR the admin SDK can now also upload streams

```typescript
async function testUploadFileStream(
  src: string,
  dest: string,
  contentType?: string,
) {
  const fp = path.join(__dirname, src);
  const stream = fs.createReadStream(fp);
  const fileSize = fs.statSync(fp).size;
  const data = await db.storage.uploadFile(dest, stream, {
    contentType: contentType,
    fileSize,
  });
  console.log('Uploaded with stream:', data);
}
```

Separately, I noticed after we migrated to `tshy` we changed our package.json for tests to be `module`. This mean using `__dirname` was broken. Fixed that here!

If this looks good will add docs in a follow-on!