### PR TITLE
Fix unlinking on delete for system namespaces

### DIFF
--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -241,12 +241,13 @@
                      :eid      eid
                      :program  (rule-model/get-program!
                                 rules
-                                [[etype      "allow" "link" fwd-label]
-                                 [etype      "allow" "update"]
-                                 [etype      "allow" "$default"]
-                                 ["$default" "allow" "link" fwd-label]
-                                 ["$default" "allow" "update"]
-                                 ["$default" "allow" "$default"]])
+                                [[etype      "allow"    "link" fwd-label]
+                                 [etype      "allow"    "update"]
+                                 [etype      "allow"    "$default"]
+                                 ["$default" "allow"    "link" fwd-label]
+                                 ["$default" "allow"    "update"]
+                                 ["$default" "allow"    "$default"]
+                                 [etype      "fallback" "link" fwd-label]])
                      :bindings {:data        entity
                                 :new-data    (get updated-entities-map key)
                                 :linked-data rev-entity
@@ -258,12 +259,13 @@
                      :eid      value
                      :program  (rule-model/get-program!
                                 rules
-                                [[rev-etype  "allow" "link" rev-label]
-                                 [rev-etype  "allow" "view"]
-                                 [rev-etype  "allow" "$default"]
-                                 ["$default" "allow" "link" rev-label]
-                                 ["$default" "allow" "view"]
-                                 ["$default" "allow" "$default"]])
+                                [[rev-etype  "allow"    "link" rev-label]
+                                 [rev-etype  "allow"    "view"]
+                                 [rev-etype  "allow"    "$default"]
+                                 ["$default" "allow"    "link" rev-label]
+                                 ["$default" "allow"    "view"]
+                                 ["$default" "allow"    "$default"]
+                                 [rev-etype  "fallback" "link" rev-label]])
                      :bindings {:data        rev-entity
                                 :new-data    (get updated-entities-map rev-key)
                                 :linked-data (get updated-entities-map key)
@@ -278,12 +280,13 @@
                   :eid      eid
                   :program  (rule-model/get-program!
                              rules
-                             [[etype      "allow" "unlink" fwd-label]
-                              [etype      "allow" "update"]
-                              [etype      "allow" "$default"]
-                              ["$default" "allow" "unlink" fwd-label]
-                              ["$default" "allow" "update"]
-                              ["$default" "allow" "$default"]])
+                             [[etype      "allow"    "unlink" fwd-label]
+                              [etype      "allow"    "update"]
+                              [etype      "allow"    "$default"]
+                              ["$default" "allow"    "unlink" fwd-label]
+                              ["$default" "allow"    "update"]
+                              ["$default" "allow"    "$default"]
+                              [etype      "fallback" "unlink" fwd-label]])
                   :bindings {:data        entity
                              :new-data    (get updated-entities-map key)
                              :linked-data rev-entity
@@ -294,12 +297,13 @@
                   :eid      value
                   :program  (rule-model/get-program!
                              rules
-                             [[rev-etype  "allow" "unlink" rev-label]
-                              [rev-etype  "allow" "view"]
-                              [rev-etype  "allow" "$default"]
-                              ["$default" "allow" "unlink" rev-label]
-                              ["$default" "allow" "view"]
-                              ["$default" "allow" "$default"]])
+                             [[rev-etype  "allow"    "unlink" rev-label]
+                              [rev-etype  "allow"    "view"]
+                              [rev-etype  "allow"    "$default"]
+                              ["$default" "allow"    "unlink" rev-label]
+                              ["$default" "allow"    "view"]
+                              ["$default" "allow"    "$default"]
+                              [rev-etype  "fallback" "unlink" rev-label]])
                   :bindings {:data        rev-entity
                              :new-data    (get updated-entities-map rev-key)
                              :linked-data entity
@@ -374,12 +378,13 @@
                      :eid      (get create-lookups-map eid eid)
                      :program  (rule-model/get-program!
                                 rules
-                                [[etype      "allow" "link" fwd-label]
-                                 [etype      "allow" "create"]
-                                 [etype      "allow" "$default"]
-                                 ["$default" "allow" "link" fwd-label]
-                                 ["$default" "allow" "create"]
-                                 ["$default" "allow" "$default"]])
+                                [[etype      "allow"    "link" fwd-label]
+                                 [etype      "allow"    "create"]
+                                 [etype      "allow"    "$default"]
+                                 ["$default" "allow"    "link" fwd-label]
+                                 ["$default" "allow"    "create"]
+                                 ["$default" "allow"    "$default"]
+                                 [etype      "fallback" "link" fwd-label]])
                      :bindings {:data        updated-entity
                                 :new-data    updated-entity
                                 :linked-data updated-rev-entity
@@ -392,12 +397,13 @@
                      :eid      (get updated-rev-entity "id")
                      :program  (rule-model/get-program!
                                 rules
-                                [[rev-etype  "allow" "link" rev-label]
-                                 [rev-etype  "allow" "view"]
-                                 [rev-etype  "allow" "$default"]
-                                 ["$default" "allow" "link" rev-label]
-                                 ["$default" "allow" "view"]
-                                 ["$default" "allow" "$default"]])
+                                [[rev-etype  "allow"    "link" rev-label]
+                                 [rev-etype  "allow"    "view"]
+                                 [rev-etype  "allow"    "$default"]
+                                 ["$default" "allow"    "link" rev-label]
+                                 ["$default" "allow"    "view"]
+                                 ["$default" "allow"    "$default"]
+                                 [rev-etype  "fallback" "link" rev-label]])
                      :bindings {:data        updated-rev-entity
                                 :new-data    updated-rev-entity
                                 :linked-data updated-entity

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -115,7 +115,7 @@
                  rest))]
     (attr-model/insert-multi! (aurora/conn-pool :write) app-id attrs {})
     (into {}
-          (for [attr attrs
+          (for [attr (attr-model/get-by-app-id app-id)
                 :let [[_ ns n] (:forward-identity attr)]]
             [(keyword ns n) (:id attr)]))))
 


### PR DESCRIPTION
See https://discord.com/channels/1031957483243188235/1196584090552512592/1410865450975498320

I removed reverse unlink check during delete for namespaces that don’t explicitly define unlink in #1583. What I missed was that we have “default rule” for system namespace and that was confusing my “is unlink defined” logic