### PR TITLE
subscribeQuery in the admin SDK

### DIFF
--- a/client/packages/admin/package.json
+++ b/client/packages/admin/package.json
@@ -45,17 +45,18 @@
     "publish-package": "pnpm publish --access public --no-git-checks"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
     "@types/node": "^22.6.1",
     "npm-run-all": "^4.1.5",
     "tshy": "^3.0.2",
-    "@arethetypeswrong/cli": "^0.17.4",
     "typescript": "^5.8.3",
     "vitest": "^0.21.0"
   },
   "dependencies": {
     "@instantdb/core": "workspace:*",
-    "@instantdb/version": "workspace:*"
+    "@instantdb/version": "workspace:*",
+    "eventsource": "^4.0.0"
   }
 }

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -843,7 +843,7 @@ class InstantAdminDatabase<
   /**
    * Use this to to get a live view of your data!
    *
-   * @see https://instantdb.com/docs/instaql
+   * @see https://www.instantdb.com/docs/backend
    *
    * @example
    *  // create a subscription to a query

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -77,6 +77,8 @@ import {
   subscribe,
   SubscribeQueryCallback,
   SubscribeQueryResponse,
+  SubscribeQueryPayload,
+  SubscriptionReadyState,
 } from './subscribe.ts';
 
 type DebugCheckResult = {
@@ -838,6 +840,41 @@ class InstantAdminDatabase<
     });
   };
 
+  /**
+   * Use this to to get a live view of your data!
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *  // create a subscription to a query
+   *  const query = { goals: { $: { where: { title: "Get Fit" } } } }
+   *  const sub = db.subscribeQuery(query);
+   *
+   *  // iterate through the results with an async iterator
+   *  for await (const payload of sub) {
+   *    if (payload.error) {
+   *      console.log(payload.error);
+   *      // Stop the subscription
+   *      sub.close();
+   *    } else {
+   *      console.log(payload.data);
+   *    }
+   *  }
+   *
+   *  // Stop the subscription
+   *  sub.close();
+   *
+   *  // Createa a subscription with a callback
+   *  const sub = db.subscribeQuery(query, (payload) => {
+   *    if (payload.error) {
+   *      console.log(payload.error);
+   *      // Stop the subscription
+   *      sub.close();
+   *    } else {
+   *      console.log(payload.data);
+   *    }
+   *  });
+   */
   subscribeQuery<Q extends ValidQuery<Q, Schema>>(
     query: Q,
     cb?: SubscribeQueryCallback<Schema, Q, Config>,
@@ -1026,6 +1063,10 @@ export {
   type InstantEntity,
   type BackwardsCompatibleSchema,
   type InstaQLFields,
+  type SubscribeQueryCallback,
+  type SubscribeQueryResponse,
+  type SubscribeQueryPayload,
+  type SubscriptionReadyState,
 
   // schema types
   type AttrsDefs,

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -864,7 +864,7 @@ class InstantAdminDatabase<
    *  // Stop the subscription
    *  sub.close();
    *
-   *  // Createa a subscription with a callback
+   *  // Create a subscription with a callback
    *  const sub = db.subscribeQuery(query, (payload) => {
    *    if (payload.error) {
    *      console.log(payload.error);

--- a/client/packages/admin/src/subscribe.ts
+++ b/client/packages/admin/src/subscribe.ts
@@ -11,7 +11,7 @@ import {
 
 export type SubscriptionReadyState = 'closed' | 'connecting' | 'open';
 
-export type SubscribeQueryResult<
+export type SubscribeQueryPayload<
   Schema extends InstantSchemaDef<any, any, any>,
   Q extends ValidQuery<Q, Schema>,
   Config extends InstantConfig<Schema, boolean> = InstantConfig<Schema, false>,
@@ -31,7 +31,7 @@ export type SubscribeQueryCallback<
   Schema extends InstantSchemaDef<any, any, any>,
   Q extends ValidQuery<Q, Schema>,
   Config extends InstantConfig<Schema, boolean> = InstantConfig<Schema, false>,
-> = (result: SubscribeQueryResult<Schema, Q, Config>) => void;
+> = (payload: SubscribeQueryPayload<Schema, Q, Config>) => void;
 
 export interface SubscribeQueryResponse<
   Schema extends InstantSchemaDef<any, any, any>,
@@ -46,7 +46,7 @@ export interface SubscribeQueryResponse<
 
   /** Async iterator of query payloads */
   [Symbol.asyncIterator](): AsyncIterableIterator<
-    SubscribeQueryResult<Schema, Q, Config>
+    SubscribeQueryPayload<Schema, Q, Config>
   >;
 
   /** Ready state of the connection */
@@ -65,13 +65,13 @@ function makeAsyncIterator<
   subscribeOnClose: (cb: () => void) => void,
   unsubscribe: (cb: SubscribeQueryCallback<Schema, Q, Config>) => void,
   readyState: () => SubscriptionReadyState,
-): AsyncGenerator<SubscribeQueryResult<Schema, Q, Config>> {
+): AsyncGenerator<SubscribeQueryPayload<Schema, Q, Config>> {
   let wakeup = null;
   let closed = false;
 
-  const backlog: SubscribeQueryResult<Schema, Q, Config>[] = [];
+  const backlog: SubscribeQueryPayload<Schema, Q, Config>[] = [];
   const handler: SubscribeQueryCallback<Schema, Q, Config> = (
-    data: SubscribeQueryResult<Schema, Q, Config>,
+    data: SubscribeQueryPayload<Schema, Q, Config>,
   ): void => {
     backlog.push(data);
     if (backlog.length > 100) {
@@ -223,7 +223,7 @@ export function subscribe<
     subscribe(cb);
   }
 
-  function deliver(result: SubscribeQueryResult<Schema, Q, Config>) {
+  function deliver(result: SubscribeQueryPayload<Schema, Q, Config>) {
     for (const sub of subscribers) {
       try {
         sub(result);

--- a/client/packages/admin/src/subscribe.ts
+++ b/client/packages/admin/src/subscribe.ts
@@ -201,9 +201,6 @@ export function subscribe<
     },
   });
 
-  // @ts-ignore
-  globalThis.es = es;
-
   const subscribers = [];
   const onCloseSubscribers = [];
 
@@ -217,10 +214,6 @@ export function subscribe<
 
   const subscribeOnClose = (cb) => {
     onCloseSubscribers.push(cb);
-  };
-
-  const unsubscribeOnClose = (cb) => {
-    onCloseSubscribers.splice(onCloseSubscribers.indexOf(cb), 1);
   };
 
   if (cb) {
@@ -307,7 +300,9 @@ export function subscribe<
     }
   };
 
-  es.onmessage = (e) => handleMessage(JSON.parse(e.data));
+  es.onmessage = (e) => {
+    handleMessage(JSON.parse(e.data));
+  };
 
   return {
     close: () => {

--- a/client/packages/admin/src/subscribe.ts
+++ b/client/packages/admin/src/subscribe.ts
@@ -312,17 +312,19 @@ export function subscribe<
     handleMessage(JSON.parse(e.data));
   };
 
-  return {
-    close: () => {
-      for (const sub of onCloseSubscribers) {
-        try {
-          sub();
-        } catch (e) {
-          console.error('Error in onClose callback', e);
-        }
+  const close = () => {
+    for (const sub of onCloseSubscribers) {
+      try {
+        sub();
+      } catch (e) {
+        console.error('Error in onClose callback', e);
       }
-      es.close();
-    },
+    }
+    es.close();
+  };
+
+  return {
+    close: close,
     [Symbol.iterator]: () => {
       throw new Error(
         'subscribeQuery does not support synchronous iteration. Use `for await` instead.',

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@instantdb/version':
         specifier: workspace:*
         version: link:../version
+      eventsource:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -554,7 +557,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^5.3.7
-        version: 5.7.5(next@15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.7.5(next@15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@instantdb/admin':
         specifier: workspace:*
         version: link:../../packages/admin
@@ -581,7 +584,7 @@ importers:
         version: 1.2.5(react@18.3.1)
       next:
         specifier: latest
-        version: 15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3472,8 +3475,8 @@ packages:
   '@next/env@15.1.6':
     resolution: {integrity: sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==}
 
-  '@next/env@15.4.5':
-    resolution: {integrity: sha512-ruM+q2SCOVCepUiERoxOmZY9ZVoecR3gcXNwCYZRvQQWRjhOiPJGmQ2fAiLR6YKWXcSAh7G79KEFxN3rwhs4LQ==}
+  '@next/env@15.5.0':
+    resolution: {integrity: sha512-sDaprBAfzCQiOgo2pO+LhnV0Wt2wBgartjrr+dpcTORYVnnXD0gwhHhiiyIih9hQbq+JnbqH4odgcFWhqCGidw==}
 
   '@next/swc-darwin-arm64@15.1.6':
     resolution: {integrity: sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==}
@@ -3481,8 +3484,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@15.4.5':
-    resolution: {integrity: sha512-84dAN4fkfdC7nX6udDLz9GzQlMUwEMKD7zsseXrl7FTeIItF8vpk1lhLEnsotiiDt+QFu3O1FVWnqwcRD2U3KA==}
+  '@next/swc-darwin-arm64@15.5.0':
+    resolution: {integrity: sha512-v7Jj9iqC6enxIRBIScD/o0lH7QKvSxq2LM8UTyqJi+S2w2QzhMYjven4vgu/RzgsdtdbpkyCxBTzHl/gN5rTRg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -3493,8 +3496,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.4.5':
-    resolution: {integrity: sha512-CL6mfGsKuFSyQjx36p2ftwMNSb8PQog8y0HO/ONLdQqDql7x3aJb/wB+LA651r4we2pp/Ck+qoRVUeZZEvSurA==}
+  '@next/swc-darwin-x64@15.5.0':
+    resolution: {integrity: sha512-s2Nk6ec+pmYmAb/utawuURy7uvyYKDk+TRE5aqLRsdnj3AhwC9IKUBmhfnLmY/+P+DnwqpeXEFIKe9tlG0p6CA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -3505,8 +3508,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@15.4.5':
-    resolution: {integrity: sha512-1hTVd9n6jpM/thnDc5kYHD1OjjWYpUJrJxY4DlEacT7L5SEOXIifIdTye6SQNNn8JDZrcN+n8AWOmeJ8u3KlvQ==}
+  '@next/swc-linux-arm64-gnu@15.5.0':
+    resolution: {integrity: sha512-mGlPJMZReU4yP5fSHjOxiTYvZmwPSWn/eF/dcg21pwfmiUCKS1amFvf1F1RkLHPIMPfocxLViNWFvkvDB14Isg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3517,8 +3520,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.4.5':
-    resolution: {integrity: sha512-4W+D/nw3RpIwGrqpFi7greZ0hjrCaioGErI7XHgkcTeWdZd146NNu1s4HnaHonLeNTguKnL2Urqvj28UJj6Gqw==}
+  '@next/swc-linux-arm64-musl@15.5.0':
+    resolution: {integrity: sha512-biWqIOE17OW/6S34t1X8K/3vb1+svp5ji5QQT/IKR+VfM3B7GvlCwmz5XtlEan2ukOUf9tj2vJJBffaGH4fGRw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3529,8 +3532,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.4.5':
-    resolution: {integrity: sha512-N6Mgdxe/Cn2K1yMHge6pclffkxzbSGOydXVKYOjYqQXZYjLCfN/CuFkaYDeDHY2VBwSHyM2fUjYBiQCIlxIKDA==}
+  '@next/swc-linux-x64-gnu@15.5.0':
+    resolution: {integrity: sha512-zPisT+obYypM/l6EZ0yRkK3LEuoZqHaSoYKj+5jiD9ESHwdr6QhnabnNxYkdy34uCigNlWIaCbjFmQ8FY5AlxA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3541,8 +3544,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.4.5':
-    resolution: {integrity: sha512-YZ3bNDrS8v5KiqgWE0xZQgtXgCTUacgFtnEgI4ccotAASwSvcMPDLua7BWLuTfucoRv6mPidXkITJLd8IdJplQ==}
+  '@next/swc-linux-x64-musl@15.5.0':
+    resolution: {integrity: sha512-+t3+7GoU9IYmk+N+FHKBNFdahaReoAktdOpXHFIPOU1ixxtdge26NgQEEkJkCw2dHT9UwwK5zw4mAsURw4E8jA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3553,8 +3556,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@15.4.5':
-    resolution: {integrity: sha512-9Wr4t9GkZmMNcTVvSloFtjzbH4vtT4a8+UHqDoVnxA5QyfWe6c5flTH1BIWPGNWSUlofc8dVJAE7j84FQgskvQ==}
+  '@next/swc-win32-arm64-msvc@15.5.0':
+    resolution: {integrity: sha512-d8MrXKh0A+c9DLiy1BUFwtg3Hu90Lucj3k6iKTUdPOv42Ve2UiIG8HYi3UAb8kFVluXxEfdpCoPPCSODk5fDcw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -3565,8 +3568,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.4.5':
-    resolution: {integrity: sha512-voWk7XtGvlsP+w8VBz7lqp8Y+dYw/MTI4KeS0gTVtfdhdJ5QwhXLmNrndFOin/MDoCvUaLWMkYKATaCoUkt2/A==}
+  '@next/swc-win32-x64-msvc@15.5.0':
+    resolution: {integrity: sha512-Fe1tGHxOWEyQjmygWkkXSwhFcTJuimrNu52JEuwItrKJVV4iRjbWp9I7zZjwqtiNnQmxoEvoisn8wueFLrNpvQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -7136,6 +7139,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@4.0.0:
+    resolution: {integrity: sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==}
+    engines: {node: '>=20.0.0'}
+
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
 
@@ -9458,8 +9465,8 @@ packages:
       sass:
         optional: true
 
-  next@15.4.5:
-    resolution: {integrity: sha512-nJ4v+IO9CPmbmcvsPebIoX3Q+S7f6Fu08/dEWu0Ttfa+wVwQRh9epcmsyCPjmL2b8MxC+CkBR97jgDhUUztI3g==}
+  next@15.5.0:
+    resolution: {integrity: sha512-N1lp9Hatw3a9XLt0307lGB4uTKsXDhyOKQo7uYMzX4i0nF/c27grcGXkLdb7VcT8QPYLBa8ouIyEoUQJ2OyeNQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -13909,14 +13916,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.4.1
 
-  '@clerk/nextjs@5.7.5(next@15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@5.7.5(next@15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 1.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.26.0
       crypto-js: 4.2.0
-      next: 15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       server-only: 0.0.1
@@ -15612,54 +15619,54 @@ snapshots:
 
   '@next/env@15.1.6': {}
 
-  '@next/env@15.4.5': {}
+  '@next/env@15.5.0': {}
 
   '@next/swc-darwin-arm64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-arm64@15.4.5':
+  '@next/swc-darwin-arm64@15.5.0':
     optional: true
 
   '@next/swc-darwin-x64@15.1.6':
     optional: true
 
-  '@next/swc-darwin-x64@15.4.5':
+  '@next/swc-darwin-x64@15.5.0':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.4.5':
+  '@next/swc-linux-arm64-gnu@15.5.0':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.4.5':
+  '@next/swc-linux-arm64-musl@15.5.0':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.4.5':
+  '@next/swc-linux-x64-gnu@15.5.0':
     optional: true
 
   '@next/swc-linux-x64-musl@15.1.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.4.5':
+  '@next/swc-linux-x64-musl@15.5.0':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.4.5':
+  '@next/swc-win32-arm64-msvc@15.5.0':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.1.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.4.5':
+  '@next/swc-win32-x64-msvc@15.5.0':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -19861,6 +19868,10 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.2
 
+  eventsource@4.0.0:
+    dependencies:
+      eventsource-parser: 3.0.2
+
   exec-async@2.2.0: {}
 
   execa@1.0.0:
@@ -22925,9 +22936,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.4.5
+      '@next/env': 15.5.0
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001696
       postcss: 8.4.31
@@ -22935,14 +22946,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.26.7)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.4.5
-      '@next/swc-darwin-x64': 15.4.5
-      '@next/swc-linux-arm64-gnu': 15.4.5
-      '@next/swc-linux-arm64-musl': 15.4.5
-      '@next/swc-linux-x64-gnu': 15.4.5
-      '@next/swc-linux-x64-musl': 15.4.5
-      '@next/swc-win32-arm64-msvc': 15.4.5
-      '@next/swc-win32-x64-msvc': 15.4.5
+      '@next/swc-darwin-arm64': 15.5.0
+      '@next/swc-darwin-x64': 15.5.0
+      '@next/swc-linux-arm64-gnu': 15.5.0
+      '@next/swc-linux-arm64-musl': 15.5.0
+      '@next/swc-linux-x64-gnu': 15.5.0
+      '@next/swc-linux-x64-musl': 15.5.0
+      '@next/swc-win32-arm64-msvc': 15.5.0
+      '@next/swc-win32-x64-msvc': 15.5.0
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'

--- a/client/sandbox/react-nextjs/components/EphemeralAppPage.tsx
+++ b/client/sandbox/react-nextjs/components/EphemeralAppPage.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react';
 import { RoomsDef, TransactionChunk } from '../../../packages/core/dist/esm';
 import { IContainEntitiesAndLinks } from '../../../packages/core/dist/esm/schemaTypes';
 
-async function provisionEphemeralApp({
+export async function provisionEphemeralApp({
   perms,
   schema,
   onCreateApp,

--- a/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
+++ b/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
@@ -20,10 +20,12 @@ function App({ app }: { app: { id: string; 'admin-token': string } }) {
   const [payloads, setPayloads] = useState<any[]>([]);
 
   useEffect(() => {
-    const sub = db.current.subscribeQuery({ test: {} }, (m) => {
+    const sub = db.current.subscribeQuery({ test: {} }, (m: any) => {
       console.log('m', m);
       setPayloads((ps) => [m, ...ps]);
     });
+    // @ts-ignore
+    globalThis.sub = sub;
     doThing(sub);
     () => {
       sub.close();
@@ -37,6 +39,7 @@ function App({ app }: { app: { id: string; 'admin-token': string } }) {
 
   return (
     <div>
+      <div>This uses the admin sdk to subscribe to a query.</div>
       <div>Check window.db for the admin db.</div>
       <div>
         <button

--- a/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
+++ b/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
@@ -1,0 +1,83 @@
+import { provisionEphemeralApp } from '../../components/EphemeralAppPage';
+import { useEffect, useRef, useState } from 'react';
+import { init, id } from '@instantdb/admin';
+import config from '../../config';
+
+let i = 0;
+const testId = id();
+
+function App({ app }: { app: { id: string; 'admin-token': string } }) {
+  const db = useRef(
+    init({ ...config, appId: app.id, adminToken: app['admin-token'] }),
+  );
+  const [payloads, setPayloads] = useState<any[]>([]);
+
+  useEffect(() => {
+    const sub = db.current.subscribeQuery(
+      { test: {} },
+      {
+        onMessage: (m) => {
+          setPayloads((ps) => [m, ...ps]);
+        },
+      },
+    );
+    () => {
+      sub.close();
+    };
+  }, []);
+
+  // @ts-ignore
+  globalThis.db = db.current;
+  // @ts-ignore
+  globalThis.id = id;
+
+  return (
+    <div>
+      <div>Check window.db for the admin db.</div>
+      <div>
+        <button
+          className="bg-black text-white m-2 p-2"
+          onClick={() => {
+            db.current.transact(db.current.tx.test[testId].update({ i: i++ }));
+          }}
+        >
+          Add data
+        </button>
+      </div>
+      <div>Payloads:</div>
+      <ul>
+        {payloads.map((p, i) => (
+          <li key={i}>
+            <pre className="text-sm">{JSON.stringify(p, null, 2)}</pre>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function Page() {
+  const [app, setApp] = useState(null);
+  const [error, setError] = useState<null | Error>(null);
+  useEffect(() => {
+    provisionEphemeralApp({})
+      .then((res) => setApp(res.app))
+      .catch((e) => {
+        console.error('Error creating app', e);
+        setError(e);
+      });
+  }, []);
+
+  if (error) {
+    return <div>There was an error {error.message}</div>;
+  }
+
+  if (app) {
+    return (
+      <div className="max-w-lg flex flex-col mt-20 mx-auto">
+        <App app={app} />
+      </div>
+    );
+  }
+  return <div className="max-w-lg flex flex-col mt-20 mx-auto">Loading...</div>;
+}

--- a/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
+++ b/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
@@ -44,9 +44,7 @@ function App({ app }: { app: { id: string; 'admin-token': string } }) {
     globalThis.sub = sub;
     setSub(sub);
     asyncIterate(sub);
-    () => {
-      sub.close();
-    };
+    return sub.close;
   }, [triggerSub]);
 
   // @ts-ignore

--- a/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
+++ b/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   init,
   id,
-  SubscribeQueryResult,
+  SubscribeQueryPayload,
   SubscribeQueryResponse,
 } from '@instantdb/admin';
 import config from '../../config';
@@ -24,7 +24,7 @@ function App({ app }: { app: { id: string; 'admin-token': string } }) {
     init({ ...config, appId: app.id, adminToken: app['admin-token'] }),
   );
   const [payloads, setPayloads] = useState<
-    SubscribeQueryResult<any, any, any>[]
+    SubscribeQueryPayload<any, any, any>[]
   >([]);
   const [sub, setSub] = useState<SubscribeQueryResponse<any, any, any> | null>(
     null,

--- a/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
+++ b/client/sandbox/react-nextjs/pages/play/admin-sdk.tsx
@@ -6,6 +6,13 @@ import config from '../../config';
 let i = 0;
 const testId = id();
 
+async function doThing(sub: any) {
+  console.log('doing thing');
+  for await (const res of sub) {
+    console.log('got a res!', res);
+  }
+}
+
 function App({ app }: { app: { id: string; 'admin-token': string } }) {
   const db = useRef(
     init({ ...config, appId: app.id, adminToken: app['admin-token'] }),
@@ -13,14 +20,11 @@ function App({ app }: { app: { id: string; 'admin-token': string } }) {
   const [payloads, setPayloads] = useState<any[]>([]);
 
   useEffect(() => {
-    const sub = db.current.subscribeQuery(
-      { test: {} },
-      {
-        onMessage: (m) => {
-          setPayloads((ps) => [m, ...ps]);
-        },
-      },
-    );
+    const sub = db.current.subscribeQuery({ test: {} }, (m) => {
+      console.log('m', m);
+      setPayloads((ps) => [m, ...ps]);
+    });
+    doThing(sub);
     () => {
       sub.close();
     };

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -7,6 +7,7 @@
         compojure/compojure {:mvn/version "1.6.2" :exclusions [instaparse/instaparse]}
         instaparse/instaparse {:mvn/version "1.5.0"}
         luminus/ring-undertow-adapter {:mvn/version "1.2.8"}
+        io.undertow/undertow-core {:mvn/version "2.3.18.Final"}
         metosin/ring-http-response {:mvn/version "0.9.2"}
         org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/core.async {:mvn/version "1.6.673"}

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -14,6 +14,7 @@
    [instant.model.app-user :as app-user-model]
    [instant.model.app-user-refresh-token :as app-user-refresh-token-model]
    [instant.model.rule :as rule-model]
+   [instant.model.instant-user :as instant-user-model]
    [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.session :as session]
    [instant.reactive.store :as rs]
@@ -144,7 +145,9 @@
                     :datalog-loader (d/make-loader)
                     :inference? inference?
                     :query query
-                    :versions (ex/get-optional-param! req [:body :versions] identity)}
+                    :versions (ex/get-optional-param! req [:body :versions] identity)
+                    :app (app-model/get-by-id {:id app-id})
+                    :creator (instant-user-model/get-by-app-id {:app-id app-id})}
                    perms)]
     (session/undertow-sse-admin-config rs/store
                                        receive-queue/receive-q

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -143,7 +143,8 @@
                     :datalog-query-fn d/query
                     :datalog-loader (d/make-loader)
                     :inference? inference?
-                    :query query}
+                    :query query
+                    :versions (ex/get-optional-param! req [:body :versions] identity)}
                    perms)]
     (session/undertow-sse-admin-config rs/store
                                        receive-queue/receive-q

--- a/server/src/instant/lib/ring/sse.clj
+++ b/server/src/instant/lib/ring/sse.clj
@@ -21,12 +21,10 @@
         (.addCloseTask conn close-task)
         (.setKeepAliveTime conn 5000)
         (on-open {:exchange conn
-                  :channel conn}))
-      (def -conn conn))))
+                  :channel conn})))))
 
 (defn sse-request [^HttpServerExchange exchange ^IPersistentMap headers ^ServerSentEventConnectionCallback callback]
   (let [handler (-> (ServerSentEventHandler. callback))]
-    (tool/def-locals)
     (when headers
       (set-headers (.getResponseHeaders exchange) headers))
     (.put (.getResponseHeaders exchange) Headers/CACHE_CONTROL "nocache")

--- a/server/src/instant/lib/ring/sse.clj
+++ b/server/src/instant/lib/ring/sse.clj
@@ -45,9 +45,8 @@
     (.put (.getResponseHeaders exchange) Headers/CACHE_CONTROL "nocache")
     (.handleRequest handler exchange)))
 
-;; XXX
 (defn send-json!
-  "Serializes `obj` to json, and sends over a websocket."
+  "Serializes `obj` to json, and sends over the SSE connection."
   [app-id obj {:keys [stub ^ServerSentEventConnection conn]}]
   (if stub
     (stub obj)

--- a/server/src/instant/lib/ring/sse.clj
+++ b/server/src/instant/lib/ring/sse.clj
@@ -1,0 +1,64 @@
+(ns instant.lib.ring.sse
+  (:refer-clojure :exclude [send])
+  (:require
+   [instant.util.e2e-tracer :as e2e-tracer]
+   [instant.util.json :refer [->json]]
+   [instant.util.tracer :as tracer]
+   [ring.adapter.undertow.headers :refer [set-headers]])
+  (:import
+   (clojure.lang IPersistentMap)
+   (io.undertow.server HttpServerExchange)
+   (io.undertow.server.handlers.sse ServerSentEventConnection ServerSentEventConnection$EventCallback ServerSentEventConnectionCallback ServerSentEventHandler)
+   (io.undertow.util Headers)
+   (org.xnio ChannelListener)))
+
+(defn sse-callback [{:keys [on-open on-close]}]
+  (reify ServerSentEventConnectionCallback
+    (^void connected [_ ^ServerSentEventConnection conn ^String _last-event-id]
+      (let [close-task (reify ChannelListener
+                         (handleEvent [_this channel]
+                           (on-close channel)))]
+        (.addCloseTask conn close-task)
+        (.setKeepAliveTime conn 5000)
+        (on-open {:exchange conn
+                  :channel conn}))
+      (def -conn conn))))
+
+(defn sse-request [^HttpServerExchange exchange ^IPersistentMap headers ^ServerSentEventConnectionCallback callback]
+  (let [handler (-> (ServerSentEventHandler. callback))]
+    (tool/def-locals)
+    (when headers
+      (set-headers (.getResponseHeaders exchange) headers))
+    (.put (.getResponseHeaders exchange) Headers/CACHE_CONTROL "nocache")
+    (.handleRequest handler exchange)))
+
+;; XXX
+(defn send-json!
+  "Serializes `obj` to json, and sends over a websocket."
+  [app-id obj {:keys [stub ^ServerSentEventConnection conn]}]
+  (if stub
+    (stub obj)
+    (let [obj-json (->json obj)
+          p (promise)]
+      (tracer/with-span! {:name "sse/send-json!"
+                          :attributes {:app-id app-id
+                                       :size (count obj-json)}}
+        (.send conn
+               ^String obj-json
+               (proxy [ServerSentEventConnection$EventCallback] []
+                 (done [_conn _data _event _id]
+                   (deliver p nil))
+                 (onError [_conn _data _event _id e]
+                   (deliver p e))))
+        (let [ret @p]
+          (when-let [tx-id (-> obj meta :tx-id)]
+            (let [tx-created-at (-> obj meta :tx-created-at)]
+              (when-let [latency-ms (e2e-tracer/tx-latency-ms tx-created-at)]
+                (tracer/add-data! {:attributes {:tx-latency-ms latency-ms}}))
+              (e2e-tracer/invalidator-tracking-step!
+                {:tx-id tx-id
+                 :tx-created-at tx-created-at
+                 :name "sse/send-json-delivered"
+                 :attributes {:session-id (-> obj meta :session-id)}})))
+          (when (instance? Throwable ret)
+            (throw ret)))))))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -744,23 +744,22 @@
   (let [pending-handlers (atom #{})]
     {:undertow/sse
      {:on-open (fn [req]
-                 (try
-                   (let [socket {:id id
-                                 :http-req (:exchange req)
-                                 :sse-conn (:channel req)
-                                 :receive-q receive-q
-                                 :pending-handlers pending-handlers
-                                 :close (fn []
-                                          (IoUtils/safeClose
-                                           ^ServerSentEventConnection (:channel req)))}]
-                     (on-open store socket)
-                     (admin-init! store id ctx)
-                     (receive-queue/put! receive-q
-                                         {:op :add-query
-                                          :session-id id
-                                          :client-event-id (random-uuid)
-                                          :q (:query ctx)
-                                          :return-type :tree}))))
+                 (let [socket {:id id
+                               :http-req (:exchange req)
+                               :sse-conn (:channel req)
+                               :receive-q receive-q
+                               :pending-handlers pending-handlers
+                               :close (fn []
+                                        (IoUtils/safeClose
+                                         ^ServerSentEventConnection (:channel req)))}]
+                   (on-open store socket)
+                   (admin-init! store id ctx)
+                   (receive-queue/put! receive-q
+                                       {:op :add-query
+                                        :session-id id
+                                        :client-event-id (random-uuid)
+                                        :q (:query ctx)
+                                        :return-type :tree})))
       :on-close (fn [_]
                   (on-close store
                             {:id id

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -388,7 +388,7 @@
            ::hint {:sess-id sess-id}}))
 
 (defn throw-socket-error! [sess-id ^IOException io-ex]
-  (throw+ {::type ::socket-missing
+  (throw+ {::type ::socket-error
            ::message (format "Socket error for session: %s" sess-id)
            ::hint {:sess-id sess-id
                    :exception-message (.getMessage io-ex)}}


### PR DESCRIPTION
Adds `subscribeQuery` over SSE for the admin SDK.

Only allows a single query per connection. Unlike websockets, the SSE connection is send-only. The client can't send new `add-query` commands through the SSE connection. If we want to multiplex, we will need to have some way to send an `add-query` POST request and have it route to the machine that holds their session (possibly through hazelcast?).

It uses our regular session middleware with a couple of small differences: 
1.`init` and `add-query` are triggered on the backend in `on-open` instead of having the user send `init` and `add-query`.
2. The session has `:sse-conn` instead of `:ws-conn`, then store/send-event dispatches based on which is in the session

## Usage

### Async iterator

```ts
const sub = db.subscribeQuery({goals: {}});

for await (const payload of sub) {
  if (payload.type === 'error') {
    console.log('error', error);
    sub.close();
  } else {
    console.log('data', payload.data)
  }
}

// To end the subscription:
sub.close();
```

### Callback

```ts
const sub = db.subscribeQuery({goals: {}}, (payload) => {
  if (payload.type === 'error') {
    console.log('error', error);
    sub.close();
  } else {
    console.log('data', payload.data)
  }
});

// To end the subscription:
sub.close();
```

Also updates undertow from 2.2.20.Final to 2.3.18.Final. I didn't see any changes in the changelog that would affect us, but I'll keep an eye on things after deploying.
