### PR TITLE
Collapse ors with  $isNull: true for indexed attrs

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -604,7 +604,13 @@
     [:and
      (if (and (= op :=)
               (set? val))
-       (in-any [f col] val (data-type->pg-type data-type))
+       (let [in-val (if (= :string data-type)
+                      val
+                      (disj val nil))
+             in-clause (in-any [f col] in-val (data-type->pg-type data-type))]
+         (if (contains? val nil)
+           [:or in-clause [:= nil [f col]]]
+           in-clause))
        [op [f col] val])
      [:=
       :checked_data_type

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -171,6 +171,16 @@
 
 (def sentinel (Object.))
 
+(defn link-etype [attrs etype link-attr-name]
+  (or (when-let [attr (attr-model/seek-by-fwd-ident-name
+                       [etype link-attr-name]
+                       attrs)]
+        (attr-model/rev-etype attr))
+      (when-let [attr (attr-model/seek-by-rev-ident-name
+                       [etype link-attr-name]
+                       attrs)]
+        (attr-model/fwd-etype attr))))
+
 (defn indexed-attr?
   "Checks if the cond path is a top-level indexed attr so that we can
    avoid checking for `isNull` on a `not` query."
@@ -220,16 +230,6 @@
   (mapv (fn [i]
           (take (inc i) path))
         (range (count path))))
-
-(defn link-etype [attrs etype link-attr-name]
-  (or (when-let [attr (attr-model/seek-by-fwd-ident-name
-                       [etype link-attr-name]
-                       attrs)]
-        (attr-model/rev-etype attr))
-      (when-let [attr (attr-model/seek-by-rev-ident-name
-                       [etype link-attr-name]
-                       attrs)]
-        (attr-model/fwd-etype attr))))
 
 (defn- normalize-ne-to-not
   "Treat `$ne` as an alias for `$not`."


### PR DESCRIPTION
This will help queries that do something like `{:or [{:status "pending"} {:status {:$isNull true}}]}`.

If `status` is indexed, we'll convert it to `{:status {:$in [nil "pending"]}}`, saving a CTE and the or gather CTE.

For the query I'm testing with, it drops the time from 140 ms to 8ms.