### PR TITLE
[order] support optimistic updates for `order: desc`

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -887,7 +887,7 @@ test('pagination first', () => {
   expect(books.length).toEqual(10);
 });
 
-test('Pagination order:desc without offsets work with optimistic updates', () => {
+test('Leading queries should ignore the start cursor', () => {
   function storeWithUpdatedNicole() {
     const chunk = tx.users[lookup('handle', 'nicolegf')].update({
       createdAt: '2025-09-05 18:53:07.993689',
@@ -909,7 +909,7 @@ test('Pagination order:desc without offsets work with optimistic updates', () =>
     return transact(store, txSteps);
   }
 
-  // Existing pageInfo from server: starts at Nicole, ends at Alex
+  // Existing pageInfo from server: starts at Nicole (2021-02-05), ends at Alex (2021-01-09)
   const pageInfo = {
     users: {
       'start-cursor': [
@@ -941,8 +941,9 @@ test('Pagination order:desc without offsets work with optimistic updates', () =>
   ).data.users.map((x) => x.handle);
   expect(existingUsers).toEqual(['nicolegf', 'alex']);
 
-  // Let's update Nicole's createdAt to be later. She should _still_ show up, even though the cursor
-  // says otherwise
+  // Let's update Nicole's createdAt to be later.
+  // She should _still_ show up,
+  // even though the cursor says otherwise
   const usersWithUpdatedNicole = query(
     { store: storeWithUpdatedNicole(), pageInfo },
     {
@@ -958,7 +959,9 @@ test('Pagination order:desc without offsets work with optimistic updates', () =>
   ).data.users.map((x) => x.handle);
   expect(usersWithUpdatedNicole).toEqual(['nicolegf', 'alex']);
 
-  // Let's add Bob. Bob _should_ show up, since we don't have any offsets on this query
+  // Let's add Bob.
+  // Bob _should_ show up,
+  // even though the cursor says otherwise
   const usersWithBob = query(
     { store: storeWithBob(), pageInfo },
     {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -530,7 +530,6 @@ export default class Reactor {
             processedTxId,
           );
           const pageInfo = result?.[0]?.data?.['page-info'];
-          debugger;
           const aggregate = result?.[0]?.data?.['aggregate'];
           return { hash, store: newStore, pageInfo, aggregate };
         });

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -529,8 +529,8 @@ export default class Reactor {
             mutations,
             processedTxId,
           );
-
           const pageInfo = result?.[0]?.data?.['page-info'];
+          debugger;
           const aggregate = result?.[0]?.data?.['aggregate'];
           return { hash, store: newStore, pageInfo, aggregate };
         });

--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -578,10 +578,8 @@ function objectAttrs(store, etype, dq) {
   return attrs;
 }
 
-function runDataloadAndReturnObjects(
-  store,
-  { etype, pageInfo, order, dq, form },
-) {
+function runDataloadAndReturnObjects(store, { etype, pageInfo, dq, form }) {
+  const order = form?.$?.order;
   const isLeadingQuery = isLeading(form);
   const direction = determineDirection(form);
 
@@ -623,7 +621,7 @@ function runDataloadAndReturnObjects(
       continue;
     }
     if (
-      !isLeading(form) &&
+      !isLeadingQuery &&
       startCursor &&
       orderAttr &&
       isBefore(startCursor, orderAttr, direction, idVec)

--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -646,6 +646,11 @@ function determineDirection(form) {
   return orderOpts[Object.keys(orderOpts)[0]] || 'asc';
 }
 
+/**
+ * A "leading" query has no `offset`, `before`, or `after`
+ *
+ * It is at the 'beginning' of the order
+ */
 function isLeading(form) {
   const offset = form.$?.offset;
   const before = form.$?.before;

--- a/client/packages/core/src/instaql.js
+++ b/client/packages/core/src/instaql.js
@@ -580,12 +580,11 @@ function objectAttrs(store, etype, dq) {
 
 function runDataloadAndReturnObjects(
   store,
-  etype,
-  direction,
-  pageInfo,
-  order,
-  dq,
+  { etype, pageInfo, order, dq, form },
 ) {
+  const isLeadingQuery = isLeading(form);
+  const direction = determineDirection(form);
+
   let idVecs = datalogQuery(store, dq);
 
   const startCursor = pageInfo?.['start-cursor'];
@@ -624,6 +623,7 @@ function runDataloadAndReturnObjects(
       continue;
     }
     if (
+      !isLeading(form) &&
       startCursor &&
       orderAttr &&
       isBefore(startCursor, orderAttr, direction, idVec)
@@ -639,13 +639,20 @@ function runDataloadAndReturnObjects(
   return objects;
 }
 
-function determineOrder(form) {
+function determineDirection(form) {
   const orderOpts = form.$?.order;
   if (!orderOpts) {
     return 'asc';
   }
 
   return orderOpts[Object.keys(orderOpts)[0]] || 'asc';
+}
+
+function isLeading(form) {
+  const offset = form.$?.offset;
+  const before = form.$?.before;
+  const after = form.$?.after;
+  return !offset && !before && !after;
 }
 
 /**
@@ -662,30 +669,23 @@ function determineOrder(form) {
  * and reduce all the triples into objects.
  */
 function resolveObjects(store, { etype, level, form, join, pageInfo }) {
-  const limit = form.$?.limit || form.$?.first || form.$?.last;
-  const offset = form.$?.offset;
-  const before = form.$?.before;
-  const after = form.$?.after;
-  const order = form.$?.order;
-  const fields = form.$?.fields;
-
   // Wait for server to tell us where we start if we don't start from the beginning
-  if ((offset || before || after) && (!pageInfo || !pageInfo['start-cursor'])) {
+  if (!isLeading(form) && (!pageInfo || !pageInfo['start-cursor'])) {
     return [];
   }
+
   const where = withJoin(makeWhere(store, etype, level, form.$?.where), join);
-
   const find = makeFind(makeVarImpl, etype, level);
+  const fields = form.$?.fields;
 
-  const objs = runDataloadAndReturnObjects(
-    store,
+  const objs = runDataloadAndReturnObjects(store, {
     etype,
-    determineOrder(form),
     pageInfo,
-    order,
-    { where, find, fields },
-  );
+    form,
+    dq: { where, find, fields },
+  });
 
+  const limit = form.$?.limit || form.$?.first || form.$?.last;
   if (limit != null) {
     const entries = Object.entries(objs);
     if (entries.length <= limit) {
@@ -693,6 +693,7 @@ function resolveObjects(store, { etype, level, form, join, pageInfo }) {
     }
     return Object.fromEntries(entries.slice(0, limit));
   }
+
   return objs;
 }
 

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.12';
+const version = 'v0.21.13';
 
 export { version };


### PR DESCRIPTION
## Context

Consider a table `docs` with `title` and `updatedAt`

```js
{ docs: { $: { order: { updatedAt: 'desc' } } } }
```

Say this returns the following docs:

```js
{ id: doc2id, title: Doc 2, updatedAt: 2 }
{ id: doc1id, title: Doc 1, updatedAt: 1 }
```

The `pageInfo` in this case would be: 

```js
{ 'start-cursor': [doc2id, updatedAtAttrId, 2, ts] }
```

## Problems

We have two problems here: 

### 1) Failed optimistic update for doc3

Imagine if the user adds `Doc 3, updatedAt: 3`

The user would expect Doc 3 to show up right away. **However, right now Doc3 would get filtered out.** 

Why?

Because `pageInfo` still says `[doc2id, updatedAt, 2]`

And in this case updatedAt: 3 would fall out of bounds for this pageInfo. Look at [isBefore](https://github.com/instantdb/instant/blob/main/client/packages/core/src/instaql.js#L533):

```js
updatedAt 3 > updatedAt 2 // therefore it is 'before' this start cursor
```

### 2) Flickering UI for an update to doc2

Now consider what happens if you change the `updatedAt` for doc2

The user would expect Doc2 to have a new updatedAt. 

However, right now Doc2 would get filtered out

Why?

This is for the same reason as our first problem. Doc2 would get an optimistic update, and “fall out” of the cursor.

## Root Cause

The problem is that though our result set changes with optimistic updates, our cursors are static -- we wait for the server to tell us about the cursors.

## Solution

We can use the fact that this is a 'leading' query to our advantage. The query is "at the beginning" of it's search. So if we get any value that 'fits' in the beginning, then we can safely apply the optimistic update

## Future work

Imagine two simultaneous queries: `Query 1: offset: 0, limit: 10` `Query 2: offset: 10, limit: 10`

We can get an optimistic update on Query 1, but we can't for Query 2 (it is not leading). 

However, since we _do_ have the dataset needed on the client, technically we _could_ make optimistic updates work. We would need to be much smarter about tracking than we are right now though. Likely it would require something more similar to Single Store.

--- 

@dwwoelfel @nezaj @tonsky @drew-harris 