### PR TITLE
Support orgs in create-instant-app

### DIFF
--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.25';
+const version = 'v0.21.26';
 
 export { version };


### PR DESCRIPTION
Following up from https://github.com/instantdb/instant/pull/1732, this adds support for creating/importing apps with orgs.

If you don't have orgs this extra prompt will be skipped.

### When creating apps
- If you have orgs, prompts: "Would you like to create the app in an organization?"
- Shows list of orgs (plus "No organization" option)
- Creates app in selected org

### When importing apps
- If you have orgs, prompts: "Would you like to import an app from an organization?"
- Shows list of orgs (plus "No organization" option)
- Fetches and displays apps from selected org
- Imports the selected app

### Implementation
- Added `fetchDashboard` to get both apps and orgs in one call
- Added `fetchOrganizationApps` to get apps from a specific org
- Filters out orgs where user only has `app-member` role (can't create apps there)
- Updated `createApp` to accept optional `orgId` parameter

https://github.com/user-attachments/assets/afa4d1f1-7082-4931-ad45-b5dc35b1536f


