### PR TITLE
Don't show error if feedback app is not configured

### DIFF
--- a/client/www/lib/intern/docs-feedback/db.ts
+++ b/client/www/lib/intern/docs-feedback/db.ts
@@ -3,7 +3,9 @@ import schema from './instant.schema';
 import config from '@/lib/config';
 
 const clientDB = init({
-  appId: process.env.NEXT_PUBLIC_FEEDBACK_APP_ID!,
+  appId:
+    process.env.NEXT_PUBLIC_FEEDBACK_APP_ID ||
+    '5d9c6277-e6ac-42d6-8e51-2354b4870c05',
   schema,
   ...config,
 });


### PR DESCRIPTION
Report: https://discord.com/channels/1031957483243188235/1421850181908824094

How it looks:

<img width="3840" height="2110" alt="Screenshot 2025-09-29 at 15 10 24" src="https://github.com/user-attachments/assets/a9a2774c-fc3c-4167-85a8-c3b709a4465e" />

Current solution is to go to `client/www` and copy `.env.example` to `.env`. It doesn’t seem to care if app exists or not

I experienced this myself once or twice after resetting the project. Very cryptic error and honestly we shouldn’t really care if feedback app is configured for running locally