### PR TITLE
Update stripe urls for org billing

### DIFF
--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -177,13 +177,14 @@
 (defn stripe-webhook-secret []
   (-> @config-map :stripe-webhook-secret crypt-util/secret-value))
 
-(defn stripe-success-url []
-  (str (dashboard-origin)
-       "/dash?t=billing"))
-
-(defn stripe-cancel-url []
-  (str (dashboard-origin)
-       "/dash?t=billing"))
+(defn stripe-return-url [type obj-id]
+  (case type
+    :app (str (dashboard-origin)
+              "/dash?t=billing&app="
+              obj-id)
+    :org (str (dashboard-origin)
+              "/dash/org?tab=billing&org="
+              obj-id)))
 
 (def test-pro-subscription "price_1P4ocVL5BwOwpxgU8Fe6oRWy")
 (def prod-pro-subscription "price_1P4nokL5BwOwpxgUpWoidzdL")

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -828,8 +828,9 @@
                   "user-id" user-id
                   "subscription-type-id" plans/PRO_SUBSCRIPTION_TYPE}
         description (str "App name: " app-title)
-        session-params {"success_url" (str (config/stripe-success-url) "&app=" app-id)
-                        "cancel_url" (str (config/stripe-cancel-url) "&app=" app-id)
+        return-url (config/stripe-return-url :app app-id)
+        session-params {"success_url" return-url
+                        "cancel_url" return-url
                         "customer" customer-id
                         "metadata" metadata
                         "allow_promotion_codes" (or (flags/promo-code-email? user-email)
@@ -857,8 +858,9 @@
                   "user-id" user-id
                   "subscription-type-id" plans/STARTUP_SUBSCRIPTION_TYPE}
         description (str "Org name: " org-title)
-        session-params {"success_url" (str (config/stripe-success-url) "&org=" org-id)
-                        "cancel_url" (str (config/stripe-cancel-url) "&org=" org-id)
+        return-url (config/stripe-return-url :org org-id)
+        session-params {"success_url" return-url
+                        "cancel_url" return-url
                         "customer" customer-id
                         "metadata" metadata
                         "allow_promotion_codes" (or (flags/promo-code-email? user-email)


### PR DESCRIPTION
Updates the url from `/dash?t=billing&org=:org-id` to `/dash/org?tab=billing&org=:org-id`.

Also combines success and cancel url into a single return-url since we use the same url for both.