### PR TITLE
Link unlink permission checks, take 2

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/linkunlink.tsx
+++ b/client/sandbox/react-nextjs/pages/play/linkunlink.tsx
@@ -1,0 +1,299 @@
+import { useState } from 'react';
+import {
+  init,
+  tx,
+  id,
+  i,
+  InstantReactAbstractDatabase,
+  InstantSchemaDef,
+} from '@instantdb/react';
+import config from '../../config';
+import EphemeralAppPage from '../../components/EphemeralAppPage';
+
+const schema = i.schema({
+  entities: {
+    groups: i.entity({
+      name: i.string(),
+    }),
+    users: i.entity({
+      name: i.string(),
+    }),
+  },
+  links: {
+    groupOwner: {
+      forward: {
+        on: 'groups',
+        has: 'one',
+        label: 'owner',
+      },
+      reverse: {
+        on: 'users',
+        has: 'many',
+        label: 'ownedGroups',
+      },
+    },
+
+    groupMembers: {
+      forward: {
+        on: 'groups',
+        has: 'many',
+        label: 'members',
+      },
+      reverse: {
+        on: 'users',
+        has: 'many',
+        label: 'groups',
+      },
+    },
+  },
+});
+
+type Schema = typeof schema;
+
+const perms = {
+  groups: {
+    allow: {
+      view: 'true',
+      create: 'true',
+      update: 'true',
+      delete: 'true',
+      link: {
+        members: 'data.owner == auth.id || linkedData.id == auth.id',
+      },
+      unlink: {
+        // both data.owner and data.ref("owner.id") works
+        members: 'auth.id in data.ref("owner.id") || linkedData.id == auth.id',
+      },
+    },
+  },
+  users: {
+    allow: {
+      view: 'true',
+      create: 'true',
+      update: 'true',
+      delete: 'true',
+    },
+  },
+};
+
+function Login({ db }: { db: InstantReactAbstractDatabase<Schema> }) {
+  const [state, setState] = useState({
+    sentEmail: '',
+    email: '',
+    code: '',
+  });
+  const { sentEmail, email, code } = state;
+  return (
+    <div>
+      <div>
+        {!sentEmail ? (
+          <div key="em">
+            <h2>Let's log you in!</h2>
+            <div>
+              <input
+                placeholder="Enter your email"
+                type="email"
+                value={email}
+                onChange={(e) => setState({ ...state, email: e.target.value })}
+              />
+            </div>
+            <div>
+              <button
+                onClick={() => {
+                  setState({ ...state, sentEmail: email });
+                  db.auth.sendMagicCode({ email }).catch((err) => {
+                    alert('Uh oh :' + err.body?.message);
+                    setState({ ...state, sentEmail: '' });
+                  });
+                }}
+              >
+                Send Code
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div key="cd">
+            <h2>Okay we sent you an email! What was the code?</h2>
+            <div>
+              <input
+                type="text"
+                placeholder="Code plz"
+                value={code || ''}
+                onChange={(e) => setState({ ...state, code: e.target.value })}
+              />
+            </div>
+            <button
+              onClick={(e) => {
+                db.auth
+                  .signInWithMagicCode({ email: sentEmail, code })
+                  .catch((err) => {
+                    alert('Uh oh :' + err.body?.message);
+                    setState({ ...state, code: '' });
+                  });
+              }}
+            >
+              Verify
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Example({
+  db,
+  user,
+}: {
+  db: InstantReactAbstractDatabase<Schema>;
+  user: { id: string };
+}) {
+  const { isLoading, error, data } = db.useQuery({
+    groups: {
+      members: {},
+      owner: {},
+    },
+    users: {},
+  });
+
+  const me = user.id;
+
+  const seedData = async () => {
+    const user1 = id();
+    const user2 = id();
+    const user3 = id();
+    const myGroup = id();
+    const alicesGroup = id();
+
+    await db.transact([
+      tx.users[me].update({ name: 'Me' }),
+      tx.users[user1].update({ name: 'Alice' }),
+      tx.users[user2].update({ name: 'Bob' }),
+      tx.users[user3].update({ name: 'Charlie' }),
+      tx.groups[myGroup].update({ name: 'My Group' }).link({ owner: me }),
+      tx.groups[alicesGroup]
+        .update({ name: 'Alice’s Group' })
+        .link({ owner: user1 }),
+    ]);
+  };
+
+  const addMember = async (groupId: string, userId: string) => {
+    try {
+      await db.transact([tx.groups[groupId].link({ members: userId })]);
+    } catch (error) {
+      console.error('Failed to add member:', error);
+      alert(`Failed to add member: ${error}`);
+    }
+  };
+
+  const removeMember = async (groupId: string, userId: string) => {
+    try {
+      await db.transact([tx.groups[groupId].unlink({ members: userId })]);
+    } catch (error) {
+      console.error('Failed to remove member:', error);
+      alert(`Failed to remove member: ${error}`);
+    }
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  const groups = data?.groups || [];
+  const users = data?.users || [];
+  const currentUser = users.find((u) => u.id === me);
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Link/Unlink Permissions Demo</h1>
+
+      <div className="mb-6 p-4 bg-gray-100 rounded">
+        <p className="mb-2">
+          Current User: {currentUser?.name || 'None'} (ID: {me || 'N/A'})
+        </p>
+        <button
+          onClick={seedData}
+          className="bg-blue-500 text-white px-4 py-2 rounded mr-2"
+        >
+          Seed Data
+        </button>
+      </div>
+
+      {groups.map((group) => {
+        const isOwner = group?.owner?.id === me;
+        const memberIds = new Set(group.members?.map((m: any) => m.id) || []);
+
+        return (
+          <div key={group.id} className="mb-6 p-4 border rounded">
+            <h2 className="text-xl font-semibold mb-2">
+              {group.name} (Owner:{' '}
+              {users.find((u) => u.id === group?.owner?.id)?.name})
+            </h2>
+
+            <div className="mb-4">
+              <h3 className="font-semibold mb-2">Current Members:</h3>
+              {group.members?.map((member: any) => (
+                <div key={member.id} className="flex items-center gap-2 mb-1">
+                  <span>{member.name}</span>
+                  <button
+                    onClick={() => removeMember(group.id, member.id)}
+                    className="text-red-500 text-sm"
+                    title={
+                      isOwner
+                        ? 'Owner can remove anyone'
+                        : 'Users can only remove themselves'
+                    }
+                  >
+                    Remove{' '}
+                    {isOwner
+                      ? '(as owner)'
+                      : member.id === me
+                        ? '(self)'
+                        : '(no permission)'}
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2">Available Users:</h3>
+              {users
+                .filter((u) => !memberIds.has(u.id))
+                .map((user) => (
+                  <div key={user.id} className="flex items-center gap-2 mb-1">
+                    <span>{user.name}</span>
+                    <button
+                      onClick={() => addMember(group.id, user.id)}
+                      className="text-green-500 text-sm"
+                    >
+                      Add
+                    </button>
+                  </div>
+                ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Router({ appId }: { appId: string }) {
+  const db = init({ ...config, appId, schema });
+
+  const auth = db.useAuth();
+  if (auth.isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (auth.error) {
+    return <div>Uh oh! {auth.error.message}</div>;
+  }
+  if (!auth.user) {
+    return <Login db={db} />;
+  }
+
+  return <Example db={db} user={auth.user} />;
+}
+
+export default function Page() {
+  return <EphemeralAppPage schema={schema} perms={perms} Component={Router} />;
+}

--- a/client/sandbox/react-nextjs/pages/play/linkunlink_ruleparams.tsx
+++ b/client/sandbox/react-nextjs/pages/play/linkunlink_ruleparams.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react';
+import { init, tx, id, i } from '@instantdb/react';
+import config from '../../config';
+import EphemeralAppPage from '../../components/EphemeralAppPage';
+
+const schema = i.schema({
+  entities: {
+    groups: i.entity({
+      name: i.string(),
+      ownerId: i.string(),
+    }),
+    users: i.entity({
+      name: i.string(),
+    }),
+  },
+  links: {
+    groupMembers: {
+      forward: {
+        on: 'groups',
+        has: 'many',
+        label: 'members',
+      },
+      reverse: {
+        on: 'users',
+        has: 'many',
+        label: 'groups',
+      },
+    },
+  },
+});
+
+const perms = {
+  groups: {
+    allow: {
+      view: 'true',
+      create: 'true',
+      update: 'true',
+      delete: 'true',
+      link: {
+        members: 'data.ownerId == ruleParams.currentUserId',
+      },
+      unlink: {
+        members:
+          'data.ownerId == ruleParams.currentUserId || linkedData.id == ruleParams.currentUserId',
+      },
+    },
+  },
+  users: {
+    allow: {
+      view: 'true',
+      create: 'true',
+      update: 'true',
+      delete: 'true',
+    },
+  },
+};
+
+function Example({ appId }: { appId: string }) {
+  const db = init({ ...config, appId, schema });
+  const [currentUserId, setCurrentUserId] = useState<string>('');
+
+  const { isLoading, error, data } = db.useQuery({
+    groups: {
+      members: {},
+    },
+    users: {},
+  });
+
+  const seedData = async () => {
+    const owner = id();
+    const user1 = id();
+    const user2 = id();
+    const user3 = id();
+    const groupId = id();
+
+    await db.transact([
+      tx.users[owner].update({ name: 'Owner' }),
+      tx.users[user1].update({ name: 'Alice' }),
+      tx.users[user2].update({ name: 'Bob' }),
+      tx.users[user3].update({ name: 'Charlie' }),
+      tx.groups[groupId].update({ name: 'Main Group', ownerId: owner }),
+    ]);
+
+    setCurrentUserId(owner);
+  };
+
+  const addMember = async (groupId: string, userId: string) => {
+    try {
+      await db.transact([
+        tx.groups[groupId]
+          .ruleParams({ currentUserId })
+          .link({ members: userId }),
+      ]);
+    } catch (error) {
+      console.error('Failed to add member:', error);
+      alert(`Failed to add member: ${error}`);
+    }
+  };
+
+  const removeMember = async (groupId: string, userId: string) => {
+    try {
+      await db.transact([
+        tx.groups[groupId]
+          .ruleParams({ currentUserId })
+          .unlink({ members: userId }),
+      ]);
+    } catch (error) {
+      console.error('Failed to remove member:', error);
+      alert(`Failed to remove member: ${error}`);
+    }
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  const groups = data?.groups || [];
+  const users = data?.users || [];
+  const currentUser = users.find((u) => u.id === currentUserId);
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Link/Unlink Permissions Demo</h1>
+
+      <div className="mb-6 p-4 bg-gray-100 rounded">
+        <p className="mb-2">
+          Current User: {currentUser?.name || 'None'} (ID:{' '}
+          {currentUserId || 'N/A'})
+        </p>
+        <button
+          onClick={seedData}
+          className="bg-blue-500 text-white px-4 py-2 rounded mr-2"
+        >
+          Seed Data
+        </button>
+        <select
+          value={currentUserId}
+          onChange={(e) => setCurrentUserId(e.target.value)}
+          className="px-4 py-2 border rounded"
+        >
+          <option value="">Select User</option>
+          {users.map((user) => (
+            <option key={user.id} value={user.id}>
+              {user.name} ({user.id.slice(0, 8)}...)
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {groups.map((group) => {
+        const isOwner = group.ownerId === currentUserId;
+        const memberIds = new Set(group.members?.map((m: any) => m.id) || []);
+
+        return (
+          <div key={group.id} className="mb-6 p-4 border rounded">
+            <h2 className="text-xl font-semibold mb-2">
+              {group.name} (Owner:{' '}
+              {users.find((u) => u.id === group.ownerId)?.name})
+            </h2>
+
+            <div className="mb-4">
+              <h3 className="font-semibold mb-2">Current Members:</h3>
+              {group.members?.map((member: any) => (
+                <div key={member.id} className="flex items-center gap-2 mb-1">
+                  <span>{member.name}</span>
+                  <button
+                    onClick={() => removeMember(group.id, member.id)}
+                    className="text-red-500 text-sm"
+                    title={
+                      isOwner
+                        ? 'Owner can remove anyone'
+                        : 'Users can only remove themselves'
+                    }
+                  >
+                    Remove{' '}
+                    {isOwner
+                      ? '(as owner)'
+                      : member.id === currentUserId
+                        ? '(self)'
+                        : '(no permission)'}
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <div>
+              <h3 className="font-semibold mb-2">Available Users:</h3>
+              {users
+                .filter((u) => !memberIds.has(u.id))
+                .map((user) => (
+                  <div key={user.id} className="flex items-center gap-2 mb-1">
+                    <span>{user.name}</span>
+                    <button
+                      onClick={() => addMember(group.id, user.id)}
+                      className="text-green-500 text-sm"
+                    >
+                      Add
+                    </button>
+                  </div>
+                ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function Page() {
+  return <EphemeralAppPage schema={schema} perms={perms} Component={Example} />;
+}

--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -109,6 +109,44 @@ a user executes, they’ll _only_ see data that they are allowed to see.
 Similarly, for each object in a transaction, we make sure to evaluate the respective `create`, `update`, and `delete` rule.
 Transactions will fail if a user does not have adequate permission.
 
+### Link, Unlink
+
+You can add checks per link attribute for cases when link is added and removed. For example:
+
+```json
+{
+  "posts": {
+    "allow": {
+      "link": {
+        "author": "linkedData.id == auth.id",
+        "reviewer": "..."
+      },
+      "unlink": {
+        "author": "linkedData.id == auth.id"
+      }
+    }
+  },
+  "users": {
+    "allow": {
+      "link": {
+        "posts": "newData.id == auth.id && linkedData.text != null"
+      },
+      "unlink": {
+        "posts": "data.id == auth.id && linkedData.text != null"
+      }
+    }
+  }
+}
+```
+
+Few things to note:
+
+1. Unlike other permissions, value for `link`/`unlink` is a map, not a string. Keys in that map are attribute labels.
+2. Permission checks can be defined either on both sides, on one side or at neither.
+3. If `link`/`unlink` permission is not defined for an attribute, it falls back to `update` check in forward direction and `view` check in reverse direction.
+4. Inside `link`/`unlink` permissions you have access to `linkedData` object which is just a shorthand for the other side of the relation.
+5. You still have access to `data` and `newData`, with the same logic as in `create`/`update` checks.
+
 ### Default permissions
 
 By default, all permissions are considered to be `"true"`. To change that, use `"$default"` key. This:
@@ -236,11 +274,15 @@ The above example shows a taste of the kind of rules you can write :)
 
 ### data
 
-`data` refers to the object you have saved. This will be populated when used for `view`, `create`, `update`, and `delete` rules
+`data` refers to the object you have saved. This will be populated when used for `view`, `create`, `update`, `delete`, `link` and `unlink` rules.
 
 ### newData
 
 In `update`, you'll also have access to `newData`. This refers to the changes that are being made to the object.
+
+### linkedData
+
+In `link`/`unlink`, you have access to `linkedData` object which is just a shorthand for the other side of the relation.
 
 ### bind
 

--- a/server/.clj-kondo/config.edn
+++ b/server/.clj-kondo/config.edn
@@ -8,4 +8,5 @@
                         instant.fixtures/with-indexing-job-queue hooks.with-indexing-job-queue/with-indexing-job-queue}}
  :lint-as {instant.jdbc.sql/with-connection clojure.core/let
            instant.util.tracer/with-exceptions-silencer clojure.core/fn
-           clojure.core.cache/defcache clojure.core/defrecord}}
+           clojure.core.cache/defcache clojure.core/defrecord
+           instant.util.test/test-matrix clojure.core/doseq}}

--- a/server/cljfmt.edn
+++ b/server/cljfmt.edn
@@ -1,3 +1,6 @@
 {:extra-indents {warn-io   [[:block 1]]
                  expect-io [[:block 0]]
-                 tag-io    [[:block 0]]}}
+                 tag-io    [[:block 0]]
+                 cond+     [[:block 0]]
+                 if+       [[:block 1]]
+                 when+     [[:block 1]]}}

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -359,6 +359,12 @@
       (.addVar "newData" type-obj)
       (.build)))
 
+(def ^:private ^CelCompiler cel-link-unlink-compiler
+  (-> (runtime-compiler-builder)
+      (.addVar "newData" type-obj)
+      (.addVar "linkedData" type-obj)
+      (.build)))
+
 ;; n.b. if you edit something here, make sure you make the
 ;;      equivalent change to iql-cel-compiler below
 (def ^:private ^CelRuntime cel-runtime
@@ -372,9 +378,9 @@
 
 (defn action->compiler [action]
   (case (name action)
-    ("view" "delete")
-    cel-view-delete-compiler
-    cel-create-update-compiler))
+    ("view" "delete") cel-view-delete-compiler
+    ("link" "unlink") cel-link-unlink-compiler
+    #_else            cel-create-update-compiler))
 
 (defn get-expr ^CelExpr [^CelNavigableExpr node]
   ;; Not sure why this is necessary, but can't call
@@ -416,7 +422,7 @@
 (defn eval-program!
   [ctx
    {:keys [cel-program etype action]}
-   {:keys [data rule-params new-data]}]
+   {:keys [data rule-params new-data linked-data]}]
   (try
     (let [bindings (HashMap.)
 
@@ -425,6 +431,8 @@
           _ (.put bindings "ruleParams" (CelMap. rule-params))
           _ (when new-data
               (.put bindings "newData" (CelMap. new-data)))
+          _ (when linked-data
+              (.put bindings "linkedData" (CelMap. linked-data)))
           result (.eval ^CelRuntime$Program cel-program
                         bindings)]
       (cond
@@ -455,7 +463,7 @@
    {:keys [^CelRuntime$Program cel-program
            etype
            action] :as program}
-   {:keys [resolver data rule-params new-data]}]
+   {:keys [resolver data rule-params new-data linked-data]}]
   (if (contains? program :result)
     (:result program)
     (try
@@ -472,6 +480,9 @@
                                "newData" (if new-data
                                            (Optional/of (CelMap. new-data))
                                            (Optional/empty))
+                               "linkedData" (if linked-data
+                                              (Optional/of (CelMap. linked-data))
+                                              (Optional/empty))
                                (Optional/empty)))))
             unknown-ctx (UnknownContext/create resolver (ImmutableList/of))
             i (AtomicInteger.)

--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -1,6 +1,7 @@
 (ns instant.db.permissioned-transaction-new
   (:require
    [clojure.string :as string]
+   [clojure+.core :as clojure+]
    [instant.db.cel :as cel]
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
@@ -194,16 +195,24 @@
 
 (defn pre-checks
   "Checks that run before tx: update, delete for attrs & objects"
-  [{:keys [admin? rules]}
+  [{:keys [attrs admin? rules]}
    entities-map
    updated-entities-map
    rule-params-map
    tx-steps]
-  (for [{:keys [op eid etype value rev-etype]} tx-steps
-        :let [key         {:eid eid :etype etype}
-              entity      (get entities-map key)
-              rule-params (get rule-params-map key)]
-        check (cond
+  (for [tx-step tx-steps
+        :let [{:keys [op eid aid etype value rev-etype]} tx-step
+              key             {:eid eid :etype etype}
+              entity          (get entities-map key)
+              update?         (some? entity)
+              ref?            (some? rev-etype)
+              [_ _ fwd-label] (:forward-identity (attr-model/seek-by-id aid attrs))
+              [_ _ rev-label] (:reverse-identity (attr-model/seek-by-id aid attrs))
+              rev-key         {:eid value :etype rev-etype}
+              rev-entity      (when ref?
+                                (get entities-map rev-key))
+              rule-params     (get rule-params-map key)]
+        check (clojure+/cond+
                 (= :update-attr op)
                 [{:scope    :attr
                   :action   :update
@@ -222,30 +231,92 @@
                   :etype    "attrs"
                   :program  {:result admin?}}]
 
-                (and (#{:add-triple :deep-merge-triple :retract-triple} op)
-                     entity) ;; update
+                (and (= :add-triple op)
+                     ref?)
                 (concat
-                 [{:scope    :object
-                   :action   :update
-                   :etype    etype
-                   :eid      eid
-                   :program  (or (rule-model/get-program! rules etype "update")
-                                 {:result true})
-                   :bindings {:data        entity
-                              :new-data    (get updated-entities-map key)
-                              :rule-params rule-params}}]
-                 ;; updating a ref adds implicit "view" check in reverse direction
-                 ;; with rule-params from forward direction
-                 (when rev-etype
-                   (when-some [rev-entity (get entities-map {:eid value :etype rev-etype})]
-                     [{:scope    :object
-                       :action   :view
-                       :etype    rev-etype
-                       :eid      value
-                       :program  (or (rule-model/get-program! rules rev-etype "view")
-                                     {:result true})
-                       :bindings {:data        rev-entity
-                                  :rule-params rule-params}}])))
+                 (when update?
+                   [{:scope    :object
+                     :action   :link
+                     :etype    etype
+                     :eid      eid
+                     :program  (rule-model/get-program!
+                                rules
+                                [[etype      "allow" "link" fwd-label]
+                                 [etype      "allow" "update"]
+                                 [etype      "allow" "$default"]
+                                 ["$default" "allow" "link" fwd-label]
+                                 ["$default" "allow" "update"]
+                                 ["$default" "allow" "$default"]])
+                     :bindings {:data        entity
+                                :new-data    (get updated-entities-map key)
+                                :linked-data rev-entity
+                                :rule-params rule-params}}])
+                 (when rev-entity
+                   [{:scope    :object
+                     :action   :link
+                     :etype    rev-etype
+                     :eid      value
+                     :program  (rule-model/get-program!
+                                rules
+                                [[rev-etype  "allow" "link" rev-label]
+                                 [rev-etype  "allow" "view"]
+                                 [rev-etype  "allow" "$default"]
+                                 ["$default" "allow" "link" rev-label]
+                                 ["$default" "allow" "view"]
+                                 ["$default" "allow" "$default"]])
+                     :bindings {:data        rev-entity
+                                :new-data    (get updated-entities-map rev-key)
+                                :linked-data (get updated-entities-map key)
+                                :rule-params (merge rule-params
+                                                    (get rule-params-map rev-key))}}]))
+
+                (and (= :retract-triple op)
+                     ref?)
+                [{:scope    :object
+                  :action   :unlink
+                  :etype    etype
+                  :eid      eid
+                  :program  (rule-model/get-program!
+                             rules
+                             [[etype      "allow" "unlink" fwd-label]
+                              [etype      "allow" "update"]
+                              [etype      "allow" "$default"]
+                              ["$default" "allow" "unlink" fwd-label]
+                              ["$default" "allow" "update"]
+                              ["$default" "allow" "$default"]])
+                  :bindings {:data        entity
+                             :new-data    (get updated-entities-map key)
+                             :linked-data rev-entity
+                             :rule-params rule-params}}
+                 {:scope    :object
+                  :action   :unlink
+                  :etype    rev-etype
+                  :eid      value
+                  :program  (rule-model/get-program!
+                             rules
+                             [[rev-etype  "allow" "unlink" rev-label]
+                              [rev-etype  "allow" "view"]
+                              [rev-etype  "allow" "$default"]
+                              ["$default" "allow" "unlink" rev-label]
+                              ["$default" "allow" "view"]
+                              ["$default" "allow" "$default"]])
+                  :bindings {:data        rev-entity
+                             :new-data    (get updated-entities-map rev-key)
+                             :linked-data entity
+                             :rule-params (merge rule-params
+                                                 (get rule-params-map rev-key))}}]
+
+                (and (#{:add-triple :deep-merge-triple} op)
+                     update?)
+                [{:scope    :object
+                  :action   :update
+                  :etype    etype
+                  :eid      eid
+                  :program  (or (rule-model/get-program! rules etype "update")
+                                {:result true})
+                  :bindings {:data        entity
+                             :new-data    (get updated-entities-map key)
+                             :rule-params rule-params}}]
 
                 (= :delete-entity op)
                 [{:scope    :object
@@ -261,18 +332,29 @@
                 [])]
     check))
 
-(defn post-checks
-  "Checks that run after tx: create, add-attr"
-  [{:keys [rules]}
+(defn post-create-checks
+  "Checks for new entities created -- assumed to be run after tx so it can
+   reference new data in rules"
+  [{:keys [attrs rules]}
    entities-map
    updated-entities-map
    rule-params-map
    create-lookups-map
    tx-steps]
-  (for [{:keys [op eid etype value rev-etype]} tx-steps
-        :let [key         {:eid eid :etype etype}
-              entity      (get entities-map key)
-              rule-params (get rule-params-map key)]
+  (for [{:keys [op eid aid etype value rev-etype]} tx-steps
+        :let [key                {:eid eid :etype etype}
+              entity             (get entities-map key)
+              updated-entity     (-> (get updated-entities-map key)
+                                     (update "id" #(or (get create-lookups-map %) (:eid key) %)))
+              create?            (nil? entity)
+              ref?               (some? rev-etype)
+              [_ _ fwd-label]    (:forward-identity (attr-model/seek-by-id aid attrs))
+              [_ _ rev-label]    (:reverse-identity (attr-model/seek-by-id aid attrs))
+              rev-key            {:eid value :etype rev-etype}
+              updated-rev-entity (when ref?
+                                   (-> (get updated-entities-map rev-key)
+                                       (update "id" #(or (get create-lookups-map %) (:eid rev-key) %))))
+              rule-params        (get rule-params-map key)]
         check (cond
                 (= :add-attr op)
                 [{:scope    :attr
@@ -282,36 +364,137 @@
                                 {:result true})
                   :bindings {:data value}}]
 
-                (and (#{:add-triple :deep-merge-triple :retract-triple} op)
-                     (not entity)) ;; create
+                (and (= :add-triple op)
+                     ref?)
                 (concat
-                 [{:scope    :object
-                   :action   :create
-                   :etype    etype
-                   :eid      (get create-lookups-map eid eid)
-                   :program  (or (rule-model/get-program! rules etype "create")
-                                 {:result true})
-                   :bindings (let [updated-entity (-> (get updated-entities-map key)
-                                                      (update "id" #(get create-lookups-map % %)))]
-                               {:data        updated-entity
+                 (when create?
+                   [{:scope    :object
+                     :action   :link
+                     :etype    etype
+                     :eid      (get create-lookups-map eid eid)
+                     :program  (rule-model/get-program!
+                                rules
+                                [[etype      "allow" "link" fwd-label]
+                                 [etype      "allow" "create"]
+                                 [etype      "allow" "$default"]
+                                 ["$default" "allow" "link" fwd-label]
+                                 ["$default" "allow" "create"]
+                                 ["$default" "allow" "$default"]])
+                     :bindings {:data        updated-entity
                                 :new-data    updated-entity
-                                :rule-params rule-params})}]
-                   ;; updating a ref adds implicit "view" check in reverse direction
-                   ;; with rule-params from forward direction
-                 (when rev-etype
-                   (when-some [rev-entity (get entities-map {:eid value :etype rev-etype})]
-                     [{:scope    :object
-                       :action   :view
-                       :etype    rev-etype
-                       :eid      value
-                       :program  (or (rule-model/get-program! rules rev-etype "view")
-                                     {:result true})
-                       :bindings {:data        rev-entity
-                                  :rule-params rule-params}}])))
+                                :linked-data updated-rev-entity
+                                :rule-params rule-params}}])
+                 (when (and updated-rev-entity
+                            (nil? (get entities-map rev-key)))
+                   [{:scope    :object
+                     :action   :link
+                     :etype    rev-etype
+                     :eid      (get updated-rev-entity "id")
+                     :program  (rule-model/get-program!
+                                rules
+                                [[rev-etype  "allow" "link" rev-label]
+                                 [rev-etype  "allow" "view"]
+                                 [rev-etype  "allow" "$default"]
+                                 ["$default" "allow" "link" rev-label]
+                                 ["$default" "allow" "view"]
+                                 ["$default" "allow" "$default"]])
+                     :bindings {:data        updated-rev-entity
+                                :new-data    updated-rev-entity
+                                :linked-data updated-entity
+                                :rule-params (merge rule-params
+                                                    (get rule-params-map rev-key))}}]))
+
+                (and (#{:add-triple :deep-merge-triple} op)
+                     create?)
+                [{:scope    :object
+                  :action   :create
+                  :etype    etype
+                  :eid      (get create-lookups-map eid eid)
+                  :program  (or (rule-model/get-program! rules etype "create")
+                                {:result true})
+                  :bindings (let [updated-entity (-> (get updated-entities-map key)
+                                                     (update "id" #(get create-lookups-map % %)))]
+                              {:data        updated-entity
+                               :new-data    updated-entity
+                               :rule-params rule-params})}]
 
                 :else
                 [])]
     check))
+
+(defn post-delete-checks
+  "Checks based on automatic retract-triples generated by delete-entity"
+  [{:keys [attrs rules]}
+   entities-map
+   updated-entities-map
+   rule-params-map
+   tx-steps
+   deleled-triples]
+  (let [delete-keys (set
+                     (for [{:keys [op eid etype]} tx-steps
+                           :when (= :delete-entity op)]
+                       {:eid eid :etype etype}))]
+
+    (for [{:keys [entity_id attr_id value]} deleled-triples
+          :let [value (if (string? value)
+                        (uuid-util/coerce value)
+                        value)
+                attr  (attr-model/seek-by-id attr_id attrs)]
+          :when (= :ref (:value-type attr))
+          :let [[_ etype     fwd-label] (:forward-identity attr)
+                [_ rev-etype rev-label] (:reverse-identity attr)
+                key             {:eid entity_id :etype etype}
+                entity          (get entities-map key)
+                rev-key         {:eid value :etype rev-etype}
+                rev-entity      (get entities-map rev-key)
+                rule-params     (get rule-params-map key)]
+          check (concat
+                 ;; do not check unlink if we are deleting the whole entity
+                 (when-not (contains? delete-keys key)
+                   [{:scope    :object
+                     :action   :unlink
+                     :etype    etype
+                     :eid      entity_id
+                     :program  (rule-model/get-program!
+                                rules
+                                [[etype      "allow" "unlink" fwd-label]
+                                 [etype      "allow" "update"]
+                                 [etype      "allow" "$default"]
+                                 ["$default" "allow" "unlink" fwd-label]
+                                 ["$default" "allow" "update"]
+                                 ["$default" "allow" "$default"]])
+                     :bindings {:data        entity
+                                :new-data    (get updated-entities-map key)
+                                :linked-data rev-entity
+                                :rule-params rule-params}}])
+
+                 ;; do not check unlink if we are deleting the whole entity
+                 (when-not (contains? delete-keys rev-key)
+                   [{:scope    :object
+                     :action   :unlink
+                     :etype    rev-etype
+                     :eid      value
+                     :program  (rule-model/get-program!
+                                rules
+                                [[rev-etype  "allow" "unlink" rev-label]
+                                 [rev-etype  "allow" "view"]
+                                 [rev-etype  "allow" "$default"]
+                                 ["$default" "allow" "unlink" rev-label]
+                                 ["$default" "allow" "view"]
+                                 ["$default" "allow" "$default"]])
+                     :bindings {:data        rev-entity
+                                :new-data    (get updated-entities-map rev-key)
+                                :linked-data entity
+                                :rule-params (merge rule-params
+                                                    (get rule-params-map rev-key))}}]))]
+      check)))
+
+(defn post-checks
+  "Checks that run after tx: create, add-attr"
+  [ctx entities-map updated-entities-map rule-params-map create-lookups-map tx-steps results]
+  (concat
+   (post-create-checks ctx entities-map updated-entities-map rule-params-map create-lookups-map tx-steps)
+   (post-delete-checks ctx entities-map updated-entities-map rule-params-map tx-steps (:delete-entity results))))
 
 (defn run-checks!
   "Runs checks, returning results (admin-check?) or throwing"
@@ -379,10 +562,14 @@
                   tx-step-maps         (resolve-lookups-tx-steps ctx entities-map tx-step-maps)
                   entities-map         (resolve-lookups-entities-map ctx entities-map)
                   updated-entities-map (update-entities-map ctx entities-map tx-step-maps)
-                  rule-params-map      (into {}
-                                             (for [{:keys [op eid etype value]} tx-step-maps
-                                                   :when (= :rule-params op)]
-                                               [{:eid eid :etype etype} value]))
+                  rule-params-map      (persistent!
+                                        (reduce
+                                         (fn [acc {:keys [op eid etype value]}]
+                                           (if (= :rule-params op)
+                                             (ucoll/update! acc {:eid eid :etype etype} merge value)
+                                             acc))
+                                         (transient {})
+                                         tx-step-maps))
 
                   ;; pre checks
                   pre-checks           (pre-checks ctx
@@ -409,7 +596,8 @@
                                                     updated-entities-map
                                                     rule-params-map
                                                     create-lookups-map
-                                                    tx-step-maps)
+                                                    tx-step-maps
+                                                    (:results tx-data))
                   post-check-results   (io/expect-io
                                          (run-checks! ctx post-checks))
 

--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -450,38 +450,34 @@
                 rule-params     (get rule-params-map key)]
           check (concat
                  ;; do not check unlink if we are deleting the whole entity
-                 (when-not (contains? delete-keys key)
+                 (clojure+/when+ (and (not (contains? delete-keys key))
+                                      :let [program (rule-model/get-program!
+                                                     rules
+                                                     [[etype      "allow" "unlink" fwd-label]
+                                                      ["$default" "allow" "unlink" fwd-label]])]
+                                      (some? program))
                    [{:scope    :object
                      :action   :unlink
                      :etype    etype
                      :eid      entity_id
-                     :program  (rule-model/get-program!
-                                rules
-                                [[etype      "allow" "unlink" fwd-label]
-                                 [etype      "allow" "update"]
-                                 [etype      "allow" "$default"]
-                                 ["$default" "allow" "unlink" fwd-label]
-                                 ["$default" "allow" "update"]
-                                 ["$default" "allow" "$default"]])
+                     :program  program
                      :bindings {:data        entity
                                 :new-data    (get updated-entities-map key)
                                 :linked-data rev-entity
                                 :rule-params rule-params}}])
 
                  ;; do not check unlink if we are deleting the whole entity
-                 (when-not (contains? delete-keys rev-key)
+                 (clojure+/when+ (and (not (contains? delete-keys rev-key))
+                                      :let [program (rule-model/get-program!
+                                                     rules
+                                                     [[rev-etype  "allow" "unlink" rev-label]
+                                                      ["$default" "allow" "unlink" rev-label]])]
+                                      (some? program))
                    [{:scope    :object
                      :action   :unlink
                      :etype    rev-etype
                      :eid      value
-                     :program  (rule-model/get-program!
-                                rules
-                                [[rev-etype  "allow" "unlink" rev-label]
-                                 [rev-etype  "allow" "view"]
-                                 [rev-etype  "allow" "$default"]
-                                 ["$default" "allow" "unlink" rev-label]
-                                 ["$default" "allow" "view"]
-                                 ["$default" "allow" "$default"]])
+                     :program  program
                      :bindings {:data        rev-entity
                                 :new-data    (get updated-entities-map rev-key)
                                 :linked-data entity

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -25,13 +25,12 @@
             [lambdaisland.uri :as uri]
             [next.jdbc.connection :as connection])
   (:import
-   (java.io File)
-   (java.util UUID)))
+   (java.io File)))
 
 (defn mock-app-req
   ([a] (mock-app-req a (instant-user-model/get-by-id {:id (:creator_id a)})))
   ([a u]
-   (let [r (instant-user-refresh-token-model/create! {:id (UUID/randomUUID) :user-id (:id u)})]
+   (let [r (instant-user-refresh-token-model/create! {:id (random-uuid) :user-id (:id u)})]
      {:headers {"authorization" (str "Bearer " (:id r))}
       :params {:app_id (:id a)}
       :body {}})))
@@ -72,11 +71,11 @@
      ~@body))
 
 (defmacro with-empty-app [f]
-  `(let [app-id# (UUID/randomUUID)
+  `(let [app-id# (random-uuid)
          app#    (app-model/create! {:title       "empty-app"
                                      :creator-id  ~test-user-id
                                      :id          app-id#
-                                     :admin-token (UUID/randomUUID)})]
+                                     :admin-token (random-uuid)})]
      (try
        (with-fail-on-warn-io
          (~f (assoc app#
@@ -162,12 +161,12 @@
        (run-zeneca-byop app# ~f))))
 
 (defn with-pro-app [owner f]
-  (let [app-id (UUID/randomUUID)
+  (let [app-id (random-uuid)
         app (app-model/create!
              {:title "test team app"
               :creator-id (:id owner)
               :id app-id
-              :admin-token (UUID/randomUUID)})
+              :admin-token (random-uuid)})
         stripe-customer (instant-stripe-customer-model/get-or-create! {:user owner})
         owner-req (mock-app-req app owner)
         _ (instant-subscription-model/create!
@@ -175,8 +174,8 @@
             :app-id app-id
             :subscription-type-id 2 ;; Pro
             :stripe-customer-id (:id stripe-customer)
-            :stripe-subscription-id (str "fake_sub_" (UUID/randomUUID))
-            :stripe-event-id (str "fake_evt_" (UUID/randomUUID))})]
+            :stripe-subscription-id (str "fake_sub_" (random-uuid))
+            :stripe-event-id (str "fake_evt_" (random-uuid))})]
     (try
       (f {:app app
           :owner owner
@@ -185,12 +184,12 @@
         (app-model/delete-immediately-by-id! {:id app-id})))))
 
 (defn with-team-app [owner invitee role f]
-  (let [app-id (UUID/randomUUID)
+  (let [app-id (random-uuid)
         app (app-model/create!
              {:title "test team app"
               :creator-id (:id owner)
               :id app-id
-              :admin-token (UUID/randomUUID)})
+              :admin-token (random-uuid)})
         invite (instant-app-member-invites/create!
                 {:app-id app-id
                  :inviter-id (:creator_id app)
@@ -208,8 +207,8 @@
             :app-id app-id
             :subscription-type-id PRO_SUBSCRIPTION_TYPE
             :stripe-customer-id (:id stripe-customer)
-            :stripe-subscription-id (str "fake_sub_" (UUID/randomUUID))
-            :stripe-event-id (str "fake_evt_" (UUID/randomUUID))})
+            :stripe-subscription-id (str "fake_sub_" (random-uuid))
+            :stripe-event-id (str "fake_evt_" (random-uuid))})
         _ (instant-app-member-invites/accept-by-id! {:id (:id invite)})]
     (try
       (f {:app app

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -325,7 +325,7 @@
         {:keys [disabled-apps enabled-apps default-value disabled?]} flag]
     (cond
       (nil? flag)
-      false
+      true
 
       disabled?
       false

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -117,13 +117,6 @@
                 expr
                 all-bind-usages)))))
 
-(defn get-expr [rule etype action]
-  (or
-   (get-in rule [etype "allow" action])
-   (get-in rule [etype "allow" "$default"])
-   (get-in rule ["$default" "allow" action])
-   (get-in rule ["$default" "allow" "$default"])))
-
 (defn patch-code
   "Don't break if the perm check is a simple boolean"
   [code]
@@ -146,7 +139,7 @@
   (when (contains? system-catalog/all-etypes etype)
     (let [compiler (cel/action->compiler action)]
       (if (and (= "$users" etype)
-               (= "view" action))
+               (#{"view" "link" "unlink"} action))
         (let [code "auth.id == data.id"
               ast (cel/->ast compiler code)]
           {:etype etype
@@ -176,34 +169,47 @@
                      (reset! program-cache
                              @(cache/lru-cache-factory {} :threshold 2048))))
 
-(defn get-program!* [rules etype action]
-  (or
-   (when-let [expr (get-expr (:code rules) etype action)]
-     (try
-       (let [code (with-binds (:code rules) etype action (patch-code expr))
-             compiler (cel/action->compiler action)
-             ast (cel/->ast compiler code)]
-         {:etype etype
-          :action action
-          :code code
-          :display-code expr
-          :cel-ast ast
-          :cel-program (cel/->program ast)
-          :ref-uses (cel/collect-ref-uses ast)
-          :where-clauses-program (when (= action "view")
-                                   (cel/where-clauses-program code))})
-       (catch CelValidationException e
-         (ex/throw-validation-err!
-          :permission
-          [etype action]
-          (->> (.getErrors e)
-               (map (fn [^CelIssue cel-issue]
-                      {:message (.getMessage cel-issue)})))))))
-   (default-program etype action)))
+(defn get-program!* [rules paths]
+  (let [[[etype _ action & _] & _] paths
+        {:keys [code]}             rules]
+    (or
+     (when-some [expr (some #(get-in code %) paths)]
+       (try
+         (let [code     (with-binds (:code rules) etype action (patch-code expr))
+               compiler (cel/action->compiler action)
+               ast      (cel/->ast compiler code)]
+           {:etype etype
+            :action action
+            :code code
+            :display-code expr
+            :cel-ast ast
+            :cel-program (cel/->program ast)
+            :ref-uses (cel/collect-ref-uses ast)
+            :where-clauses-program (when (= action "view")
+                                     (cel/where-clauses-program code))})
+         (catch CelValidationException e
+           (ex/throw-validation-err!
+            :permission
+            [etype action]
+            (->> (.getErrors e)
+                 (map (fn [^CelIssue cel-issue]
+                        {:message (.getMessage cel-issue)})))))))
+     (default-program etype action))))
 
-(defn get-program! [rules etype action]
-  (lookup-or-miss program-cache [rules etype action] (fn [[rules etype action]]
-                                                       (get-program!* rules etype action))))
+(defn get-program!
+  ([rules paths]
+   (lookup-or-miss
+    program-cache
+    [rules paths]
+    (fn [[rules paths]]
+      (get-program!* rules paths))))
+  ([rules etype action]
+   (get-program!
+    rules
+    [[etype      "allow" action]
+     [etype      "allow" "$default"]
+     ["$default" "allow" action]
+     ["$default" "allow" "$default"]])))
 
 (defn $users-validation-errors
   "Only allow users to changes the `view` rules for $users, since we don't have

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -596,3 +596,9 @@
 (defn restart []
   (stop-global)
   (start-global))
+
+(defn before-ns-unload []
+  (stop-global))
+
+(defn after-ns-reload []
+  (start-global))

--- a/server/src/instant/util/coll.clj
+++ b/server/src/instant/util/coll.clj
@@ -1,5 +1,7 @@
 (ns instant.util.coll
-  (:require [medley.core :as medley]))
+  (:require
+   [clojure+.walk :as walk]
+   [medley.core :as medley]))
 
 (defn split-last [coll]
   (list (butlast coll)
@@ -263,3 +265,13 @@
   "update for transients"
   [m k f & args]
   (assoc! m k (apply f (get m k) args)))
+
+(defn collect [pred form]
+  (let [res (volatile! (transient []))]
+    (walk/postwalk
+     (fn [form]
+       (when (pred form)
+         (vswap! res conj! form))
+       form)
+     form)
+    (persistent! @res)))

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -1,6 +1,7 @@
 (ns instant.util.test
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [clojure+.walk :as walk]
    [instant.config :as config]
    [instant.db.attr-sketch :as cms]
@@ -12,6 +13,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.model.rule :as rule-model]
    [instant.reactive.aggregator :as aggregator]
+   [instant.util.coll :as coll]
    [instant.util.exception :as ex]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
    [next.jdbc])
@@ -117,6 +119,21 @@
                 :let [[_ ns n] (:forward-identity attr)]]
             [(keyword ns n) (:id attr)]))))
 
+(defn resolve-attrs [attrs tx]
+  (for [step tx]
+    (cond-> step
+      (and (vector? (-> step (nth 1))) (contains? attrs (-> step (nth 1) first)))
+      (update-in [1 0] attrs)
+
+      (and (> (count step) 2)
+           (contains? attrs (-> step (nth 2))))
+      (update-in [2] attrs)
+
+      (and (> (count step) 3)
+           (vector? (-> step (nth 3)))
+           (contains? attrs (-> step (nth 3) first)))
+      (update-in [3 0] attrs))))
+
 (defn insert-entities
   "Insert entities in more human-readable form (attrs by their ns/ident value,
    not by attr-id). All entities must have :db/id presudo-attr:
@@ -171,6 +188,16 @@
   (parse-uuid
     (str s (subs "00000000-0000-0000-0000-000000000000" (count s)))))
 
+(defn rand-string
+  ([]
+   (rand-string (+ 13 (rand-int 13))))
+  ([len]
+   (string/join
+    (repeatedly len #(rand-nth "qwertyuiopasdfghjklzxcvbnm")))))
+
+(defn rand-email []
+  (str (rand-string 13) "@" (rand-string 13) (rand-nth [".com" ".net" ".org" ".int" ".edu" ".gov" ".mil"])))
+
 (defmacro perm-err? [& body]
   `(try
      ~@body
@@ -180,6 +207,9 @@
          (if (= ::ex/permission-denied (::ex/type (ex-data instant-ex#)))
            instant-ex#
            (throw e#))))))
+
+(defmacro perm-pass? [& body]
+  `(boolean (not (perm-err? ~@body))))
 
 (defmacro validation-err? [& body]
   `(try
@@ -236,3 +266,29 @@
          original-lookup# (var-get #'cms/lookup)]
      (with-redefs [cms/lookup (partial lookup-with-in-memory-sketches original-lookup# sketches# (:id ~app))]
        ~@body)))
+
+(defn- collect-symbols [with-let? bindings]
+  (vec
+   (distinct
+    (for [[left right] (partition 2 bindings)
+          sym          (cond
+                         (= :let left)  (if with-let?
+                                          (->> right
+                                             (partition 2)
+                                             (map first)
+                                             (mapcat #(coll/collect symbol? %)))
+                                          [])
+                         (symbol? left) [left]
+                         :else          (coll/collect symbol? left))]
+      sym))))
+
+(defmacro test-matrix
+  "Similar to doseq, but records current testing context via `testing`,
+   and avoids “method body too large” produced by doseq"
+  [bindings & body]
+  (let [all-keys      (collect-symbols true bindings)
+        variable-keys (mapv keyword (collect-symbols false bindings))]
+    `(doseq [var# (for ~bindings (array-map ~@(mapcat #(vector (keyword %) %) all-keys)))
+             :let [{:keys ~all-keys} var#]]
+       (clojure.test/testing (str (select-keys var# ~variable-keys))
+         ~@body))))

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -343,7 +343,9 @@
 (defmacro profile [options? & body]
   `(prof/profile ~options? ~@body))
 
-(def prof-serve-ui prof/serve-ui)
+(defn prof-serve-ui
+  ([] (prof/serve-ui 8080))
+  ([port] (prof/serve-ui port)))
 
 (defmacro bench [& body]
   `(do

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -2371,13 +2371,16 @@
             ;; link check can be not defined at all (then update/view fallback is used),
             ;; defined only for one side (then other side will use a fallback), or be
             ;; defined for both sides
-            [attr posts-param users-param] [[:posts/fallback "posts_delete" "users_view"]
-                                            [:posts/fwd-only "posts_delete" "users_view"]
+            [attr posts-param users-param] [[:posts/fallback "posts_delete" nil]
+                                            [:posts/fwd-only "posts_delete" nil]
                                             [:posts/rev-only "posts_delete" "users_rev_only"]
                                             [:posts/fwd-rev  "posts_delete" "users_fwd_rev"]]
-            rule-params                    [{posts-param false users-param true}
-                                            {posts-param true  users-param false}
-                                            {posts-param true  users-param true}]
+            rule-params                    (if users-param
+                                             [{posts-param false users-param true}
+                                              {posts-param true  users-param false}
+                                              {posts-param true  users-param true}]
+                                             [{posts-param false}
+                                              {posts-param true}])
             ;; rule params for reverse direction can be placed on forward one, e.g.
             ;; db.tx.posts[id].link({user: ...}).ruleParams({user_param: ...})
             user-params-pos                [:post :user]]
@@ -2418,13 +2421,16 @@
             ;; link check can be not defined at all (then update/view fallback is used),
             ;; defined only for one side (then other side will use a fallback), or be
             ;; defined for both sides
-            [attr posts-param users-param] [[:posts/fallback "posts_update"   "users_delete"]
+            [attr posts-param users-param] [[:posts/fallback nil              "users_delete"]
                                             [:posts/fwd-only "posts_fwd_only" "users_delete"]
-                                            [:posts/rev-only "posts_update"   "users_delete"]
+                                            [:posts/rev-only nil              "users_delete"]
                                             [:posts/fwd-rev  "posts_fwd_rev"  "users_delete"]]
-            rule-params                    [{posts-param false users-param true}
-                                            {posts-param true  users-param false}
-                                            {posts-param true  users-param true}]]
+            rule-params                    (if posts-param
+                                             [{posts-param false users-param true}
+                                              {posts-param true  users-param false}
+                                              {posts-param true  users-param true}]
+                                             [{users-param false}
+                                              {users-param true}])]
            (let [user-id     (random-uuid)
                  user-email  (test-util/rand-email)
                  user-ref    (case ref-type

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as string]
    [clojure.test :as test :refer [are deftest is testing]]
-   [clojure+.walk :as walk]
    [instant.config :as config]
    [instant.db.cel :as cel]
    [instant.data.bootstrap :as bootstrap]
@@ -14,7 +13,6 @@
    [instant.db.model.triple :as triple-model]
    [instant.model.app-file :as app-file-model]
    [instant.db.permissioned-transaction :as permissioned-tx]
-   [instant.db.permissioned-transaction-new :as permissioned-tx-new]
    [instant.db.transaction :as tx]
    [instant.fixtures :refer [with-empty-app
                              with-zeneca-app
@@ -24,114 +22,11 @@
    [instant.model.app :as app-model]
    [instant.model.app-user :as app-user-model]
    [instant.model.rule :as rule-model]
-   [instant.util.coll :as coll]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
    [instant.util.exception :as ex]
-   [instant.util.test :as test-util :refer [suid validation-err? perm-err? timeout-err?]]
+   [instant.util.test :as test-util :refer [suid validation-err? perm-err? perm-pass? timeout-err?]]
    [instant.util.date :as date-util]
-   [instant.util.uuid :as uuid-util]
-   [next.jdbc])
-  (:import
-   (java.util UUID)))
-
-(defn- abstract-results
-  "Does what’s described in normalize-results items 2-4"
-  [uuid->serial form]
-  (let [uuid->serial (atom uuid->serial)
-        serial       (atom 0)]
-    (->> form
-         (walk/postwalk
-          (fn [form]
-            (if (and (map? form) (contains? form :created_at))
-              (assoc form :created_at "ignored")
-              form)))
-         (walk/postwalk
-          (fn [form]
-            (let [as-uuid (uuid-util/coerce form)]
-              (cond
-                (and as-uuid (not (@uuid->serial as-uuid)))
-                (let [next-serial (str "uuid-" (swap! serial inc))]
-                  (swap! uuid->serial assoc as-uuid next-serial)
-                  next-serial)
-
-                as-uuid
-                (@uuid->serial as-uuid)
-
-                :else
-                form))))
-         (map (fn [result-map]
-                (-> result-map
-                    (coll/update-in-when [:add-triple] set)
-                    (coll/update-in-when [:retract-triple] set)
-                    (coll/update-in-when [:deep-merge-triple] set)
-                    (coll/update-in-when [:delete-entity] set)
-                    (coll/update-in-when [:add-attr :attrs] set)
-                    (coll/update-in-when [:add-attr :idents] set)
-                    (coll/update-in-when [:add-attr :triples] set)))))))
-
-(defn- normalize-results
-  "Given a list of old transact! results and new ones, normalizes them so they
-   can be compared for equivalence.
-
-   This is done by:
-
-   1. Determining UUIDs that appear in both result sets. These are kept intact
-   2. Sequentially replacing non-shared UUIDs with strings like \"uuid-18\",
-   3. Replacing :created_at with \"ignored\"
-   4. Turning lists into sets"
-  [old new]
-  (let [seen       (atom #{})
-        uuid->self (atom {})]
-    (walk/postwalk
-     (fn [form]
-       (when-some [as-uuid (uuid-util/coerce form)]
-         (swap! seen conj as-uuid)))
-     old)
-    (walk/postwalk
-     (fn [form]
-       (when-some [as-uuid (uuid-util/coerce form)]
-         (when (@seen as-uuid)
-           (swap! uuid->self assoc as-uuid as-uuid)))
-       form)
-     new)
-    [(abstract-results @uuid->self old)
-     (abstract-results @uuid->self new)]))
-
-(defn- sequential-uuid-generator
-  "Fake UUID generator so that most of allocated UUIDs will be the same.
-   The ones assigned by Postgres (lookup inserts) are still out of our control"
-  []
-  (let [counter (atom -9223372036854775808)]
-    (fn []
-      (UUID. 0x0000000000008000 (swap! counter inc)))))
-
-;; TODO this is only needed until we’ve switched to permissioned-transaction-new
-(test/use-fixtures :each
-  (fn [f]
-    (let [transact!     permissioned-tx/transact-impl!
-          results       (atom [])
-          transact-new! permissioned-tx-new/transact!
-          results-new   (atom [])]
-      (with-redefs [permissioned-tx/transact-impl!
-                    (fn [ctx tx-steps]
-                      (let [res (transact! ctx tx-steps)]
-                        (swap! results conj (:results res))
-                        res))
-                    permissioned-tx-new/transact!
-                    (fn [ctx tx-steps]
-                      (let [res (transact-new! ctx tx-steps)]
-                        (swap! results-new conj (:results res))
-                        res))]
-        (testing "permissioned-transaction"
-          (with-redefs [random-uuid (sequential-uuid-generator)]
-            (f)))
-        (binding [permissioned-tx/*new-permissioned-transact?* true]
-          (testing "permissioned-transaction-new"
-            (with-redefs [random-uuid (sequential-uuid-generator)]
-              (f)))))
-      (let [[normalized-old normalized-new] (normalize-results @results @results-new)]
-        (is (= normalized-old
-               normalized-new))))))
+   [next.jdbc]))
 
 (defn- fetch-triples
   ([app-id] (fetch-triples app-id []))
@@ -2234,6 +2129,389 @@
                     set)
                book-id)))))))
 
+(deftest link-perms
+  (with-empty-app
+    (fn [{app-id   :id
+          make-ctx :make-ctx}]
+      (let [attrs
+            (test-util/make-attrs
+             app-id
+             [[:users/id    :required? :index? :unique?]
+              [:users/email :unique?]
+              [:posts/id    :required? :index? :unique?]
+              [:posts/title :unique?]
+              [[:posts/fallback :users/rev-fallback]]
+              [[:posts/fwd-only :users/rev-fwd-only]]
+              [[:posts/rev-only :users/rev-rev-only]]
+              [[:posts/fwd-rev  :users/rev-fwd-rev]]])
+            transact! #(when (seq %)
+                         (permissioned-tx/transact!
+                          (make-ctx)
+                          (test-util/resolve-attrs attrs %)))]
+        (rule-model/put!
+         (aurora/conn-pool :write)
+         {:app-id app-id
+          :code {:posts
+                 {:allow
+                  {:create "ruleParams.posts_create"
+                   :update "ruleParams.posts_update"
+                   :link   {"fwd-only" "ruleParams.posts_fwd_only"
+                            "fwd-rev"  "ruleParams.posts_fwd_rev"}}}
+
+                 :users
+                 {:allow
+                  {:view   "ruleParams.users_view"
+                   :create "ruleParams.users_create"
+                   :update "ruleParams.users_update"
+                   :link   {"rev-rev-only" "ruleParams.users_rev_only"
+                            "rev-fwd-rev"  "ruleParams.users_fwd_rev"}}}}})
+
+        (test-util/test-matrix
+         ;; we test both cases when either user or post are created in the same
+         ;; transaction or already exist
+         [user-action       [:create :update]
+          post-action       [:create :update]
+          ref-type          [:id :lookup]
+          ;; link check can be not defined at all (then update/view fallback is used),
+          ;; defined only for one side (then other side will use a fallback), or be
+          ;; defined for both sides
+          attr              [:posts/fallback
+                             :posts/fwd-only
+                             :posts/rev-only
+                             :posts/fwd-rev]
+          :let              [[posts-param users-param]
+                             (case [post-action attr]
+                               [:create :posts/fallback] ["posts_create"   "users_view"]
+                               [:create :posts/fwd-only] ["posts_fwd_only" "users_view"]
+                               [:create :posts/rev-only] ["posts_create"   "users_rev_only"]
+                               [:create :posts/fwd-rev]  ["posts_fwd_rev"  "users_fwd_rev"]
+                               [:update :posts/fallback] ["posts_update"   "users_view"]
+                               [:update :posts/fwd-only] ["posts_fwd_only" "users_view"]
+                               [:update :posts/rev-only] ["posts_update"   "users_rev_only"]
+                               [:update :posts/fwd-rev]  ["posts_fwd_rev"  "users_fwd_rev"])]
+          rule-params       [{posts-param true  users-param false}
+                             {posts-param false users-param true}
+                             {posts-param true  users-param true}]
+          ;; rule params for reverse direction can be placed on forward one, e.g.
+          ;; db.tx.posts[id].link({user: ...}).ruleParams({user_param: ...})
+          user-params-pos   [:post :user]]
+         (let [user-id     (random-uuid)
+               user-email  (test-util/rand-email)
+               user-ref    (case ref-type
+                             :id     user-id
+                             :lookup [:users/email user-email])
+               post-id     (random-uuid)
+               post-title  (test-util/rand-string)
+               post-ref    (case ref-type
+                             :id     post-id
+                             :lookup [:posts/title post-title])
+               user-tx     (case ref-type
+                             :id
+                             [[:add-triple  user-id :users/id    user-id]
+                              [:add-triple  user-id :users/email user-email]
+                              [:rule-params user-id "users"      {"users_create" true}]]
+                             :lookup
+                             [[:add-triple  user-ref :users/id    user-ref]
+                              [:rule-params user-ref "users"      {"users_create" true}]])
+               post-tx     (case ref-type
+                             :id
+                             [[:add-triple  post-id :posts/id    post-id]
+                              [:add-triple  post-id :posts/title post-title]
+                              [:rule-params post-id "posts"      {"posts_create" true}]]
+                             :lookup
+                             [[:add-triple  post-ref :posts/id    post-ref]
+                              [:rule-params post-ref "posts"      {"posts_create" true}]])
+
+               _           (transact!
+                            (concat
+                             (when (= :update user-action)
+                               user-tx)
+                             (when (= :update post-action)
+                               post-tx)))
+
+               tx          (concat
+                            (when (= :create user-action)
+                              user-tx)
+                            (when (= :create post-action)
+                              post-tx)
+                            (case user-params-pos
+                              :user
+                              [[:rule-params user-ref "users" (select-keys rule-params [users-param])]
+                               [:rule-params post-ref "posts" (select-keys rule-params [posts-param])]]
+                              :post
+                              [[:rule-params post-ref "posts" rule-params]])
+                            [[:add-triple post-ref attr user-ref]])
+
+               expected    (every? true? (vals rule-params))]
+
+           (is (= expected (perm-pass? (transact! tx))))))))))
+
+(deftest unlink-perms
+  (with-empty-app
+    (fn [{app-id   :id
+          make-ctx :make-ctx}]
+      (let [attrs
+            (test-util/make-attrs
+             app-id
+             [[:users/id    :required? :index? :unique?]
+              [:users/email :unique?]
+              [:posts/id    :required? :index? :unique?]
+              [:posts/title :unique?]
+              [[:posts/fallback :users/rev-fallback]]
+              [[:posts/fwd-only :users/rev-fwd-only]]
+              [[:posts/rev-only :users/rev-rev-only]]
+              [[:posts/fwd-rev  :users/rev-fwd-rev]]])
+            transact! #(permissioned-tx/transact!
+                        (make-ctx)
+                        (test-util/resolve-attrs attrs %))]
+        (rule-model/put!
+         (aurora/conn-pool :write)
+         {:app-id app-id
+          :code {:posts
+                 {:allow
+                  {:update "ruleParams.posts_update"
+                   :unlink {"fwd-only" "ruleParams.posts_fwd_only"
+                            "fwd-rev"  "ruleParams.posts_fwd_rev"}}}
+
+                 :users
+                 {:allow
+                  {:view   "ruleParams.users_view"
+                   :update "ruleParams.users_update"
+                   :unlink {"rev-rev-only" "ruleParams.users_rev_only"
+                            "rev-fwd-rev"  "ruleParams.users_fwd_rev"}}}}})
+
+        (test-util/test-matrix
+         [ref-type     [:id :lookup]
+          ;; link check can be not defined at all (then update/view fallback is used),
+          ;; defined only for one side (then other side will use a fallback), or be
+          ;; defined for both sides
+          attr              [:posts/fallback
+                             :posts/fwd-only
+                             :posts/rev-only
+                             :posts/fwd-rev]
+          :let              [[posts-param users-param]
+                             (case attr
+                               :posts/fallback ["posts_update"   "users_view"]
+                               :posts/fwd-only ["posts_fwd_only" "users_view"]
+                               :posts/rev-only ["posts_update"   "users_rev_only"]
+                               :posts/fwd-rev  ["posts_fwd_rev"  "users_fwd_rev"])]
+          rule-params       [{posts-param true  users-param false}
+                             {posts-param false users-param true}
+                             {posts-param true  users-param true}]
+          ;; rule params for reverse direction can be placed on forward one, e.g.
+          ;; db.tx.posts[id].link({user: ...}).ruleParams({user_param: ...})
+          user-params-pos   [:post :user]]
+         (let [user-id     (random-uuid)
+               user-email  (test-util/rand-email)
+               user-ref    (case ref-type
+                             :id     user-id
+                             :lookup [:users/email user-email])
+               post-id     (random-uuid)
+               post-title  (test-util/rand-string)
+               post-ref    (case ref-type
+                             :id     post-id
+                             :lookup [:posts/title post-title])
+               _           (transact!
+                            [[:add-triple  user-id :users/id    user-id]
+                             [:add-triple  user-id :users/email user-email]
+                             [:add-triple  post-id :posts/id    post-id]
+                             [:add-triple  post-id :posts/title post-title]])
+
+               tx          (concat
+                            [[:retract-triple post-ref attr user-ref]]
+                            (case user-params-pos
+                              :user
+                              [[:rule-params user-ref "users" (select-keys rule-params [users-param])]
+                               [:rule-params post-ref "posts" (select-keys rule-params [posts-param])]]
+                              :post
+                              [[:rule-params post-ref "posts" rule-params]]))
+
+               expected    (every? true? (vals rule-params))]
+
+           (is (= expected (perm-pass? (transact! tx))))))))))
+
+(deftest unlink-perms-during-delete
+  (with-empty-app
+    (fn [{app-id   :id
+          make-ctx :make-ctx}]
+      (let [attrs
+            (test-util/make-attrs
+             app-id
+             [[:users/id    :required? :index? :unique?]
+              [:users/email :unique?]
+              [:posts/id    :required? :index? :unique?]
+              [:posts/title :unique?]
+              [[:posts/fallback :users/rev-fallback]]
+              [[:posts/fwd-only :users/rev-fwd-only]]
+              [[:posts/rev-only :users/rev-rev-only]]
+              [[:posts/fwd-rev  :users/rev-fwd-rev]]])
+            transact! #(permissioned-tx/transact!
+                        (make-ctx)
+                        (test-util/resolve-attrs attrs %))]
+        (rule-model/put!
+         (aurora/conn-pool :write)
+         {:app-id app-id
+          :code {:posts
+                 {:allow
+                  {:update "ruleParams.posts_update"
+                   :delete "ruleParams.posts_delete"
+                   :unlink {"fwd-only" "ruleParams.posts_fwd_only"
+                            "fwd-rev"  "ruleParams.posts_fwd_rev"}}}
+
+                 :users
+                 {:allow
+                  {:view   "ruleParams.users_view"
+                   :delete "ruleParams.users_delete"
+                   :unlink {"rev-rev-only" "ruleParams.users_rev_only"
+                            "rev-fwd-rev"  "ruleParams.users_fwd_rev"}}}}})
+
+        (testing "deleting post"
+          (test-util/test-matrix
+           [ref-type                       [:id :lookup]
+            ;; link check can be not defined at all (then update/view fallback is used),
+            ;; defined only for one side (then other side will use a fallback), or be
+            ;; defined for both sides
+            [attr posts-param users-param] [[:posts/fallback "posts_delete" "users_view"]
+                                            [:posts/fwd-only "posts_delete" "users_view"]
+                                            [:posts/rev-only "posts_delete" "users_rev_only"]
+                                            [:posts/fwd-rev  "posts_delete" "users_fwd_rev"]]
+            rule-params                    [{posts-param false users-param true}
+                                            {posts-param true  users-param false}
+                                            {posts-param true  users-param true}]
+            ;; rule params for reverse direction can be placed on forward one, e.g.
+            ;; db.tx.posts[id].link({user: ...}).ruleParams({user_param: ...})
+            user-params-pos                [:post :user]]
+           (let [user-id     (random-uuid)
+                 user-email  (test-util/rand-email)
+                 user-ref    (case ref-type
+                               :id     user-id
+                               :lookup [:users/email user-email])
+                 post-id     (random-uuid)
+                 post-title  (test-util/rand-string)
+                 post-ref    (case ref-type
+                               :id     post-id
+                               :lookup [:posts/title post-title])
+                 _           (transact!
+                              [[:add-triple  user-id :users/id    user-id]
+                               [:add-triple  user-id :users/email user-email]
+                               [:rule-params user-id "users"      {"users_view" true}]
+                               [:add-triple  post-id :posts/id    post-id]
+                               [:add-triple  post-id :posts/title post-title]
+                               [:add-triple  post-id attr         user-id]])
+
+                 tx          (concat
+                              [[:delete-entity post-ref "posts"]]
+                              (case user-params-pos
+                                :user
+                                [[:rule-params user-ref "users" (select-keys rule-params [users-param])]
+                                 [:rule-params post-ref "posts" (select-keys rule-params [posts-param])]]
+                                :post
+                                [[:rule-params post-ref "posts" rule-params]]))
+
+                 expected    (every? true? (vals rule-params))]
+
+             (is (= expected (perm-pass? (transact! tx)))))))
+
+        (testing "deleting user"
+          (test-util/test-matrix
+           [ref-type                       [:id :lookup]
+            ;; link check can be not defined at all (then update/view fallback is used),
+            ;; defined only for one side (then other side will use a fallback), or be
+            ;; defined for both sides
+            [attr posts-param users-param] [[:posts/fallback "posts_update"   "users_delete"]
+                                            [:posts/fwd-only "posts_fwd_only" "users_delete"]
+                                            [:posts/rev-only "posts_update"   "users_delete"]
+                                            [:posts/fwd-rev  "posts_fwd_rev"  "users_delete"]]
+            rule-params                    [{posts-param false users-param true}
+                                            {posts-param true  users-param false}
+                                            {posts-param true  users-param true}]]
+           (let [user-id     (random-uuid)
+                 user-email  (test-util/rand-email)
+                 user-ref    (case ref-type
+                               :id     user-id
+                               :lookup [:users/email user-email])
+                 post-id     (random-uuid)
+                 post-title  (test-util/rand-string)
+                 post-ref    (case ref-type
+                               :id     post-id
+                               :lookup [:posts/title post-title])
+                 _           (transact!
+                              [[:add-triple  user-id :users/id    user-id]
+                               [:add-triple  user-id :users/email user-email]
+                               [:rule-params user-id "users"      {"users_view" true}]
+                               [:add-triple  post-id :posts/id    post-id]
+                               [:add-triple  post-id :posts/title post-title]
+                               [:add-triple  post-id attr         user-id]])
+
+                 tx          [[:delete-entity user-ref "users"]
+                              [:rule-params user-ref "users" (select-keys rule-params [users-param])]
+                              [:rule-params post-ref "posts" (select-keys rule-params [posts-param])]]
+
+                 expected    (every? true? (vals rule-params))]
+
+             (is (= expected (perm-pass? (transact! tx)))))))))))
+
+(deftest linked-data-perm
+  (with-empty-app
+    (fn [{app-id   :id
+          make-ctx :make-ctx}]
+      (let [attrs
+            (test-util/make-attrs
+             app-id
+             [[:users/id    :required? :index? :unique?]
+              [:users/email :unique?]
+              [:posts/id    :required? :index? :unique?]
+              [:posts/title :unique?]
+              [[:posts/ref :users/rev-ref]]])
+            transact! #(permissioned-tx/transact!
+                        (make-ctx)
+                        (test-util/resolve-attrs attrs %))]
+        (rule-model/put!
+         (aurora/conn-pool :write)
+         {:app-id app-id
+          :code {:posts
+                 {:allow
+                  {:link   {"ref" "newData.title == linkedData.email"}
+                   :unlink {"ref" "data.title == linkedData.email"}}}
+                 :users
+                 {:allow
+                  {:link   {"rev-ref" "newData.email == linkedData.title"}
+                   :unlink {"rev-ref" "data.email == linkedData.title"}}}}})
+
+        (testing "pre-checks"
+          (let [user-id     (random-uuid)
+                user-email  (test-util/rand-email)
+                post-id     (random-uuid)
+                post-title  user-email]
+            (transact!
+             [[:add-triple user-id :users/id    user-id]
+              [:add-triple user-id :users/email user-email]
+              [:add-triple post-id :posts/id    post-id]
+              [:add-triple post-id :posts/title post-title]])
+            (is (not (perm-err?
+                      (transact!
+                       [[:add-triple post-id :posts/ref user-id]]))))
+            (is (not (perm-err?
+                      (transact!
+                       [[:retract-triple post-id :posts/ref user-id]]))))))
+
+        (testing "post-checks"
+          (let [user-id     (random-uuid)
+                user-email  (test-util/rand-email)
+                post-id     (random-uuid)
+                post-title  user-email]
+            (is (not (perm-err?
+                      (transact!
+                       [[:add-triple user-id :users/id    user-id]
+                        [:add-triple user-id :users/email user-email]
+                        [:add-triple post-id :posts/id    post-id]
+                        [:add-triple post-id :posts/title post-title]
+                        [:add-triple post-id :posts/ref user-id]]))))
+
+            (is (not (perm-err?
+                      (transact!
+                       [[:retract-triple post-id :posts/ref user-id]]))))))))))
+
 (deftest lookup-perms
   (with-empty-app
     (fn [{app-id :id}]
@@ -2310,10 +2588,10 @@
                  (aurora/conn-pool :write)
                  {:app-id app-id
                   :code {:profiles {:allow
-                                    {:create "size(data.ref('org.id')) == 1"
-                                     :update  "size(data.ref('org.id')) == 1"
-                                     :view  "size(data.ref('org.id')) == 1"
-                                     :delete  "size(data.ref('org.id')) == 1"}}}})
+                                    {:create "size(data.ref('org.id')) == 1 // create"
+                                     :update "size(data.ref('org.id')) == 1 // update"
+                                     :view   "size(data.ref('org.id')) == 1 // view"
+                                     :delete "size(data.ref('org.id')) == 1 // delete"}}}})
               rules (rule-model/get-by-app-id {:app-id app-id})
               ctx {:db {:conn-pool (aurora/conn-pool :write)}
                    :app-id app-id
@@ -2361,7 +2639,6 @@
                                             app-id
                                             [[:= :attr-id p-fullname-aid]
                                              [:= :entity-id stopa-eid]])
-
                         first
                         :triple
                         last))))
@@ -3401,9 +3678,13 @@
                        book-creator-attr-id
                        [(resolvers/->uuid r :$users/email) "test@example.com"]]]]
 
-        (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps))
-        (permissioned-tx/transact! (assoc (make-ctx)
-                                          :current-user {:id user-id}) tx-steps)
+        (is (perm-err? (permissioned-tx/transact! (make-ctx) tx-steps)))
+
+        (is (not (perm-err? (permissioned-tx/transact!
+                             (assoc (make-ctx)
+                                    :current-user {:id user-id})
+                             tx-steps))))
+
         (is (= (test-util/pretty-perm-q
                 (assoc (make-ctx) :current-user {:id user-id})
                 {:books {:$ {:where {:creator (str user-id)}}


### PR DESCRIPTION
Changed the logic so that `delete` checks `link`/`unlink` only if they are explicitly defined (no fallback to `update`/`view` rules in that case)

For create/update, other side is still checked for view, but this is current behavior, so it should not break anything

#1514 #1581 