### PR TITLE
Fix up our make dev for filter

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -3,7 +3,7 @@ MAKE = make $(MAKEFLAGS)
 
 dev:
 	@echo "Booting up frontend..."
-	pnpm run dev --ui tui $(filter --filter%,$(MAKECMDGOALS))
+	pnpm run dev --ui tui $(filter-out $@,$(MAKECMDGOALS))
 
 lint:
 	pnpm run check-format

--- a/client/README.md
+++ b/client/README.md
@@ -47,7 +47,7 @@ You can either add `--filter` to make dev:
 
 ```bash
 # Run dev for a sandbox app
-make dev --filter create-instant-app
+make dev --- --filter create-instant-app
 ```
 
 Or cd into the package and run a separate command there:


### PR DESCRIPTION
I was a biit to trusting with claude on our make dev command. 

**The Problem** 

`make` itself expects that arguments denote recipes or build targets. 

So if you pass in 

```bash
make dev foo
```

It's going to try build dev AND foo

And if you pass in

```bash
make dev --foo
```

It thinks you are passing an option to make itself, and will complain that `--foo` is not a valid option

**The solution** 

We can use standard `--` to denote the end of arguments. So now we write: 

```bash
make dev --filter sb-task-tracker 
```

And bam, it works.

**Interesting reading** 
- https://askubuntu.com/questions/1410401/arguments-for-make
- https://stackoverflow.com/questions/2214575/passing-arguments-to-make-run#:~:text=Idelic-,Over%20a%20year%20ago,-It%20does%20work


@dwwoelfel @nezaj @tonsky @drew-harris 