### PR TITLE
[bugfix] w/stringify-keys for rules-code

### DIFF
--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -107,7 +107,7 @@
   (let [{user-id :id} (req->superadmin-user! :apps/write req)
         title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         schema (get-in req [:body :schema])
-        rules-code (get-in req [:body :perms])
+        rules-code (ex/get-optional-param! req [:body :perms] w/stringify-keys)
         _ (when rules-code
             (ex/assert-valid! :perms rules-code (rule-model/validation-errors
                                                  rules-code)))


### PR DESCRIPTION
Right now when we check for validation-errors on `rules`, we expect the json to have string keys. But the server automatically keywordizes keys. 

In our original endpoint we used `ex/get-param!` with w/stringify-keys to get around this issue. 

I went ahead and updated our remaining endpoints to do the same. 

**Considerations for the future**

This feels a _bit_ brittle. Right now we always have to remember to do three things when getting rules: 1. stringify, 2. validate, 3. save. Maybe we can create one function that does this. I skipped past this for now, as no clean solution came to mind. 

@dwwoelfel @nezaj @tonsky @drew-harris 

