### PR TITLE
[Admin] Support impersonation for storage

### DIFF
--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.4';
+const version = 'v0.21.5';
 
 export { version };

--- a/client/sandbox/admin-sdk-express/src/index.ts
+++ b/client/sandbox/admin-sdk-express/src/index.ts
@@ -184,6 +184,30 @@ async function testUploadFileStream(
   console.log('Uploaded with stream:', data);
 }
 
+async function testUploadFileAsGuestFails(
+  src: string,
+  dest: string,
+  contentType?: string,
+) {
+  const buffer = fs.readFileSync(path.join(__dirname, src));
+  const guestDb = db.asUser({ guest: true });
+
+  const prefix = 'Uploading file as guest with default perms';
+  const message = `${prefix} should not be supported`;
+  try {
+    await guestDb.storage.uploadFile(dest, buffer, {
+      contentType: contentType,
+    });
+    throw new Error(message);
+  } catch (err) {
+    if (err instanceof Error && err.message === message) {
+      throw err;
+    } else {
+      console.log(`${prefix} failed as expected!`);
+    }
+  }
+}
+
 async function testQueryFiles() {
   const res = await query({ $files: {} });
   console.log(JSON.stringify(res, null, 2));
@@ -277,6 +301,7 @@ async function testDeleteAllowedInTx(
 // testUploadFile('circle_blue.jpg', 'circle_blue.jpg', 'image/jpeg');
 // testUploadFile("circle_blue.jpg", "circle_blue2.jpg", "image/jpeg");
 // testUploadFileStream("circle_blue.jpg", "circle_blue.jpg", "image/jpeg");
+// testUploadFileAsGuestFails("circle_blue.jpg", "circle_blue.jpg", "image/jpeg");
 // testQueryFiles()
 // testDeleteSingleFile("circle_blue.jpg");
 // testDeleteBulkFile(["circle_blue.jpg", "circle_blue2.jpg"]);

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -429,7 +429,7 @@
 ;; Storage
 
 (defn upload-put [req]
-  (let [{:keys [app-id]} (req->app-id-authed! req :storage/write)
+  (let [{:keys [app-id] :as perms} (get-perms! req :storage/write)
         params (:headers req)
         path (ex/get-param! params ["path"] string-util/coerce-non-blank-str)
         file (ex/get-param! req [:body] identity)
@@ -440,23 +440,27 @@
                                                 :content-type content-type
                                                 :content-disposition content-disposition
                                                 :content-length (:content-length req)
-                                                :skip-perms-check? true}
+                                                :current-user (:current-user perms)
+                                                :skip-perms-check? (:admin? perms)}
                                                file)]
     (response/ok {:data data})))
 
 (defn file-delete [req]
-  (let [{:keys [app-id]} (req->app-id-authed! req :storage/write)
+  (let [{:keys [app-id] :as perms} (get-perms! req :storage/write)
         filename (ex/get-param! req [:params :filename] string-util/coerce-non-blank-str)
         data (storage-coordinator/delete-file! {:app-id app-id
                                                 :path filename
-                                                :skip-perms-check? true})]
+                                                :current-user (:current-user perms)
+                                                :skip-perms-check? (:admin? perms)})]
     (response/ok {:data data})))
 
 (defn files-delete [req]
-  (let [{:keys [app-id]} (req->app-id-authed! req :storage/write)
+  (let [{:keys [app-id] :as perms} (get-perms! req :storage/write)
         filenames (ex/get-param! req [:body :filenames] vec)
         data (storage-coordinator/delete-files! {:app-id app-id
-                                                 :paths filenames})]
+                                                 :paths filenames
+                                                 :current-user (:current-user perms)
+                                                 :skip-perms-check? (:admin? perms)})]
     (response/ok {:data data})))
 
 (comment

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1040,7 +1040,8 @@
   (let [filenames (ex/get-param! req [:body :filenames] vec)
         {{app-id :id} :app} (req->app-and-user! :collaborator req)
         data (storage-coordinator/delete-files! {:app-id app-id
-                                                 :paths filenames})]
+                                                 :paths filenames
+                                                 :skip-perms-check? true})]
     (response/ok {:data data})))
 
 ;; ---

--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -54,8 +54,13 @@
 
 (defn delete-files!
   "Deletes multiple files from both Instant and S3."
-  [{:keys [app-id paths]}]
+  [{:keys [app-id paths current-user skip-perms-check?]}]
   (storage-beta/assert-storage-enabled! app-id)
+  (when (not skip-perms-check?)
+    (doseq [path paths]
+      (assert-storage-permission! "delete" {:app-id app-id
+                                            :path path
+                                            :current-user current-user})))
   (let [deleted (app-file-model/delete-by-paths! {:app-id app-id :paths paths})
         locations (mapv :location-id deleted)
         ids (mapv :id deleted)

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -14,6 +14,7 @@
             [instant.model.app-user :as app-user-model]
             [instant.model.rule :as rule-model]
             [instant.util.s3 :as s3-util]
+            [instant.storage.s3 :as s3-storage]
             [instant.reactive.ephemeral :as eph])
   (:import [java.util UUID]))
 
@@ -928,11 +929,14 @@
                    body))))))))
 
 (deftest storage-impersonation-test
-  (with-redefs [;; Mock the S3 operations that would hit AWS
+  (with-redefs [;; Prevent AWS SDK initialization to avoid CI issues
+                s3-storage/s3-client (constantly nil)
+                s3-storage/s3-async-client (constantly nil)
+                ;; Mock the S3 operations that would use these clients
                 s3-util/upload-stream-to-s3 (constantly nil)
                 s3-util/delete-object (constantly nil)
                 s3-util/delete-objects-paginated (constantly nil)
-                ;; This is called after upload
+                ;; Mock head-object which is called after upload to get metadata
                 s3-util/head-object (fn [_client _bucket _key]
                                       {:object-metadata
                                        {:content-length 5

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -13,6 +13,7 @@
             [instant.model.app-user-refresh-token :as app-user-refresh-token-model]
             [instant.model.app-user :as app-user-model]
             [instant.model.rule :as rule-model]
+            [instant.util.s3 :as s3-util]
             [instant.reactive.ephemeral :as eph])
   (:import [java.util UUID]))
 
@@ -927,198 +928,203 @@
                    body))))))))
 
 (deftest storage-impersonation-test
-  (with-empty-app
-    (fn [{app-id :id admin-token :admin-token :as _app}]
-      (let [user-email "test-user@example.com"
-            user-ret (refresh-tokens-post
-                      {:body {:email user-email}
-                       :headers {"app-id" app-id
-                                 "authorization" (str "Bearer " admin-token)}})
-            user-token (-> user-ret :body :user :refresh_token)
+  (with-redefs [;; Mock the S3 operations that would hit AWS
+                s3-util/upload-stream-to-s3 (constantly nil)
+                s3-util/delete-object (constantly nil)
+                s3-util/delete-objects-paginated (constantly nil)
+                ;; This is called after upload
+                s3-util/head-object (fn [_client _bucket _key]
+                                      {:object-metadata
+                                       {:content-length 5
+                                        :content-type "text/plain"
+                                        :last-modified (java.time.Instant/now)}})]
+    (with-empty-app
+      (fn [{app-id :id admin-token :admin-token :as _app}]
+        (let [user-email "test-user@example.com"
+              user-ret (refresh-tokens-post
+                        {:body {:email user-email}
+                         :headers {"app-id" app-id
+                                   "authorization" (str "Bearer " admin-token)}})
+              user-token (-> user-ret :body :user :refresh_token)
 
-            ;; Only authenticated users can create/delete files
-            _ (rule-model/put!
-               {:app-id app-id
-                :code {"$files" {:allow {:create "auth.id != null"
-                                         :delete "auth.id != null"
-                                         :view "true"}}}})
+              ;; Only authenticated users can create/delete files
+              _ (rule-model/put!
+                 {:app-id app-id
+                  :code {"$files" {:allow {:create "auth.id != null"
+                                           :delete "auth.id != null"
+                                           :view "true"}}}})
 
-            ;; Mock file content
-            file-content (byte-array [1 2 3 4 5])]
+              make-file-content (fn [] (java.io.ByteArrayInputStream. (byte-array [1 2 3 4 5])))]
 
-        (testing "admin can upload"
-          (let [ret (upload-put
-                     {:body file-content
+          (testing "admin can upload"
+            (let [ret (upload-put
+                       {:body (make-file-content)
+                        :headers {"app-id" app-id
+                                  "authorization" (str "Bearer " admin-token)
+                                  "path" "admin-file.txt"
+                                  "content-type" "text/plain"}
+                        :content-length 5})]
+              (is (= 200 (:status ret)))
+              (is (some? (-> ret :body :data :id)))))
+
+          (testing "user with email can upload"
+            (let [ret (upload-put
+                       {:body (make-file-content)
+                        :headers {"app-id" app-id
+                                  "authorization" (str "Bearer " admin-token)
+                                  "as-email" user-email
+                                  "path" "user-file.txt"
+                                  "content-type" "text/plain"}
+                        :content-length 5})]
+              (is (= 200 (:status ret)))
+              (is (some? (-> ret :body :data :id)))))
+
+          (testing "guest cannot upload"
+            (let [ret (upload-put
+                       {:body (make-file-content)
+                        :headers {"app-id" app-id
+                                  "authorization" (str "Bearer " admin-token)
+                                  "as-guest" "true"
+                                  "path" "guest-file.txt"
+                                  "content-type" "text/plain"}
+                        :content-length 5})]
+              (is (= 400 (:status ret)))
+              (is (= :permission-denied (-> ret :body :type)))))
+
+          (testing "user with token can upload"
+            (let [ret (upload-put
+                       {:body (make-file-content)
+                        :headers {"app-id" app-id
+                                  "authorization" (str "Bearer " admin-token)
+                                  "as-token" user-token
+                                  "path" "token-file.txt"
+                                  "content-type" "text/plain"}
+                        :content-length 5})]
+              (is (= 200 (:status ret)))
+              (is (some? (-> ret :body :data :id)))))
+
+          (testing "admin can delete"
+            (let [upload-ret (upload-put
+                              {:body (make-file-content)
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "path" "delete-test.txt"
+                                         "content-type" "text/plain"}
+                               :content-length 5})
+                  _ (is (= 200 (:status upload-ret)))
+                  delete-ret (file-delete
+                              {:params {:filename "delete-test.txt"}
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)}})]
+              (is (= 200 (:status delete-ret)))
+              (is (some? (-> delete-ret :body :data :id)))))
+
+          (testing "user can delete"
+            (let [upload-ret (upload-put
+                              {:body (make-file-content)
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "path" "user-delete-test.txt"
+                                         "content-type" "text/plain"}
+                               :content-length 5})
+                  _ (is (= 200 (:status upload-ret)))
+                  delete-ret (file-delete
+                              {:params {:filename "user-delete-test.txt"}
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "as-email" user-email}})]
+              (is (= 200 (:status delete-ret)))
+              (is (some? (-> delete-ret :body :data :id)))))
+
+          (testing "guest cannot delete"
+            (let [;; First upload a file as admin
+                  upload-ret (upload-put
+                              {:body (make-file-content)
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "path" "guest-delete-test.txt"
+                                         "content-type" "text/plain"}
+                               :content-length 5})
+                  _ (is (= 200 (:status upload-ret)))
+                  ;; Try to delete it as guest
+                  delete-ret (file-delete
+                              {:params {:filename "guest-delete-test.txt"}
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "as-guest" "true"}})]
+              (is (= 400 (:status delete-ret)))
+              (is (= :permission-denied (-> delete-ret :body :type)))))
+
+          (testing "admin can bulk delete"
+            (let [_ (upload-put
+                     {:body (make-file-content)
                       :headers {"app-id" app-id
                                 "authorization" (str "Bearer " admin-token)
-                                "path" "admin-file.txt"
+                                "path" "bulk1.txt"
                                 "content-type" "text/plain"}
-                      :content-length 5})]
-            (is (= 200 (:status ret)))
-            (is (some? (-> ret :body :data :id)))))
-
-        (testing "user with email can upload"
-          (let [ret (upload-put
-                     {:body file-content
+                      :content-length 5})
+                  _ (upload-put
+                     {:body (make-file-content)
                       :headers {"app-id" app-id
                                 "authorization" (str "Bearer " admin-token)
-                                "as-email" user-email
-                                "path" "user-file.txt"
+                                "path" "bulk2.txt"
                                 "content-type" "text/plain"}
-                      :content-length 5})]
-            (is (= 200 (:status ret)))
-            (is (some? (-> ret :body :data :id)))))
+                      :content-length 5})
+                  ;; Then delete them
+                  delete-ret (files-delete
+                              {:body {:filenames ["bulk1.txt" "bulk2.txt"]}
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)}})]
+              (is (= 200 (:status delete-ret)))
+              (is (= 2 (count (-> delete-ret :body :data :ids))))))
 
-        (testing "guest cannot upload"
-          (let [ret (upload-put
-                     {:body file-content
+          (testing "user can bulk delete"
+            (let [_ (upload-put
+                     {:body (make-file-content)
                       :headers {"app-id" app-id
                                 "authorization" (str "Bearer " admin-token)
-                                "as-guest" "true"
-                                "path" "guest-file.txt"
+                                "path" "user-bulk1.txt"
                                 "content-type" "text/plain"}
-                      :content-length 5})]
-            (is (= 400 (:status ret)))
-            (is (= :permission-denied (-> ret :body :type)))))
-
-        (testing "user with token can upload"
-          (let [ret (upload-put
-                     {:body file-content
+                      :content-length 5})
+                  _ (upload-put
+                     {:body (make-file-content)
                       :headers {"app-id" app-id
                                 "authorization" (str "Bearer " admin-token)
-                                "as-token" user-token
-                                "path" "token-file.txt"
+                                "path" "user-bulk2.txt"
                                 "content-type" "text/plain"}
-                      :content-length 5})]
-            (is (= 200 (:status ret)))
-            (is (some? (-> ret :body :data :id)))))
+                      :content-length 5})
+                  ;; Then delete them as impersonated user
+                  delete-ret (files-delete
+                              {:body {:filenames ["user-bulk1.txt" "user-bulk2.txt"]}
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "as-email" user-email}})]
+              (is (= 200 (:status delete-ret)))
+              (is (= 2 (count (-> delete-ret :body :data :ids))))))
 
-        (testing "admin can delete"
-          (let [;; First upload a file
-                upload-ret (upload-put
-                            {:body file-content
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "path" "delete-test.txt"
-                                       "content-type" "text/plain"}
-                             :content-length 5})
-                _ (is (= 200 (:status upload-ret)))
-                ;; Then delete it
-                delete-ret (file-delete
-                            {:params {:filename "delete-test.txt"}
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)}})]
-            (is (= 200 (:status delete-ret)))
-            (is (some? (-> delete-ret :body :data :id)))))
-
-        (testing "user can delete"
-          (let [;; First upload a file as admin
-                upload-ret (upload-put
-                            {:body file-content
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "path" "user-delete-test.txt"
-                                       "content-type" "text/plain"}
-                             :content-length 5})
-                _ (is (= 200 (:status upload-ret)))
-                ;; Then delete it
-                delete-ret (file-delete
-                            {:params {:filename "user-delete-test.txt"}
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "as-email" user-email}})]
-            (is (= 200 (:status delete-ret)))
-            (is (some? (-> delete-ret :body :data :id)))))
-
-        (testing "guest cannot delete"
-          (let [;; First upload a file as admin
-                upload-ret (upload-put
-                            {:body file-content
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "path" "guest-delete-test.txt"
-                                       "content-type" "text/plain"}
-                             :content-length 5})
-                _ (is (= 200 (:status upload-ret)))
-                ;; Try to delete it as guest
-                delete-ret (file-delete
-                            {:params {:filename "guest-delete-test.txt"}
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "as-guest" "true"}})]
-            (is (= 400 (:status delete-ret)))
-            (is (= :permission-denied (-> delete-ret :body :type)))))
-
-        (testing "admin can bulk delete"
-          (let [_ (upload-put
-                   {:body file-content
-                    :headers {"app-id" app-id
-                              "authorization" (str "Bearer " admin-token)
-                              "path" "bulk1.txt"
-                              "content-type" "text/plain"}
-                    :content-length 5})
-                _ (upload-put
-                   {:body file-content
-                    :headers {"app-id" app-id
-                              "authorization" (str "Bearer " admin-token)
-                              "path" "bulk2.txt"
-                              "content-type" "text/plain"}
-                    :content-length 5})
-                ;; Then delete them
-                delete-ret (files-delete
-                            {:body {:filenames ["bulk1.txt" "bulk2.txt"]}
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)}})]
-            (is (= 200 (:status delete-ret)))
-            (is (= 2 (count (-> delete-ret :body :data :ids))))))
-
-        (testing "user can bulk delete"
-          (let [_ (upload-put
-                   {:body file-content
-                    :headers {"app-id" app-id
-                              "authorization" (str "Bearer " admin-token)
-                              "path" "user-bulk1.txt"
-                              "content-type" "text/plain"}
-                    :content-length 5})
-                _ (upload-put
-                   {:body file-content
-                    :headers {"app-id" app-id
-                              "authorization" (str "Bearer " admin-token)
-                              "path" "user-bulk2.txt"
-                              "content-type" "text/plain"}
-                    :content-length 5})
-                ;; Then delete them as impersonated user
-                delete-ret (files-delete
-                            {:body {:filenames ["user-bulk1.txt" "user-bulk2.txt"]}
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "as-email" user-email}})]
-            (is (= 200 (:status delete-ret)))
-            (is (= 2 (count (-> delete-ret :body :data :ids))))))
-
-        (testing "guest cannot bulk delete"
-          (let [_ (upload-put
-                   {:body file-content
-                    :headers {"app-id" app-id
-                              "authorization" (str "Bearer " admin-token)
-                              "path" "guest-bulk1.txt"
-                              "content-type" "text/plain"}
-                    :content-length 5})
-                _ (upload-put
-                   {:body file-content
-                    :headers {"app-id" app-id
-                              "authorization" (str "Bearer " admin-token)
-                              "path" "guest-bulk2.txt"
-                              "content-type" "text/plain"}
-                    :content-length 5})
-                ;; Try to delete them as guest
-                delete-ret (files-delete
-                            {:body {:filenames ["guest-bulk1.txt" "guest-bulk2.txt"]}
-                             :headers {"app-id" app-id
-                                       "authorization" (str "Bearer " admin-token)
-                                       "as-guest" "true"}})]
-            (is (= 400 (:status delete-ret)))
-            (is (= :permission-denied (-> delete-ret :body :type)))))))))
+          (testing "guest cannot bulk delete"
+            (let [_ (upload-put
+                     {:body (make-file-content)
+                      :headers {"app-id" app-id
+                                "authorization" (str "Bearer " admin-token)
+                                "path" "guest-bulk1.txt"
+                                "content-type" "text/plain"}
+                      :content-length 5})
+                  _ (upload-put
+                     {:body (make-file-content)
+                      :headers {"app-id" app-id
+                                "authorization" (str "Bearer " admin-token)
+                                "path" "guest-bulk2.txt"
+                                "content-type" "text/plain"}
+                      :content-length 5})
+                  ;; Try to delete them as guest
+                  delete-ret (files-delete
+                              {:body {:filenames ["guest-bulk1.txt" "guest-bulk2.txt"]}
+                               :headers {"app-id" app-id
+                                         "authorization" (str "Bearer " admin-token)
+                                         "as-guest" "true"}})]
+              (is (= 400 (:status delete-ret)))
+              (is (= :permission-denied (-> delete-ret :body :type))))))))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
One of our users mentioned surprise that uploading as guest would work with the admin sdk. Normally we don't do permission checks for admin usage but we do allow impersonation for queries and transact.

This PR enables impersonation for storage methods too.

```typescript
const scopedDb = db.asUser({ email: 'alyssa_p_hacker@instantdb.com' });
const buffer = fs.readFileSync(path.join(__dirname, src));
// admin storage will run with scoped permissions
const { data } = await scopedDb.storage.uploadFile(dest, buffer, {
  contentType: contentType,
});
```

Added some tests for both client and server!

Once this is deployed will follow-up with a PR for docs!