### PR TITLE
create-instant-app trim prompt.

### DIFF
--- a/client/packages/create-instant-app/src/utils/validateAppName.ts
+++ b/client/packages/create-instant-app/src/utils/validateAppName.ts
@@ -34,6 +34,10 @@ export const parseNameAndPath = (rawInput: string) => {
   return [appName, path] as const;
 };
 
+export const coerceAppName = (rawInput: string): string => {
+  return rawInput.trim();
+};
+
 /** Validate a string against allowed package.json names */
 export const validateAppName = (rawInput: string): string | undefined => {
   const input = removeTrailingSlash(rawInput);


### PR DESCRIPTION
When I wrote some text like `awesome-todos ` in the app name, we would get a validation error.

This is because `validateAppName` did not accept the empty character, and it's used in `p.text`. We never got the chance to trim. 

To solve, I added a new `coerceAppName`, which for now just trims. I use it in both places where we accept input, and pass the coerced version on to validateAppName

@drew-harris @dwwoelfel  @nezaj @tonsky