### PR TITLE
Increase timeout for aggregator test

### DIFF
--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -116,7 +116,7 @@
     (wait-for #(> 0 (compare lsn
                              (cms/get-start-lsn (aurora/conn-pool :read)
                                                 {:slot-name slot-name})))
-              1000)))
+              10000)))
 
 (deftest captures-changes
   (with-empty-app


### PR DESCRIPTION
I've noticed the aggregator test is timing out occasionally. If the problem is that the test machines are way underpowered, then just updating the time out might help.

Seemed to work on the run for the push.