### PR TITLE
Only run clojure tests on push

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,7 +1,6 @@
 name: Clojure CI
 
 on:
-  pull_request:
   push:
 
 jobs:


### PR DESCRIPTION
Skips the PR runs for clojure tests. 

I'm not sure they're all that useful because we already have the tests run on every push.