### PR TITLE
Experiment with adding back `e` to the ave_index

### DIFF
--- a/server/resources/migrations/90_add_e_to_ave_index.down.sql
+++ b/server/resources/migrations/90_add_e_to_ave_index.down.sql
@@ -1,0 +1,2 @@
+--  Run `drop index concurrently ave_index_with_e` in production
+drop index if exists ave_index_with_e;

--- a/server/resources/migrations/90_add_e_to_ave_index.down.sql
+++ b/server/resources/migrations/90_add_e_to_ave_index.down.sql
@@ -1,2 +1,2 @@
---  Run `drop index concurrently ave_index_with_e` in production
-drop index if exists ave_index_with_e;
+--  Run `drop index concurrently ave_with_e_index` in production
+drop index if exists ave_with_e_index;

--- a/server/resources/migrations/90_add_e_to_ave_index.up.sql
+++ b/server/resources/migrations/90_add_e_to_ave_index.up.sql
@@ -1,0 +1,3 @@
+-- Create concurrently in production
+--  create index concurrently ave_index_with_e on triples(app_id, attr_id, value, entity_id) where ave;
+create index if not exists ave_index_with_e on triples(app_id, attr_id, value, entity_id) where ave;

--- a/server/resources/migrations/90_add_e_to_ave_index.up.sql
+++ b/server/resources/migrations/90_add_e_to_ave_index.up.sql
@@ -1,3 +1,3 @@
 -- Create concurrently in production
---  create index concurrently ave_index_with_e on triples(app_id, attr_id, value, entity_id) where ave;
-create index if not exists ave_index_with_e on triples(app_id, attr_id, value, entity_id) where ave;
+--  create index concurrently ave_with_e_index on triples(app_id, attr_id, value, entity_id) where ave;
+create index if not exists ave_with_e_index on triples(app_id, attr_id, value, entity_id) where ave;

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -823,21 +823,6 @@
           :idx-key :ave
           :data-type :date}]))
 
-(defn pg-hint-index [[tag v :as idx]]
-  (if (and (= tag :map)
-           (= (:idx-key v) :ave))
-    (case (:data-type v)
-      :string :triples_string_trgm_gist_idx
-      :number :triples_number_type_idx
-      :boolean :triples_boolean_type_idx
-      :date :triples_date_type_idx)
-    (case (idx-key idx)
-      :ea :ea_index
-      :eav :eav_index
-      :av :av_index
-      :ave :ave_index
-      :vae :vae_index)))
-
 (defn- where-clause
   "
     Given a named pattern, return a where clause with the constants:

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -770,52 +770,58 @@
              clause))
          clauses)))
 
-(def index-configs
-  [{:name :ea_index
-    :cols [:e :a]
-    :idx-key :ea}
+(defn index-configs []
+  (keep identity
+        [{:name :ea_index
+          :cols [:e :a]
+          :idx-key :ea}
 
-   {:name :triples_pkey
-    :cols [:e :a]}
+         {:name :triples_pkey
+          :cols [:e :a]}
 
-   {:name :ave_index
-    :cols [:a :v]
-    :idx-key :ave}
+         {:name :ave_index
+          :cols [:a :v]
+          :idx-key :ave}
 
-   {:name :eav_uuid_index
-    :cols [:e :a :v]
-    :idx-key :eav}
+         (when (flags/toggled? :ave-with-e-index)
+           {:name :ave_with_e_index
+            :cols [:a :v :e]
+            :idx-key :ave})
 
-   {:name :triples_string_trgm_gist_idx
-    :cols [:a :v]
-    :idx-key :ave
-    :data-type :string}
+         {:name :eav_uuid_index
+          :cols [:e :a :v]
+          :idx-key :eav}
 
-   {:name :vae_uuid_index
-    :cols [:v :a :e]
-    :idx-key :vae}
+         {:name :triples_string_trgm_gist_idx
+          :cols [:a :v]
+          :idx-key :ave
+          :data-type :string}
 
-   {:name :triples_created_at_idx
-    :cols [:a :created-at]}
+         {:name :vae_uuid_index
+          :cols [:v :a :e]
+          :idx-key :vae}
 
-   {:name :av_index
-    :cols [:a :v :e]
-    :idx-key :av}
+         {:name :triples_created_at_idx
+          :cols [:a :created-at]}
 
-   {:name :triples_number_type_idx
-    :cols [:a :v]
-    :idx-key :ave
-    :data-type :number}
+         {:name :av_index
+          :cols [:a :v :e]
+          :idx-key :av}
 
-   {:name :triples_boolean_type_idx
-    :cols [:a :v]
-    :idx-key :ave
-    :data-type :boolean}
+         {:name :triples_number_type_idx
+          :cols [:a :v]
+          :idx-key :ave
+          :data-type :number}
 
-   {:name :triples_date_type_idx
-    :cols [:a :v]
-    :idx-key :ave
-    :data-type :date}])
+         {:name :triples_boolean_type_idx
+          :cols [:a :v]
+          :idx-key :ave
+          :data-type :boolean}
+
+         {:name :triples_date_type_idx
+          :cols [:a :v]
+          :idx-key :ave
+          :data-type :date}]))
 
 (defn pg-hint-index [[tag v :as idx]]
   (if (and (= tag :map)
@@ -1330,7 +1336,7 @@
                                                             second
                                                             :$comparator
                                                             :op)))))))))
-                index-configs)
+                (index-configs))
 
         ;; Gets the components that we know (either constants or defined
         ;; in the symbol map by a previous CTE)


### PR DESCRIPTION
Now that we're using pg_hint_plan, we can slowly roll out changes to the underlying indexes.

This adds the entity_id back to the `ave_index`. There are a lot of queries where we use the primary key instead of the ave_index because it makes the join more efficient. With the `entity_id` in the ave index, it makes it much more efficient.

We initially removed it in https://github.com/instantdb/instant/pull/622.

It's behind a feature flag toggle at `ave-with-e-index`

Deploy plan:

- [ ] Merge into main
- [ ] Run `create index concurrently ave_index_with_e on triples(app_id, attr_id, value, entity_id) where ave` to create the index
- [ ] Run the migration file
- [ ] Deploy the code
- [ ] Flip the toggle and check that no queries are going crazy


Later (if this goes well)
- [ ] Remove `ave_index` from the index list (behind a flag)
- [ ] Check that everything is okay 
- [ ] Remove from the index list
- [ ] Drop the ave_index from the db
- [ ] Do the same process for the rest of the ave indexes