### PR TITLE
A couple of honeycomb fixes

### DIFF
--- a/server/refinery/rules.yaml
+++ b/server/refinery/rules.yaml
@@ -9,7 +9,7 @@ Samplers:
           - Name: keep errors
             SampleRate: 1
             Conditions:
-              - Field: error
+              - Field: root.error
                 Operator: exists
 
           - Name: default rule

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -188,9 +188,7 @@
                                            :throw-on-missing-attrs? throw-on-missing-attrs?}
                                           steps)
         {tx-id :id} (permissioned-tx/transact! ctx tx-steps)]
-    (cond
-      :else
-      (response/ok {:tx-id tx-id}))))
+    (response/ok {:tx-id tx-id})))
 
 (defn transact-perms-check [req]
   (let [{:keys [app-id] :as perms} (get-perms! req :data/write)

--- a/server/src/instant/gauges.clj
+++ b/server/src/instant/gauges.clj
@@ -106,7 +106,11 @@
                       (catch Throwable t
                         [{:path "instant.gauges.metric-fn-error"
                           :value (.getMessage t)}])))])]
-    (into {} (keep (juxt :path :value) metrics))))
+    (reduce (fn [acc {:keys [path value]}]
+              (if path
+                (assoc acc path value)
+                acc))
+            metrics)))
 
 (comment
   (gauges))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -341,11 +341,11 @@
 (defn hz-jmx-stats []
   (for [^ObjectName n (jmx/mbean-names "com.hazelcast:*")
         a (jmx/attribute-names n)
+        ;; Filter out properties with tags or else we'll
+        ;; overload honeycomb
+        :when (not (.getKeyProperty n "tag0"))
         :let [prefix (.getKeyProperty n "prefix")
-              tag (.getKeyProperty n "tag0")
-              k (if tag
-                  (format "hz.%s.%s.%s" prefix tag (name a))
-                  (format "hz.%s.%s" prefix (name a)))]]
+              k (format "hz.%s.%s" prefix (name a))]]
     [{:path k
       :value (clojure.java.jmx/read n a)}]))
 


### PR DESCRIPTION
A couple of small honeycomb fixes:

1. Reduces the number of fields we send for hazelcast in gauges. It was exceeding what refinery would forward to the honeycomb API.
2. Only bypass sampling for errors if it's a top-level error. We're seeing spikes in ordinary errors, like missing a required field, and it's causing us to exceed our honeycomb limits.