### PR TITLE
Remove extra db.ts from expo template

### DIFF
--- a/client/packages/create-instant-app/template/base/expo/db.ts
+++ b/client/packages/create-instant-app/template/base/expo/db.ts
@@ -1,7 +1,0 @@
-import { init } from "@instantdb/react-native";
-import schema from "../instant.schema";
-
-export const db = init({
-  appId: process.env.EXPO_PUBLIC_INSTANT_APP_ID!,
-  schema,
-});

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.14';
+const version = 'v0.21.15';
 
 export { version };


### PR DESCRIPTION
Got a report from a user we had an extra `db.ts` in the expo template -- removing it here!