### PR TITLE
[conc] set limit to 20

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "turbo run build --cache-dir=.turbo --no-update-notifier",
-    "dev": "turbo run dev --filter=!@instantdb/mcp --parallel --no-update-notifier",
+    "dev": "turbo run dev --filter=!@instantdb/mcp --parallel --concurrency=20 --no-update-notifier",
     "test": "turbo run test:ci --no-update-notifier",
     "bench": "turbo run bench:ci --no-update-notifier",
     "format": "prettier --write --ignore-path .prettierignore --ignore-path ../.gitignore --config ./.prettierrc \"**/*.{ts,tsx,js,jsx,json,md}\"",


### PR DESCRIPTION
Our tasks were often getting stuck in dev. Adding --concurrency=20 _seems_ to fix it.

See: https://github.com/vercel/turborepo/issues/7924#issuecomment-2129262139

By default turbo has a concurrency limit of 10. When the `parallel` flag is turned on, theoretically the `concurrency` option is ignored. But as this user has reported, that is not the case. 

Aside: 
We may want to remove some of our dev tasks -- i.e the nuxt template, et al.

@drew-harris @dwwoelfel @nezaj @tonsky 