### PR TITLE
Tweak deadlock-prevention ordering

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -304,7 +304,8 @@
         lookup-ref-inserts
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
-                        :from :enhanced-lookup-refs}]
+                        :from :enhanced-lookup-refs
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
          :on-conflict [:app-id :attr-id [:json_null_to_null :value] {:where :av}]
          :do-nothing true
          :returning :*}
@@ -363,7 +364,8 @@
         ea-index-inserts
         {:insert-into [[[:triples :t] triple-cols]
                        {:select triple-cols
-                        :from :enhanced-triples}]
+                        :from :enhanced-triples
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
          :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
          :do-update-set {:value :excluded.value
                          :value-md5 :excluded.value-md5}
@@ -450,7 +452,7 @@
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
                         :from :enhanced-lookup-refs
-                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
          :on-conflict [:app-id :attr-id [:json_null_to_null :value] {:where :av}]
          :do-nothing true
          :returning :*}
@@ -560,7 +562,7 @@
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
                         :from :ea-triples-distinct
-                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
          :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
          :do-update-set {:value :excluded.value
                          :value-md5 :excluded.value-md5}
@@ -570,7 +572,7 @@
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
                         :from :remaining-triples
-                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
          :on-conflict [:app-id :entity-id :attr-id :value-md5]
          :do-nothing true
          :returning :*}
@@ -654,7 +656,7 @@
         {:insert-into [[:triples triple-cols]
                        {:select triple-cols
                         :from :indexed-null-triples
-                        :order-by [[:app-id :asc] [:attr-id :asc] [:value-md5 :asc]]}]
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
          :on-conflict [:app-id :entity-id :attr-id :value-md5]
          :do-nothing true
          :returning [:entity-id :attr-id]}

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -22,7 +22,6 @@
    [instant.model.app :as app-model]
    [instant.model.app-user :as app-user-model]
    [instant.model.rule :as rule-model]
-   [instant.util.async :as ua]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
    [instant.util.exception :as ex]
    [instant.util.test :as test-util :refer [suid validation-err? perm-err? perm-pass? timeout-err?]]
@@ -4471,7 +4470,7 @@
 
 
               txes (mapv (fn [conn tx-data]
-                           (ua/vfuture
+                           (future
                              (triple-model/insert-multi! conn attrs app-id (map rest tx-data))))
                          conns tx-datas)]
 

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -22,6 +22,7 @@
    [instant.model.app :as app-model]
    [instant.model.app-user :as app-user-model]
    [instant.model.rule :as rule-model]
+   [instant.util.async :as ua]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
    [instant.util.exception :as ex]
    [instant.util.test :as test-util :refer [suid validation-err? perm-err? perm-pass? timeout-err?]]
@@ -4427,6 +4428,56 @@
                          (assoc (make-ctx) :db {:conn-pool conn})
                          [[:add-triple book-id title-aid "Test"]])))))))
 
+
+(deftest deadlock
+  (with-zeneca-app
+    (fn [{app-id :id} r]
+      (with-open [pool (aurora/start-pool 10 (config/get-aurora-config))
+                  conn1 (next.jdbc/get-connection pool)
+                  conn2 (next.jdbc/get-connection pool)
+                  conn3 (next.jdbc/get-connection pool)
+                  conn4 (next.jdbc/get-connection pool)
+                  conn5 (next.jdbc/get-connection pool)
+                  conn6 (next.jdbc/get-connection pool)
+                  conn7 (next.jdbc/get-connection pool)
+                  conn8 (next.jdbc/get-connection pool)
+                  conn9 (next.jdbc/get-connection pool)
+                  conn10 (next.jdbc/get-connection pool)]
+        (let [attrs (attr-model/get-by-app-id app-id)
+              id-attr-id (resolvers/->uuid r :users/id)
+              handle-attr-id (resolvers/->uuid r :users/handle)
+              bookshelves-attr-id (resolvers/->uuid r :users/bookshelves)
+              alex-eid (resolvers/->uuid r "eid-alex")
+              stopa-eid (resolvers/->uuid r "eid-stepan-parunashvili")
+              nicole-eid (resolvers/->uuid r "eid-nicole")
+              eid-nonfiction (resolvers/->uuid r "eid-nonfiction")
+
+              conns [conn1 conn2 conn3 conn4 conn5 conn6 conn7 conn8 conn9 conn10]
+
+              tx-datas (mapv (fn [_]
+                               (let [id (random-uuid)]
+                                 [[:add-triple id id-attr-id (str id)]
+                                  [:add-triple id handle-attr-id (str id)]
+                                  [:add-triple alex-eid id-attr-id (str alex-eid)]
+                                  [:add-triple alex-eid handle-attr-id (str "alex" id)]
+                                  [:add-triple alex-eid bookshelves-attr-id eid-nonfiction]
+                                  [:add-triple stopa-eid id-attr-id (str stopa-eid)]
+                                  [:add-triple stopa-eid handle-attr-id (str "stopa" id)]
+                                  [:add-triple stopa-eid bookshelves-attr-id eid-nonfiction]
+                                  [:add-triple nicole-eid id-attr-id (str nicole-eid)]
+                                  [:add-triple nicole-eid handle-attr-id (str "nicole" id)]
+                                  [:add-triple nicole-eid bookshelves-attr-id eid-nonfiction]]))
+                             (range (count conns)))
+
+
+              txes (mapv (fn [conn tx-data]
+                           (ua/vfuture
+                             (tx/transact! conn attrs app-id tx-data)))
+                         conns tx-datas)]
+
+          (doseq [tx txes]
+           (testing "connection did not deadlock"
+              (is @tx))))))))
 
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -4432,7 +4432,7 @@
 (deftest deadlock
   (with-zeneca-app
     (fn [{app-id :id} r]
-      (with-open [pool (aurora/start-pool 10 (config/get-aurora-config))
+      (with-open [pool (aurora/start-pool 12 (config/get-aurora-config))
                   conn1 (next.jdbc/get-connection pool)
                   conn2 (next.jdbc/get-connection pool)
                   conn3 (next.jdbc/get-connection pool)
@@ -4472,7 +4472,7 @@
 
               txes (mapv (fn [conn tx-data]
                            (ua/vfuture
-                             (tx/transact! conn attrs app-id tx-data)))
+                             (triple-model/insert-multi! conn attrs app-id (map rest tx-data))))
                          conns tx-datas)]
 
           (doseq [tx txes]


### PR DESCRIPTION
Updates the ordering on inserts to match the primary key. The ordering to avoid deadlocks was introduced in https://github.com/instantdb/instant/pull/1562. Making the ordering match the primary key seems to work better. 

I also managed to create a test case that demonstrates the deadlocks. You can see it fail before the ordering change here: https://github.com/instantdb/instant/actions/runs/17309198926/job/49139603660#step:10:30360

Other ideas in case we're still seeing deadlocks after this change:

1. Split out `av` inserts into their own CTEs and order the inserts to match the `av_index` column order (similar for `eav_uuid_index`). We may just be screwed here if we have to lock for the primary key and av index separately and those lock in different orders--not 100% sure how it works.
2. Do a `select * from triples for update` on the enhanced triples. This also worked if I ordered by the primary key.