### PR TITLE
Denormalize subscription_id on app

### DIFF
--- a/server/resources/migrations/81_denormalize_subscription.down.sql
+++ b/server/resources/migrations/81_denormalize_subscription.down.sql
@@ -1,0 +1,1 @@
+alter table apps drop column subscription_id;

--- a/server/resources/migrations/81_denormalize_subscription.up.sql
+++ b/server/resources/migrations/81_denormalize_subscription.up.sql
@@ -1,0 +1,13 @@
+alter table apps add column subscription_id uuid references instant_subscriptions (id) on delete set null;
+create index on apps (subscription_id);
+
+-- Migration to set the subscription_id on the apps
+with subscriptions as (
+  select distinct on (app_id) *
+    from instant_subscriptions
+  order by app_id, created_at desc
+)
+update apps
+   set subscription_id = s.id
+  from subscriptions as s
+  where s.app_id = apps.id;

--- a/server/src/instant/model/instant_subscription.clj
+++ b/server/src/instant/model/instant_subscription.clj
@@ -2,6 +2,7 @@
   (:require
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
+   [instant.model.app :as app-model]
    [instant.util.hsql :as uhsql]))
 
 (def create-q
@@ -25,7 +26,7 @@
   ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [user-id app-id subscription-type-id
                  stripe-customer-id stripe-subscription-id stripe-event-id]}]
-   (let [subscription-id (random-uuid)]
+   (app-model/with-cache-invalidation app-id
      (sql/execute-one! ::create!
                        conn
                        (uhsql/formatp create-q

--- a/server/src/instant/model/instant_subscription.clj
+++ b/server/src/instant/model/instant_subscription.clj
@@ -26,7 +26,6 @@
   ([conn {:keys [user-id app-id subscription-type-id
                  stripe-customer-id stripe-subscription-id stripe-event-id]}]
    (let [subscription-id (random-uuid)]
-     (tool/def-locals)
      (sql/execute-one! ::create!
                        conn
                        (uhsql/formatp create-q


### PR DESCRIPTION
This PR makes it easier to determine if an app is on a paid plan.

Instead of querying for the newest row in the instant_subscriptions table, we update the app with the subscription_id when we create it.

Includes a migration to update all of the existing apps. If someone subscribes between the time I run the migration and the time that I deploy the code, I'll run the migration again to update their row.