### PR TITLE
Fix subscription error

### DIFF
--- a/server/src/instant/model/instant_subscription.clj
+++ b/server/src/instant/model/instant_subscription.clj
@@ -9,8 +9,8 @@
   (uhsql/preformat
    {:with [[:subscription {:insert-into :instant-subscriptions
                            :values [{:id :?id
-                                     :user-id :?user-id
-                                     :app-id :?app-id
+                                     :user-id [:cast :?user-id :uuid]
+                                     :app-id [:cast :?app-id :uuid]
                                      :subscription-type-id :?subscription-type-id
                                      :stripe-customer-id :?stripe-customer-id
                                      :stripe-subscription-id :?stripe-subscription-id

--- a/server/src/instant/stripe.clj
+++ b/server/src/instant/stripe.clj
@@ -81,8 +81,8 @@
              {:keys [app-id user-id]} :metadata}
             (:object data)
 
-            shared {:user-id user-id
-                    :app-id app-id
+            shared {:user-id (parse-uuid user-id)
+                    :app-id (parse-uuid app-id)
                     :stripe-customer-id customer-id
                     :stripe-subscription-id subscription-id
                     :stripe-event-id id}]


### PR DESCRIPTION
We were getting an error processing subscriptions because the user_id was a string instead of a uuid. 

I made it a uuid and also cast it to a uuid in the query for good measure.