### PR TITLE
Fix doc on undefined in merge

### DIFF
--- a/client/www/pages/docs/instaml.md
+++ b/client/www/pages/docs/instaml.md
@@ -117,7 +117,11 @@ db.transact(db.tx.games[gameId].merge({ state: { '0-1': 'blue' } }));
 
 `merge` only merges objects. Calling `merge` on **arrays, numbers, or booleans** will overwrite the values.
 
-Sometimes you may want to remove keys from a nested object. You can do so by calling `merge` with a key set to `null` or `undefined`. This will remove the corresponding property from the object.
+Sometimes you may want to remove keys from a nested object. You can do so by calling `merge` with a key set to `null`. This will remove the corresponding property from the object.
+
+{% callout type="note" %}
+Setting a key to `undefined` will have no effect. Set the key to `null` to remove the property.
+{% /callout %}
 
 ```javascript
 // State: {'0-0': 'red', '0-1': 'blue' }


### PR DESCRIPTION
The doc for merge was outdated. We [make a change here](https://github.com/instantdb/instant/pull/1060) to ignore undefined on the client to match what the server does.

When we serialize to JSON and send to the server, the undefineds will get stripped and we'll never see them. So we pushed that change to fix a bug where a key would disappear for the optimistic update, then reappear when the server came back with the new data.


New doc:
<img width="628" height="453" alt="image" src="https://github.com/user-attachments/assets/db06ff58-9996-4505-84a6-f93eb5901bea" />