### PR TITLE
Prevent logging parameters in auto explain

### DIFF
--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -400,10 +400,7 @@
                   conn
                   q
                   ;; Don't send the bins to honeycomb
-                  {:skip-log-params (not debug-queries)
-                   ;; Don't log statements
-                   :postgres-config [{:setting "auto_explain.log_min_duration"
-                                      :value "-1"}]})))
+                  {:skip-log-params (not debug-queries)})))
 
 (defn find-or-create-sketches!
   "Takes a set of {:app-id :attr-id} maps and returns a map of
@@ -511,10 +508,7 @@
                       conn
                       (hsql/format q {:params params})
                       ;; Don't send the bins to honeycomb
-                      {:skip-log-params (not debug-queries)
-                       ;; Don't log statements
-                       :postgres-config [{:setting "auto_explain.log_min_duration"
-                                          :value "-1"}]})))
+                      {:skip-log-params (not debug-queries)})))
 
 ;; -------------
 ;; Bootstrapping
@@ -578,7 +572,4 @@
                      conn
                      q
                      ;; Don't send the bins to honeycomb
-                     {:skip-log-params (not debug-queries)
-                      ;; Don't log statements
-                      :postgres-config [{:setting "auto_explain.log_min_duration"
-                                         :value "-1"}]})))
+                     {:skip-log-params (not debug-queries)})))

--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -400,7 +400,10 @@
                   conn
                   q
                   ;; Don't send the bins to honeycomb
-                  {:skip-log-params (not debug-queries)})))
+                  {:skip-log-params (not debug-queries)
+                   ;; Don't log statements
+                   :postgres-config [{:setting "auto_explain.log_min_duration"
+                                      :value "-1"}]})))
 
 (defn find-or-create-sketches!
   "Takes a set of {:app-id :attr-id} maps and returns a map of
@@ -508,7 +511,10 @@
                       conn
                       (hsql/format q {:params params})
                       ;; Don't send the bins to honeycomb
-                      {:skip-log-params (not debug-queries)})))
+                      {:skip-log-params (not debug-queries)
+                       ;; Don't log statements
+                       :postgres-config [{:setting "auto_explain.log_min_duration"
+                                          :value "-1"}]})))
 
 ;; -------------
 ;; Bootstrapping
@@ -572,4 +578,7 @@
                      conn
                      q
                      ;; Don't send the bins to honeycomb
-                     {:skip-log-params (not debug-queries)})))
+                     {:skip-log-params (not debug-queries)
+                      ;; Don't log statements
+                      :postgres-config [{:setting "auto_explain.log_min_duration"
+                                         :value "-1"}]})))

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -168,3 +168,11 @@
     (is (thrown-with-msg? ExceptionInfo #"Missing parameter: \?b"
                           (let [q "WHERE ?a = ?b"]
                             (sql/format q {"?a" 1}))))))
+
+(deftest setting-settings-works
+  (is (= {:auto_explain.log_parameter_max_length "0"}
+         (sql/select-one (aurora/conn-pool :read)
+                         ["show auto_explain.log_parameter_max_length"])))
+  (is (= {:setting 60}
+         (sql/select-one (aurora/conn-pool :read)
+                         ["select extract(epoch from current_setting('idle_in_transaction_session_timeout')::interval)::int setting"]))))


### PR DESCRIPTION
This applies a connection-level setting to prevent auto_explain from logging parameters. It is applied whenever hikari creates a new connection for its pool.

We would set it in the db config, but aurora doesn't give us a way to modify that setting.