### PR TITLE
Make aggregator resilient to huge transactions

### DIFF
--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -395,7 +395,10 @@
             (recur (.read stream)))
 
           (:insert :update :delete)
-          (let [put-result (a/alt!! [[to record]] :put)]
+          (let [put-result (a/alt!! [[to record]] :put
+                                    ;; The close signal chan keeps us from
+                                    ;; waiting to put on a closed `to` channel
+                                    close-signal-chan :closed)]
             (when (and (= put-result :put)
                        (not (.isClosed stream)))
               (recur (.read stream)))))))))

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -390,11 +390,13 @@
         (recur (.read stream)))
       (let [record (wal-buffer->record buffer)]
         (case (:action record)
-          (:begin :close :truncate :message)
+          (:begin :truncate :message)
           (when-not (.isClosed stream)
             (recur (.read stream)))
 
-          (:insert :update :delete)
+          ;; Process the close so that we update the lsn in the
+          ;; wal_aggregator_status table
+          (:insert :update :delete :close)
           (let [put-result (a/alt!! [[to record]] :put
                                     ;; The close signal chan keeps us from
                                     ;; waiting to put on a closed `to` channel

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -363,7 +363,7 @@
                                        :max-size sketch-flush-max-items
                                        :combine combine-sketch-changes
                                        :init nil
-                                       :size (fn [{:keys [changes] :as x}]
+                                       :size (fn [{:keys [changes]}]
                                                (count changes))})
 
         shuffler

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -259,10 +259,10 @@
                  :lsn lsn
                  :triples-data (update-triple update-data
                                               identity-data)}]))))]
-    (when (and (seq sketch-changes)
-               ;; When we restart the slot, it will also include the last
-               ;; transaction that we processed. Setting the
-               (= -1 (compare start-lsn lsn)))
+    ;; When we restart the slot, it will also include the last
+    ;; transaction that we processed, so we need to filter out anything
+    ;; less than or equal to that lsn
+    (when (= -1 (compare start-lsn lsn))
       {:sketch-changes sketch-changes
        :lsn lsn})))
 

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -1,5 +1,6 @@
 (ns instant.reactive.aggregator-test
   (:require
+   [tool]
    [clojure.string :as string]
    [clojure.test :as test :refer [deftest is testing]]
    [instant.data.bootstrap :as bootstrap]
@@ -475,9 +476,9 @@
                       (is (= [{:next.jdbc/update-count 4}] check-result)))
 
                     ;; Wait for the sketches to catch up
-                    (wait-for #(> 0 (compare start-lsn
-                                             (cms/get-start-lsn (aurora/conn-pool :read)
-                                                                {:slot-name slot-name})))
+                    (wait-for #(> 0 (compare (tool/inspect start-lsn)
+                                             (tool/inspect (cms/get-start-lsn (aurora/conn-pool :read)
+                                                                              {:slot-name slot-name}))))
                               1000)
 
                     (testing "adding checked-data-type works"

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -404,6 +404,7 @@
     (fn [app]
       (with-redefs [agg/test-filter
                     (fn [changes]
+                      (tool/inspect changes)
                       (vec (filter (fn [change]
                                      (let [app-id (get-in change [:triples-data :app-id])]
                                        (if *in-test*

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -450,6 +450,8 @@
                                                                 {:slot-name slot-name})))
                               1000)
 
+                    (Thread/sleep 1000)
+
                     (testing "removing checked-data-type works"
                       (check-sketches app r)))
 
@@ -471,6 +473,8 @@
                                              (cms/get-start-lsn (aurora/conn-pool :read)
                                                                 {:slot-name slot-name})))
                               1000)
+
+                    (Thread/sleep 1000)
 
                     (testing "adding checked-data-type works"
                       (check-sketches app r)))

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -1,6 +1,5 @@
 (ns instant.reactive.aggregator-test
   (:require
-   [tool]
    [clojure.string :as string]
    [clojure.test :as test :refer [deftest is testing]]
    [instant.data.bootstrap :as bootstrap]
@@ -476,9 +475,9 @@
                       (is (= [{:next.jdbc/update-count 4}] check-result)))
 
                     ;; Wait for the sketches to catch up
-                    (wait-for #(> 0 (compare (tool/inspect start-lsn)
-                                             (tool/inspect (cms/get-start-lsn (aurora/conn-pool :read)
-                                                                              {:slot-name slot-name}))))
+                    (wait-for #(> 0 (compare start-lsn
+                                             (cms/get-start-lsn (aurora/conn-pool :read)
+                                                                {:slot-name slot-name})))
                               1000)
 
                     (testing "adding checked-data-type works"

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -458,8 +458,6 @@
                                                                 {:slot-name slot-name})))
                               1000)
 
-                    (Thread/sleep 1000)
-
                     (testing "removing checked-data-type works"
                       (check-sketches app r)))
 
@@ -477,12 +475,10 @@
                       (is (= [{:next.jdbc/update-count 4}] check-result)))
 
                     ;; Wait for the sketches to catch up
-                    (wait-for #(> 0 (compare start-lsn
-                                             (cms/get-start-lsn (aurora/conn-pool :read)
-                                                                {:slot-name slot-name})))
+                    (wait-for #(> 0 (compare (tool/inspect start-lsn)
+                                             (tool/inspect (cms/get-start-lsn (aurora/conn-pool :read)
+                                                                              {:slot-name slot-name}))))
                               1000)
-
-                    (Thread/sleep 1000)
 
                     (testing "adding checked-data-type works"
                       (check-sketches app r)))

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -154,7 +154,7 @@
                                             update triples set value = '\"alex2\"'::jsonb
                                                      where app_id = ? and attr_id = ? and entity_id = ?
                                                  returning *
-                                          ) select * from write, pg_current_wal_insert_lsn() as lsn"
+                                          ) select * from write, pg_current_wal_lsn() as lsn"
                                          (:id app)
                                          (resolvers/->uuid zeneca-r :users/handle)
                                          (resolvers/->uuid zeneca-r "eid-alex")])
@@ -179,7 +179,7 @@
                                                      where app_id = ? and attr_id = ? and eav
                                                        and entity_id = ? and value = ?::jsonb
                                                  returning *
-                                          ) select * from write, pg_current_wal_insert_lsn() as lsn"
+                                          ) select * from write, pg_current_wal_lsn() as lsn"
                                          (->json (str (resolvers/->uuid zeneca-r "eid-web-development-with-clojure")))
                                          (:id app)
                                          (resolvers/->uuid zeneca-r :bookshelves/books)
@@ -267,7 +267,7 @@
                                                update triples set value = '\"alex3\"'::jsonb
                                                         where app_id = ? and attr_id = ? and entity_id = ?
                                                     returning *
-                                             ) select * from write, pg_current_wal_insert_lsn() as lsn"
+                                             ) select * from write, pg_current_wal_lsn() as lsn"
                                              (:id app)
                                              (resolvers/->uuid r :users/handle)
                                              (resolvers/->uuid r "eid-alex")])]
@@ -352,7 +352,7 @@
                                             where app_id = ? and attr_id = ? and entity_id = ?
                                            returning entity_id
                                          )
-                                         select *, pg_current_wal_insert_lsn() as lsn from write"
+                                         select *, pg_current_wal_lsn() as lsn from write"
                                          (:id app)
                                          (resolvers/->uuid r :movie/title)
                                          (resolvers/->uuid r "eid-alien")])]
@@ -425,7 +425,7 @@
                         where app_id = ? and attr_id = ? and entity_id = ?
                        returning entity_id
                      )
-                     select *, pg_current_wal_insert_lsn() as lsn from write"
+                     select *, pg_current_wal_lsn() as lsn from write"
                     ;; Add a string that's big so that postgres will to toast it
                     (str (apply str (repeat 10000000 " "))
                          "2025-08-12T23:00:31.368181Z")
@@ -442,7 +442,7 @@
                                             where app_id = ? and attr_id = ? and checked_data_type = 'date'
                                            returning entity_id
                                          )
-                                         select *, pg_current_wal_insert_lsn() as lsn from write"
+                                         select *, pg_current_wal_lsn() as lsn from write"
                                          (:id app)
                                          (resolvers/->uuid r :users/createdAt)]))]
 
@@ -464,7 +464,7 @@
                                             where app_id = ? and attr_id = ? and checked_data_type is null
                                            returning entity_id
                                          )
-                                         select *, pg_current_wal_insert_lsn() as lsn from write"
+                                         select *, pg_current_wal_lsn() as lsn from write"
                                          (:id app)
                                          (resolvers/->uuid r :users/createdAt)]))]
 

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -267,9 +267,7 @@
                         pid-b (shutdown-b))
 
                       ;; Create another update
-                      (let [start-lsn (cms/get-start-lsn (aurora/conn-pool :read)
-                                                         {:slot-name slot-name})
-                            update-res (sql/do-execute!
+                      (let [update-res (sql/do-execute!
                                          (aurora/conn-pool :write)
                                          ["update triples set value = '\"alex3\"'::jsonb
                                             where app_id = ? and attr_id = ? and entity_id = ?"

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -1,5 +1,6 @@
 (ns instant.reactive.aggregator-test
   (:require
+   [tool]
    [clojure.string :as string]
    [clojure.test :as test :refer [deftest is testing]]
    [instant.data.bootstrap :as bootstrap]

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -113,7 +113,7 @@
                                          (not= app-id (:id app)))))
                                    changes)))]
         (binding [*in-test* true]
-          (let [slot-suffix (crypt-util/random-hex 16)
+          (let [slot-suffix (str "cc_" (crypt-util/random-hex 16))
                 slot-name (wal/full-slot-name agg/slot-type slot-suffix)
                 get-aggregator-status
                 (fn []
@@ -315,7 +315,7 @@
                                          (not= app-id (:id app)))))
                                    changes)))]
         (binding [*in-test* true]
-          (let [slot-suffix (crypt-util/random-hex 16)
+          (let [slot-suffix (str "vtl_" (crypt-util/random-hex 16))
                 slot-name (wal/full-slot-name agg/slot-type slot-suffix)]
             (try
               (bootstrap/add-movies-to-app! (:id app))
@@ -411,7 +411,7 @@
                                          (not= app-id (:id app)))))
                                    changes)))]
         (binding [*in-test* true]
-          (let [slot-suffix (crypt-util/random-hex 16)
+          (let [slot-suffix (str "cdt_" (crypt-util/random-hex 16))
                 slot-name (wal/full-slot-name agg/slot-type slot-suffix)]
             (try
               (bootstrap/add-zeneca-to-app! {:checked-data? true


### PR DESCRIPTION
When we get a giant transaction from a COPY or an app delete, we collect all of the changes for the transaction in memory and then apply them in the invalidator.

This can cause the jvm to run out of memory and crash. With the invalidator, we'll create a new slot the next time we start up that skips over the giant transaction, so it's self-healing in a way.

The aggregator will keep trying and failing to process the giant transaction.

This PR fixes the problem for the aggregator by ignoring transaction boundaries and just putting the `update`, `delete`, and `insert` records directly into the process channel. It doesn't wait for all of the changes for the transaction and just handles them as they come. This is fine for the aggregator--it doesn't need to care about transactions. We can't do the same for the invalidator because we need the `tx-id` from the `transactions` table.