### PR TITLE
[server] order triple inserts

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -449,7 +449,8 @@
         lookup-ref-inserts
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
-                        :from :enhanced-lookup-refs}]
+                        :from :enhanced-lookup-refs
+                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
          :on-conflict [:app-id :attr-id [:json_null_to_null :value] {:where :av}]
          :do-nothing true
          :returning :*}
@@ -558,7 +559,8 @@
         ea-index-inserts
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
-                        :from :ea-triples-distinct}]
+                        :from :ea-triples-distinct
+                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
          :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
          :do-update-set {:value :excluded.value
                          :value-md5 :excluded.value-md5}
@@ -567,7 +569,8 @@
         remaining-inserts
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
-                        :from :remaining-triples}]
+                        :from :remaining-triples
+                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
          :on-conflict [:app-id :entity-id :attr-id :value-md5]
          :do-nothing true
          :returning :*}
@@ -650,7 +653,8 @@
         indexed-null-inserts
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
-                        :from :indexed-null-triples}]
+                        :from :indexed-null-triples
+                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
          :on-conflict [:app-id :entity-id :attr-id :value-md5]
          :do-nothing true
          :returning [:entity-id :attr-id]}
@@ -1002,8 +1006,8 @@
                      (.plus (Duration/ofDays 1))
                      (.truncatedTo ChronoUnit/DAYS))
       "yesterday" (-> now
-                     (.plus (Duration/ofDays -1))
-                     (.truncatedTo ChronoUnit/DAYS)))))
+                      (.plus (Duration/ofDays -1))
+                      (.truncatedTo ChronoUnit/DAYS)))))
 
 ;; Docs on DateTimeFormatterBuilder
 ;; https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/time/format/DateTimeFormatterBuilder.html


### PR DESCRIPTION
We had a bunch deadlock-detected errors when an instant startup did a big push of transactions. Instant is being used as a queue, which creates a lot of contention: 

https://ui.honeycomb.io/instantdb/environments/prod/datasets/instant-server/result/BxYcNG8M9Z1?vs=hideCompare

**Here's one intuition as to why:**

Imagine two transactions that work on `entity-a` and `entity-b`

```
tx1: take lock on entity-a 
tx2: take lock on entity-b
tx1: wait for lock on entity-b
tx2: wait for lock on entity-a
```

Postgres takes a lock when we do an insert on a row. If we don't order correctly, we could cause a deadlock. 

**Note:** I was not able to repro this locally. 

But, we are seeing those errors. Let's see if shipping this fixes it. 

@nezaj @dwwoelfel @tonsky @drew-harris 