### PR TITLE
Subscriptions for orgs

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -116,7 +116,7 @@ type Screen =
   | 'personal-access-tokens'
   | 'new'
   | 'invites'
-  | 'orgs';
+  | 'org';
 
 function defaultTab(screen: 'main'): MainTabId;
 function defaultTab(screen: 'user-settings'): UserSettingsTabId;
@@ -474,14 +474,14 @@ function Dashboard() {
       </div>
     );
   }
-  if (screen === 'orgs') {
+  if (screen === 'org') {
     return (
       <div className="flex h-full w-full flex-col overflow-hidden md:flex-row">
         <Head>
           <title>Instant - Orgs playground</title>
         </Head>
         <StyledToastContainer />
-        <Orgs />
+        <Orgs orgId={router.query.org} />
       </div>
     );
   }

--- a/server/resources/migrations/82_org_subscriptions.down.sql
+++ b/server/resources/migrations/82_org_subscriptions.down.sql
@@ -1,0 +1,11 @@
+alter table instant_stripe_customers drop constraint requires_user_or_org;
+
+alter table instant_stripe_customers drop column org_id;
+alter table instant_stripe_customers alter column user_id set not null;
+
+alter table orgs drop column billing_email;
+alter table orgs drop column subscription_id;
+
+alter table instant_subscriptions drop constraint requires_app_or_org;
+
+delete from instant_subscription_types where id = 3;

--- a/server/resources/migrations/82_org_subscriptions.up.sql
+++ b/server/resources/migrations/82_org_subscriptions.up.sql
@@ -1,0 +1,18 @@
+alter table instant_stripe_customers alter column user_id drop not null;
+alter table instant_stripe_customers add column org_id uuid references orgs (id);
+create unique index on instant_stripe_customers (org_id);
+
+alter table instant_stripe_customers add constraint requires_user_or_org check (
+  (user_id is not null and org_id is null) or
+  (org_id is not null and user_id is null)
+);
+
+alter table orgs add column billing_email text;
+alter table orgs add column subscription_id uuid references instant_subscriptions (id);
+
+alter table instant_subscriptions add constraint requires_app_or_org check (
+  (app_id is not null and org_id is null) or
+  (org_id is not null and app_id is null)
+);
+
+insert into instant_subscription_types (id, name) values (3, 'Startup');

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -192,6 +192,15 @@
      :prod prod-pro-subscription
      test-pro-subscription)))
 
+(def test-startup-subscription "price_1RvkYbL5BwOwpxgUoDyhZtzN")
+(def prod-startup-subscription "price_1RvkPZL5BwOwpxgUSVW7f2dd")
+(defn stripe-startup-subscription
+  ([] (stripe-startup-subscription {:env (get-env)}))
+  ([{:keys [env]}]
+   (case env
+     :prod prod-startup-subscription
+     test-startup-subscription)))
+
 (defn get-honeycomb-api-key []
   (some-> @config-map :honeycomb-api-key crypt-util/secret-value))
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -789,7 +789,7 @@
 
 (defn org-checkout-session-post [req]
   (let [{{org-id :id org-title :title :as org} :org
-         {user-id :id user-email :email :as user} :user} (req->org-and-user! :collaborator req)
+         {user-id :id user-email :email} :user} (req->org-and-user! :collaborator req)
         {:keys [name]} (instant-subscription-model/get-by-org-id {:org-id org-id})
         already-subscribed? (not (or (= name default-subscription) (nil? name)))
         _ (when already-subscribed?

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -766,8 +766,10 @@
         already-subscribed? (not (or (= name default-subscription) (nil? name)))
         _ (when already-subscribed?
             (ex/throw-record-not-unique! :instant-subscription))
-        {customer-id :id} (instant-stripe-customer-model/get-or-create! {:user user})
-        metadata {"app-id" app-id "user-id" user-id}
+        {customer-id :id} (instant-stripe-customer-model/get-or-create-for-user! {:user user})
+        metadata {"app-id" app-id
+                  "user-id" user-id
+                  "subscription-type-id" stripe/STARTUP_SUBSCRIPTION_TYPE}
         description (str "App name: " app-title)
         session-params {"success_url" (str (config/stripe-success-url) "&app=" app-id)
                         "cancel_url" (str (config/stripe-cancel-url) "&app=" app-id)
@@ -785,10 +787,50 @@
         session (Session/create ^Map session-params)]
     (response/ok {:id (.getId session)})))
 
+(defn org-checkout-session-post [req]
+  (let [{{org-id :id org-title :title :as org} :org
+         {user-id :id user-email :email :as user} :user} (req->org-and-user! :collaborator req)
+        {:keys [name]} (instant-subscription-model/get-by-org-id {:org-id org-id})
+        already-subscribed? (not (or (= name default-subscription) (nil? name)))
+        _ (when already-subscribed?
+            (ex/throw-record-not-unique! :instant-subscription))
+        {customer-id :id} (instant-stripe-customer-model/get-or-create-for-org! {:org org
+                                                                                 :user-email user-email})
+        metadata (tool/inspect {"org-id" org-id
+                                "user-id" user-id
+                                "subscription-type-id" stripe/STARTUP_SUBSCRIPTION_TYPE})
+        description (str "Org name: " org-title)
+        session-params {"success_url" (str (config/stripe-success-url) "&org=" org-id)
+                        "cancel_url" (str (config/stripe-cancel-url) "&org=" org-id)
+                        "customer" customer-id
+                        "metadata" metadata
+                        "allow_promotion_codes" (or (flags/promo-code-email? user-email)
+                                                    (flags/promo-code-email? (:billing_email org))
+                                                    (admin-email? user-email))
+                        "subscription_data" {"metadata" metadata
+                                             "description" description
+                                             "billing_cycle_anchor"
+                                             (.toEpochSecond (date/first-of-next-month-est))}
+                        "mode" "subscription"
+                        "line_items" [{"price" (config/stripe-startup-subscription)
+                                       "quantity" 1}]}
+        session (Session/create ^Map session-params)]
+    (response/ok {:id (.getId session)})))
+
 (defn create-portal [req]
   (let [{{app-id :id} :app user :user} (req->app-and-user! req)
-        {customer-id :id} (instant-stripe-customer-model/get-or-create! {:user user})
+        {customer-id :id} (instant-stripe-customer-model/get-or-create-for-user! {:user user})
         session-params {"return_url" (str (config/stripe-success-url) "&app=" app-id)
+                        "customer" customer-id}
+        session (com.stripe.model.billingportal.Session/create ^Map session-params)]
+    (response/ok {:url (.getUrl session)})))
+
+(defn org-create-portal [req]
+  (let [{{org-id :id :as org} :org user :user} (req->org-and-user! :collaborator req)
+        {customer-id :id} (instant-stripe-customer-model/get-or-create-for-org!
+                           {:org org
+                            :user-email (:email user)})
+        session-params {"return_url" (str (config/stripe-success-url) "&org=" org-id)
                         "customer" customer-id}
         session (com.stripe.model.billingportal.Session/create ^Map session-params)]
     (response/ok {:url (.getUrl session)})))
@@ -1744,6 +1786,8 @@
   (DELETE "/dash/orgs/:org_id/invite/revoke" [] team-member-invite-revoke-delete)
   (DELETE "/dash/orgs/:org_id/members/remove" [] team-member-remove-delete)
   (POST "/dash/orgs/:org_id/members/update" [] team-member-update-post)
+  (POST "/dash/orgs/:org_id/checkout_session" [] org-checkout-session-post)
+  (POST "/dash/orgs/:org_id/portal_session" [] org-create-portal)
 
 
   (GET "/dash/ws_playground" [] ws-playground-get)

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -218,7 +218,7 @@
               :creator-id (:id owner)
               :id app-id
               :admin-token (random-uuid)})
-        stripe-customer (instant-stripe-customer-model/get-or-create! {:user owner})
+        stripe-customer (instant-stripe-customer-model/get-or-create-for-user! {:user owner})
         owner-req (mock-app-req app owner)
         _ (instant-subscription-model/create!
            {:user-id (:id owner)
@@ -252,7 +252,7 @@
                  :role role})
         owner-req (mock-app-req app owner)
         invitee-req (mock-app-req app invitee)
-        stripe-customer (instant-stripe-customer-model/get-or-create! {:user owner})
+        stripe-customer (instant-stripe-customer-model/get-or-create-for-user! {:user owner})
         _ (instant-subscription-model/create!
            {:user-id (:id owner)
             :app-id app-id

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -103,6 +103,15 @@
          (with-fail-on-warn-io
            (~f org#))
          (finally
+           (sql/do-execute! (aurora/conn-pool :write)
+                            ["update orgs set subscription_id = null where id = ?::uuid"
+                             (:id org#)])
+           (sql/do-execute! (aurora/conn-pool :write)
+                            ["delete from instant_subscriptions where org_id = ?::uuid"
+                             (:id org#)])
+           (sql/do-execute! (aurora/conn-pool :write)
+                            ["delete from instant_stripe_customers where org_id = ?::uuid"
+                             (:id org#)])
            (org-model/delete! {:org-id (:id org#)}))))))
 
 (defmacro with-empty-app

--- a/server/src/instant/model/instant_stripe_customer.clj
+++ b/server/src/instant/model/instant_stripe_customer.clj
@@ -6,8 +6,8 @@
    (com.stripe.model Customer)
    (java.util Map)))
 
-(defn- create!
-  ([params] (create! (aurora/conn-pool :write) params))
+(defn- create-for-user!
+  ([params] (create-for-user! (aurora/conn-pool :write) params))
   ([conn {:keys [user]}]
    (let [{:keys [id email]} user
          opts {"metadata" {"instant_user_id" id}}
@@ -21,6 +21,21 @@
                         ON CONFLICT (user_id) DO NOTHING RETURNING *"
                         customer-id id]))))
 
+(defn- create-for-org!
+  ([params] (create-for-org! (aurora/conn-pool :write) params))
+  ([conn {:keys [org user-email]}]
+   (let [opts {"metadata" {"instant_org_id" (:id org)}}
+         email (or (:billing_email org) user-email)
+         with-email (if email
+                      (assoc opts "email" email)
+                      opts)
+         customer (Customer/create ^Map with-email)
+         customer-id (.getId customer)]
+     (sql/execute-one! conn
+                       ["INSERT INTO instant_stripe_customers (id, org_id) VALUES (?, ?::uuid)
+                        ON CONFLICT (org_id) DO NOTHING RETURNING *"
+                        customer-id (:id org)]))))
+
 (defn- get-by-instant-user-id
   "Get a stripe customer information by instant user id."
   ([params] (get-by-instant-user-id (aurora/conn-pool :read) params))
@@ -29,9 +44,24 @@
                    ["SELECT * FROM instant_stripe_customers WHERE user_id = ?::uuid"
                     user-id])))
 
-(defn get-or-create!
+(defn- get-by-org-id
+  ([params] (get-by-org-id (aurora/conn-pool :read) params))
+  ([conn {:keys [org-id]}]
+   (sql/select-one conn
+                   ["select * from instant_stripe_customers where org_id = ?::uuid"
+                    org-id])))
+
+(defn get-or-create-for-user!
   "Get or create a stripe customer from an instant user."
-  ([params] (get-or-create! (aurora/conn-pool :write) params))
+  ([params] (get-or-create-for-user! (aurora/conn-pool :write) params))
   ([conn {:keys [user]}]
    (or (get-by-instant-user-id conn {:user-id (:id user)})
-       (create! conn {:user user}))))
+       (create-for-user! conn {:user user}))))
+
+(defn get-or-create-for-org!
+  "Get or create a stripe customer from an instant user."
+  ([params] (get-or-create-for-org! (aurora/conn-pool :write) params))
+  ([conn {:keys [org user-email]}]
+   (or (get-by-org-id conn {:org-id (:id org)})
+       (create-for-org! conn {:org org
+                              :user-email user-email}))))

--- a/server/src/instant/model/instant_subscription.clj
+++ b/server/src/instant/model/instant_subscription.clj
@@ -11,20 +11,29 @@
                            :values [{:id :?id
                                      :user-id [:cast :?user-id :uuid]
                                      :app-id [:cast :?app-id :uuid]
+                                     :org-id [:cast :?org-id :uuid]
                                      :subscription-type-id :?subscription-type-id
                                      :stripe-customer-id :?stripe-customer-id
                                      :stripe-subscription-id :?stripe-subscription-id
                                      :stripe-event-id :?stripe-event-id}]
                            :returning :*}]
+           ;; Will update either the app or org, depending on whether
+           ;; app-id or org-id is provided.
+           ;; There is a constraint on the subscription that prevents
+           ;; adding both
            [:app-update {:update :apps
                          :set {:subscription-id :?id}
-                         :where [:= :id :?app-id]}]]
+                         :where [:= :id :?app-id]}]
+           [:org-update {:update :orgs
+                         :set {:subscription-id :?id}
+                         :where [:= :id :?org-id]}]]
     :select :*
     :from :subscription}))
 
 (defn create!
+  "Creates a subscription on either an app or an org. Pass one of org-id or app-id."
   ([params] (create! (aurora/conn-pool :write) params))
-  ([conn {:keys [user-id app-id subscription-type-id
+  ([conn {:keys [user-id org-id app-id subscription-type-id
                  stripe-customer-id stripe-subscription-id stripe-event-id]}]
    (app-model/with-cache-invalidation app-id
      (sql/execute-one! ::create!
@@ -33,6 +42,7 @@
                                       {:id (random-uuid)
                                        :user-id user-id
                                        :app-id app-id
+                                       :org-id org-id
                                        :subscription-type-id subscription-type-id
                                        :stripe-customer-id stripe-customer-id
                                        :stripe-subscription-id stripe-subscription-id
@@ -41,14 +51,16 @@
 (defn get-by-event-id
   ([params] (get-by-event-id (aurora/conn-pool :read) params))
   ([conn {:keys [event-id]}]
-   (sql/select-one conn
+   (sql/select-one ::get-by-event-id
+                   conn
                    ["SELECT * FROM instant_subscriptions WHERE stripe_event_id = ?"
                     event-id])))
 
 (defn get-by-app-id
   ([params] (get-by-app-id (aurora/conn-pool :read) params))
   ([conn {:keys [app-id]}]
-   (sql/select-one conn
+   (sql/select-one ::get-by-app-id
+                   conn
                    ["SELECT s.id, s.app_id, s.stripe_subscription_id, t.name
                     FROM instant_subscriptions s
                     JOIN instant_subscription_types t on s.subscription_type_id = t.id
@@ -56,6 +68,20 @@
                     ORDER BY s.created_at DESC
                     LIMIT 1"
                     app-id])))
+
+(def get-by-org-id-q
+  (uhsql/preformat {:select [:s.id :s.org_id :s.stripe_subscription_id, :t.name]
+                    :from :orgs
+                    :join [[:instant_subscriptions :s] [:= :s.id :orgs.subscription_id]
+                           [:instant_subscription_types :t] [:= :s.subscription_type_id :t.id]]
+                    :where [:= :orgs.id :?org-id]}))
+
+(defn get-by-org-id
+  ([params] (get-by-org-id (aurora/conn-pool :read) params))
+  ([conn {:keys [org-id]}]
+   (sql/select-one ::get-by-org-id
+                   conn
+                   (uhsql/formatp get-by-org-id-q {:org-id org-id}))))
 
 (comment
   (get-by-app-id {:app-id "b40b42d5-d857-431b-90f5-f0cf36b146dd"}))

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -21,7 +21,7 @@
 (defn get-by-id!
   ([params] (get-by-id! (aurora/conn-pool :read) params))
   ([conn {:keys [id]}]
-   (ex/assert-record! (get-by-id {:id id})
+   (ex/assert-record! (get-by-id conn {:id id})
                       :org
                       {:args [{:id id}]})))
 

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -11,20 +11,31 @@
                     :from :orgs
                     :where [:= :id :?id]}))
 
-(defn get-by-id!
-  ([params] (get-by-id! (aurora/conn-pool :read) params))
+(defn get-by-id
+  ([params] (get-by-id (aurora/conn-pool :read) params))
   ([conn {:keys [id]}]
    (let [params {:id id}
          query (uhsql/formatp by-id-q params)]
-     (ex/assert-record! (sql/select-one ::get-by-id conn query)
-                        :org
-                        {:args [{:id id}]}))))
+     (sql/select-one ::get-by-id conn query))))
+
+(defn get-by-id!
+  ([params] (get-by-id! (aurora/conn-pool :read) params))
+  ([conn {:keys [id]}]
+   (ex/assert-record! (get-by-id {:id id})
+                      :org
+                      {:args [{:id id}]})))
 
 (def all-for-user-q
-  (uhsql/preformat {:select [:o.id :o.title :o.created-at :o.updated-at :m.role]
+  (uhsql/preformat {:select [:o.id
+                             :o.title
+                             :o.created-at
+                             :o.updated-at
+                             :m.role
+                             [[:coalesce [:= :3 :s.subscription_type_id] false] :paid]]
                     :from [[:orgs :o]]
                     :join [[:org-members :m] [:and
                                               [:= :m.org_id :o.id]]]
+                    :left-join [[:instant-subscriptions :s] [:= :o.subscription-id :s.id]]
                     :where [:= :m.user-id :?user-id]}))
 
 (defn get-all-for-user
@@ -96,9 +107,15 @@
 
 
 (def org-for-user-q
-  (uhsql/preformat {:select [:o.id :o.title :o.created-at :o.updated-at :m.role]
+  (uhsql/preformat {:select [:o.id
+                             :o.title
+                             :o.created-at
+                             :o.updated-at
+                             :m.role
+                             [[:coalesce [:= :3 :s.subscription_type_id] false] :paid]]
                     :from [[:orgs :o]]
                     :join [[:org-members :m] [:= :o.id :m.org-id]]
+                    :left-join [[:instant-subscriptions :s] [:= :o.subscription-id :s.id]]
                     :where [:and
                             [:= :m.user-id :?user-id]
                             [:= :o.id :?org-id]]}))

--- a/server/src/instant/stripe.clj
+++ b/server/src/instant/stripe.clj
@@ -118,7 +118,6 @@
                                                              ;; TODO(orgs): remove when backend
                                                              ;;             is fully deployed
                                                              PRO_SUBSCRIPTION_TYPE))]
-            (tool/def-locals)
             (instant-subscription-model/create! opts)
             (when (= :prod (config/get-env))
               (ping-js-on-new-customer {:user-id user-id
@@ -129,7 +128,6 @@
           "customer.subscription.deleted"
           (let [opts (assoc shared :subscription-type-id FREE_SUBSCRIPTION_TYPE)
                 {:keys [user-id app-id org-id]} opts]
-            (tool/def-locals)
             (when (and app-id (app-model/get-by-id {:id app-id}))
               (instant-subscription-model/create! opts))
             (when (and org-id (org-model/get-by-id  {:id org-id}))

--- a/server/test/instant/stripe_test.clj
+++ b/server/test/instant/stripe_test.clj
@@ -3,8 +3,6 @@
    [clojure.test :as test :refer [deftest is]]
    [instant.config :as config]
    [instant.fixtures :refer [with-empty-app with-org with-user]]
-   [instant.jdbc.aurora :as aurora]
-   [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
    [instant.model.instant-subscription :as instant-subscription-model]

--- a/server/test/instant/stripe_test.clj
+++ b/server/test/instant/stripe_test.clj
@@ -2,33 +2,56 @@
   (:require
    [clojure.test :as test :refer [deftest is]]
    [instant.config :as config]
-   [instant.fixtures :refer [with-empty-app]]
+   [instant.fixtures :refer [with-empty-app with-org with-user]]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
    [instant.model.instant-subscription :as instant-subscription-model]
+   [instant.model.org :as org-model]
    [instant.stripe :as stripe]))
 
-(defn event-data [{:keys [app-id user-id customer]}]
+(defn event-data [{:keys [app-id org-id user-id customer subscription-type-id]}]
   {:object {:customer customer,
             :subscription "sub_1P70xAL5BwOwpxgUX9Vepd6n",
-            :metadata {:app-id app-id,
-                       :user-id user-id}}})
+            :metadata {:app-id (str app-id)
+                       :user-id (str user-id)
+                       :org-id (str org-id)
+                       :subscription-type-id (str subscription-type-id)}}})
 
 (defn with-stripe-customer [f]
   (when (config/stripe-secret)
     (with-empty-app
       (fn [{app-id :id creator-id :creator_id}]
         (stripe/init)
-        (let [customer (instant-stripe-customer-model/get-or-create! {:user {:id creator-id}})
+        (let [customer (instant-stripe-customer-model/get-or-create-for-user! {:user {:id creator-id}})
               customer-id (:id customer)]
           (f (event-data {:app-id app-id
                           :user-id creator-id
-                          :customer customer-id})))))))
+                          :customer customer-id
+                          :subscription-type-id stripe/PRO_SUBSCRIPTION_TYPE})))))))
+
+(defn with-stripe-org-customer [f]
+  (when (config/stripe-secret)
+    (with-user
+      (fn [u]
+        (with-org
+          (:id u)
+          (fn [org]
+            (stripe/init)
+            (let [customer (instant-stripe-customer-model/get-or-create-for-org!
+                            {:org org
+                             :user-email (:email u)})
+                  customer-id (:id customer)]
+              (f (event-data {:org-id (:id org)
+                              :user-id (:id u)
+                              :customer customer-id
+                              :subscription-type-id stripe/STARTUP_SUBSCRIPTION_TYPE})))))))))
 
 (deftest handle-stripe-events
   (with-stripe-customer
     (fn [data]
-      (let [{:keys [app-id]} (-> data :object :metadata)
+      (let [app-id (-> data :object :metadata :app-id parse-uuid)
             upgrade-event {:type "checkout.session.completed"
                            :id "evt_upgrade"
                            :data data}
@@ -57,5 +80,38 @@
         (stripe/handle-stripe-webhook-event upgrade-event)
         (is (= "Free"
                (:name (instant-subscription-model/get-by-app-id {:app-id app-id}))))))))
+
+(deftest handle-stripe-events-for-org
+  (with-stripe-org-customer
+    (fn [data]
+      (let [org-id (-> data :object :metadata :org-id parse-uuid)
+            upgrade-event {:type "checkout.session.completed"
+                           :id "evt_upgrade"
+                           :data data}
+            downgrade-event {:type "customer.subscription.deleted"
+                             :id "evt_downgrade"
+                             :data data}]
+
+        ;; No subscription exists at first
+        (is (nil? (instant-subscription-model/get-by-org-id {:org-id org-id})))
+
+        ;; Subscription is created
+        (stripe/handle-stripe-webhook-event upgrade-event)
+        (let [sub (instant-subscription-model/get-by-org-id {:org-id org-id})]
+          (is (= "Startup" (:name sub)))
+          (is (= (:id sub)
+                 (:subscription_id (org-model/get-by-id! {:id org-id})))))
+
+        ;; Subscription is downgraded
+        (stripe/handle-stripe-webhook-event downgrade-event)
+        (let [sub (instant-subscription-model/get-by-org-id {:org-id org-id})]
+          (is (= "Free" (:name sub)))
+          (is (= (:id sub)
+                 (:subscription_id (org-model/get-by-id! {:id org-id})))))
+
+        ;; Re-processing the upgrade event should not create a new subscription
+        (stripe/handle-stripe-webhook-event upgrade-event)
+        (is (= "Free"
+               (:name (instant-subscription-model/get-by-org-id {:org-id org-id}))))))))
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Adds subscriptions for orgs that closely match the structure of subscriptions for apps.

We reuse the same `instant_subscriptions` and `instant_stripe_customers` tables. Each table has a new `org_id` column and a constraint that ensures they have exactly one of `app_id` or `org_id` (sub `user_id` for `app_id` in the stripe_customers table).

We tie the stripe customer to an org instead of a user so that if a user leaves the org, we don't lose billing for the org. I added a billing_email field to the orgs table so that users could set a generic email (e.g. billing@) (no route for updating that yet). 