### PR TITLE
Show org members on app page

### DIFF
--- a/client/www/lib/hooks/useWorkspace.tsx
+++ b/client/www/lib/hooks/useWorkspace.tsx
@@ -37,7 +37,7 @@ export type OrgWorkspace = {
   type: 'org';
 } & ApiOrgResponse;
 
-type Workspace = { type: 'personal'; apps: InstantApp[] } | OrgWorkspace;
+export type Workspace = { type: 'personal'; apps: InstantApp[] } | OrgWorkspace;
 
 const getOrgDetails = async (params: {
   orgId: string;

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -69,6 +69,7 @@ import clsx from 'clsx';
 import { createPortal } from 'react-dom';
 import { NextPageWithLayout } from '../_app';
 import { capitalize } from 'lodash';
+import { Workspace } from '@/lib/hooks/useWorkspace';
 
 // (XXX): we may want to expose this underlying type
 type InstantReactClient = ReturnType<typeof init>;
@@ -529,6 +530,7 @@ function Dashboard() {
                       tab={tab}
                       nav={nav}
                       onDeleteApp={onDeleteApp}
+                      workspace={dashResponse.data.workspace}
                     />
                   ) : null}
                 </div>
@@ -656,6 +658,7 @@ function DashboardContent({
   nav,
   role,
   onDeleteApp,
+  workspace,
 }: {
   connection: { db: InstantReactClient };
   app: InstantApp;
@@ -664,6 +667,7 @@ function DashboardContent({
   role: Role;
   nav: (q: { s: string; app?: string; t?: string }, cb?: () => void) => void;
   onDeleteApp: (app: InstantApp) => void;
+  workspace: Workspace;
 }) {
   // Subscribe to schema changes at the dashboard level
   const schemaData = useSchemaQuery(connection.db);
@@ -703,6 +707,7 @@ function DashboardContent({
           app={app}
           onDelete={() => onDeleteApp(app)}
           nav={nav}
+          workspace={workspace}
         />
       ) : tab === 'billing' && isMinRole('collaborator', role) ? (
         <Billing appId={appId} />


### PR DESCRIPTION
Shows the org members on the team page for the app. 

This will make it easier for users to see who has access to an app.

This is what it looks like on an unpaid app in an org:
<img width="682" height="182" alt="image" src="https://github.com/user-attachments/assets/8e309b38-2c9f-40c7-a831-87695bc5bc7d" />

Paid app in an org:
<img width="687" height="338" alt="image" src="https://github.com/user-attachments/assets/d80fd530-5ba7-489a-8b16-a5b2066bb445" />

Other changes
- I made the buttons on the admin page varient=secondary because there were too many big blue buttons on the page
- I only show the transfer-to-org button if the user has the proper permissions