### PR TITLE
Fix invite email

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -978,8 +978,9 @@
           [:p
            (:email user)
            " invited you to collaborate on their "
-           (case :org "organization"
-                 :app "app")
+           (case type
+             :org "organization"
+             :app "app")
            " " title "."]
           [:p "Navigate to "
            [:a {:href "https://instantdb.com/dash?s=invites"}


### PR DESCRIPTION
The case statement was missing the expression, so it always returned "app".