### PR TITLE
Change link unlink fallback

### DIFF
--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -224,8 +224,7 @@ You can use `$default` as the namespace:
 
 You can specify default link/unlink permission (these will apply to all attributes) and override it for specific attributes:
 
-```
-json
+```json
 {
   "users": {
     "allow": {

--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -19,6 +19,12 @@ const rules = {
       "create": "isOwner",
       "update": "isOwner && isStillOwner",
       "delete": "isOwner",
+      "link": {
+        "creator": "isOwner && isStillOwner"
+      },
+      "unlink": {
+        "creator": "isOwner"
+      }
     },
     "bind": [
       "isOwner", "auth.id != null && auth.id == data.creatorId",
@@ -53,9 +59,9 @@ For each app in your dashboard, you’ll see a permissions editor. Permissions a
 
 ## Namespaces
 
-For each namespace you can define `allow` rules for `view`, `create`, `update`, `delete`. Rules must be boolean expressions.
+For each namespace you can define `allow` rules for `view`, `create`, `update`, `delete`, `link`, `unlink`. Rules must be boolean expressions.
 
-If a rule is not set then by default it evaluates to true. The following three rulesets are all equivalent
+If a rule is not set then by default it evaluates to true. The following four rulesets are all equivalent:
 
 In this example we explicitly set each action for `todos` to true
 
@@ -66,7 +72,13 @@ In this example we explicitly set each action for `todos` to true
       "view": "true",
       "create": "true",
       "update": "true",
-      "delete": "true"
+      "delete": "true",
+      "link": {
+        "creator": "true"
+      },
+      "unlink": {
+        "creator": "true"
+      }
     }
   }
 }
@@ -118,6 +130,7 @@ You can add checks per link attribute for cases when link is added and removed. 
   "posts": {
     "allow": {
       "link": {
+        // linkedData here is user, same as data.author
         "author": "linkedData.id == auth.id",
         "reviewer": "..."
       },
@@ -129,6 +142,8 @@ You can add checks per link attribute for cases when link is added and removed. 
   "users": {
     "allow": {
       "link": {
+        // data & newData here are user
+        // linkedData is post, same as data.posts
         "posts": "newData.id == auth.id && linkedData.text != null"
       },
       "unlink": {
@@ -143,8 +158,8 @@ Few things to note:
 
 1. Unlike other permissions, value for `link`/`unlink` is a map, not a string. Keys in that map are attribute labels.
 2. Permission checks can be defined either on both sides, on one side or at neither.
-3. If `link`/`unlink` permission is not defined for an attribute, it falls back to `update` check in forward direction and `view` check in reverse direction.
-4. Inside `link`/`unlink` permissions you have access to `linkedData` object which is just a shorthand for the other side of the relation.
+3. If `link`/`unlink` permissions are not defined for an attribute in either direction, it falls back to `update` check in forward direction and `view` check in reverse direction.
+4. Inside `link`/`unlink` permissions you have access to `linkedData` object which is a shorthand for the other side of the relation.
 5. You still have access to `data` and `newData`, with the same logic as in `create`/`update` checks.
 
 ### Default permissions

--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -212,13 +212,17 @@
                                    (get entities-map rev-key))
               rule-params        (get rule-params-map key)
               link-program       (when ref?
-                                   (rule-model/get-program! rules [[etype "allow" "link" fwd-label]]))
+                                   (rule-model/get-program! rules [[etype "allow" "link" fwd-label]
+                                                                   [etype "allow" "link" "$default"]]))
               rev-link-program   (when ref?
-                                   (rule-model/get-program! rules [[rev-etype "allow" "link" rev-label]]))
+                                   (rule-model/get-program! rules [[rev-etype "allow" "link" rev-label]
+                                                                   [rev-etype "allow" "link" "$default"]]))
               unlink-program     (when ref?
-                                   (rule-model/get-program! rules [[etype "allow" "unlink" fwd-label]]))
+                                   (rule-model/get-program! rules [[etype "allow" "unlink" fwd-label]
+                                                                   [etype "allow" "unlink" "$default"]]))
               rev-unlink-program (when ref?
-                                   (rule-model/get-program! rules [[rev-etype "allow" "unlink" rev-label]]))]
+                                   (rule-model/get-program! rules [[rev-etype "allow" "unlink" rev-label]
+                                                                   [rev-etype "allow" "unlink" "$default"]]))]
         check (clojure+/cond+
                 (= :update-attr op)
                 [{:scope    :attr
@@ -301,8 +305,7 @@
                      :action   :unlink
                      :etype    etype
                      :eid      eid
-                     :program  (or (rule-model/get-program! rules [[etype "allow" "unlink" fwd-label]])
-                                   {:result true})
+                     :program  unlink-program
                      :bindings {:data        entity
                                 :new-data    (get updated-entities-map key)
                                 :linked-data rev-entity
@@ -395,9 +398,11 @@
                                            (update "id" #(or (get create-lookups-map %) (:eid rev-key) %))))
               rule-params        (get rule-params-map key)
               link-program       (when ref?
-                                   (rule-model/get-program! rules [[etype "allow" "link" fwd-label]]))
+                                   (rule-model/get-program! rules [[etype "allow" "link" fwd-label]
+                                                                   [etype "allow" "link" "$default"]]))
               rev-link-program   (when ref?
-                                   (rule-model/get-program! rules [[rev-etype "allow" "link" rev-label]]))]
+                                   (rule-model/get-program! rules [[rev-etype "allow" "link" rev-label]
+                                                                   [rev-etype "allow" "link" "$default"]]))]
         check (clojure+/cond+
                 (= :add-attr op)
                 [{:scope    :attr

--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -202,15 +202,23 @@
    tx-steps]
   (for [tx-step tx-steps
         :let [{:keys [op eid aid etype value rev-etype]} tx-step
-              key             {:eid eid :etype etype}
-              entity          (get entities-map key)
-              ref?            (some? rev-etype)
-              [_ _ fwd-label] (:forward-identity (attr-model/seek-by-id aid attrs))
-              [_ _ rev-label] (:reverse-identity (attr-model/seek-by-id aid attrs))
-              rev-key         {:eid value :etype rev-etype}
-              rev-entity      (when ref?
-                                (get entities-map rev-key))
-              rule-params     (get rule-params-map key)]
+              key                {:eid eid :etype etype}
+              entity             (get entities-map key)
+              ref?               (some? rev-etype)
+              [_ _ fwd-label]    (:forward-identity (attr-model/seek-by-id aid attrs))
+              [_ _ rev-label]    (:reverse-identity (attr-model/seek-by-id aid attrs))
+              rev-key            {:eid value :etype rev-etype}
+              rev-entity         (when ref?
+                                   (get entities-map rev-key))
+              rule-params        (get rule-params-map key)
+              link-program       (when ref?
+                                   (rule-model/get-program! rules [[etype "allow" "link" fwd-label]]))
+              rev-link-program   (when ref?
+                                   (rule-model/get-program! rules [[rev-etype "allow" "link" rev-label]]))
+              unlink-program     (when ref?
+                                   (rule-model/get-program! rules [[etype "allow" "unlink" fwd-label]]))
+              rev-unlink-program (when ref?
+                                   (rule-model/get-program! rules [[rev-etype "allow" "unlink" rev-label]]))]
         check (clojure+/cond+
                 (= :update-attr op)
                 [{:scope    :attr
@@ -230,85 +238,110 @@
                   :etype    "attrs"
                   :program  {:result admin?}}]
 
+                ;; if link is defined on at least one side
                 (and (= :add-triple op)
-                     ref?)
+                     ref?
+                     (or link-program rev-link-program))
                 (concat
-                 (when entity
+                 (when (and entity link-program)
                    [{:scope    :object
                      :action   :link
                      :etype    etype
                      :eid      eid
-                     :program  (rule-model/get-program!
-                                rules
-                                [[etype      "allow"    "link" fwd-label]
-                                 [etype      "allow"    "update"]
-                                 [etype      "allow"    "$default"]
-                                 ["$default" "allow"    "link" fwd-label]
-                                 ["$default" "allow"    "update"]
-                                 ["$default" "allow"    "$default"]
-                                 [etype      "fallback" "link" fwd-label]])
+                     :program  link-program
                      :bindings {:data        entity
                                 :new-data    (get updated-entities-map key)
                                 :linked-data rev-entity
                                 :rule-params rule-params}}])
-                 (when rev-entity
+                 (when (and rev-entity rev-link-program)
                    [{:scope    :object
                      :action   :link
                      :etype    rev-etype
                      :eid      value
-                     :program  (rule-model/get-program!
-                                rules
-                                [[rev-etype  "allow"    "link" rev-label]
-                                 [rev-etype  "allow"    "view"]
-                                 [rev-etype  "allow"    "$default"]
-                                 ["$default" "allow"    "link" rev-label]
-                                 ["$default" "allow"    "view"]
-                                 ["$default" "allow"    "$default"]
-                                 [rev-etype  "fallback" "link" rev-label]])
+                     :program  rev-link-program
                      :bindings {:data        rev-entity
                                 :new-data    (get updated-entities-map rev-key)
                                 :linked-data (get updated-entities-map key)
                                 :rule-params (merge rule-params
                                                     (get rule-params-map rev-key))}}]))
 
+                ;; fallback when link isn´t defined on either side
+                (and (= :add-triple op)
+                     ref?)
+                (concat
+                 (when entity
+                   [{:scope    :object
+                     :action   :update
+                     :etype    etype
+                     :eid      eid
+                     :program  (or (rule-model/get-program! rules etype "update")
+                                   {:result true})
+                     :bindings {:data        entity
+                                :new-data    (get updated-entities-map key)
+                                :rule-params rule-params}}])
+                 (when rev-entity
+                   [{:scope    :object
+                     :action   :view
+                     :etype    rev-etype
+                     :eid      value
+                     :program  (or (rule-model/get-program! rules rev-etype "view")
+                                   {:result true})
+                     :bindings {:data        rev-entity
+                                :new-data    (get updated-entities-map rev-key)
+                                :rule-params (merge rule-params
+                                                    (get rule-params-map rev-key))}}]))
+
+                ;; if unlink is defined on at least one side
+                (and (= :retract-triple op)
+                     ref?
+                     (or unlink-program rev-unlink-program))
+                (concat
+                 (when (and entity unlink-program)
+                   [{:scope    :object
+                     :action   :unlink
+                     :etype    etype
+                     :eid      eid
+                     :program  (or (rule-model/get-program! rules [[etype "allow" "unlink" fwd-label]])
+                                   {:result true})
+                     :bindings {:data        entity
+                                :new-data    (get updated-entities-map key)
+                                :linked-data rev-entity
+                                :rule-params rule-params}}])
+                 (when (and rev-entity rev-unlink-program)
+                   [{:scope    :object
+                     :action   :unlink
+                     :etype    rev-etype
+                     :eid      value
+                     :program  rev-unlink-program
+                     :bindings {:data        rev-entity
+                                :new-data    (get updated-entities-map rev-key)
+                                :linked-data entity
+                                :rule-params (merge rule-params
+                                                    (get rule-params-map rev-key))}}]))
+
+                ;; fallback when unlink isn´t defined on either side
                 (and (= :retract-triple op)
                      ref?)
                 (concat
                  (when entity
                    [{:scope    :object
-                     :action   :unlink
+                     :action   :update
                      :etype    etype
                      :eid      eid
-                     :program  (rule-model/get-program!
-                                rules
-                                [[etype      "allow"    "unlink" fwd-label]
-                                 [etype      "allow"    "update"]
-                                 [etype      "allow"    "$default"]
-                                 ["$default" "allow"    "unlink" fwd-label]
-                                 ["$default" "allow"    "update"]
-                                 ["$default" "allow"    "$default"]
-                                 [etype      "fallback" "unlink" fwd-label]])
+                     :program  (or (rule-model/get-program! rules etype "update")
+                                   {:result true})
                      :bindings {:data        entity
                                 :new-data    (get updated-entities-map key)
-                                :linked-data rev-entity
                                 :rule-params rule-params}}])
                  (when rev-entity
                    [{:scope    :object
-                     :action   :unlink
+                     :action   :view
                      :etype    rev-etype
                      :eid      value
-                     :program  (rule-model/get-program!
-                                rules
-                                [[rev-etype  "allow"    "unlink" rev-label]
-                                 [rev-etype  "allow"    "view"]
-                                 [rev-etype  "allow"    "$default"]
-                                 ["$default" "allow"    "unlink" rev-label]
-                                 ["$default" "allow"    "view"]
-                                 ["$default" "allow"    "$default"]
-                                 [rev-etype  "fallback" "unlink" rev-label]])
+                     :program  (or (rule-model/get-program! rules rev-etype "view")
+                                   {:result true})
                      :bindings {:data        rev-entity
                                 :new-data    (get updated-entities-map rev-key)
-                                :linked-data entity
                                 :rule-params (merge rule-params
                                                     (get rule-params-map rev-key))}}]))
 
@@ -360,8 +393,12 @@
               updated-rev-entity (when ref?
                                    (some-> (get updated-entities-map rev-key)
                                            (update "id" #(or (get create-lookups-map %) (:eid rev-key) %))))
-              rule-params        (get rule-params-map key)]
-        check (cond
+              rule-params        (get rule-params-map key)
+              link-program       (when ref?
+                                   (rule-model/get-program! rules [[etype "allow" "link" fwd-label]]))
+              rev-link-program   (when ref?
+                                   (rule-model/get-program! rules [[rev-etype "allow" "link" rev-label]]))]
+        check (clojure+/cond+
                 (= :add-attr op)
                 [{:scope    :attr
                   :action   :create
@@ -370,23 +407,46 @@
                                 {:result true})
                   :bindings {:data value}}]
 
+                ;; if link is defined on at least one side
+                (and (= :add-triple op)
+                     ref?
+                     (or link-program rev-link-program))
+                (concat
+                 (when (and create? link-program)
+                   [{:scope    :object
+                     :action   :link
+                     :etype    etype
+                     :eid      (get create-lookups-map eid eid)
+                     :program  link-program
+                     :bindings {:data        updated-entity
+                                :new-data    updated-entity
+                                :linked-data updated-rev-entity
+                                :rule-params rule-params}}])
+                 (when (and updated-rev-entity
+                            (nil? (get entities-map rev-key))
+                            rev-link-program)
+                   [{:scope    :object
+                     :action   :link
+                     :etype    rev-etype
+                     :eid      (get updated-rev-entity "id")
+                     :program  rev-link-program
+                     :bindings {:data        updated-rev-entity
+                                :new-data    updated-rev-entity
+                                :linked-data updated-entity
+                                :rule-params (merge rule-params
+                                                    (get rule-params-map rev-key))}}]))
+
+                ;; fallback when link isn´t defined on either side
                 (and (= :add-triple op)
                      ref?)
                 (concat
                  (when create?
                    [{:scope    :object
-                     :action   :link
+                     :action   :create
                      :etype    etype
                      :eid      (get create-lookups-map eid eid)
-                     :program  (rule-model/get-program!
-                                rules
-                                [[etype      "allow"    "link" fwd-label]
-                                 [etype      "allow"    "create"]
-                                 [etype      "allow"    "$default"]
-                                 ["$default" "allow"    "link" fwd-label]
-                                 ["$default" "allow"    "create"]
-                                 ["$default" "allow"    "$default"]
-                                 [etype      "fallback" "link" fwd-label]])
+                     :program  (or (rule-model/get-program! rules etype "create")
+                                   {:result true})
                      :bindings {:data        updated-entity
                                 :new-data    updated-entity
                                 :linked-data updated-rev-entity
@@ -394,18 +454,11 @@
                  (when (and updated-rev-entity
                             (nil? (get entities-map rev-key)))
                    [{:scope    :object
-                     :action   :link
+                     :action   :view
                      :etype    rev-etype
                      :eid      (get updated-rev-entity "id")
-                     :program  (rule-model/get-program!
-                                rules
-                                [[rev-etype  "allow"    "link" rev-label]
-                                 [rev-etype  "allow"    "view"]
-                                 [rev-etype  "allow"    "$default"]
-                                 ["$default" "allow"    "link" rev-label]
-                                 ["$default" "allow"    "view"]
-                                 ["$default" "allow"    "$default"]
-                                 [rev-etype  "fallback" "link" rev-label]])
+                     :program  (or (rule-model/get-program! rules rev-etype "view")
+                                   {:result true})
                      :bindings {:data        updated-rev-entity
                                 :new-data    updated-rev-entity
                                 :linked-data updated-entity

--- a/server/src/instant/db/permissioned_transaction_new.clj
+++ b/server/src/instant/db/permissioned_transaction_new.clj
@@ -546,13 +546,6 @@
                                                     (get rule-params-map rev-key))}}]))]
       check)))
 
-(defn post-checks
-  "Checks that run after tx: create, add-attr"
-  [ctx entities-map updated-entities-map rule-params-map create-lookups-map tx-steps results]
-  (concat
-   (post-create-checks ctx entities-map updated-entities-map rule-params-map create-lookups-map tx-steps)
-   (post-delete-checks ctx entities-map updated-entities-map rule-params-map tx-steps (:delete-entity results))))
-
 (defn run-checks!
   "Runs checks, returning results (admin-check?) or throwing"
   [ctx checks]
@@ -648,13 +641,12 @@
                                               (map :eid)
                                               (filter lookup-ref?)
                                               (triple-model/fetch-lookups->eid tx-conn app-id)))
-                  post-checks          (post-checks ctx
-                                                    entities-map
-                                                    updated-entities-map
-                                                    rule-params-map
-                                                    create-lookups-map
-                                                    tx-step-maps
-                                                    (:results tx-data))
+                  post-checks          (post-create-checks ctx
+                                                           entities-map
+                                                           updated-entities-map
+                                                           rule-params-map
+                                                           create-lookups-map
+                                                           tx-step-maps)
                   post-check-results   (io/expect-io
                                          (run-checks! ctx post-checks))
 


### PR DESCRIPTION
Per @nezaj request, link/unlink now work like this:

- if `link` is not defined for either direction, `update`/`view` fallback is used
- if `link` is defined for one direction, only that `link` permission is checked. The other side is not using `update`/`view` fallback (this is the part that changed)
- if `link` is defined for both directions, both are checked and results are ANDed

Same logic for `unlink`

Second change relates to `delete`. Before, when we were deleting entity and that entity had links, we were checking both `delete` for entity and `unlink` for the other side of the relation. After this PR, we only check `delete`.

Third change is introduction of `$default` for links. If you don’t want to list all attribute names manually, you can use `$default` as attribute name & override selected attributes:

```json
"todos": {
  "allow": {
    "update": "...",
    "link": {
      "author": "...",
      "$default": "..."
    }
  }
}
```

This PR also updates documentation for link/unlink on our website.