### PR TITLE
Remove app members that are already on the org on transfer

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1264,9 +1264,13 @@
 (defn app-transfer-to-org [req]
   (let [{{app-id :id} :app} (req->app-and-user! :owner req)
         {{org-id :id} :org} (req->org-and-user! :admin req)
-        {:keys [credit]} (org-model/transfer-app-to-org! {:app-id app-id
+        {:keys [credit removed_app_members_already_on_paid_org]} (org-model/transfer-app-to-org! {:app-id app-id
                                                           :org-id org-id})]
-    (response/ok {:credit credit})))
+    (response/ok {:credit credit
+                  :app_member_changes {:removed (map (fn [member]
+                                                       {:member member
+                                                        :reason "user_is_member_of_org"})
+                                                     removed_app_members_already_on_paid_org)}})))
 
 ;; ---
 ;; Storage

--- a/server/src/instant/db/indexing_jobs.clj
+++ b/server/src/instant/db/indexing_jobs.clj
@@ -1114,10 +1114,10 @@
     (doseq [attr attrs]
       (loop [total 0]
         (println "Starting" (str "app_id=" (:app_id attr)) (str "attr_id=" (:id attr)))
-        (let [update-count (time (index--insert-nulls (aurora/conn-pool :write)
-                                                      {:attr_id (:id attr)
-                                                       :app_id (:app_id attr)
-                                                       :job_type "index"}))]
+        (let [update-count (index--insert-nulls (aurora/conn-pool :write)
+                                                {:attr_id (:id attr)
+                                                 :app_id (:app_id attr)
+                                                 :job_type "index"})]
           (println "Updated" (+ total update-count) "for" (str "app_id=" (:app_id attr)) (str "attr_id=" (:id attr)))
           (when (pos? update-count)
             (recur (long (+ total update-count)))))))))

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -301,9 +301,9 @@
                           (fn [app]
                             (let [stripe-customer (instant-stripe-customer-model/get-or-create-for-user! {:user owner})
                                   _ (stripe/add-payment-method-for-test-customer (:id stripe-customer))
-                                  stripe-subscription-id (time (stripe/create-pro-subscription {:customer-id (:id stripe-customer)
-                                                                                                :app app
-                                                                                                :user owner}))
+                                  stripe-subscription-id (stripe/create-pro-subscription {:customer-id (:id stripe-customer)
+                                                                                          :app app
+                                                                                          :user owner})
                                   subscription (instant-subscription-model/create! {:user-id (:id owner)
                                                                                     :org-id (:id org)
                                                                                     :subscription-type-id plans/STARTUP_SUBSCRIPTION_TYPE

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -86,7 +86,8 @@
                                           [:org-members :m] [:= :m.org-id :o.id]]
                                    :where [:and
                                            [:= :m.user-id :?user-id]
-                                           [:= :o.id :?org-id]]}
+                                           [:= :o.id :?org-id]
+                                           [:= nil :a.deletion-marked-at]]}
 
                                   {:select :a.id
                                    :from [[:apps :a]]

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -781,7 +781,6 @@
                                         {:headers {:Authorization (str "Bearer " (:refresh-token owner))
                                                    :Content-Type "application/json"}
                                          :as :json})]
-                    (println (:body resp))
 
                     (is (= (:status expected)
                            (:status resp)))

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -9,6 +9,8 @@
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.instant-stripe-customer :as stripe-customer-model]
+   [instant.model.org-members :as org-members]
+   [instant.model.app-members :as app-members]
    [instant.stripe :as stripe]
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [->json]]
@@ -698,7 +700,6 @@
                                           :Content-Type "application/json"}
                                 :as :json})
                     :body
-                    tool/inspect
                     :credit)))
       (let [app (app-model/get-by-id! {:id (:id app)})]
         (is (nil? (:creator_id app)))
@@ -713,27 +714,89 @@
         false
         owner
         (fn [{:keys [app stripe-subscription-id]}]
-          (is (neg? (-> (http/post (format "%s/dash/apps/%s/transfer_to_org/%s"
-                                           config/server-origin
-                                           (:id app)
-                                           (:id org))
-                                   {:headers {:Authorization (str "Bearer " (:refresh-token owner))
-                                              :Content-Type "application/json"}
-                                    :as :json})
-                        :body
-                        :credit)))
-          ;; is app transfered
-          (is (nil? (:creator_id (app-model/get-by-id! {:id (:id app)}))))
-          (is (= (:id org) (:org_id (app-model/get-by-id! {:id (:id app)}))))
 
-          (is (= "canceled" (.getStatus (stripe/subscription stripe-subscription-id))))
+          (let [resp (http/post (format "%s/dash/apps/%s/transfer_to_org/%s"
+                                        config/server-origin
+                                        (:id app)
+                                        (:id org))
+                                {:headers {:Authorization (str "Bearer " (:refresh-token owner))
+                                           :Content-Type "application/json"}
+                                 :as :json})]
+            (is (neg? (-> resp
+                          :body
+                          :credit)))
+            ;; is app transfered
+            (is (nil? (:creator_id (app-model/get-by-id! {:id (:id app)}))))
+            (is (= (:id org) (:org_id (app-model/get-by-id! {:id (:id app)}))))
 
-          ;; does the customer have a credit
-          (let [sub-id (:stripe_subscription_id
-                        (sql/select-one (aurora/conn-pool :read)
-                                        ["select * from instant_subscriptions s join orgs o on o.subscription_id = s.id where o.id = ?::uuid" (:id org)]))]
-            ;; If this fails around midnight on the last day of the month, just try again
-            (is (neg? (stripe/customer-balance-by-subscription sub-id)))))))))
+            (is (= "canceled" (.getStatus (stripe/subscription stripe-subscription-id))))
+
+            ;; does the customer have a credit
+            (let [sub-id (:stripe_subscription_id
+                          (sql/select-one (aurora/conn-pool :read)
+                                          ["select * from instant_subscriptions s join orgs o on o.subscription_id = s.id where o.id = ?::uuid" (:id org)]))]
+              ;; If this fails around midnight on the last day of the month, just try again
+              (is (neg? (stripe/customer-balance-by-subscription sub-id))))))))))
+
+(deftest members-transfer-for-paid-orgs
+  (with-startup-org
+    true
+    (fn [{:keys [org owner]}]
+      (doseq [{:keys [app-role org-role expected]} [{:app-role "admin"
+                                                     :org-role "admin"
+                                                     :expected {:status 200
+                                                                :org-role "admin"
+                                                                :app-role nil}}
+                                                    {:app-role "collaborator"
+                                                     :org-role "admin"
+                                                     :expected {:status 200
+                                                                :org-role "admin"
+                                                                :app-role nil}}
+                                                    {:app-role "admin"
+                                                     :org-role "collaborator"
+                                                     :expected {:status 200
+                                                                :org-role "collaborator"
+                                                                :app-role "admin"}}
+                                                    {:app-role "collaborator"
+                                                     :org-role "collaborator"
+                                                     :expected {:status 200
+                                                                :org-role "collaborator"
+                                                                :app-role nil}}]]
+        (testing (format "app-role=%s, org-role=%s" app-role org-role)
+          (with-user
+            (fn [app-member]
+              (with-empty-app
+                (:id owner)
+                (fn [app]
+                  (is (app-members/create! {:app-id (:id app)
+                                            :user-id (:id app-member)
+                                            :role app-role}))
+                  (is (org-members/create! {:org-id (:id org)
+                                            :user-id (:id app-member)
+                                            :role org-role}))
+                  (let [resp (http/post (format "%s/dash/apps/%s/transfer_to_org/%s"
+                                                config/server-origin
+                                                (:id app)
+                                                (:id org))
+                                        {:headers {:Authorization (str "Bearer " (:refresh-token owner))
+                                                   :Content-Type "application/json"}
+                                         :as :json})]
+                    (println (:body resp))
+
+                    (is (= (:status expected)
+                           (:status resp)))
+
+                    (is (= (:app-role expected)
+                           (:member_role
+                            (app-members/get-by-app-and-user {:app-id (:id app)
+                                                              :user-id (:id app-member)})))
+                        (format "user has role `%s` on app after transfer" (:app-role expected)))
+
+                    (is (= (:org-role expected)
+                           (:role
+                            (org-members/get-by-org-and-user {:org-id (:id org)
+                                                              :user-id (:id app-member)})))
+                        (format "user has role `%s` on org after transfer" (:org-role expected)))))))))))))
 
 (deftest transfer-paid-app-to-unpaid-org
   (with-org-user-and-app

--- a/server/test/instant/model/orgs_test.clj
+++ b/server/test/instant/model/orgs_test.clj
@@ -1,6 +1,6 @@
 (ns instant.model.orgs-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is]]
    [instant.fixtures :refer [with-startup-org]]
    [instant.model.app :as app-model]
    [instant.model.org :as org-model]))

--- a/server/test/instant/model/orgs_test.clj
+++ b/server/test/instant/model/orgs_test.clj
@@ -1,0 +1,22 @@
+(ns instant.model.orgs-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.fixtures :refer [with-startup-org]]
+   [instant.model.app :as app-model]
+   [instant.model.org :as org-model]))
+
+(deftest apps-for-org
+  (with-startup-org
+    true
+    (fn [{:keys [owner org app]}]
+      (is (= [(:id app)]
+             (map :id
+                  (org-model/apps-for-org {:org-id (:id org)
+                                           :user-id (:id owner)}))))
+
+      (app-model/mark-for-deletion! {:id (:id app)})
+
+      (is (= []
+             (map :id
+                  (org-model/apps-for-org {:org-id (:id org)
+                                           :user-id (:id owner)})))))))


### PR DESCRIPTION
Updates the transfer route to remove members from the app where the user has a matching role on the org.

Returns the removed app members in the body as:

```json
{
  "app_member_changes" : {
    "removed" : [ {
      "member" : {
        "id" : "628e83f7-8923-4f3a-b6a8-04f6a9f62543",
        "email" : "me@example.com",
        "role" : "collaborator"
      },
      "reason" : "user_is_member_of_org"
    } ]
  }
}
```

cc @drew-harris 