### PR TITLE
Redirect to org if the app is in another org

### DIFF
--- a/client/www/components/dash/ProfilePanel.tsx
+++ b/client/www/components/dash/ProfilePanel.tsx
@@ -100,7 +100,7 @@ export const ProfilePanel = () => {
                 <button
                   onClick={() => {
                     dashResponse.setWorkspace(org.id);
-                    router.push({ pathname: 'dash', query: { org: org.id } });
+                    router.push({ pathname: '/dash', query: { org: org.id } });
                     close();
                   }}
                   className="py-2 text-left grow px-2"

--- a/client/www/components/dash/ProfilePanel.tsx
+++ b/client/www/components/dash/ProfilePanel.tsx
@@ -64,9 +64,9 @@ export const ProfilePanel = () => {
               )}
             >
               <button
-                onClick={() => {
+                onClick={async () => {
                   dashResponse.setWorkspace('personal');
-                  router.push('/dash/', undefined, { shallow: true });
+                  router.push('/dash');
                   close();
                 }}
                 className="py-2 text-left grow px-2"
@@ -100,7 +100,7 @@ export const ProfilePanel = () => {
                 <button
                   onClick={() => {
                     dashResponse.setWorkspace(org.id);
-                    router.push('/dash/', undefined, { shallow: true });
+                    router.push({ pathname: 'dash', query: { org: org.id } });
                     close();
                   }}
                   className="py-2 text-left grow px-2"

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -28,7 +28,7 @@ import { ReactElement, useContext, useEffect, useRef, useState } from 'react';
 
 import config from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
-import { jsonMutate } from '@/lib/fetch';
+import { jsonFetch, jsonMutate } from '@/lib/fetch';
 import { successToast } from '@/lib/toast';
 import { InstantApp, SchemaNamespace } from '@/lib/types';
 
@@ -68,7 +68,6 @@ import clsx from 'clsx';
 import { createPortal } from 'react-dom';
 import { NextPageWithLayout } from '../_app';
 import { capitalize } from 'lodash';
-import { useOrgPaid } from '@/lib/hooks/useOrgPaid';
 
 // (XXX): we may want to expose this underlying type
 type InstantReactClient = ReturnType<typeof init>;
@@ -224,6 +223,7 @@ function Dashboard() {
   const appId =
     (router.query.app as string) ||
     getInitialApp(apps, fetchedDash.data.currentWorkspaceId);
+
   const screen = ((router.query.s as string) || 'main') as Screen;
   const tab = screenTab(screen, router.query.t as string);
 
@@ -303,31 +303,75 @@ function Dashboard() {
     const isAppIdValid = Boolean(apps.find((a) => a.id === appId));
     if (appId && isAppIdValid) return;
 
-    const firstApp = apps?.[0];
-    if (!firstApp) return;
-
     const lastApp = getLocallySavedApp(dashResponse.data.currentWorkspaceId);
+
     const lastAppId =
       lastApp && Boolean(apps.find((a) => a.id === lastApp.id))
         ? lastApp.id
         : null;
 
+    const firstApp = apps?.[0];
+
     const defaultAppId = lastAppId ?? firstApp.id;
-    if (!defaultAppId) return;
 
-    router.replace({
-      query: {
-        s: 'main',
-        app: defaultAppId,
-        t: tab,
-      },
-    });
+    const replaceDefault = () => {
+      if (!defaultAppId) return;
 
-    setLocallySavedApp({
-      id: defaultAppId,
-      orgId: dashResponse.data.currentWorkspaceId,
-    });
-  }, [dashResponse.data?.currentWorkspaceId, appId]);
+      router.replace({
+        query: {
+          s: 'main',
+          app: defaultAppId,
+          t: tab,
+        },
+      });
+
+      setLocallySavedApp({
+        id: defaultAppId,
+        orgId: dashResponse.data.currentWorkspaceId,
+      });
+    };
+
+    if (appId && appId !== lastAppId) {
+      let cancel = false;
+      // If we didn't find the app, check if the app lives on
+      // a different org and redirect to that.
+      jsonFetch(`${config.apiURI}/dash/apps/${appId}`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => {
+          if (
+            res?.app?.org_id &&
+            !cancel &&
+            res?.app?.org_id !== router.query.org
+          ) {
+            dashResponse.setWorkspace(res.app.org_id);
+            router.replace({
+              query: {
+                s: 'main',
+                app: appId,
+                org: res?.app?.org_id,
+                t: tab,
+              },
+            });
+          } else {
+            replaceDefault();
+          }
+        })
+        .catch((e) => {
+          console.error('e', e);
+          if (!cancel) {
+            replaceDefault();
+          }
+        });
+
+      return () => {
+        cancel = true;
+      };
+    }
+
+    replaceDefault();
+  }, [dashResponse.data?.currentWorkspaceId, appId, router.query.org]);
 
   useEffect(() => {
     if (!app) return;

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -340,11 +340,8 @@ function Dashboard() {
         headers: { Authorization: `Bearer ${token}` },
       })
         .then((res) => {
-          if (
-            res?.app?.org_id &&
-            !cancel &&
-            res?.app?.org_id !== router.query.org
-          ) {
+          if (cancel) return;
+          if (res?.app?.org_id && res?.app?.org_id !== router.query.org) {
             dashResponse.setWorkspace(res.app.org_id);
             router.replace({
               query: {
@@ -359,7 +356,6 @@ function Dashboard() {
           }
         })
         .catch((e) => {
-          console.error('e', e);
           if (!cancel) {
             replaceDefault();
           }

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -312,7 +312,7 @@ function Dashboard() {
 
     const firstApp = apps?.[0];
 
-    const defaultAppId = lastAppId ?? firstApp.id;
+    const defaultAppId = lastAppId ?? firstApp?.id;
 
     const replaceDefault = () => {
       if (!defaultAppId) return;

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -413,7 +413,7 @@
   (app-model/delete-immediately-by-id! {:id app-id}))
 
 (defn apps-get [req]
-  (let [{:keys [app user]} (req->app-and-user! :collaborator req)]
+  (let [{:keys [app]} (req->app-and-user! :collaborator req)]
     (response/ok {:app app})))
 
 (defn apps-delete [req]

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -412,6 +412,10 @@
 
   (app-model/delete-immediately-by-id! {:id app-id}))
 
+(defn apps-get [req]
+  (let [{:keys [app user]} (req->app-and-user! :collaborator req)]
+    (response/ok {:app app})))
+
 (defn apps-delete [req]
   (let [{:keys [app user]} (req->app-and-user! :admin req)
         app-id (:id app)]
@@ -1745,6 +1749,7 @@
   (GET "/dash" [] dash-get)
   (POST "/dash/apps" [] apps-post)
   (POST "/dash/profiles" [] profiles-post)
+  (GET "/dash/apps/:app_id" [] apps-get)
   (DELETE "/dash/apps/:app_id" [] apps-delete)
   (POST "/dash/apps/:app_id/clear" [] apps-clear)
   (POST "/dash/apps/:app_id/rules" [] rules-post)


### PR DESCRIPTION
If you go directly to an org's `app` and it's not in the apps from the dash response, we'll find the org that the app belongs to and redirect to the app with the org.

Test plan:

1. Go to the url for an app in an org, copy the url and make sure to remove any `org` param.
2. Go to your personal account and click on an app. 
3. Paste in the url you copied and make sure that it landed on the same app from step 1

cc @drew-harris 
