### PR TITLE
Allow access to app through org's role

### DIFF
--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -289,7 +289,10 @@
                     (fn [org]
                       (with-empty-app
                         (fn [app]
-                          (let [stripe-customer (instant-stripe-customer-model/get-or-create-for-org! {:org org})
+                          (let [stripe-customer (sql/execute-one! (aurora/conn-pool :write)
+                                                                  ["insert into instant_stripe_customers (id, org_id) values (?::text, ?::uuid) returning *"
+                                                                   (str "test_" (crypt-util/random-hex 8))
+                                                                   (:id org)])
                                 subscription (instant-subscription-model/create! {:user-id (:id owner)
                                                                                   :org-id (:id org)
                                                                                   :subscription-type-id stripe/STARTUP_SUBSCRIPTION_TYPE

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -16,8 +16,9 @@
             [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
             [instant.model.member-invites :as member-invites]
             [instant.model.org :as org-model]
+            [instant.model.org-members :as instant-org-members]
             [instant.model.rule :as rule-model]
-            [instant.stripe :refer [PRO_SUBSCRIPTION_TYPE]]
+            [instant.stripe :as stripe :refer [PRO_SUBSCRIPTION_TYPE]]
             [instant.db.pg-introspect :as pg-introspect]
             [instant.jdbc.sql :as sql]
             [instant.jdbc.aurora :as aurora]
@@ -273,3 +274,43 @@
         (app-model/delete-immediately-by-id! {:id app-id})
         (instant-app-members/delete-by-id! {:id (:id member)})
         (member-invites/delete-by-id! {:id (:id invite)})))))
+
+(defn with-startup-org [f]
+  (with-user
+    (fn [owner]
+      (with-user
+        (fn [collaborator]
+          (with-user
+            (fn [admin]
+              (with-user
+                (fn [outside-user]
+                  (with-org
+                    (:id owner)
+                    (fn [org]
+                      (with-empty-app
+                        (fn [app]
+                          (let [stripe-customer (instant-stripe-customer-model/get-or-create-for-org! {:org org})
+                                subscription (instant-subscription-model/create! {:user-id (:id owner)
+                                                                                  :org-id (:id org)
+                                                                                  :subscription-type-id stripe/STARTUP_SUBSCRIPTION_TYPE
+                                                                                  :stripe-customer-id (:id stripe-customer)
+                                                                                  :stripe-subscription-id (str "fake_sub_" (random-uuid))
+                                                                                  :stripe-event-id (str "fake_evt_" (random-uuid))})]
+                            (sql/do-execute! (aurora/conn-pool :write) ["update apps set org_id = ?::uuid where id = ?::uuid"
+                                                                        (:id org)
+                                                                        (:id app)])
+                            (sql/do-execute! (aurora/conn-pool :write) ["update orgs set subscription_id = ?::uuid where id = ?::uuid"
+                                                                        (:id subscription)
+                                                                        (:id org)])
+                            (instant-org-members/create! {:org-id (:id org)
+                                                          :user-id (:id collaborator)
+                                                          :role "collaborator"})
+                            (instant-org-members/create! {:org-id (:id org)
+                                                          :user-id (:id admin)
+                                                          :role "admin"}))
+                          (f {:app app
+                              :org org
+                              :owner owner
+                              :collaborator collaborator
+                              :admin admin
+                              :outside-user outside-user}))))))))))))))

--- a/server/src/instant/model/instant_subscription.clj
+++ b/server/src/instant/model/instant_subscription.clj
@@ -61,7 +61,7 @@
   ([conn {:keys [app-id]}]
    (sql/select-one ::get-by-app-id
                    conn
-                   ["SELECT s.id, s.app_id, s.stripe_subscription_id, t.name
+                   ["SELECT s.id, s.app_id, s.stripe_subscription_id, t.name, s.subscription_type_id
                     FROM instant_subscriptions s
                     JOIN instant_subscription_types t on s.subscription_type_id = t.id
                     WHERE s.app_id = ?::uuid
@@ -70,7 +70,11 @@
                     app-id])))
 
 (def get-by-org-id-q
-  (uhsql/preformat {:select [:s.id :s.org_id :s.stripe_subscription_id, :t.name]
+  (uhsql/preformat {:select [:s.id
+                             :s.org_id
+                             :s.stripe_subscription_id
+                             :t.name
+                             :s.subscription_type_id]
                     :from :orgs
                     :join [[:instant_subscriptions :s] [:= :s.id :orgs.subscription_id]
                            [:instant_subscription_types :t] [:= :s.subscription_type_id :t.id]]

--- a/server/src/instant/model/org_members.clj
+++ b/server/src/instant/model/org_members.clj
@@ -23,3 +23,10 @@
                        WHERE id = ?::uuid"
                       role
                       id])))
+
+(defn get-by-org-and-user
+  ([params] (get-by-org-and-user (aurora/conn-pool :read) params))
+  ([conn {:keys [org-id user-id]}]
+   (sql/select-one conn
+                   ["SELECT * FROM org_members WHERE org_id = ?::uuid AND user_id = ?::uuid"
+                    org-id user-id])))

--- a/server/src/instant/oauth_apps/routes.clj
+++ b/server/src/instant/oauth_apps/routes.clj
@@ -4,7 +4,7 @@
             [hiccup2.core :as h]
             [instant.auth.oauth :refer [verify-pkce!]]
             [instant.config :as config]
-            [instant.dash.routes :refer [get-member-role req->auth-user!]]
+            [instant.dash.routes :refer [get-app-member-role get-org-member-role req->auth-user!]]
             [instant.model.app :as app-model]
             [instant.model.oauth-app :as oauth-app-model]
             [instant.runtime.routes :refer [format-cookie parse-cookie]]
@@ -230,8 +230,9 @@
                          (= "localhost" (:host (uri/parse (:redirect_uri redirect)))))
                      (not (app-model/get-by-id-and-creator {:app-id (:app_id oauth-app)
                                                             :user-id (:id user)}))
-                     (not (get-member-role (:app_id oauth-app)
-                                           (:id user))))
+                     (let [app (app-model/get-by-id! {:id (:app_id oauth-app)})]
+                       (not (or (get-app-member-role app (:id user))
+                                (get-org-member-role app (:id user))))))
             (oauth-app-model/deny-redirect! {:redirect-id redirect-id})
             (ex/throw+ {::ex/type ::ex/permission-denied
                         ::ex/message

--- a/server/src/instant/stripe.clj
+++ b/server/src/instant/stripe.clj
@@ -26,6 +26,10 @@
 (defn pro-plan? [{:keys [name]}]
   (= name "Pro"))
 
+(defn plan-supports-members? [{:keys [subscription_type_id]}]
+  (or (= subscription_type_id PRO_SUBSCRIPTION_TYPE)
+      (= subscription_type_id STARTUP_SUBSCRIPTION_TYPE)))
+
 (defn ping-js-on-new-customer [{:keys [user-id org-id app-id]}]
   (let [{email :email} (instant-user-model/get-by-id {:id user-id})
         title (cond app-id

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -295,6 +295,11 @@
                                                 :hint cause-message}))}
             e)))
 
+(defn throw-insufficient-plan! [{:keys [capability]}]
+  (throw+ {::type ::permission-denied
+           ::message (format "The plan for your app or organization does not support %s."
+                             capability)}))
+
 ;; -----------
 ;; Validations
 

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -397,7 +397,7 @@
 
 (deftest app-access-works-through-orgs
   (with-startup-org
-    (fn [{:keys [app org owner collaborator admin outside-user]}]
+    (fn [{:keys [app owner collaborator admin outside-user]}]
       ;; Check a path available to all members of the app
       (let [auth-path (format "%s/dash/apps/%s/auth" config/server-origin (:id app))]
         (doseq [{:keys [user expected type]} [{:type "owner"

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -3,10 +3,11 @@
    [clj-http.client :as http]
    [clojure.test :refer [deftest is testing]]
    [instant.config :as config]
-   [instant.fixtures :refer [random-email with-empty-app with-org with-user]]
+   [instant.fixtures :refer [random-email with-empty-app with-org with-user with-startup-org]]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
-   [instant.util.json :refer [->json]]))
+   [instant.util.json :refer [->json]]
+   [instant.dash.routes :as route]))
 
 (deftest app-invites-work
   (with-redefs [config/postmark-send-enabled? (constantly false)]
@@ -393,3 +394,87 @@
 
                     (is (not member))
                     (is (= "revoked" (:status invite)))))))))))))
+
+(deftest app-access-works-through-orgs
+  (with-startup-org
+    (fn [{:keys [app org owner collaborator admin outside-user]}]
+      ;; Check a path available to all members of the app
+      (let [auth-path (format "%s/dash/apps/%s/auth" config/server-origin (:id app))]
+        (doseq [{:keys [user expected type]} [{:type "owner"
+                                               :user owner
+                                               :expected 200}
+                                              {:type "collaborator"
+                                               :user collaborator
+                                               :expected 200}
+                                              {:type "admin"
+                                               :user admin
+                                               :expected 200}
+                                              {:type "outside-user"
+                                               :user outside-user
+                                               :expected 400}]]
+          (testing type
+            (is (= expected (:status (http/get auth-path
+                                               {:throw-exceptions false
+                                                :headers {:Authorization (str "Bearer " (:refresh-token user))
+                                                          :Content-Type "application/json"}
+                                                :as :json})))))))
+
+      (testing "req->app-and-user!"
+        (doseq [{:keys [user expected type role]} [{:type "owner"
+                                                    :user owner
+                                                    :role :owner
+                                                    :expected :ok}
+                                                   {:type "owner"
+                                                    :user owner
+                                                    :role :admin
+                                                    :expected :ok}
+                                                   {:type "owner"
+                                                    :user owner
+                                                    :role :collaborator
+                                                    :expected :ok}
+
+                                                   {:type "collaborator"
+                                                    :user collaborator
+                                                    :role :owner
+                                                    :expected :error}
+                                                   {:type "collaborator"
+                                                    :user collaborator
+                                                    :role :admin
+                                                    :expected :error}
+                                                   {:type "collaborator"
+                                                    :user collaborator
+                                                    :role :collaborator
+                                                    :expected :ok}
+
+                                                   {:type "admin"
+                                                    :user admin
+                                                    :role :owner
+                                                    :expected :error}
+                                                   {:type "admin"
+                                                    :user admin
+                                                    :role :admin
+                                                    :expected :ok}
+                                                   {:type "admin"
+                                                    :user admin
+                                                    :role :collaborator
+                                                    :expected :ok}
+
+                                                   {:type "outside-user"
+                                                    :user outside-user
+                                                    :role :owner
+                                                    :expected :error}
+                                                   {:type "outside-user"
+                                                    :user outside-user
+                                                    :role :admin
+                                                    :expected :error}
+                                                   {:type "outside-user"
+                                                    :user outside-user
+                                                    :role :collaborator
+                                                    :expected :error}]]
+          (testing (format "%s with role %s" type role)
+            (let [req {:params {:app_id (:id app)}
+                       :headers {"authorization" (str "Bearer " (:refresh-token user))}}]
+              (case expected
+                :ok (is (= (:id app)
+                           (:id (:app (route/req->app-and-user! role req)))))
+                :error (is (thrown? Exception (route/req->app-and-user! role req)))))))))))

--- a/server/test/instant/test_core.clj
+++ b/server/test/instant/test_core.clj
@@ -8,6 +8,7 @@
    [instant.core :as core]
    [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
+   [instant.stripe :as stripe]
    [instant.system-catalog-migration :as system-catalog-migration]
    [instant.util.crypt :as crypt-util]
    [instant.util.tracer :as tracer]))
@@ -22,6 +23,7 @@
   (aurora/start)
   (core/start)
   (system-catalog-migration/ensure-attrs-on-system-catalog-app)
+  (stripe/init)
   (let [results (test-suite-fn)]
     (aurora/stop)
     (core/stop)


### PR DESCRIPTION
Updates the dash routes to allow access to an app through access to the org. For example, if you have the `:owner` role on the org, then you'll pass checks for the `:owner` role on the app.

It's a little complicated because you might have access to the app through the org or you might be added to the app itself.