### PR TITLE
Improve reconnect handling for admin subscribe

### DIFF
--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.8';
+const version = 'v0.21.9';
 
 export { version };

--- a/server/src/instant/lib/ring/sse.clj
+++ b/server/src/instant/lib/ring/sse.clj
@@ -74,3 +74,14 @@
                  :attributes {:session-id (-> obj meta :session-id)}})))
           (when (instance? Throwable ret)
             (throw ret)))))))
+
+(defn set-retry-interval!
+  "Instructs the client how long to wait to retry after a connection error."
+  [app-id ^Long interval-ms {:keys [stub ^ServerSentEventConnection conn]}]
+  (if stub
+    nil
+    (tracer/with-span! {:name "sse/set-retry!"
+                        :attributes {:app-id app-id
+                                     :interval-ms interval-ms}}
+      (.sendRetry conn
+                  interval-ms))))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -18,6 +18,7 @@
    [instant.grouped-queue :as grouped-queue]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
+   [instant.lib.ring.sse :as sse]
    [instant.model.app :as app-model]
    [instant.model.app-admin-token :as app-admin-token-model]
    [instant.model.app-user :as app-user-model]
@@ -754,6 +755,8 @@
                                          ^ServerSentEventConnection (:channel req)))}]
                    (on-open store socket)
                    (admin-init! store id ctx)
+                   ;; If we got this far, retry on disconnect after half a second
+                   (sse/set-retry-interval! (:app-id ctx) 500 {:conn (:channel req)})
                    (receive-queue/put! receive-q
                                        {:op :add-query
                                         :session-id id

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -756,7 +756,9 @@
                    (on-open store socket)
                    (admin-init! store id ctx)
                    ;; If we got this far, retry on disconnect after half a second
-                   (sse/set-retry-interval! (:app-id ctx) 500 {:conn (:channel req)})
+                   (sse/set-retry-interval! (:app-id ctx)
+                                            (flags/flag :sse-retry-interval-ms 500)
+                                            {:conn (:channel req)})
                    (receive-queue/put! receive-q
                                        {:op :add-query
                                         :session-id id


### PR DESCRIPTION
Two changes here:
1. If admin-init succeeds, set the retry interval on the connection to 500ms (configurable with an instant-config flag). The default is 3 seconds, which is a bit too long. 
2. Only deliver an error on disconnect if we don't reconnect after 5 seconds. 