### PR TITLE
Fix create-instant-app for expo

### DIFF
--- a/client/packages/create-instant-app/template/base/expo/babel.config.js
+++ b/client/packages/create-instant-app/template/base/expo/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = function (api) {
   api.cache(true);
   return {
+    plugins: [
+      "react-native-reanimated/plugin",
+    ],
     presets: [
       ["babel-preset-expo", { jsxImportSource: "nativewind" }],
       "nativewind/babel",

--- a/client/packages/create-instant-app/template/base/expo/package.json
+++ b/client/packages/create-instant-app/template/base/expo/package.json
@@ -43,6 +43,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
+    "react-native-worklets": "^0.5.1",
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.16';
+const version = 'v0.21.17';
 
 export { version };


### PR DESCRIPTION
Adds missing dependency and babel config for create-instant-apps with expo

Right now if you use `create-instant-app` with expo you'll get some errors when running the app on ios.

First we'll get a missing dependency error

<img width="3202" height="738" alt="CleanShot 2025-09-17 at 16 13 02@2x" src="https://github.com/user-attachments/assets/be545b59-43ab-4bba-b142-93429289a522" />

And then you'll get a babel error

<img width="2386" height="164" alt="CleanShot 2025-09-17 at 17 00 35@2x" src="https://github.com/user-attachments/assets/2e275ce2-0b15-4fca-bf88-115fa40d5b88" />
