### PR TITLE
Don't log bins in auto-explain

### DIFF
--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -400,7 +400,10 @@
                   conn
                   q
                   ;; Don't send the bins to honeycomb
-                  {:skip-log-params (not debug-queries)})))
+                  {:skip-log-params (not debug-queries)
+                   ;; Don't log statements
+                   :postgres-config [{:setting "auto_explain.log_min_duration"
+                                      :value "-1"}]})))
 
 (defn find-or-create-sketches!
   "Takes a set of {:app-id :attr-id} maps and returns a map of
@@ -508,7 +511,10 @@
                       conn
                       (hsql/format q {:params params})
                       ;; Don't send the bins to honeycomb
-                      {:skip-log-params (not debug-queries)})))
+                      {:skip-log-params (not debug-queries)
+                       ;; Don't log statements
+                       :postgres-config [{:setting "auto_explain.log_min_duration"
+                                          :value "-1"}]})))
 
 ;; -------------
 ;; Bootstrapping
@@ -572,4 +578,7 @@
                      conn
                      q
                      ;; Don't send the bins to honeycomb
-                     {:skip-log-params (not debug-queries)})))
+                     {:skip-log-params (not debug-queries)
+                      ;; Don't log statements
+                      :postgres-config [{:setting "auto_explain.log_min_duration"
+                                         :value "-1"}]})))


### PR DESCRIPTION
Alternative to https://github.com/instantdb/instant/pull/1579 because aurora won't let us set `auto_explain.log_parameter_max_length`

This will help reduce the amount of postgres logs we produce.