### PR TITLE
Try ReentrantLock in reactive store

### DIFF
--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -54,6 +54,12 @@ const _schema = i.schema({
       "disabled-apps": i.any().optional(),
       "enabled-apps": i.any().optional(),
     }),
+    "store-fair-lock": i.entity({
+      "default-value": i.boolean().optional(),
+      disabled: i.boolean().optional(),
+      "disabled-apps": i.any().optional(),
+      "enabled-apps": i.any().optional(),
+    }),
     "power-user-emails": i.entity({
       email: i.string().unique(),
     }),

--- a/server/src/instant/util/lang.clj
+++ b/server/src/instant/util/lang.clj
@@ -20,3 +20,11 @@
       (when (and val# (not (instance? Var$Unbound val#)))
         (~method val#)
         (Var/.doReset var# nil)))))
+
+(defmacro with-reentrant-lock [lock-expr & body]
+  `(let [lockee# ~(with-meta lock-expr {:tag 'java.util.concurrent.locks.ReentrantLock})]
+     (.lock lockee#)
+     (try
+       ~@body
+       (finally
+         (.unlock lockee#)))))

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -286,7 +286,7 @@
                  (resolvers/walk-friendly movies-resolver (map remove-created-at result)))))))))
 
 (defn- get-datalog-cache-for-app [store app-id]
-  (let [db  @(rs/app-conn store app-id)]
+  (let [db @(rs/app-conn store app-id)]
     (->> (ds/q '{:find [?query ?result]
                  :in [$ ?app-id]
                  :where [[?e :datalog-query/app-id ?app-id]
@@ -297,7 +297,7 @@
          (into {}))))
 
 (defn- get-subscriptions-for-app-id [store app-id]
-  (let [db  @(rs/app-conn store app-id)]
+  (let [db @(rs/app-conn store app-id)]
     (for [datom (ds/datoms db :aevt :subscription/app-id)
           :when (= app-id (:v datom))
           :let  [ent (ds/entity db (:e datom))]]


### PR DESCRIPTION
We seem to have long pauses (10+ seconds) in reactive store

<img width="1632" height="1090" alt="image" src="https://github.com/user-attachments/assets/17080ca9-0eba-4710-82ee-457e6d365210" />

These seem to be related to high congestion on a lock (see lock_time_ms above)

One thing we can try is ReentrantLock.

On its own, it could be faster. That’s what we will be testing by default.

Another option is to try making it fair. Javadoc (highlight mine):

> When set true, under contention, locks favor granting access to the longest-waiting thread. Otherwise this lock does not guarantee any particular access order. Programs using fair locks accessed by many threads may display lower overall throughput (i.e., are slower; often much slower) than those using the default setting, but have __smaller variances in times to obtain locks__ and __guarantee lack of starvation__.

I made the fairness enabled through a flag, in case we see a catastrophic uptick in latency.

Deployment plan:

- push flags config cd server/flags-config && pnpm i && pnpm run push
