### PR TITLE
Initial support for orgs

### DIFF
--- a/client/www/components/dash/Orgs.tsx
+++ b/client/www/components/dash/Orgs.tsx
@@ -1,0 +1,89 @@
+import config from '@/lib/config';
+import { TokenContext } from '@/lib/contexts';
+import { jsonFetch } from '@/lib/fetch';
+import { useContext } from 'react';
+import { Button } from '../ui';
+import { useDashFetch } from '@/lib/hooks/useDashFetch';
+
+function createOrg(token: string, params: { title: string }) {
+  return jsonFetch(`${config.apiURI}/dash/orgs`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  });
+}
+
+function deleteOrg(token: string, params: { id: string }) {
+  return jsonFetch(`${config.apiURI}/dash/orgs/${params.id}`, {
+    method: 'DELETE',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+  });
+}
+
+export default function Orgs() {
+  const token = useContext(TokenContext);
+
+  const dashResponse = useDashFetch();
+
+  if (dashResponse.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (dashResponse.error || !dashResponse.data) {
+    return (
+      <div>
+        Error: <pre>{JSON.stringify(dashResponse.error, null, 2)}</pre>
+      </div>
+    );
+  }
+
+  const orgs = dashResponse.data.orgs;
+
+  return (
+    <div className="flex-1 flex flex-col p-4 max-w-2xl mx-auto">
+      <div>
+        {(orgs || []).map((org) => {
+          return (
+            <div>
+              {org.title}{' '}
+              <Button
+                variant="subtle"
+                onClick={async () => {
+                  await deleteOrg(token, { id: org.id });
+                  dashResponse.mutate();
+                }}
+              >
+                Delete
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex justify-between flex-row items-center">
+        <Button
+          onClick={async () => {
+            const title = prompt('Give your org a name');
+            try {
+              if (!title) {
+                throw new Error('Missing title.');
+              }
+              await createOrg(token, { title: title });
+              dashResponse.mutate();
+            } catch (e) {
+              console.error('Error creating org', e);
+              alert((e as Error).message);
+            }
+          }}
+        >
+          Create new org
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/www/lib/types.ts
+++ b/client/www/lib/types.ts
@@ -17,6 +17,7 @@ export type InstantApp = {
     body: string;
     subject: string;
   } | null;
+  org: { id: string; title: string } | null;
 };
 
 export type InstantMember = {
@@ -101,6 +102,12 @@ export type DashResponse = {
     email: string;
     id: string;
   };
+  orgs?: {
+    id: string;
+    title: string;
+    created_at: string;
+    role: 'owner' | 'admin' | 'collaborator';
+  }[];
 };
 
 export type AppError = { body: { message: string } | undefined };

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -84,6 +84,7 @@ import clsx from 'clsx';
 import AuthorizedOAuthAppsScreen from '@/components/dash/AuthorizedOAuthAppsScreen';
 import { useNamespacesQuery, useSchemaQuery } from '@/lib/hooks/explorer';
 import { getLocallySavedApp, setLocallySavedApp } from '@/lib/locallySavedApp';
+import Orgs from '@/components/dash/Orgs';
 
 // (XXX): we may want to expose this underlying type
 type InstantReactClient = ReturnType<typeof init>;
@@ -114,7 +115,8 @@ type Screen =
   | 'user-settings'
   | 'personal-access-tokens'
   | 'new'
-  | 'invites';
+  | 'invites'
+  | 'orgs';
 
 function defaultTab(screen: 'main'): MainTabId;
 function defaultTab(screen: 'user-settings'): UserSettingsTabId;
@@ -427,6 +429,7 @@ function Dashboard() {
       invites: [],
       user_app_role: 'owner',
       magic_code_email_template: null,
+      org: null,
     };
 
     dashResponse.mutate(
@@ -468,6 +471,17 @@ function Dashboard() {
         </Head>
         <StyledToastContainer />
         <PersonalAccessTokensScreen className="mx-auto" />
+      </div>
+    );
+  }
+  if (screen === 'orgs') {
+    return (
+      <div className="flex h-full w-full flex-col overflow-hidden md:flex-row">
+        <Head>
+          <title>Instant - Orgs playground</title>
+        </Head>
+        <StyledToastContainer />
+        <Orgs />
       </div>
     );
   }

--- a/server/resources/migrations/79_add_orgs.down.sql
+++ b/server/resources/migrations/79_add_orgs.down.sql
@@ -1,0 +1,9 @@
+alter table instant_subscriptions alter column app_id set not null;
+alter table instant_subscriptions alter column user_id set not null;
+alter table instant_subscriptions drop column org_id;
+
+alter table apps alter column creator_id set not null;
+alter table apps drop column org_id;
+
+drop table org_members;
+drop table orgs;

--- a/server/resources/migrations/79_add_orgs.up.sql
+++ b/server/resources/migrations/79_add_orgs.up.sql
@@ -1,0 +1,44 @@
+create table orgs (
+  id uuid primary key,
+  title text not null check (length(title) <= 140),
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now()
+);
+
+create trigger update_updated_at_trigger
+before update on orgs
+for each row
+execute function update_updated_at_column();
+
+create table org_members (
+  id uuid primary key,
+  org_id uuid not null references orgs (id) on delete cascade,
+  user_id uuid not null references instant_users (id) on delete cascade,
+  -- multiple roles??
+  -- maybe we want capabilities instead?
+  role text not null,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  unique (org_id, user_id)
+);
+
+-- Unique constraint adds index on org_id for cascade delete
+-- Create index on user_id for cascade delete
+create index on org_members (user_id);
+
+create trigger update_updated_at_trigger
+before update on org_members
+for each row
+execute function update_updated_at_column();
+
+-- XXX: How should we handle org deletion?
+alter table apps add column org_id uuid references orgs (id);
+create index on apps (org_id);
+
+alter table apps alter column creator_id drop not null;
+
+alter table instant_subscriptions add column org_id uuid references orgs (id);
+create index on instant_subscriptions (org_id);
+
+alter table instant_subscriptions alter column user_id drop not null;
+alter table instant_subscriptions alter column app_id drop not null;

--- a/server/resources/migrations/79_add_orgs.up.sql
+++ b/server/resources/migrations/79_add_orgs.up.sql
@@ -14,8 +14,6 @@ create table org_members (
   id uuid primary key,
   org_id uuid not null references orgs (id) on delete cascade,
   user_id uuid not null references instant_users (id) on delete cascade,
-  -- multiple roles??
-  -- maybe we want capabilities instead?
   role text not null,
   created_at timestamp with time zone not null default now(),
   updated_at timestamp with time zone not null default now(),
@@ -31,7 +29,8 @@ before update on org_members
 for each row
 execute function update_updated_at_column();
 
--- XXX: How should we handle org deletion?
+-- No cascade on apps when the org is deleted. You'll have to delete
+-- the apps before deleting the org.
 alter table apps add column org_id uuid references orgs (id);
 create index on apps (org_id);
 

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -1,0 +1,92 @@
+(ns instant.model.org
+  (:require
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.model.app :as app-model]
+   [instant.util.exception :as ex]
+   [instant.util.hsql :as uhsql]))
+
+(def all-for-user-q
+  (uhsql/preformat {:select [:o.id :o.title :o.created-at :o.updated-at :m.role]
+                    :from [[:orgs :o]]
+                    :join [[:org-members :m] [:and
+                                              [:= :m.org_id :o.id]]]
+                    :where [:= :m.user-id :?user-id]}))
+
+(defn get-all-for-user
+  ([params] (get-all-for-user (aurora/conn-pool :read) params))
+  ([conn {:keys [user-id]}]
+   (let [params {:user-id user-id}
+         query (uhsql/formatp all-for-user-q params)]
+     (sql/select ::get-all-for-user conn query))))
+
+(def apps-for-org-q
+  (app-model/make-apps-q {:select :a.id
+                          :from [[:apps :a]]
+                          :join [[:orgs :o] [:= :a.org_id :o.id]
+                                 [:org-members :m] [:= :m.org-id :o.id]]
+                          :where [:and
+                                  [:= :m.user-id :?user-id]
+                                  [:= :m.org-id :?org-id]]}))
+
+(defn apps-for-org
+  ([params] (apps-for-org (aurora/conn-pool :read) params))
+  ([conn {:keys [user-id org-id]}]
+   (let [params {:user-id user-id
+                 :org-id org-id}
+         query (uhsql/formatp apps-for-org-q params)]
+     (sql/select ::apps-for-org conn query))))
+
+(def org-for-user-q
+  (uhsql/preformat {:select [:o.id :o.title :o.created-at :o.updated-at :m.role]
+                    :from [[:orgs :o]]
+                    :join [[:org-members :m] [:= :o.id :m.org-id]]
+                    :where [:= :m.user-id :?user-id]}))
+
+(defn get-org-for-user!
+  ([params] (get-org-for-user! (aurora/conn-pool :read) params))
+  ([conn {:keys [org-id user-id]}]
+   (let [params {:user-id user-id
+                 :org-id org-id}
+         query (uhsql/formatp org-for-user-q params)]
+     (some-> (sql/select-one ::get-org-for-user! conn query)
+             (update :role keyword)
+             (ex/assert-record! :org {:args [{:user-id user-id
+                                              :org-id org-id}]})))))
+
+
+(def create-org-q
+  (uhsql/preformat {:with [[:org {:insert-into :orgs
+                                  :values [{:id :?org-id
+                                            :title :?title}]
+                                  :returning :*}]
+                           [:member {:insert-into :org-members
+                                     :values [{:id :?member-id
+                                               :org-id :?org-id
+                                               :user-id :?user-id
+                                               :role [:inline "owner"]}]}]]
+                    :select [:id :title :created-at :updated-at]
+                    :from :org}))
+
+(defn create!
+  ([params] (create! (aurora/conn-pool :write) params))
+  ([conn {:keys [user-id
+                 title]}]
+   (let [params {:user-id user-id
+                 :org-id (random-uuid)
+                 :member-id (random-uuid)
+                 :title title}
+         query (uhsql/formatp create-org-q params)]
+     (sql/execute-one! ::create! conn query))))
+
+(def delete-org-q
+  (uhsql/preformat {:delete-from :orgs
+                    :where [:= :id :?org-id]
+                    :returning :*}))
+
+(defn delete!
+  ([params] (delete! (aurora/conn-pool :write) params))
+  ([conn {:keys [org-id]}]
+   (let [params {:org-id org-id}
+         query (uhsql/formatp delete-org-q params)]
+     (sql/execute-one! ::delete! conn query))))


### PR DESCRIPTION
Creates tables to hold orgs and adds a hidden page on the dashboard where we can start testing it.

Changes in this PR:
1. Creates the orgs table and the org members table and updates subscriptions to allow them to attach to orgs.
2. Creates dash routes for fetching, creating, and deleting orgs

The org members has a similar structure to the app members with the same set of roles. The main difference is that the org has no creator_id--instead we create an org_member with role "owner". That way you can have multiple "creators" and your org isn't tied to a single person.

Still a lot to do for full support for orgs:
1. Add/remove members
2. Add app to an org
3. Transfer apps between orgs
4. Add subscriptions to an org
5. Update permissions everywhere so that org access propagates to app access
6. UI

