### PR TITLE
Cleanup hints

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1570,7 +1570,6 @@
   single go. Then we a second pass with the counts and it determines
   the best index."
   [ctx nested-named-patterns]
-  (tool/def-locals)
   (try
     (let [sketch-keys (all-required-sketch-keys ctx nested-named-patterns)
           sketches (cms/lookup (:conn-pool (:db ctx)) sketch-keys)]

--- a/server/src/instant/db/hint_testing.clj
+++ b/server/src/instant/db/hint_testing.clj
@@ -113,19 +113,8 @@
                       (catch Exception e
                         (tracer/add-exception! e {:escaping? false})
                         e))))
-            new (tracer/with-span! {:name "test-pg-hints-for-datalog/with-hint-plan"}
-                  (binding [d/*enable-pg-hints* true
-                            d/*estimate-with-sketch* false]
-                    (try
-                      (let [res (explain-datalog ctx patterns)]
-                        (tracer/add-data! {:attributes res})
-                        res)
-                      (catch Exception e
-                        (tracer/add-exception! e {:escaping? false})
-                        e))))
             sketches (tracer/with-span! {:name "test-pg-hints-for-datalog/with-sketches"}
-                       (binding [d/*enable-pg-hints* true
-                                 d/*estimate-with-sketch* true]
+                       (binding [d/*enable-pg-hints* true]
                          (try
                            (let [res (explain-datalog ctx patterns)]
                              (tracer/add-data! {:attributes res})
@@ -134,23 +123,13 @@
                              (tracer/add-exception! e {:escaping? false})
                              e))))]
         (tracer/add-data! {:attributes {:without.ms (:time old)
-                                        :with.ms (:time new)
                                         :with-sketch.ms (:time sketches)
                                         :without.error (instance? Exception old)
-                                        :with.error (instance? Exception new)
                                         :with-sketch.error (instance? Exception sketches)
-                                        :improvement (- (or (:time sketches)
-                                                            (* 1000 10))
-                                                        (or (:time new)
-                                                            (* 1000 10)))
                                         :base-improvement (- (or (:time sketches)
                                                                  (* 1000 10))
                                                              (or (:time old)
                                                                  (* 1000 10)))
-                                        :index-diff (when (and (:indexes new)
-                                                               (:indexes sketches))
-                                                      (->json (diff-indexes (:indexes new)
-                                                                            (:indexes sketches))))
                                         :base-index-diff (when (and (:indexes old)
                                                                     (:indexes sketches))
                                                            (->json (diff-indexes (:indexes old)

--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -2150,7 +2150,7 @@
         rule-params (:$$ruleParams o)
         o (dissoc o :$$ruleParams)
         rules (or (when rules-override {:app_id app-id :code rules-override})
-                  (rule-model/get-by-app-id {:app-id app-id}))
+                  (rule-model/get-by-app-id (:conn-pool (:db ctx)) {:app-id app-id}))
 
         rule-wheres (get-rule-wheres ctx rule-params rules o)
         ctx (assoc ctx :rule-wheres rule-wheres)

--- a/server/src/instant/model/rule.clj
+++ b/server/src/instant/model/rule.clj
@@ -61,8 +61,10 @@
   ([{:keys [app-id]}]
    (cache/get rule-cache app-id get-by-app-id*))
   ([conn {:keys [app-id]}]
-   ;; Don't cache if we're using a custom connection
-   (get-by-app-id* conn app-id)))
+   (if (= conn (aurora/conn-pool :read))
+     (get-by-app-id {:app-id app-id})
+     ;; Don't cache if we're using a custom connection
+     (get-by-app-id* conn app-id))))
 
 (defn get-by-app-ids
   ([params]

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2768,8 +2768,7 @@
              ("eid-stepan-parunashvili" :users/id "eid-stepan-parunashvili"))}))))))
 
 (deftest comparators
-  (binding [d/*enable-pg-hints* true
-            d/*estimate-with-sketch* true]
+  (binding [d/*enable-pg-hints* true]
     (with-zeneca-checked-data-app
       (fn [app _r]
         (with-sketches app
@@ -3015,8 +3014,7 @@
                                     ("eid-nonfiction" :bookshelves/order 1))}))))))
 
 (deftest lookup-unique-uses-the-av-index
-  (binding [d/*enable-pg-hints* true
-            d/*estimate-with-sketch* true]
+  (binding [d/*enable-pg-hints* true]
     (with-zeneca-app
       (fn [app _r]
         (let [attr-ids {:id (random-uuid)
@@ -4733,8 +4731,7 @@
   (with-zeneca-app
     (fn [app _r]
       (with-sketches app
-        (binding [d/*enable-pg-hints* true
-                  d/*estimate-with-sketch* true]
+        (binding [d/*enable-pg-hints* true]
           (next-jdbc/with-transaction [conn (aurora/conn-pool :read)]
             (next-jdbc/execute! conn ["select set_config('pg_hint_plan.debug_print', 'verbose', true)"])
             (next-jdbc/execute! conn ["select set_config('pg_hint_plan.message_level', 'warning', true)"])


### PR DESCRIPTION
Cleans up some of the code around pg_hints.

1. Removes the code that used database count queries. That was just for testing the proof of concept.
2. Removes the double-pass through `annotate-patterns`. We used the first pass to figure out what count queries to run and which sketches to fetch, but now we don't need to figure out count queries and it's easy to walk the patterns to figure out the sketches we need.
