### PR TITLE
Remove limit on free orgs, always show storage and db usage

### DIFF
--- a/client/www/components/dash/Billing.tsx
+++ b/client/www/components/dash/Billing.tsx
@@ -213,16 +213,13 @@ export default function Billing({ appId }: { appId: string }) {
         </h2>
         <ProgressBar width={progress} />
         <div className="flex justify-start text-sm pt-3 space-x-2 pl-2">
-          {totalAppBytes > 0 && (
-            <span className="text-sm font-mono text-gray-500">
-              DB ({friendlyUsage(totalAppBytes)})
-            </span>
-          )}
-          {totalStorageBytes > 0 && (
-            <span className="text-sm font-mono text-gray-500">
-              Storage ({friendlyUsage(totalStorageBytes)})
-            </span>
-          )}
+          <span className="text-sm font-mono text-gray-500">
+            DB ({friendlyUsage(totalAppBytes)})
+          </span>
+
+          <span className="text-sm font-mono text-gray-500">
+            Storage ({friendlyUsage(totalStorageBytes)})
+          </span>
         </div>
       </div>
       {isFreeTier ? (

--- a/client/www/components/dash/org-management/OrgBilling.tsx
+++ b/client/www/components/dash/org-management/OrgBilling.tsx
@@ -112,23 +112,21 @@ export const OrgBilling = () => {
         <div className="flex gap-2 items-end p-2 justify-between">
           <span className="font-bold">Usage (all apps)</span>{' '}
           <span className="font-mono text-sm">
-            {friendlyUsage(totalUsageBytes)} / {friendlyUsage(progressDen)}
+            {friendlyUsage(totalUsageBytes)}{' '}
+            {isPaid && <span>/ {friendlyUsage(progressDen)}</span>}
           </span>
         </div>
-        <ProgressBar width={progress} />
+        {isPaid && <ProgressBar width={progress} />}
         <div
           className={cn('flex justify-start text-sm space-x-2 pl-2', 'pt-3')}
         >
-          {totalAppBytes > 0 && (
-            <span className="text-sm font-mono text-gray-500">
-              DB ({friendlyUsage(totalAppBytes)})
-            </span>
-          )}
-          {totalStorageBytes > 0 && (
-            <span className="text-sm font-mono pb-3 text-gray-500">
-              Storage ({friendlyUsage(totalStorageBytes)})
-            </span>
-          )}
+          <span className="text-sm font-mono text-gray-500">
+            DB ({friendlyUsage(totalAppBytes)})
+          </span>
+
+          <span className="text-sm font-mono pb-3 text-gray-500">
+            Storage ({friendlyUsage(totalStorageBytes)})
+          </span>
         </div>
       </div>
       <SectionHeading className="pt-8">Billing</SectionHeading>


### PR DESCRIPTION
Removes the data limit on free orgs, since we haven't settled on what we think the limit should be.

Also shows the db usage and storage usage breakdown, even when it is 0.

Free org
<img width="630" height="375" alt="image" src="https://github.com/user-attachments/assets/e26a871e-8618-48f0-a59a-1a66da6b6e17" />

Paid org
<img width="656" height="376" alt="image" src="https://github.com/user-attachments/assets/a5dbbc05-1cce-449b-9b30-f76a879326dd" />

