### PR TITLE
Use attr_sketch pg_triple_size to calculate db size

### DIFF
--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -379,7 +379,7 @@
 
   Usage is comprised of both raw data and overhead data (indexes, toast tables, etc.).
 
-  sum(pg_column_size(t)) calculates the total data size for the specified app_id.
+  sum(pg_triples_size) calculates the total data size for the specified app_id.
   pg_total_relation_size('triples') / pg_relation_size('triples') calculates
   the ratio of the total table size to the actual data size. This ratio
   represents the overhead factor.

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -392,12 +392,12 @@
     ::app-usage
     conn
     ["SELECT
-     (sum(pg_column_size(t)) *
+     (sum(s.triples_pg_size) *
         CASE
             WHEN pg_relation_size('triples') = 0 THEN 1
             ELSE pg_total_relation_size('triples') / pg_relation_size('triples')
         END) as num_bytes
-     FROM triples t WHERE t.app_id = ?::uuid" app-id])))
+     FROM attr_sketches s WHERE s.app_id = ?::uuid" app-id])))
 
 (defn decrypt-connection-string [app-id encrypted-connection-string]
   (-> (crypt-util/aead-decrypt {:ciphertext encrypted-connection-string


### PR DESCRIPTION
This PR is fully deployed, so we can start using the new fields: https://github.com/instantdb/instant/pull/1634

Calculates db_size with the new pg_triple_size on attr sketches, which is much faster for apps with lots of tripes.

Tested that the sizes match up and confirmed that pg_size is working properly with `select * from triples where pg_size <> pg_column_size(triples)` (returns 0 results).

