### PR TITLE
Add constraint to app requiring org or creator

### DIFF
--- a/server/resources/migrations/89_creator_or_org_on_app.down.sql
+++ b/server/resources/migrations/89_creator_or_org_on_app.down.sql
@@ -1,0 +1,1 @@
+alter table apps drop constraint requires_creator_or_org;

--- a/server/resources/migrations/89_creator_or_org_on_app.up.sql
+++ b/server/resources/migrations/89_creator_or_org_on_app.up.sql
@@ -1,0 +1,4 @@
+alter table apps add constraint requires_creator_or_org check (
+  (creator_id is not null and org_id is null) or
+  (org_id is not null and creator_id is null)
+);

--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -313,7 +313,7 @@
                                                                                     :stripe-customer-id (:id stripe-customer)
                                                                                     :stripe-subscription-id stripe-subscription-id
                                                                                     :stripe-event-id (str "fake_evt_" (random-uuid))})]
-                              (sql/do-execute! (aurora/conn-pool :write) ["update apps set org_id = ?::uuid where id = ?::uuid"
+                              (sql/do-execute! (aurora/conn-pool :write) ["update apps set org_id = ?::uuid, creator_id = null where id = ?::uuid"
                                                                           (:id org)
                                                                           (:id app)])
                               (sql/do-execute! (aurora/conn-pool :write) ["update orgs set subscription_id = ?::uuid where id = ?::uuid"

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -574,7 +574,7 @@
         (fn [app-2]
           ;; Add the second app to the org
           (sql/do-execute! (aurora/conn-pool :write)
-                           ["update apps set org_id = ?::uuid where id = ?::uuid"
+                           ["update apps set org_id = ?::uuid, creator_id = null where id = ?::uuid"
                             (:id org)
                             (:id app-2)])
 
@@ -663,7 +663,7 @@
           (fn [{pro-app :app}]
             ;; Add the second app to the org
             (sql/do-execute! (aurora/conn-pool :write)
-                             ["update apps set org_id = ?::uuid where id = ?::uuid"
+                             ["update apps set org_id = ?::uuid, creator_id = null where id = ?::uuid"
                               (:id org)
                               (:id pro-app)])
             (dotimes [x 2]


### PR DESCRIPTION
Ensure that apps have either a creator_id or an org_id, but not both.