### PR TITLE
Dash: Sort apps, clean up app styles

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -731,6 +731,13 @@ function ExplorerTab({
   );
 }
 
+function compareAppTitles(a: InstantApp, b: InstantApp): number {
+  return a.title.localeCompare(b.title, undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  });
+}
+
 function AppCombobox({
   apps,
   appId,
@@ -751,12 +758,7 @@ function AppCombobox({
     ? apps.filter((a) => a.title.toLowerCase().includes(appQuery))
     : apps;
 
-  const sortedApps = filteredApps.toSorted((a, b) =>
-    a.title.localeCompare(b.title, undefined, {
-      sensitivity: 'base',
-      numeric: true,
-    }),
-  );
+  const sortedApps = filteredApps.toSorted(compareAppTitles);
 
   return (
     <Combobox
@@ -805,7 +807,10 @@ function AppCombobox({
           <ComboboxOption
             key={app.id}
             value={app}
-            className="group cursor-pointer px-3 py-2 text-sm data-[focus]:bg-gray-100"
+            className={clsx(
+              'group cursor-pointer px-3 py-2 text-sm data-[focus]:bg-gray-100',
+              app.id === appId && 'bg-gray-200 data-[focus]:bg-gray-200',
+            )}
           >
             <div className="">{app.title}</div>
           </ComboboxOption>


### PR DESCRIPTION
Report: https://discord.com/channels/1031957483243188235/1258878823529844766/1419961650487754773

Before:

<img width="756" height="984" alt="Screenshot 2025-09-23 at 18 04 45" src="https://github.com/user-attachments/assets/67703fde-6cc7-4053-82e1-31460fc45fcd" />

After:

<img width="754" height="744" alt="Screenshot 2025-09-23 at 18 04 38" src="https://github.com/user-attachments/assets/2cf8062d-e7ea-4a41-816e-b48e38d7b7c3" />

(also cleaned up styles a bit)