### PR TITLE
Update create instant app title

### DIFF
--- a/client/packages/create-instant-app/src/index.ts
+++ b/client/packages/create-instant-app/src/index.ts
@@ -30,7 +30,7 @@ const main = async () => {
       ['-h', '--help', '--version', '-V'].includes(arg),
     )
   ) {
-    renderTitle(theme);
+    renderTitle();
   }
 
   const project = await runCli();

--- a/client/packages/create-instant-app/src/utils/title.ts
+++ b/client/packages/create-instant-app/src/utils/title.ts
@@ -1,25 +1,17 @@
 import { intro } from '@clack/prompts';
 import chalk from 'chalk';
-import { Theme } from '~/terminalTheme.js';
 
-const darkTitle = `            _           _               _
- ████████  (_)         | |             | |
- ████   █   _ _ __  ___| |_ __ _ _ _  _| |_
- ████   █  | | '_ \\/ __| __/ _\\\`| '_ \\| __|
- ████   █  | | | | \\__ \\ || (_| | | | | |_
- ████████  |_|_| |_|___/\\__\\__,_|_| |_|\\__|`;
-
-const lightTitle = `            _           _               _
+const title = `            _           _               _
  ████████  (_)         | |             | |
  █   ████   _ _ __  ___| |_ __ _ _ _  _| |_
  █   ████  | | '_ \\/ __| __/ _\\\`| '_ \\| __|
  █   ████  | | | | \\__ \\ || (_| | | | | |_
  ████████  |_|_| |_|___/\\__\\__,_|_| |_|\\__|`;
 
-export const renderTitle = (theme: Theme) => {
+export const renderTitle = () => {
   intro(
     '\n' +
-      (theme === 'dark' ? darkTitle : lightTitle)
+      title
         .split('\n')
         .map(
           (line) =>


### PR DESCRIPTION
I noticed when running create instant app the logo is slightly off. Regardless of whether we are in light or dark mode, we want to render the same title.

**Before**
<img width="1010" height="480" alt="CleanShot 2025-09-12 at 18 02 12@2x" src="https://github.com/user-attachments/assets/db31c96d-e4ca-4318-b9ba-9978c1cf9154" />


**After**
<img width="932" height="502" alt="CleanShot 2025-09-12 at 18 02 30@2x" src="https://github.com/user-attachments/assets/17743d6d-2425-411b-9688-27052684c79c" />

This also works as expected for light mode

<img width="812" height="338" alt="CleanShot 2025-09-12 at 18 08 09@2x" src="https://github.com/user-attachments/assets/69cc46e7-0af2-4b83-a988-fb4da0ecdaf9" />

