### PR TITLE
Fix optimistic update for entity that exists but triple with attr does not

### DIFF
--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -719,25 +719,32 @@ test('objects are created by etype', () => {
 test('create and update triples in one tx', () => {
   const userId = randomUUID();
 
-  const getUser = (store) => query(
-    { store },
-    { users: { $: { where: { id: userId } }}}
-  ).data.users[0];
+  const getUser = (store) =>
+    query({ store }, { users: { $: { where: { id: userId } } } }).data.users[0];
 
   const chunk1 = tx.users[userId].create({
     email: 'e@mail',
-    handle: 'handle'
+    handle: 'handle',
   });
-  const store1 = transact(store, instaml.transform({ attrs: store.attrs }, chunk1));
+  const store1 = transact(
+    store,
+    instaml.transform({ attrs: store.attrs }, chunk1),
+  );
   const user1 = getUser(store1);
   expect(user1.email).toEqual('e@mail');
   expect(user1.fullName).toEqual(undefined);
 
-  const chunk2 = tx.users[userId].update({
-    email: 'e@mail 2',
-    fullName: 'Full Name'
-  }, { upsert: false });
-  const store2 = transact(store1, instaml.transform({ attrs: store.attrs }, chunk2));
+  const chunk2 = tx.users[userId].update(
+    {
+      email: 'e@mail 2',
+      fullName: 'Full Name',
+    },
+    { upsert: false },
+  );
+  const store2 = transact(
+    store1,
+    instaml.transform({ attrs: store.attrs }, chunk2),
+  );
   const user2 = getUser(store2);
   expect(user2.email).toEqual('e@mail 2');
   expect(user2.fullName).toEqual('Full Name');

--- a/client/packages/core/__tests__/src/instaql.test.js
+++ b/client/packages/core/__tests__/src/instaql.test.js
@@ -716,6 +716,33 @@ test('objects are created by etype', () => {
   expect(newStopa.email).toEqual('stopa@instantdb.com');
 });
 
+test('create and update triples in one tx', () => {
+  const userId = randomUUID();
+
+  const getUser = (store) => query(
+    { store },
+    { users: { $: { where: { id: userId } }}}
+  ).data.users[0];
+
+  const chunk1 = tx.users[userId].create({
+    email: 'e@mail',
+    handle: 'handle'
+  });
+  const store1 = transact(store, instaml.transform({ attrs: store.attrs }, chunk1));
+  const user1 = getUser(store1);
+  expect(user1.email).toEqual('e@mail');
+  expect(user1.fullName).toEqual(undefined);
+
+  const chunk2 = tx.users[userId].update({
+    email: 'e@mail 2',
+    fullName: 'Full Name'
+  }, { upsert: false });
+  const store2 = transact(store1, instaml.transform({ attrs: store.attrs }, chunk2));
+  const user2 = getUser(store2);
+  expect(user2.email).toEqual('e@mail 2');
+  expect(user2.fullName).toEqual('Full Name');
+});
+
 test('object values', () => {
   const stopa = query(
     { store },

--- a/client/packages/core/src/store.js
+++ b/client/packages/core/src/store.js
@@ -674,34 +674,36 @@ function findTriple(store, rawTriple) {
 }
 
 export function transact(store, txSteps) {
-  const txStepsFiltered = txSteps.filter(([action, eid, attrId, value, opts]) => {
-    if (action !== 'add-triple' && action !== 'deep-merge-triple') {
+  const txStepsFiltered = txSteps.filter(
+    ([action, eid, attrId, value, opts]) => {
+      if (action !== 'add-triple' && action !== 'deep-merge-triple') {
+        return true;
+      }
+
+      const mode = opts?.mode;
+      if (mode !== 'create' && mode !== 'update') {
+        return true;
+      }
+
+      let exists = false;
+
+      const attr = getAttr(store.attrs, attrId);
+      if (attr) {
+        const idAttr = getPrimaryKeyAttr(store, attr['forward-identity'][1]);
+        exists = undefined !== findTriple(store, [eid, idAttr.id, eid]);
+      }
+
+      if (mode === 'create' && exists) {
+        return false;
+      }
+
+      if (mode === 'update' && !exists) {
+        return false;
+      }
+
       return true;
-    }
-
-    const mode = opts?.mode;
-    if (mode !== 'create' && mode !== 'update') {
-      return true;
-    }
-
-    let exists = false;
-
-    const attr = getAttr(store.attrs, attrId);
-    if (attr) {
-      const idAttr = getPrimaryKeyAttr(store, attr['forward-identity'][1]);
-      exists = undefined !== findTriple(store, [eid, idAttr.id, eid]);
-    }
-
-    if (mode === 'create' && exists) {
-      return false;
-    }
-
-    if (mode === 'update' && !exists) {
-      return false;
-    }
-
-    return true;
-  });
+    },
+  );
 
   return create(store, (draft) => {
     txStepsFiltered.forEach((txStep) => {


### PR DESCRIPTION
Reported by Kosmik https://discord.com/channels/1031957483243188235/1417133699094548601

Core of the issue is strict update mode on the client was filtering out triples if entity existed but triple with previous value didn't. Observed result was that in case like this

```
db.transact(
  db.tx.stickers[id].create({ v: 0 });
);

db.transact(
  db.tx.stickers[id].update({ v: 1, resizable: true });
);
```

after second transact you were getting query results with `{ v: 1 }` but without `resizable`