### PR TITLE
Handle a few cases where we didn't filter deleted apps

### DIFF
--- a/server/src/instant/model/member_invites.clj
+++ b/server/src/instant/model/member_invites.clj
@@ -91,6 +91,7 @@
              :where [:and
                      [:= :i.invitee-email :?email]
                      [:= :i.status [:inline "pending"]]
+                     [:= nil :a.deletion-marked-at]
                      [:>= :i.sent_at [:- :%now [:interval [:inline "3 days"]]]]]}
             {:select [[[:inline "org"] :type]
                       :i.id

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -63,6 +63,7 @@
                                                        [:instant-subscriptions :app-s] [:= :app-s.app_id :a.id]]
                                            :where [:and
                                                    [:= :m.user-id :?user-id]
+                                                   [:= nil :a.deletion-marked-at]
                                                    [:or
                                                     [:= :org-s.subscription_type_id [:inline plans/STARTUP_SUBSCRIPTION_TYPE]]
                                                     [:= :app-s.subscription_type_id [:inline plans/PRO_SUBSCRIPTION_TYPE]]]]}]
@@ -98,6 +99,7 @@
                                    :where [:and
                                            [:= :m.user-id :?user-id]
                                            [:= :o.id :?org-id]
+                                           [:= nil :a.deletion-marked-at]
                                            [:or
                                             [:= :org-s.subscription_type_id [:inline plans/STARTUP_SUBSCRIPTION_TYPE]]
                                             [:= :app-s.subscription_type_id [:inline plans/PRO_SUBSCRIPTION_TYPE]]]]}]}))
@@ -195,6 +197,7 @@
                                            :where [:and
                                                    [:= :o.id :?org-id]
                                                    [:= :m.user-id :?user-id]
+                                                   [:= nil :a.deletion-marked-at]
                                                    [:or
                                                     [:= :org-s.subscription_type_id [:inline plans/STARTUP_SUBSCRIPTION_TYPE]]
                                                     [:= :app-s.subscription_type_id [:inline plans/PRO_SUBSCRIPTION_TYPE]]]]
@@ -267,7 +270,9 @@
                               :num_bytes]]
                     :from [[:attr-sketches :s]]
                     :join [[:apps :a] [:= :s.app_id :a.id]]
-                    :where [:= :a.org_id :?org-id]}))
+                    :where [:and
+                            [:= :a.org_id :?org-id]
+                            [:= nil :a.deletion-marked-at]]}))
 
 (defn org-usage
   "Estimates amount of bytes used for an orgs's triples.

--- a/server/test/instant/model/orgs_test.clj
+++ b/server/test/instant/model/orgs_test.clj
@@ -3,9 +3,10 @@
    [clojure.test :refer [deftest is]]
    [instant.fixtures :refer [with-startup-org]]
    [instant.model.app :as app-model]
+   [instant.model.app-members :as app-members]
    [instant.model.org :as org-model]))
 
-(deftest apps-for-org
+(deftest apps-for-org-filters-deletions
   (with-startup-org
     true
     (fn [{:keys [owner org app]}]
@@ -13,6 +14,31 @@
              (map :id
                   (org-model/apps-for-org {:org-id (:id org)
                                            :user-id (:id owner)}))))
+
+      (app-model/mark-for-deletion! {:id (:id app)})
+
+      (is (= []
+             (map :id
+                  (org-model/apps-for-org {:org-id (:id org)
+                                           :user-id (:id owner)})))))))
+
+(deftest apps-for-org-filters-deletions-for-app-members
+  (with-startup-org
+    true
+    (fn [{:keys [owner org app outside-user]}]
+      (is (= []
+             (map :id
+                  (org-model/apps-for-org {:org-id (:id org)
+                                           :user-id (:id outside-user)}))))
+
+      (app-members/create! {:app-id (:id app)
+                            :user-id (:id outside-user)
+                            :role "admin"})
+
+      (is (= [(:id app)]
+             (map :id
+                  (org-model/apps-for-org {:org-id (:id org)
+                                           :user-id (:id outside-user)}))))
 
       (app-model/mark-for-deletion! {:id (:id app)})
 


### PR DESCRIPTION
Fixes a few more places where deleted apps weren't filtered:

1. Fetching orgs where you are a member of the app, but not the org
2. Fetching an org's apps where you are a member of an app, but not the org
3. Fetching org data usage
4. Showing invites to an app