### PR TITLE
Only save caches on main

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -214,8 +214,6 @@ jobs:
           ~/.gitlibs
           ~/.deps.clj
         key: cljdeps-${{ hashFiles('server/deps.edn') }}
-        restore-keys: |
-          cljdeps-
 
 
   clj-build-check:

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -206,7 +206,7 @@ jobs:
         report_paths: '**/server/target/test-results/*.xml'
 
     - name: Save Clojure Dependencies Cache
-      if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
+      if: github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -161,8 +161,8 @@ jobs:
       with:
         cli: 1.11.3.1463
 
-    - name: Cache Clojure Dependencies
-      uses: actions/cache@v4
+    - name: Restore Clojure Dependencies Cache
+      uses: actions/cache/restore@v4
       with:
         path: |
           ~/.m2/repository
@@ -204,6 +204,19 @@ jobs:
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/server/target/test-results/*.xml'
+
+    - name: Save Clojure Dependencies Cache
+      if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.deps.clj
+        key: cljdeps-${{ hashFiles('server/deps.edn') }}
+        restore-keys: |
+          cljdeps-
+
 
   clj-build-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -124,8 +124,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 23
-          cache: 'pnpm'
-          cache-dependency-path: client/pnpm-lock.yaml
+          package-manager-cache: false
+
+      - name: Get pnpm cache directory path
+        id: pnpm-cache-dir-path
+        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
         working-directory: client
@@ -146,6 +156,14 @@ jobs:
       - name: Run benchmarks
         working-directory: client
         run: pnpm run bench
+
+      - uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
+        with:
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
   check_formatting:
     name: Check formatting
@@ -175,8 +193,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 23
-          cache: 'pnpm'
+          package-manager-cache: false
           cache-dependency-path: client/pnpm-lock.yaml
+
+      - name: Get pnpm cache directory path
+        id: pnpm-cache-dir-path
+        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
         working-directory: client
@@ -208,8 +237,19 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 23
-        cache: 'pnpm'
-        cache-dependency-path: client
+        package-manager-cache: false
+
+    - name: Get pnpm cache directory path
+      id: pnpm-cache-dir-path
+      run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
     - name: Install dependencies
       working-directory: 'client'
       run: pnpm i --frozen-lockfile
@@ -257,10 +297,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 23
-          cache: 'pnpm'
-          cache-dependency-path: client/pnpm-lock.yaml
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
+
+      - name: Get pnpm cache directory path
+        id: pnpm-cache-dir-path
+        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
         working-directory: client
@@ -338,10 +388,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 23
-          cache: 'pnpm'
-          cache-dependency-path: client/pnpm-lock.yaml
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
+
+      - name: Get pnpm cache directory path
+        id: pnpm-cache-dir-path
+        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
         working-directory: client
@@ -395,8 +455,19 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 23
-        cache: 'pnpm'
-        cache-dependency-path: client
+        package-manager-cache: false
+
+    - name: Get pnpm cache directory path
+      id: pnpm-cache-dir-path
+      run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
     - name: Install Vercel CLI
       run: npm install --g vercel@canary
     - name: Pull Vercel Environment Information
@@ -476,8 +547,18 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 23
-        cache: 'pnpm'
-        cache-dependency-path: client
+        package-manager-cache: false
+    - name: Get pnpm cache directory path
+      id: pnpm-cache-dir-path
+      run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
     - name: Install Vercel CLI
       run: npm install --g vercel@canary
     - name: Pull Vercel Environment Information
@@ -511,8 +592,19 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 23
-        cache: 'pnpm'
-        cache-dependency-path: client
+        package-manager-cache: false
+
+    - name: Get pnpm cache directory path
+      id: pnpm-cache-dir-path
+      run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
     - name: Install Vercel CLI
       run: npm install --g vercel@canary
     - name: Pull Vercel Environment Information

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -157,6 +157,11 @@ jobs:
         working-directory: client
         run: pnpm run bench
 
+      - name: Prune cache
+        if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
+        working-directory: client
+        run: pnpm prune
+
       - uses: actions/cache/save@v4
         if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
         with:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -121,7 +121,7 @@ jobs:
           version: '10.2.0'
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 23
           package-manager-cache: false
@@ -193,7 +193,7 @@ jobs:
           version: '10.2.0'
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 23
           package-manager-cache: false
@@ -237,7 +237,7 @@ jobs:
       with:
         version: '10.2.0'
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 23
         package-manager-cache: false
@@ -297,7 +297,7 @@ jobs:
           version: '10.2.0'
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 23
           package-manager-cache: false
@@ -388,7 +388,7 @@ jobs:
           version: '10.2.0'
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 23
           package-manager-cache: false
@@ -455,7 +455,7 @@ jobs:
       with:
         version: '10.2.0'
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 23
         package-manager-cache: false
@@ -547,7 +547,7 @@ jobs:
       with:
         version: '10.2.0'
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 23
         package-manager-cache: false
@@ -592,7 +592,7 @@ jobs:
       with:
         version: '10.2.0'
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 23
         package-manager-cache: false

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
@@ -161,9 +161,7 @@ jobs:
         if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
 
   check_formatting:
     name: Check formatting
@@ -203,7 +201,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
@@ -246,7 +244,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-
 
@@ -308,7 +306,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
@@ -399,7 +397,7 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
@@ -464,7 +462,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-
 
@@ -555,7 +553,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-
 
@@ -601,7 +599,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-pnpm-{{ hashFiles('client/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -158,12 +158,12 @@ jobs:
         run: pnpm run bench
 
       - name: Prune cache
-        if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
+        if: github.ref == 'refs/heads/main'
         working-directory: client
         run: pnpm prune
 
       - uses: actions/cache/save@v4
-        if: github.ref == 'refs/heads/only-cache-on-main' # XXX: TESTING
+        if: github.ref == 'refs/heads/main'
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('client/pnpm-lock.yaml') }}


### PR DESCRIPTION
We're constantly bumping up against our 10GB cache limit because GitHub treats the branch name as a hidden part of the cache key. 

You can only use the cache from the main branch on the main branch, but the main branch's caches can be used on any branch. If we only cache on main, then we shouldn't create as many caches, but most builds will still benefit from the cache. You'll just be missing any new deps you add on your branch.

This splits our cache into one restore cache step, which always runs, and one save cache step, which only runs on main.