### PR TITLE
Add json encoders for cel types

### DIFF
--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -10,6 +10,7 @@
    [instant.util.coll :as ucoll]
    [instant.util.exception :as ex]
    [instant.util.io :as io]
+   [instant.util.json :as json]
    [instant.util.tracer :as tracer]
    [instant.comment :as c]
    [instant.data.resolvers :as resolvers])
@@ -176,6 +177,8 @@
   (iterator [_]
     (java.util.List/.iterator xs)))
 
+(json/add-encoder CelList json/encode-java-list)
+
 (deftype CelMap [m]
   java.util.Map
   (get [_ k]
@@ -193,6 +196,8 @@
     (->> (keys (or m {}))
          (map (fn [k] [k (get-cel-value m k)]))
          set)))
+
+(json/add-encoder CelMap json/encode-java-map)
 
 (defn stringify [x]
   (cond
@@ -252,6 +257,8 @@
   (ref [_ path-str]
     (ref-impl ctx m etype path-str)))
 
+(json/add-encoder DataCelMap json/encode-java-map)
+
 (deftype AuthCelMap [ctx ^CelMap m]
   java.util.Map
   (get [_ k]
@@ -267,6 +274,8 @@
                                        #"^\$user\."
                                        "")]
       (ref-impl ctx m "$users" path))))
+
+(json/add-encoder AuthCelMap json/encode-java-map)
 
 (def ^MapType type-obj (MapType/create SimpleType/STRING SimpleType/DYN))
 

--- a/server/src/instant/util/json.clj
+++ b/server/src/instant/util/json.clj
@@ -1,13 +1,20 @@
 (ns instant.util.json
   (:require [cheshire.core :as cheshire]
-            [cheshire.generate :refer [add-encoder encode-nil encode-str]]
+            [cheshire.generate :refer [encode-nil encode-str]]
             [cheshire.factory :as factory]
             [cheshire.parse :as parse])
   (:import (com.google.protobuf NullValue)
            (dev.cel.expr Value)
            (com.fasterxml.jackson.core JsonGenerator JsonFactory)
            (com.google.protobuf.util JsonFormat)
-           (java.time Instant)))
+           (java.time Instant)
+           (java.util Map List)))
+
+(def add-encoder cheshire.generate/add-encoder)
+(def encode-java-map (fn [^Map m ^JsonGenerator jg]
+                       (cheshire.generate/encode-map (into {} m) jg)))
+(def encode-java-list (fn [^List l ^JsonGenerator jg]
+                       (cheshire.generate/encode-seq (seq l) jg)))
 
 ;; Encode NullValue as nil
 (add-encoder NullValue encode-nil)


### PR DESCRIPTION
Adds JSON encoders for cel types so that you can debug cel rules in the sandbox.

Example of it in action: 

The rule is set to `data` and you can see the data in the output of the rule on the right.

<img width="935" height="412" alt="image" src="https://github.com/user-attachments/assets/f4f8abb1-cb8c-484c-9d6b-109760c4978e" />
