### PR TITLE
[dev] make dev -> tui

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -3,7 +3,7 @@ MAKE = make $(MAKEFLAGS)
 
 dev:
 	@echo "Booting up frontend..."
-	pnpm run dev
+	pnpm run dev --ui tui
 
 lint:
 	pnpm run check-format


### PR DESCRIPTION
@drew-harris showed me this nifty `--ui tui` flag from `pnpm run dev`. 

It's really handy for seeing how every task is doing. I thought it would be good to make this the default in make dev. 

<img width="1716" height="2070" alt="image" src="https://github.com/user-attachments/assets/777a1b52-2b51-4c9c-9d99-cf83f8f5558a" />

I left this flag out of the main package.json, as there may be some need a dev has to see the output as stdout. In that case they can just `pnpm run dev`


@dwwoelfel @nezaj @tonsky @drew-harris 