### PR TITLE
Add `skipCascadePermissionCheck` rule for cascade delete operations

### DIFF
--- a/client/packages/core/src/rulesTypes.ts
+++ b/client/packages/core/src/rulesTypes.ts
@@ -6,6 +6,7 @@ type InstantRulesAttrsAllowBlock = {
   create?: string | null | undefined;
   update?: string | null | undefined;
   delete?: string | null | undefined;
+  skipCascadePermissionCheck?: string | null | undefined;
 };
 
 export type InstantRulesAllowBlock = InstantRulesAttrsAllowBlock & {

--- a/client/sandbox/react-nextjs/pages/play/cascade-permission-delete.tsx
+++ b/client/sandbox/react-nextjs/pages/play/cascade-permission-delete.tsx
@@ -1,0 +1,395 @@
+import React, { useState, useEffect } from 'react';
+import { i, id, InstantReactAbstractDatabase } from '@instantdb/react';
+import { provisionEphemeralApp } from '../../components/EphemeralAppPage';
+import config from '../../config';
+import { init } from '@instantdb/react';
+
+// Schema definition with cascade delete
+const schema = i.schema({
+  entities: {
+    posts: i.entity({
+      title: i.string(),
+    }),
+    comments: i.entity({
+      text: i.string(),
+    }),
+  },
+  links: {
+    postComments: {
+      forward: { on: 'posts', has: 'many', label: 'comments' },
+      reverse: {
+        on: 'comments',
+        has: 'one',
+        label: 'post',
+        onDelete: 'cascade',
+      },
+    },
+  },
+});
+
+type Schema = typeof schema;
+
+const perms = {
+  posts: {
+    allow: {
+      create: 'true',
+      delete: 'true',
+    },
+  },
+  comments: {
+    allow: {
+      create: 'true',
+      view: 'true',
+      update: 'false',
+      delete: 'false', // Comments cannot be deleted directly
+    },
+  },
+};
+
+const permsWithSkip = {
+  posts: {
+    allow: {
+      create: 'true',
+      delete: 'true',
+      skipCascadePermissionCheck: 'true', // Allow cascade deletes to skip permission checks
+    },
+  },
+  comments: {
+    allow: {
+      create: 'true',
+      view: 'true',
+      update: 'false',
+      delete: 'false', // Comments cannot be deleted directly
+    },
+  },
+};
+
+function CascadePermissionDemo() {
+  const [appWithSkip, setAppWithSkip] = useState<{
+    db: InstantReactAbstractDatabase<Schema>;
+    appId: string;
+  } | null>(null);
+  const [appNoSkip, setAppNoSkip] = useState<{
+    db: InstantReactAbstractDatabase<Schema>;
+    appId: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function setupApps() {
+      try {
+        // Create first ephemeral app with skipCascadePermissionCheck enabled
+        const res1 = await provisionEphemeralApp({
+          schema,
+          perms: permsWithSkip,
+        });
+        if (res1.app) {
+          const db1 = init<Schema>({
+            ...config,
+            appId: res1.app.id,
+            schema,
+          });
+          setAppWithSkip({ db: db1, appId: res1.app.id });
+        }
+
+        // Create second ephemeral app without skipCascadePermissionCheck
+        const res2 = await provisionEphemeralApp({ schema, perms });
+        if (res2.app) {
+          const db2 = init<Schema>({
+            ...config,
+            appId: res2.app.id,
+            schema,
+          });
+          setAppNoSkip({ db: db2, appId: res2.app.id });
+        }
+      } catch (error) {
+        console.error('Failed to provision apps:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    setupApps();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-6">
+          Loading Cascade Permission Check Demo...
+        </h1>
+      </div>
+    );
+  }
+
+  if (!appWithSkip || !appNoSkip) {
+    return (
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-6">Failed to load demo apps</h1>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-6">Cascade Permission Check Demo</h1>
+
+      <div className="mb-6 bg-blue-50 p-4 rounded">
+        <h2 className="text-lg font-semibold mb-2">How this demo works:</h2>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>
+            Posts have a cascade delete relationship with comments (deleting a
+            post deletes its comments)
+          </li>
+          <li>Permission rules: Posts can be deleted</li>
+          <li>
+            Permission rules: Comments cannot be deleted directly (delete:
+            false)
+          </li>
+          <li>
+            Left app: skipCascadePermissionCheck = true (cascade deletes bypass
+            comment permissions)
+          </li>
+          <li>
+            Right app: skipCascadePermissionCheck = false (cascade deletes check
+            comment permissions)
+          </li>
+        </ul>
+      </div>
+
+      <div className="grid grid-cols-2 gap-8">
+        <AppInstance
+          title="With Skip Cascade Permission Check"
+          subtitle="Deleting posts will succeed even though comments have restrictive permissions"
+          db={appWithSkip.db}
+          highlightColor="green"
+        />
+        <AppInstance
+          title="Without Skip Cascade Permission Check"
+          subtitle="Deleting posts will fail because comments cannot be deleted"
+          db={appNoSkip.db}
+          highlightColor="red"
+        />
+      </div>
+    </div>
+  );
+}
+
+interface AppInstanceProps {
+  title: string;
+  subtitle: string;
+  db: InstantReactAbstractDatabase<Schema>;
+  highlightColor: 'green' | 'red';
+}
+
+function AppInstance({
+  title,
+  subtitle,
+  db,
+  highlightColor,
+}: AppInstanceProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Query posts and comments
+  const { data, isLoading } = db.useQuery({
+    posts: {
+      comments: {},
+    },
+  });
+
+  const createPostWithComments = async () => {
+    setError(null);
+    setSuccess(null);
+    setLoading(true);
+
+    try {
+      const postId = id();
+      const comment1Id = id();
+      const comment2Id = id();
+
+      // Create a post with comments
+      await db.transact([
+        db.tx.posts[postId].update({
+          title: `Post ${Date.now()}`,
+        }),
+        db.tx.comments[comment1Id].update({
+          text: 'First comment',
+        }),
+        db.tx.comments[comment2Id].update({
+          text: 'Second comment',
+        }),
+        db.tx.posts[postId].link({ comments: comment1Id }),
+        db.tx.posts[postId].link({ comments: comment2Id }),
+      ]);
+
+      setSuccess('Created post with 2 comments');
+    } catch (err) {
+      setError(
+        `Failed to create: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deletePost = async (postId: string) => {
+    setError(null);
+    setSuccess(null);
+    setLoading(true);
+
+    try {
+      // Try to delete the post (which should cascade to comments)
+      await db.transact(db.tx.posts[postId].delete());
+      setSuccess('Successfully deleted post and its comments!');
+    } catch (err) {
+      setError(
+        `Failed to delete: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deleteComment = async (commentId: string) => {
+    setError(null);
+    setSuccess(null);
+    setLoading(true);
+
+    try {
+      // Try to delete a comment directly (should always fail due to permissions)
+      await db.transact(db.tx.comments[commentId].delete());
+      setSuccess('Successfully deleted comment!');
+    } catch (err) {
+      setError(
+        `Failed to delete comment: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const borderColor =
+    highlightColor === 'green' ? 'border-green-500' : 'border-red-500';
+  const bgColor = highlightColor === 'green' ? 'bg-green-50' : 'bg-red-50';
+
+  return (
+    <div className={`border-2 ${borderColor} rounded-lg p-6 ${bgColor}`}>
+      <h2 className="text-xl font-bold mb-2">{title}</h2>
+      <p className="text-sm text-gray-600 mb-4">{subtitle}</p>
+
+      <div className="mb-4">
+        <button
+          onClick={createPostWithComments}
+          disabled={loading}
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 disabled:opacity-50"
+        >
+          Create Post with Comments
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="mb-4 p-3 bg-green-100 border border-green-400 text-green-700 rounded text-sm">
+          {success}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <div>
+          <h3 className="font-semibold mb-2">
+            Posts ({data?.posts?.length || 0})
+          </h3>
+          {isLoading ? (
+            <p className="text-gray-500">Loading...</p>
+          ) : (
+            <div className="space-y-2">
+              {data?.posts?.map((post) => (
+                <div key={post.id} className="bg-white p-3 rounded shadow">
+                  <div className="flex justify-between items-center">
+                    <div>
+                      <p className="font-medium">{post.title}</p>
+                    </div>
+                    <button
+                      onClick={() => deletePost(post.id)}
+                      disabled={loading}
+                      className="bg-red-500 text-white px-3 py-1 rounded text-sm hover:bg-red-600 disabled:opacity-50"
+                    >
+                      Delete Post
+                    </button>
+                  </div>
+                  <div className="mt-2 text-xs text-gray-600">
+                    {post.comments?.length || 0} comments
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Comments</h3>
+          {isLoading ? (
+            <p className="text-gray-500">Loading...</p>
+          ) : (
+            <div className="space-y-2">
+              {data?.posts?.flatMap((post) =>
+                post.comments?.map((comment) => (
+                  <div key={comment.id} className="bg-white p-3 rounded shadow">
+                    <div className="flex justify-between items-center">
+                      <div>
+                        <p className="text-sm">{comment.text}</p>
+                        <p className="text-xs text-gray-500">
+                          Post: {post.title}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => deleteComment(comment.id)}
+                        disabled={loading}
+                        className="bg-red-500 text-white px-3 py-1 rounded text-sm hover:bg-red-600 disabled:opacity-50"
+                        title="Direct comment deletion should fail due to permissions"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                )),
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 p-3 bg-gray-100 rounded text-xs">
+        <p className="font-semibold">Expected behavior:</p>
+        <ul className="list-disc list-inside mt-1 space-y-1">
+          {highlightColor === 'green' ? (
+            <>
+              <li>
+                ✅ Deleting posts succeeds (cascaded comment deletes bypass
+                permission check)
+              </li>
+              <li>❌ Deleting comments directly fails (permission denied)</li>
+            </>
+          ) : (
+            <>
+              <li>
+                ❌ Deleting posts fails (cascaded comment deletes are permission
+                checked)
+              </li>
+              <li>❌ Deleting comments directly fails (permission denied)</li>
+            </>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default CascadePermissionDemo;

--- a/client/www/components/dash/Perms.tsx
+++ b/client/www/components/dash/Perms.tsx
@@ -167,6 +167,7 @@ const rulesSchema = (namespaces: SchemaNamespace[] | null) => {
           create: { type: 'string' },
           update: { type: 'string' },
           delete: { type: 'string' },
+          skipCascadePermissionCheck: { type: 'string' },
           view: { type: 'string' },
           link: {
             type: 'object',

--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -200,13 +200,14 @@
   (let [parent-delete-checks (for [{:keys [op eid etype cascade-delete?]} tx-steps
                                    :when (and (= :delete-entity op)
                                               (not cascade-delete?))
-                                   :let [skip-expr (get-in (:code rules)
-                                                           [etype "allow" "skipCascadePermissionCheck"])]
-                                   :when skip-expr]
+                                   :let [skip-program (rule-model/get-program!
+                                                       rules
+                                                       [[etype "allow" "skipCascadePermissionCheck"]
+                                                        ["$default" "allow" "skipCascadePermissionCheck"]])]
+                                   :when skip-program]
                                {:etype    etype
                                 :eid      eid
-                                :program  (rule-model/get-program! rules
-                                                                   [[etype "allow" "skipCascadePermissionCheck"]])
+                                :program  skip-program
                                 :bindings {:data (get entities-map {:eid eid :etype etype})
                                            :rule-params (get rule-params-map {:eid eid :etype etype})}})
         ;; Evaluate the skip rules (but don't throw on failure)

--- a/server/src/instant/db/transaction.clj
+++ b/server/src/instant/db/transaction.clj
@@ -512,10 +512,12 @@
         (concat
          tx-step-maps
          ;; Add delete operations for cascaded entities only
-         (for [{:keys [entity_id etype]} cascaded-entities]
+         (for [{:keys [entity_id etype parent_id]} cascaded-entities]
            {:op :delete-entity
             :eid entity_id
-            :etype etype})
+            :etype etype
+            :cascade-delete? true
+            :cascade-parent-id parent_id})
          ;; Add rule-params for cascaded entities that have a parent with rule-params
          (for [{:keys [entity_id etype parent_id]} cascaded-entities
                :let [rule-params (get parent-id->rule-params parent_id)]

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -4600,6 +4600,67 @@
               deleted-triples (count (:delete-entity (:results res)))]
           (is (= (-> @children (* 2) (+ 1)) deleted-triples)))))))
 
+(deftest skip-cascade-permission-check
+  (with-empty-app
+    (fn [{app-id :id}]
+      ;; Create schema with posts -> comments cascade
+      (let [attr->id (test-util/make-attrs
+                      app-id
+                      [[:posts/id :unique? :index?]
+                       [:posts/creatorId]
+                       [:comments/id :unique? :index?]
+                       [[:comments/post :posts/comments] :on-delete]])
+
+            user-id (suid "a1")
+            other-user-id (suid "a2")
+            post-id (suid "b1")
+            comment1-id (suid "c1")
+            comment2-id (suid "c2")
+
+            ;; Set up rules: only post creator can delete posts, comments cannot be deleted
+            _ (rule-model/put! (aurora/conn-pool :write)
+                               {:app-id app-id
+                                :code {"posts" {"allow" {"delete" "auth.id == data.creatorId"}}
+                                       "comments" {"allow" {"delete" "false"}}}})
+
+            ;; Insert test data
+            _ (test-util/insert-entities
+               app-id attr->id
+               [{:db/id post-id :posts/id post-id :posts/creatorId user-id}
+                {:db/id comment1-id :comments/id comment1-id :comments/post post-id}
+                {:db/id comment2-id :comments/id comment2-id :comments/post post-id}])
+
+            make-ctx (fn [user-id]
+                       {:db {:conn-pool (aurora/conn-pool :write)}
+                        :app-id app-id
+                        :attrs (attr-model/get-by-app-id app-id)
+                        :datalog-query-fn d/query
+                        :rules (rule-model/get-by-app-id (aurora/conn-pool :read) {:app-id app-id})
+                        :current-user {:id user-id}})]
+
+        (testing "Delete with cascade fails due to comment permissions"
+          (is (not (perm-pass? (permissioned-tx/transact!
+                                (make-ctx user-id)
+                                [[:delete-entity post-id "posts"]])))))
+
+        (testing "Non-owner still cannot delete even with skipCascadePermissionCheck true"
+          (rule-model/put! (aurora/conn-pool :write)
+                           {:app-id app-id
+                            :code {"posts" {"allow" {"delete" "auth.id == data.creatorId" "skipCascadePermissionCheck" "true"}}
+                                   "comments" {"allow" {"delete" "false"}}}})
+          (is (not (perm-pass? (permissioned-tx/transact!
+                                (make-ctx other-user-id)
+                                [[:delete-entity post-id "posts"]])))))
+
+        (testing "Delete with skipCascadePermissionCheck supports permissions rules"
+          (rule-model/put! (aurora/conn-pool :write)
+                           {:app-id app-id
+                            :code {"posts" {"allow" {"delete" "auth.id == data.creatorId" "skipCascadePermissionCheck" "auth.id == data.creatorId"}}
+                                   "comments" {"allow" {"delete" "false"}}}})
+          (is (perm-pass? (permissioned-tx/transact!
+                           (make-ctx user-id)
+                           [[:delete-entity post-id "posts"]]))))))))
+
 (deftest too-many-params
   (with-zeneca-app
     (fn [app r]


### PR DESCRIPTION
Based on our discussion, adds a new permission rule `skipCascadePermissionCheck` that allows parent entities to bypass permission checks on their cascaded deletions

### Problem

When using cascade deletes with restrictive permissions on related entities, legitimate delete operations would fail. For example, if comments have `delete: "false"` permissions but are set to cascade-delete when their parent post is deleted, deleting the post would fail even though the user has permission to delete the post itself.

### Solution

- Added `skipCascadePermissionCheck` as a permission rule that can be evaluated like any other CEL expression
- Modified `expand-delete-entity-cascade` to mark cascaded deletes
- Evaluates `skipCascadePermissionCheck` for parent entities before running permission checks
- Cascaded deletes skip permission checks only if their parent's `skipCascadePermissionCheck` rule passes
- Supports both entity-specific and `$default` rules with proper fallback behavior
- Adds type for our dashboard editor and in `ruleTypes` for our packages

### Usage

```javascript
// Simple boolean flag
const perms = {
  posts: {
    allow: {
      delete: "auth.id == data.creatorId",
      skipCascadePermissionCheck: "true"
    }
  },
  comments: {
    allow: {
      delete: "false"  // Comments can't be deleted directly, but cascade with posts
    }
  }
};

// With permission expression
const perms = {
  posts: {
    allow: {
      delete: "auth.id == data.creatorId",
      skipCascadePermissionCheck: "auth.id == data.creatorId"  // Only skip for post owner
    }
  }
};

// Using $default
const perms = {
  $default: {
    allow: {
      skipCascadePermissionCheck: "auth.ref('$users.role.type') == 'admin'"  // Admins skip cascade checks
    }
  }
};
```

Also verified this works with the play example (included in PR)!

If this looks good will bump up the version and update docs!