### PR TITLE
Test optimizations

### DIFF
--- a/server/resources/migrations/88_force_index_lookup_on_triple.down.sql
+++ b/server/resources/migrations/88_force_index_lookup_on_triple.down.sql
@@ -1,0 +1,45 @@
+create or replace function triples_update_batch_trigger()
+returns trigger as $$
+begin
+  -- Don't let this trigger cause itself to fire. We let it fire
+  -- twice because postgres 16 has some bug (fixed in 17) where
+  -- pg_column_size on insert is different than pg_column_size on
+  -- update, possibly due to how it handles nulls? If that happens,
+  -- then the second time it fires it will get the right value.
+  if pg_trigger_depth() > 2 then
+    return null;
+  end if;
+
+  if pg_trigger_depth() <= 1 then
+    -- Update sweeper with deleted files
+    with old_files as (
+      select app_id, value #>> '{}' as location_id
+       from oldrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    ), new_files as (
+      select app_id, value #>> '{}' as location_id
+       from newrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    )
+    insert into app_files_to_sweep (app_id, location_id)
+      select o.app_id, o.location_id
+      from old_files o
+      left join new_files n
+             on o.app_id = n.app_id
+            and o.location_id = n.location_id
+          where o.location_id is not null and n.location_id is null
+      on conflict do nothing;
+  end if;
+
+  update triples t
+     set pg_size = public.triples_column_size(t)
+    from newrows s
+  where s.app_id = t.app_id
+    and s.entity_id = t.entity_id
+    and s.attr_id = t.attr_id
+    and s.value_md5 = t.value_md5
+    and public.triples_column_size(t) is distinct from t.pg_size;
+
+  return null;
+end;
+$$ language plpgsql;

--- a/server/resources/migrations/88_force_index_lookup_on_triple.up.sql
+++ b/server/resources/migrations/88_force_index_lookup_on_triple.up.sql
@@ -1,0 +1,45 @@
+create or replace function triples_update_batch_trigger()
+returns trigger as $$
+begin
+  -- Don't let this trigger cause itself to fire. We let it fire
+  -- twice because postgres 16 has some bug (fixed in 17) where
+  -- pg_column_size on insert is different than pg_column_size on
+  -- update, possibly due to how it handles nulls? If that happens,
+  -- then the second time it fires it will get the right value.
+  if pg_trigger_depth() > 2 then
+    return null;
+  end if;
+
+  if pg_trigger_depth() <= 1 then
+    -- Update sweeper with deleted files
+    with old_files as (
+      select app_id, value #>> '{}' as location_id
+       from oldrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    ), new_files as (
+      select app_id, value #>> '{}' as location_id
+       from newrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    )
+    insert into app_files_to_sweep (app_id, location_id)
+      select o.app_id, o.location_id
+      from old_files o
+      left join new_files n
+             on o.app_id = n.app_id
+            and o.location_id = n.location_id
+          where o.location_id is not null and n.location_id is null
+      on conflict do nothing;
+  end if;
+
+  update triples t
+     set pg_size = public.triples_column_size(t)
+    from newrows s
+  where t.app_id = s.app_id
+    and t.entity_id = s.entity_id
+    and t.attr_id = s.attr_id
+    and t.value_md5 = s.value_md5
+    and public.triples_column_size(t) is distinct from t.pg_size;
+
+  return null;
+end;
+$$ language plpgsql;

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -47,8 +47,10 @@
                          :job-stage (:job_stage job)
                          :work-estimate (:work_estimate job)
                          :work-completed (:work_completed job)
-                         :ms-since-creation (ms-since (:created_at job) now)
-                         :ms-since-update (ms-since (:updated_at job) now)}
+                         :ms-since-creation (when-let [created-at (:created_at job)]
+                                              (ms-since created-at now))
+                         :ms-since-update (when-let [updated-at (:updated_at job)]
+                                            (ms-since updated-at now))}
                         (when (and (= "completed" (:job_status job))
                                    (:done_at job)
                                    (:created_at job))

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -17,7 +17,7 @@
             [clojure.test :refer [deftest testing is]]))
 
 (def wait-timeout (if (= :test (config/get-env))
-                    5000
+                    10000
                     1000))
 
 (defmacro check-estimate [job]

--- a/server/test/instant/db/indexing_jobs_test.clj
+++ b/server/test/instant/db/indexing_jobs_test.clj
@@ -445,141 +445,143 @@
                              :setting-unique?)))))))))))
 
 (deftest rejects-not-unique-values
-  (with-indexing-job-queue job-queue
-    (with-empty-app
-      (fn [app]
-        (let [attr-id (random-uuid)
+  (with-redefs [jobs/batch-size 10]
+    (with-indexing-job-queue job-queue
+      (with-empty-app
+        (fn [app]
+          (let [attr-id (random-uuid)
 
-              _ (tx/transact! (aurora/conn-pool :write)
-                              (attr-model/get-by-app-id (:id app))
-                              (:id app)
-                              [[:add-attr {:id attr-id
-                                           :forward-identity [(random-uuid) "etype" "label"]
-                                           :unique? false
-                                           :index? false
-                                           :value-type :blob
-                                           :cardinality :one}]])
-              _ (dotimes [x 5]
-                  (tx/transact! (aurora/conn-pool :write)
+                _ (tx/transact! (aurora/conn-pool :write)
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)
-                                (for [i (range 1002)]
-                                  [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
-              _ (tx/transact! (aurora/conn-pool :write)
-                              (attr-model/get-by-app-id (:id app))
-                              (:id app)
-                              [[:add-triple (random-uuid) attr-id "a"]
-                               [:add-triple (random-uuid) attr-id "a"]])
-              job (jobs/create-job!
-                   {:app-id (:id app)
-                    :attr-id attr-id
-                    :job-type "unique"})
+                                [[:add-attr {:id attr-id
+                                             :forward-identity [(random-uuid) "etype" "label"]
+                                             :unique? false
+                                             :index? false
+                                             :value-type :blob
+                                             :cardinality :one}]])
+                _ (dotimes [x 5]
+                    (tx/transact! (aurora/conn-pool :write)
+                                  (attr-model/get-by-app-id (:id app))
+                                  (:id app)
+                                  (for [i (range 12)]
+                                    [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
+                _ (tx/transact! (aurora/conn-pool :write)
+                                (attr-model/get-by-app-id (:id app))
+                                (:id app)
+                                [[:add-triple (random-uuid) attr-id "a"]
+                                 [:add-triple (random-uuid) attr-id "a"]])
+                job (jobs/create-job!
+                     {:app-id (:id app)
+                      :attr-id attr-id
+                      :job-type "unique"})
 
-              _ (jobs/enqueue-job job-queue job)
-              _ (wait-for (fn []
-                            (every? (fn [{:keys [id]}]
-                                      (= "errored" (:job_status (jobs/get-by-id id))))
-                                    [job]))
-                          wait-timeout)
-              triples (triple-model/fetch (aurora/conn-pool :read)
-                                          (:id app)
-                                          [[:= :attr-id attr-id]])
-              job-for-client (jobs/get-by-id-for-client (:app_id job) (:id job))]
-          (is (pos? (count triples)))
+                _ (jobs/enqueue-job job-queue job)
+                _ (wait-for (fn []
+                              (every? (fn [{:keys [id]}]
+                                        (= "errored" (:job_status (jobs/get-by-id id))))
+                                      [job]))
+                            wait-timeout)
+                triples (triple-model/fetch (aurora/conn-pool :read)
+                                            (:id app)
+                                            [[:= :attr-id attr-id]])
+                job-for-client (jobs/get-by-id-for-client (:app_id job) (:id job))]
+            (is (pos? (count triples)))
 
-          (is (every? (fn [{:keys [index]}]
-                        (not (contains? index :av)))
-                      triples))
-          (let [attrs (attr-model/get-by-app-id (:id app))]
-            (is (not (-> (attr-model/seek-by-id attr-id attrs)
-                         :unique?)))
-            (is (not (-> (attr-model/seek-by-id attr-id attrs)
-                         :setting-unique?))))
+            (is (every? (fn [{:keys [index]}]
+                          (not (contains? index :av)))
+                        triples))
+            (let [attrs (attr-model/get-by-app-id (:id app))]
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :unique?)))
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :setting-unique?))))
 
-          ;; XXX: next up, check that we get an invalid triple
-          (is (= "triple-not-unique-error" (:error job-for-client)))
+            ;; XXX: next up, check that we get an invalid triple
+            (is (= "triple-not-unique-error" (:error job-for-client)))
 
-          (is (= ["a" "a"]
-                 (map #(get % "value") (-> job-for-client
-                                           :invalid_triples_sample)))))))))
+            (is (= ["a" "a"]
+                   (map #(get % "value") (-> job-for-client
+                                             :invalid_triples_sample))))))))))
 
 (deftest rejects-too-large-values
-  (with-indexing-job-queue job-queue
-    (with-empty-app
-      (fn [app]
-        (let [id-attr-id (random-uuid)
-              attr-id (random-uuid)
+  (with-redefs [jobs/batch-size 10]
+    (with-indexing-job-queue job-queue
+      (with-empty-app
+        (fn [app]
+          (let [id-attr-id (random-uuid)
+                attr-id (random-uuid)
 
-              _ (tx/transact! (aurora/conn-pool :write)
-                              (attr-model/get-by-app-id (:id app))
-                              (:id app)
-                              [[:add-attr {:id id-attr-id
-                                           :forward-identity [(random-uuid) "etype" "id"]
-                                           :unique? true
-                                           :index? false
-                                           :value-type :blob
-                                           :cardinality :one}]
-                               [:add-attr {:id attr-id
-                                           :forward-identity [(random-uuid) "etype" "label"]
-                                           :unique? false
-                                           :index? false
-                                           :value-type :blob
-                                           :cardinality :one}]])
-              _ (dotimes [x 5]
-                  (tx/transact! (aurora/conn-pool :write)
+                _ (tx/transact! (aurora/conn-pool :write)
                                 (attr-model/get-by-app-id (:id app))
                                 (:id app)
-                                (for [i (range 1002)]
-                                  [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
-              bad-id (random-uuid)
-              _ (tx/transact! (aurora/conn-pool :write)
-                              (attr-model/get-by-app-id (:id app))
-                              (:id app)
-                              [[:add-triple bad-id attr-id (apply str (repeatedly 1024 random-uuid))]])
-              unique-job (jobs/create-job!
-                          {:app-id (:id app)
-                           :attr-id attr-id
-                           :job-type "unique"})
-              index-job (jobs/create-job!
-                         {:app-id (:id app)
-                          :attr-id attr-id
-                          :job-type "index"})
+                                [[:add-attr {:id id-attr-id
+                                             :forward-identity [(random-uuid) "etype" "id"]
+                                             :unique? true
+                                             :index? false
+                                             :value-type :blob
+                                             :cardinality :one}]
+                                 [:add-attr {:id attr-id
+                                             :forward-identity [(random-uuid) "etype" "label"]
+                                             :unique? false
+                                             :index? false
+                                             :value-type :blob
+                                             :cardinality :one}]])
+                _ (dotimes [x 5]
+                    (tx/transact! (aurora/conn-pool :write)
+                                  (attr-model/get-by-app-id (:id app))
+                                  (:id app)
+                                  (for [i (range 12)]
+                                    [:add-triple (random-uuid) attr-id (format "%s-%s" x i)])))
+                bad-id (random-uuid)
+                _ (tx/transact! (aurora/conn-pool :write)
+                                (attr-model/get-by-app-id (:id app))
+                                (:id app)
+                                [[:add-triple bad-id attr-id (apply str (repeatedly 1024 random-uuid))]])
+                unique-job (jobs/create-job!
+                            {:app-id (:id app)
+                             :attr-id attr-id
+                             :job-type "unique"})
+                index-job (jobs/create-job!
+                           {:app-id (:id app)
+                            :attr-id attr-id
+                            :job-type "index"})
 
-              _ (jobs/enqueue-job job-queue unique-job)
-              _ (jobs/enqueue-job job-queue index-job)
-              _ (wait-for (fn []
-                            (every? (fn [{:keys [id]}]
-                                      (not (contains? #{"processing" "waiting"} (:job_status (jobs/get-by-id id)))))
-                                    [unique-job
-                                     index-job]))
-                          wait-timeout)
-              triples (triple-model/fetch (aurora/conn-pool :read)
-                                          (:id app)
-                                          [[:= :attr-id attr-id]])
-              unique-job-for-client (jobs/get-by-id-for-client (:id app) (:id unique-job))
-              index-job-for-client (jobs/get-by-id-for-client (:id app) (:id index-job))]
-          (is (pos? (count triples)))
+                _ (jobs/enqueue-job job-queue unique-job)
+                _ (jobs/enqueue-job job-queue index-job)
+                _ (wait-for (fn []
+                              (every? (fn [{:keys [id]}]
+                                        (not (contains? #{"processing" "waiting"} (:job_status (jobs/get-by-id id)))))
+                                      [unique-job
+                                       index-job]))
+                            wait-timeout)
+                triples (triple-model/fetch (aurora/conn-pool :read)
+                                            (:id app)
+                                            [[:= :attr-id attr-id]])
+                unique-job-for-client (jobs/get-by-id-for-client (:id app) (:id unique-job))
+                index-job-for-client (jobs/get-by-id-for-client (:id app) (:id index-job))]
+            (is (pos? (count triples)))
 
-          (is (every? (fn [{:keys [index]}]
-                        (and (not (contains? index :ave))
-                             (not (contains? index :av))))
-                      triples))
-          (let [attrs (attr-model/get-by-app-id (:id app))]
-            (is (not (-> (attr-model/seek-by-id attr-id attrs)
-                         :unique?)))
-            (is (not (-> (attr-model/seek-by-id attr-id attrs)
-                         :setting-unique?)))
-            (is (not (-> (attr-model/seek-by-id attr-id attrs)
-                         :index?)))
-            (is (not (-> (attr-model/seek-by-id attr-id attrs)
-                         :indexing?))))
+            (is (every? (fn [{:keys [index]}]
+                          (and (not (contains? index :ave))
+                               (not (contains? index :av))))
+                        triples))
+            (let [attrs (attr-model/get-by-app-id (:id app))]
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :unique?)))
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :setting-unique?)))
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :index?)))
+              (is (not (-> (attr-model/seek-by-id attr-id attrs)
+                           :indexing?))))
 
-          (is (= "triple-too-large-error" (:error unique-job-for-client)))
-          (is (= "triple-too-large-error" (:error index-job-for-client)))
+            (is (= "triple-too-large-error" (:error unique-job-for-client)))
+            (is (= "triple-too-large-error" (:error index-job-for-client)))
 
-          (is (= [(str bad-id)]
-                 (map #(get % "entity_id") (-> unique-job-for-client
-                                               :invalid_triples_sample)))))))))
+            (is (= [(str bad-id)]
+                   (map #(get % "entity_id") (-> unique-job-for-client
+                                                 :invalid_triples_sample))))))))))
 
 (deftest required-works-with-no-errors
   (with-indexing-job-queue job-queue


### PR DESCRIPTION
Adds a few optimizations for the tests:

1. Updates the order we check the rows in the triples_batch_update postgres function. We were doing `join_row.col = triples.col`, and postgres was using the triples_created_at index. Switching the order (`triples.col = join_row.col`) seems to make postgres use the primary key. Only seems to be an issue during the tests.
2. Reduce the batch size for some indexing job tests so that we don't have to update as many triples to test everything.
3. Fixes an error calculating the job span attrs when we don't get back a job.

Much easier to review with whitespace turned off.