### PR TITLE
Increase span attr limit

### DIFF
--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -35,6 +35,7 @@
     (throw (Exception. "Call to trace before initialization."))))
 
 (def span-limits (.. (SpanLimits/builder)
+                     ;; https://docs.honeycomb.io/get-started/best-practices/organizing-data/#limits-for-events
                      (setMaxNumberOfAttributes 1900)
                      (build)))
 


### PR DESCRIPTION
Increases the span attribute limit from 128 to 1900. Honeycomb's API limit is 2000, so this leaves a little headroom for refinery to add attrs. 

This will fix a problem where we're missing some of the attributes for the gauges.