### PR TITLE
Return org owner as creator for org apps

### DIFF
--- a/server/resources/migrations/86_at_least_one_owner_on_org.down.sql
+++ b/server/resources/migrations/86_at_least_one_owner_on_org.down.sql
@@ -1,0 +1,5 @@
+drop trigger org_members_after_delete_trigger on org_members;
+drop trigger org_members_after_update_trigger on org_members;
+
+drop function org_members_after_delete_trigger;
+drop function org_members_after_update_trigger;

--- a/server/resources/migrations/86_at_least_one_owner_on_org.up.sql
+++ b/server/resources/migrations/86_at_least_one_owner_on_org.up.sql
@@ -1,0 +1,84 @@
+create or replace function org_members_after_update_trigger()
+returns trigger as $$
+declare
+  org_id uuid;
+  owner_member_id uuid;
+begin
+  -- prevent removing the last owner
+  if old.role <> 'owner' or new.role = 'owner' then
+    return new;
+  end if;
+
+  if old.org_id <> new.org_id then
+    raise exception 'modify_org_id_on_org_member';
+  end if;
+
+  select orgs.id into org_id
+    from orgs
+   where orgs.id = new.org_id;
+
+  -- Skip the check if the org was deleted.
+  if org_id is null then
+    return new;
+  end if;
+
+  select m.id into owner_member_id
+    from org_members m
+   where m.org_id = new.org_id
+     and m.role = 'owner'
+   limit 1;
+
+  if owner_member_id is null then
+    raise exception 'remove_last_org_owner';
+  end if;
+
+  return new;
+
+end;
+$$ language plpgsql;
+
+create or replace function org_members_after_delete_trigger()
+returns trigger as $$
+declare
+  org_id uuid;
+  owner_member_id uuid;
+begin
+  -- prevent removing the last owner
+
+  if old.role <> 'owner' then
+    return old;
+  end if;
+
+  select orgs.id into org_id
+    from orgs
+   where orgs.id = old.org_id;
+
+  -- Skip the check if the org was deleted.
+  if org_id is null then
+    return new;
+  end if;
+
+  select m.id into owner_member_id
+    from org_members m
+   where m.org_id = old.org_id
+     and m.role = 'owner'
+   limit 1;
+
+  if owner_member_id is null then
+    raise exception 'remove_last_org_owner';
+  end if;
+
+  return old;
+
+end;
+$$ language plpgsql;
+
+create or replace trigger org_members_after_update_trigger
+  after update on org_members
+  for each row
+  execute function org_members_after_update_trigger();
+
+create or replace trigger org_members_after_delete_trigger
+  after delete on org_members
+  for each row
+  execute function org_members_after_delete_trigger();

--- a/server/resources/migrations/86_at_least_one_owner_on_org.up.sql
+++ b/server/resources/migrations/86_at_least_one_owner_on_org.up.sql
@@ -55,7 +55,7 @@ begin
 
   -- Skip the check if the org was deleted.
   if org_id is null then
-    return new;
+    return old;
   end if;
 
   select m.id into owner_member_id

--- a/server/src/instant/model/instant_user.clj
+++ b/server/src/instant/model/instant_user.clj
@@ -75,8 +75,17 @@
                     iu.*
                     FROM instant_users iu
                     JOIN apps a
-                    ON iu.id = a.creator_id
+                        ON iu.id = a.creator_id
+                        or iu.id = (select m.user_id
+                                      from org_members m
+                                      join orgs o on o.id = m.org_id
+                                      join apps a on o.id = a.org_id
+                                     where a.id = ?::uuid
+                                       and m.role = 'owner'
+                                  order by m.created_at asc
+                                     limit 1)
                     WHERE a.id = ?::uuid"
+                   app-id
                    app-id]))
 
 (defn get-by-app-id

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -605,11 +605,21 @@
         (default-psql-throw! e data hint))
 
       :raise-exception
-      (throw+ {::type ::sql-raise
-               ::message (format "Raised Exception: %s" server-message)
-               ::hint hint
-               ::pg-error-data data}
-              e)
+      (case server-message
+        "modify_org_id_on_org_member"
+        (throw+ {::type ::validation-failed
+                 ::message "Org members can not move between orgs."})
+
+        "remove_last_org_owner"
+        (throw+ {::type ::validation-failed
+                 ::message "There must be at least one member of the org that is an owner."})
+
+        #_else
+        (throw+ {::type ::sql-raise
+                 ::message (format "Raised Exception: %s" server-message)
+                 ::hint hint
+                 ::pg-error-data data}
+                e))
 
       (default-psql-throw! e data hint))))
 

--- a/server/test/instant/model/instant_user_test.clj
+++ b/server/test/instant/model/instant_user_test.clj
@@ -1,4 +1,4 @@
-(ns instant.model.instnat-user-test
+(ns instant.model.instant-user-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [instant.fixtures :refer [with-empty-app with-org with-user]]

--- a/server/test/instant/model/instant_user_test.clj
+++ b/server/test/instant/model/instant_user_test.clj
@@ -1,0 +1,29 @@
+(ns instant.model.instnat-user-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.fixtures :refer [with-empty-app with-org with-user]]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.model.instant-user :as instant-user]))
+
+(deftest get-by-app-id
+  (with-user
+    (fn [u]
+      (testing "works for apps with creators"
+        (with-empty-app
+          (:id u)
+          (fn [app]
+            (is (= (:id u)
+                   (:id (instant-user/get-by-app-id {:app-id (:id app)})))))))
+      (testing "works for apps on orgs"
+        (with-org
+          (:id u)
+          (fn [org]
+            (with-empty-app
+              (fn [app]
+                (sql/do-execute! (aurora/conn-pool :write)
+                                 ["update apps set creator_id = null, org_id = ?::uuid where id = ?::uuid"
+                                  (:id org)
+                                  (:id app)])
+                (is (= (:id u)
+                       (:id (instant-user/get-by-app-id {:app-id (:id app)}))))))))))))

--- a/server/test/instant/model/org_members_test.clj
+++ b/server/test/instant/model/org_members_test.clj
@@ -1,0 +1,33 @@
+(ns instant.model.org-member-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.fixtures :refer [with-org with-user]]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.model.org-members :as org-members]))
+
+(deftest cant-remove-last-owner
+  (with-user
+    (fn [u]
+      (with-org
+        (:id u)
+        (fn [org]
+          (tool/def-locals)
+          (println (sql/select (aurora/conn-pool :read)
+                               ["select * from org_members where org_id = ?::uuid" (:id org)]))
+          (let [member-id (:id (sql/select-one (aurora/conn-pool :read)
+                                               ["select id from org_members where org_id = ?::uuid" (:id org)]))]
+            (is member-id)
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"There must be at least one member of the org that is an owner"
+                                  (org-members/update-role {:role "admin"
+                                                            :id member-id})))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"There must be at least one member of the org that is an owner"
+                                  (sql/do-execute! (aurora/conn-pool :write)
+                                                   ["delete from org_members where org_id = ?::uuid" (:id org)])))
+
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"There must be at least one member of the org that is an owner"
+                                  (sql/do-execute! (aurora/conn-pool :write)
+                                                   ["delete from instant_users where id = ?::uuid" (:id u)])))))))))

--- a/server/test/instant/model/org_members_test.clj
+++ b/server/test/instant/model/org_members_test.clj
@@ -1,6 +1,6 @@
-(ns instant.model.org-member-test
+(ns instant.model.org-members-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is]]
    [instant.fixtures :refer [with-org with-user]]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]

--- a/server/test/instant/model/org_members_test.clj
+++ b/server/test/instant/model/org_members_test.clj
@@ -12,9 +12,6 @@
       (with-org
         (:id u)
         (fn [org]
-          (tool/def-locals)
-          (println (sql/select (aurora/conn-pool :read)
-                               ["select * from org_members where org_id = ?::uuid" (:id org)]))
           (let [member-id (:id (sql/select-one (aurora/conn-pool :read)
                                                ["select id from org_members where org_id = ?::uuid" (:id org)]))]
             (is member-id)


### PR DESCRIPTION
This PR does two things:

1. When we fetch the app's creator on an org app, we return the org's creator.
2. We prevent an org from removing its last owner.

We accomplish (2) with a trigger on org_members. It prevents deleting or updating the role on a member if the change would remove the last owner (unless the transaction also deletes the org).