### PR TITLE
Postpone user creation during magic code auth (part 1)

### DIFF
--- a/server/src/instant/model/app_user_magic_code.clj
+++ b/server/src/instant/model/app_user_magic_code.clj
@@ -20,7 +20,7 @@
 
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id id code user-id]}]
+  ([conn {:keys [app-id id code user-id email]}]
    (update-op
     conn
     {:app-id app-id
@@ -30,7 +30,8 @@
                   [:add-triple id (resolve-id :codeHash) (-> code
                                                              crypt-util/str->sha256
                                                              crypt-util/bytes->hex-string)]
-                  [:add-triple id (resolve-id :$user) user-id]])
+                  [:add-triple id (resolve-id :$user) user-id]
+                  [:add-triple id (resolve-id :email) email]])
       (assoc (get-entity id)
              :code code)))))
 

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -71,7 +71,8 @@
                     {:app-id app-id
                      :id (random-uuid)
                      :code (app-user-magic-code-model/rand-code)
-                     :user-id user-id})]
+                     :user-id user-id
+                     :email   email})]
 
     {:user u
      :created-user? (not existing-u)

--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -161,6 +161,11 @@
               :unique? false
               :index? true
               :checked-data-type :string)
+   (make-attr "$magicCodes" "email"
+              :unique? false
+              :index? true
+              :checked-data-type :string)
+   ;; TODO remove after migrating to $magicCodes.email
    (make-attr "$magicCodes" "$user"
               :reverse-identity (get-ident-spec "$users" "$magicCodes")
               :index? true


### PR DESCRIPTION
Prerequisite for #1730

Adds and fills $magicCodes.email, but doesn't use them yet. After a 24h has passed, it’ll be safe to deploy #1730