### PR TITLE
put old usage bar back for paid org

### DIFF
--- a/client/www/components/dash/Billing.tsx
+++ b/client/www/components/dash/Billing.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 
 export const GB_1 = 1024 * 1024 * 1024;
 export const GB_10 = 10 * GB_1;
+export const GB_250 = 250 * GB_1;
 
 export function roundToDecimal(num: number, decimalPlaces: number) {
   const factor = Math.pow(10, decimalPlaces);

--- a/client/www/components/dash/org-management/OrgBilling.tsx
+++ b/client/www/components/dash/org-management/OrgBilling.tsx
@@ -7,7 +7,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { messageFromInstantError } from '@/lib/errors';
 import { InstantIssue } from '@instantdb/core';
 import { errorToast } from '@/lib/toast';
-import { friendlyUsage, GB_1, GB_10, ProgressBar } from '../Billing';
+import { friendlyUsage, GB_1, GB_10, GB_250, ProgressBar } from '../Billing';
 import { useFetchedDash } from '../MainDashLayout';
 import { Button, cn, Content, SectionHeading } from '@/components/ui';
 import { OrgWorkspace } from '@/lib/hooks/useWorkspace';
@@ -103,7 +103,7 @@ export const OrgBilling = () => {
   const totalStorageBytes = data['total-storage-bytes'] || 0;
   const totalUsageBytes = totalAppBytes + totalStorageBytes;
   const isFreeTier = data['subscription-name'] === 'Free';
-  const progressDen = isFreeTier ? GB_1 : GB_10;
+  const progressDen = isFreeTier ? GB_1 : GB_250;
   const progress = Math.round((totalUsageBytes / progressDen) * 100);
 
   return (
@@ -111,18 +111,13 @@ export const OrgBilling = () => {
       <div className="flex flex-col bg-white gap px-2 pt-1 rounded border">
         <div className="flex gap-2 items-end p-2 justify-between">
           <span className="font-bold">Usage (all apps)</span>{' '}
-          {!isPaid && (
-            <span className="font-mono text-sm">
-              {friendlyUsage(totalUsageBytes)} / {friendlyUsage(progressDen)}
-            </span>
-          )}
+          <span className="font-mono text-sm">
+            {friendlyUsage(totalUsageBytes)} / {friendlyUsage(progressDen)}
+          </span>
         </div>
-        {!isPaid && <ProgressBar width={progress} />}
+        <ProgressBar width={progress} />
         <div
-          className={cn(
-            'flex justify-start text-sm space-x-2 pl-2',
-            !isPaid && 'pt-3',
-          )}
+          className={cn('flex justify-start text-sm space-x-2 pl-2', 'pt-3')}
         >
           {totalAppBytes > 0 && (
             <span className="text-sm font-mono text-gray-500">


### PR DESCRIPTION
with usage limit of 250gb

BEFORE:
<img width="983" height="534" alt="image" src="https://github.com/user-attachments/assets/211d07e0-0911-4459-9f28-9e4e73e25a45" />

AFTER:
<img width="984" height="560" alt="image" src="https://github.com/user-attachments/assets/29fe282a-467f-4c94-9a1b-63d19e7060e0" />
