### PR TITLE
Don't log bins in auto-explain (take 2)

### DIFF
--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -381,29 +381,31 @@
                       :attr-ids (with-meta (mapv :attr-id keys)
                                   {:pgtype "uuid[]"}))
         cols [:id :app-id :attr-id :width :depth :total :total-not-binned :bins]
-        q (hsql/format {:with [[:data {:select [[:%gen_random_uuid :id]
+        q (hsql/format {:with [[:setting
+                                {:select [[[:set_config [:inline "auto_explain.log_min_duration"] [:inline "-1"] :true] :config]]}
+                                :materialized]
+                               [:data {:select [[:%gen_random_uuid :id]
                                                 [[:unnest :?app-ids] :app-id]
                                                 [[:unnest :?attr-ids] :attr-id]
                                                 [:?width :width]
                                                 [:?depth :depth]
                                                 [:?total :total]
                                                 [:?total-not-binned :total-not-binned]
-                                                [:?bins :bins]]}]]
-                        :insert-into [[:attr-sketches cols]
-                                      {:select (qualify-cols :data cols)
-                                       :from :data
-                                       :join [:attrs [:= :attrs.id :data.attr-id]
-                                              :apps [:= :apps.id :data.app-id]]}]
-                        :returning :*}
+                                                [:?bins :bins]]}]
+                               [:changes {:insert-into [[:attr-sketches cols]
+                                                        {:select (qualify-cols :data cols)
+                                                         :from :data
+                                                         :join [:attrs [:= :attrs.id :data.attr-id]
+                                                                :apps [:= :apps.id :data.app-id]]}]
+                                          :returning :*}]]
+                        :select [:changes.* [{:select :config :from :setting} :ignored]]
+                        :from :changes}
                        {:params params})]
     (sql/execute! ::create-empty-sketch-rows!
                   conn
                   q
                   ;; Don't send the bins to honeycomb
-                  {:skip-log-params (not debug-queries)
-                   ;; Don't log statements
-                   :postgres-config [{:setting "auto_explain.log_min_duration"
-                                      :value "-1"}]})))
+                  {:skip-log-params (not debug-queries)})))
 
 (defn find-or-create-sketches!
   "Takes a set of {:app-id :attr-id} maps and returns a map of
@@ -466,7 +468,10 @@
                         :slot-name slot-name
                         :process-id process-id}
                        sketches)
-        q {:with [[:data {:select [[[:unnest :?id] :id]
+        q {:with [[:setting
+                   {:select [[[:set_config [:inline "auto_explain.log_min_duration"] [:inline "-1"] :true] :config]]}
+                   :materialized]
+                  [:data {:select [[[:unnest :?id] :id]
                                    [[:unnest :?width] :width]
                                    [[:unnest :?depth] :depth]
                                    [[:unnest :?total] :total]
@@ -504,17 +509,14 @@
                                true
                                :else [:raise_exception_message [:inline "lsn is not what we expected, another machine may have stolen the replication slot"]]]
                               :ok]]}]]
-           :select :*
-           :from :update-wal-aggregator-status
+           :select [:s.* [{:select :config :from :setting} :ignored]]
+           :from [[:update-wal-aggregator-status :s]]
            :where [:= true {:select :ok :from :check-empty}]}]
     (sql/execute-one! ::save-sketches!
                       conn
                       (hsql/format q {:params params})
                       ;; Don't send the bins to honeycomb
-                      {:skip-log-params (not debug-queries)
-                       ;; Don't log statements
-                       :postgres-config [{:setting "auto_explain.log_min_duration"
-                                          :value "-1"}]})))
+                      {:skip-log-params (not debug-queries)})))
 
 ;; -------------
 ;; Bootstrapping
@@ -554,7 +556,10 @@
         cols [:id :max-lsn :app-id :attr-id
               :width :depth :total :total-not-binned :bins
               :reverse-width :reverse-depth :reverse-total :reverse-bins]
-        q (hsql/format {:with [[:data {:select [[:%gen_random_uuid :id]
+        q (hsql/format {:with [[:setting
+                                {:select [[[:set_config [:inline "auto_explain.log_min_duration"] [:inline "-1"] :true] :config]]}
+                                :materialized]
+                               [:data {:select [[:%gen_random_uuid :id]
                                                 [lsn :max-lsn]
                                                 [[:unnest :?app-id] :app-id]
                                                 [[:unnest :?attr-id] :attr-id]
@@ -566,19 +571,19 @@
                                                 [[:unnest :?reverse-width] :reverse-width]
                                                 [[:unnest :?reverse-depth] :reverse-depth]
                                                 [[:unnest :?reverse-total] :reverse-total]
-                                                [[:unnest :?reverse-bins] :reverse-bins]]}]]
-                        :insert-into [[:attr-sketches cols]
-                                      {:select (qualify-cols :data cols)
-                                       :from :data
-                                       ;; Filter out sketches for attrs/apps that were deleted
-                                       :join [:attrs [:= :attrs.id :data.attr-id]
-                                              :apps [:= :apps.id :data.app-id]]}]}
+                                                [[:unnest :?reverse-bins] :reverse-bins]]}]
+                               [:changes {:insert-into [[:attr-sketches cols]
+                                                        {:select (qualify-cols :data cols)
+                                                         :from :data
+                                                         ;; Filter out sketches for attrs/apps that were deleted
+                                                         :join [:attrs [:= :attrs.id :data.attr-id]
+                                                                :apps [:= :apps.id :data.app-id]]}]
+                                          :returning :*}]]
+                        :select [:changes.* [{:select :config :from :setting} :ignored]]
+                        :from :changes}
                        {:params params})]
     (sql/do-execute! ::insert-initial-sketches!
                      conn
                      q
                      ;; Don't send the bins to honeycomb
-                     {:skip-log-params (not debug-queries)
-                      ;; Don't log statements
-                      :postgres-config [{:setting "auto_explain.log_min_duration"
-                                         :value "-1"}]})))
+                     {:skip-log-params (not debug-queries)})))

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -192,8 +192,10 @@
    Defaults to one minute, but can be modified with a flag in an emergency."
   [config]
   (let [conn (next-jdbc/get-connection config)]
-    (next-jdbc/execute! conn ["select set_config('idle_in_transaction_session_timeout', ?::text, false)"
-                              (flags/flag :idle-in-transaction-session-timeout (* 1000 60))])
+    (next-jdbc/execute! conn ["select set_config('auto_explain.log_parameter_max_length', ?::text, false)"
+                              0
+                              ;;(flags/flag :idle-in-transaction-session-timeout (* 1000 60))
+                              ])
     conn))
 
 (defn aurora-cluster-datasource

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -193,9 +193,7 @@
   [config]
   (let [conn (next-jdbc/get-connection config)]
     (next-jdbc/execute! conn ["select set_config('auto_explain.log_parameter_max_length', ?::text, false)"
-                              0
-                              ;;(flags/flag :idle-in-transaction-session-timeout (* 1000 60))
-                              ])
+                              (flags/flag :idle-in-transaction-session-timeout (* 1000 60))])
     conn))
 
 (defn aurora-cluster-datasource

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -86,7 +86,8 @@
                                          :copy-sql (copy-sql-for-app-ids [(:id app)])
                                          :acquire-slot-interval-ms 10000
                                          :sketch-flush-ms 10
-                                         :sketch-flush-max-items 1000})]
+                                         :sketch-flush-max-items 1000
+                                         :skip-empty-updates false})]
                 (try
                   (check-sketches app movies-r)
                   (check-sketches app (resolvers/make-zeneca-resolver (:id app)))
@@ -144,7 +145,8 @@
                                            :acquire-slot-interval-ms 100
                                            :sketch-flush-ms 10
                                            :sketch-flush-max-items 1000
-                                           :process-id pid-a})
+                                           :process-id pid-a
+                                           :skip-empty-updates false})
                     shutdown-b (agg/start {:slot-suffix slot-suffix
                                            :copy-sql (copy-sql-for-app-ids [(:id app)])
                                            :acquire-slot-interval-ms 100
@@ -238,13 +240,15 @@
                                            :acquire-slot-interval-ms 10
                                            :sketch-flush-ms 10
                                            :sketch-flush-max-items 1000
-                                           :process-id pid-a})
+                                           :process-id pid-a
+                                           :skip-empty-updates false})
                     shutdown-b (agg/start {:slot-suffix slot-suffix
                                            :copy-sql (copy-sql-for-app-ids [(:id app)])
                                            :acquire-slot-interval-ms 10
                                            :sketch-flush-ms 10
                                            :sketch-flush-max-items 1000
-                                           :process-id pid-b})]
+                                           :process-id pid-b
+                                           :skip-empty-updates false})]
                 (try
                   (let [r (resolvers/make-zeneca-resolver (:id app))]
                     (let [update-res (sql/do-execute! (aurora/conn-pool :write)
@@ -324,7 +328,8 @@
                                          :copy-sql (copy-sql-for-app-ids [(:id app)])
                                          :acquire-slot-interval-ms 10000
                                          :sketch-flush-ms 10
-                                         :sketch-flush-max-items 1000})]
+                                         :sketch-flush-max-items 1000
+                                         :skip-empty-updates false})]
 
                 (try
                   (testing "handles value-too-large in setup"
@@ -419,7 +424,8 @@
                                          :copy-sql (copy-sql-for-app-ids [(:id app)])
                                          :acquire-slot-interval-ms 10000
                                          :sketch-flush-ms 10
-                                         :sketch-flush-max-items 1000})]
+                                         :sketch-flush-max-items 1000
+                                         :skip-empty-updates false})]
                 (try
 
                   (testing "setting the date worked"


### PR DESCRIPTION
Follow up to https://github.com/instantdb/instant/pull/1580. That approach doesn't work because you can't use set-setting in a write connection unless auto-commit is off. This PR puts the set_config directly in the CTE (which is a lot easier than making the connection not use auto-commit).

It also disables handling empty updates in the aggregator in dev. When the aggregator processes an update, it writes to the database, which will trigger the aggregator on the next cycle. So in dev the aggregator will run in a loop every 10 seconds. It was enabled in the first place in https://github.com/instantdb/instant/pull/1576 so that the tests would know when all of their writes had been acknowledged. Now we just ignore those empty updates in dev.