### PR TITLE
custom claude code path + show cursor after ctrl c

### DIFF
--- a/client/packages/create-instant-app/src/claude.ts
+++ b/client/packages/create-instant-app/src/claude.ts
@@ -145,6 +145,7 @@ export const promptClaude = async (prompt: string, projectDir: string) => {
         'Do not use the instant mcp server to create a new app, a fresh app id has already been placed in the .env file. Do not attempt to start a dev server.',
       permissionMode: 'bypassPermissions', // todo: make more strict
       env: process.env,
+      pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_PATH,
     },
     prompt: prompt,
   })) {

--- a/client/packages/create-instant-app/src/index.ts
+++ b/client/packages/create-instant-app/src/index.ts
@@ -117,3 +117,9 @@ main().catch((err) => {
   process.stdout.write(SHOW_CURSOR);
   process.exit(1);
 });
+
+// On ctrl-c, show cursor again
+process.on('SIGINT', () => {
+  process.stdout.write(SHOW_CURSOR);
+  process.exit(0);
+});

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.10';
+const version = 'v0.21.11';
 
 export { version };


### PR DESCRIPTION
Small pr to allow people to set CLAUDE_CODE_PATH environment variable
I tried using the `which` command to find it but that doesn't play nice with claude code sdk. 

Also fixed an issue where ctrl-c kept hiding the cursor.