### PR TITLE
Make cli aware of orgs

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -334,6 +334,10 @@ program
   .command('create-app')
   .description('Generate an app ID and admin token for a new app.')
   .option('-t --title', 'Title for the created app')
+  .option(
+    '-o --org <org-id>',
+    'The (optional) id of the organization to create the app in.',
+  )
   .action(async (opts) => {
     await checkVersion();
     const authToken = await readAuthTokenOrLoginWithErrorLogging();
@@ -753,7 +757,7 @@ async function promptCreateApp(opts) {
 
   const allowedOrgs = res.data.orgs.filter((org) => org.role !== 'app-member');
 
-  let org_id = opts.orgId;
+  let org_id = opts.org;
 
   if (!org_id && allowedOrgs.length) {
     const choices = [{ name: '(No organization)', value: null }];
@@ -834,14 +838,14 @@ async function promptImportAppOrCreateApp() {
       /*defaultAnswer=*/ true,
     );
     if (!ok) return { ok: false };
-    return await promptCreateApp({ orgId });
+    return await promptCreateApp({ org: orgId });
   }
 
   apps.sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at));
 
   const choice = await select({
     message: 'Which app would you like to import?',
-    choices: res.data.apps.map((app) => {
+    choices: apps.map((app) => {
       return { name: `${app.title} (${app.id})`, value: app.id };
     }),
   }).catch(() => null);

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.23';
+const version = 'v0.21.24';
 
 export { version };

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -345,7 +345,16 @@ function Dashboard() {
       })
         .then((res) => {
           if (cancel) return;
-          if (res?.app?.org_id && res?.app?.org_id !== router.query.org) {
+          if (
+            res?.app?.creator_id &&
+            dashResponse.data?.currentWorkspaceId &&
+            dashResponse.data?.currentWorkspaceId !== 'personal'
+          ) {
+            dashResponse.setWorkspace('personal');
+          } else if (
+            res?.app?.org_id &&
+            res?.app?.org_id !== router.query.org
+          ) {
             dashResponse.setWorkspace(res.app.org_id);
             router.replace({
               query: {


### PR DESCRIPTION
When you do `create-app`, it will ask you which org to pull from (if you have orgs). 

<img width="513" height="115" alt="image" src="https://github.com/user-attachments/assets/7d599426-083d-4703-b2bd-b65da45a9789" />

For pull, it will ask you which org to check if you want to import an app.

<img width="526" height="120" alt="image" src="https://github.com/user-attachments/assets/79502f64-47e5-4db5-a36c-d9c26eb1ccbe" />


Demo: https://asciinema.org/a/q0p1jbTA4s8CEzOYpZu420FB6

Also fixes a bug in the dashboard where it can't find an app if you go to the direct url after being in an org.
