### PR TITLE
Fix trace info for queries using pg_hint_plan

### DIFF
--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -381,13 +381,7 @@
                       (let [debug-info (str "-- trace-id=" trace-id
                                             ", span-id=" span-id
                                             "\n")]
-                        (if-not (string/starts-with? s "/*+")
-                          (str debug-info s)
-                          (let [end-comment (or (when-let [i (string/index-of s "*/")]
-                                                  (+ i 2))
-                                                (count s))]
-                            (str (subs s 0 end-comment)
-                                 (subs s end-comment)))))))
+                        (str debug-info s))))
     query))
 
 (defn apply-postgres-config [postgres-config created-connection? ^Connection c]

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -381,7 +381,14 @@
                       (let [debug-info (str "-- trace-id=" trace-id
                                             ", span-id=" span-id
                                             "\n")]
-                        (str debug-info s))))
+                        (if-not (string/starts-with? s "/*+")
+                          (str debug-info s)
+                          (let [end-comment (or (when-let [i (string/index-of s "*/")]
+                                                  (+ i 2))
+                                                (count s))]
+                            (str (subs s 0 end-comment)
+                                 debug-info
+                                 (subs s end-comment)))))))
     query))
 
 (defn apply-postgres-config [postgres-config created-connection? ^Connection c]


### PR DESCRIPTION
This adds back the `-- trace-id=x, span-id = y` comment for queries that use pg_hint_plan.

It looks like in the original PR I forgot to add in the debug-info.

We can't just put the debug hint at the beginning with pg-hint-plan. In postgres 16, if the hint plan comment isn't the first comment, then the hints won't be applied.

Tested that it works:

```clojure
instant.jdbc.sql> (tool/with-prod-conn [conn]
                    (tracer/with-span! {:name "test"}
                      (select conn
                              (honey.sql/format {:raw "explain analyze"
                                                 :select :id
                                                 :from :apps
                                                 :where [:= :id (random-uuid)]
                                                 :pg-hints [[:'SeqScan :apps]]}))))
[{:QUERY PLAN
  "Seq Scan on apps  (cost=0.00..318.59 rows=1 width=16) (actual time=2.441..2.442 rows=0 loops=1)"}
 {:QUERY PLAN
  "  Filter: (id = '58c9ba87-06a4-448c-aa9b-0b00fd21ce96'::uuid)"}
 {:QUERY PLAN "  Rows Removed by Filter: 12638"}
 {:QUERY PLAN "Planning Time: 1.013 ms"}
 {:QUERY PLAN "Execution Time: 2.466 ms"}]
```

Query it generated:
```
/*+
SeqScan(apps)
*/
-- trace-id=e88e57f8d2574a662ae4f7345dcd23e5, span-id=39a2947408779295
explain analyze
SELECT
  id
FROM
  apps
WHERE
  id = '58c9ba87-06a4-448c-aa9b-0b00fd21ce96' :: uuid
```

