### PR TITLE
Handle `$isNull` sketch counts for unindexed fields

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -655,6 +655,8 @@
                 [[(level-sym last-etype last-level)
                   (:id id-attr)
                   {:$isNull {:attr-id (:id value-attr)
+                             :indexed? (and (:index? value-attr)
+                                            (not (:indexing? value-attr)))
                              :indexed-checked-type (when (and (:index? value-attr)
                                                               (not (:indexing? value-attr)))
                                                      (:checked-data-type value-attr))

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -243,6 +243,7 @@
   (with-open [conn (next.jdbc/get-connection (config/get-aurora-config))]
     (reduce (fn [acc sketch]
               (assoc acc (select-keys sketch [:app-id :attr-id]) sketch))
+            {}
             (aggregator/initial-sketch-seq conn
                                            (format "copy (select app_id, attr_id, entity_id, value, checked_data_type, created_at, eav, ea, pg_size from triples where app_id = '%s'::uuid order by app_id, attr_id) to stdout with (format binary)"
                                                    app-id)))))

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -9,7 +9,7 @@
             [instant.data.resolvers :as resolvers]
             [instant.jdbc.sql :as sql]
             [instant.fixtures :refer [with-movies-app with-zeneca-app with-zeneca-checked-data-app]]
-            [instant.util.test :refer [in-memory-sketches-for-app make-attrs]]))
+            [instant.util.test :refer [in-memory-sketches-for-app]]))
 
 (defn make-ctx [app]
   {:db {:conn-pool (aurora/conn-pool :read)}
@@ -465,8 +465,7 @@
                                   {:keys [ref? indexed? reverse?]} c
                                   id-aid (random-uuid)
                                   aid (random-uuid)
-                                  ref-id-aid (random-uuid)
-                                  ref-aid (random-uuid)]
+                                  ref-id-aid (random-uuid)]
                               (tx/transact! (aurora/conn-pool :write)
                                             (attr-model/get-by-app-id (:id app))
                                             (:id app)

--- a/server/test/instant/db/datalog_test.clj
+++ b/server/test/instant/db/datalog_test.clj
@@ -5,9 +5,11 @@
             [instant.config :as config]
             [instant.db.datalog :as d]
             [instant.db.model.attr :as attr-model]
+            [instant.db.transaction :as tx]
             [instant.data.resolvers :as resolvers]
             [instant.jdbc.sql :as sql]
-            [instant.fixtures :refer [with-movies-app with-zeneca-app]]))
+            [instant.fixtures :refer [with-movies-app with-zeneca-app with-zeneca-checked-data-app]]
+            [instant.util.test :refer [in-memory-sketches-for-app make-attrs]]))
 
 (defn make-ctx [app]
   {:db {:conn-pool (aurora/conn-pool :read)}
@@ -438,6 +440,144 @@
         (is (= #{[["eid-alex" :users/id "eid-alex" 1610218387993]]}
                (resolvers/walk-friendly r
                                         (:join-rows res))))))))
+
+(deftest sketch-size-test
+  (with-zeneca-checked-data-app
+    (fn [app r]
+      (let [cases (for [indexed? [true false]
+                        ref? [false true]
+                        ;; TODO: cardinality many
+                        cardinality [:one :many]
+                        reverse? [false true]
+                        :when (not (and (not ref?)
+                                        (or (= cardinality :many)
+                                            reverse?)))]
+                    {:indexed? indexed?
+                     :ref? ref?
+                     ;; TODO: test cardinality many
+                     ;;:cardinality cardinality
+                     :reverse? reverse?})
+
+            isnull-cases (mapv
+                          (fn [c i]
+                            (let [ns (str "is-null-" i)
+                                  ref-ns (str ns "-ref")
+                                  {:keys [ref? indexed? reverse?]} c
+                                  id-aid (random-uuid)
+                                  aid (random-uuid)
+                                  ref-id-aid (random-uuid)
+                                  ref-aid (random-uuid)]
+                              (tx/transact! (aurora/conn-pool :write)
+                                            (attr-model/get-by-app-id (:id app))
+                                            (:id app)
+                                            (concat [[:add-attr {:id id-aid
+                                                                 :forward-identity [(random-uuid) ns "id"]
+                                                                 :unique? true
+                                                                 :index? true
+                                                                 :value-type :blob
+                                                                 :cardinality :one}]]
+                                                    (if-not ref?
+                                                      [[:add-attr {:id aid
+                                                                   :forward-identity [(random-uuid) ns "value"]
+                                                                   :unique? false
+                                                                   :index? indexed?
+                                                                   :value-type :blob
+                                                                   :cardinality :one}]]
+
+                                                      [[:add-attr {:id ref-id-aid
+                                                                   :forward-identity [(random-uuid) ref-ns "id"]
+                                                                   :unique? true
+                                                                   :index? false
+                                                                   :value-type :blob
+                                                                   :cardinality :one}]
+                                                       (if reverse?
+                                                         [:add-attr {:id aid
+                                                                     :forward-identity [(random-uuid) ref-ns "ref"]
+                                                                     :reverse-identity [(random-uuid) ns "reverse-ref"]
+                                                                     :unique? false
+                                                                     :index? indexed?
+                                                                     :value-type :ref
+                                                                     :cardinality :one}]
+                                                         [:add-attr {:id aid
+                                                                     :forward-identity [(random-uuid) ns "ref"]
+                                                                     :reverse-identity [(random-uuid) (str ns "-ref") "reverse-ref"]
+                                                                     :unique? false
+                                                                     :index? indexed?
+                                                                     :value-type :ref
+                                                                     :cardinality :one}])])
+
+                                                    (mapcat (fn [i]
+                                                              (let [id (random-uuid)
+                                                                    ref-id (random-uuid)]
+                                                                (concat (when ref?
+                                                                          [[:add-triple ref-id ref-id-aid ref-id]])
+                                                                        [[:add-triple id id-aid (str id)]]
+                                                                        (case (int i)
+                                                                          0 nil ;; undefined
+                                                                          1 (if ref?
+                                                                              nil ;; no null for a ref
+                                                                              [[:add-triple id aid nil]]) ;; null
+                                                                          2 [[:add-triple id aid (if ref?
+                                                                                                   (str ref-id)
+                                                                                                   "v1")]]))))
+                                                            (range 3))))
+                              {:settings c
+                               :props {:id-attr-id id-aid
+                                       :attr-id aid
+                                       :indexed? indexed?
+                                       :ref? ref?
+                                       :reverse? (:reverse? c)
+                                       :forward-attr-id aid}}))
+                          cases
+                          (range (count cases)))
+            sketches (in-memory-sketches-for-app (:id app))
+            ctx (assoc (make-ctx app)
+                       :sketches sketches)
+            ->pattern (fn [p]
+                        (second (first (d/->named-patterns [p]))))
+            estimate-rows (fn [p]
+                            (d/estimate-rows ctx (->pattern p)))]
+        (testing "values"
+          (is (= 4 (estimate-rows [:ea '?e (resolvers/->uuid r :users/id) '?v])))
+          (is (= 1 (estimate-rows [:av '?e (resolvers/->uuid r :users/handle) "alex"])))
+          (is (= 0 (estimate-rows [:av '?e (resolvers/->uuid r :users/handle) "nobody"]))))
+
+        (testing "eid"
+          (is (= 1 (estimate-rows [:ea
+                                   #{(resolvers/->uuid r "eid-alex")}
+                                   (resolvers/->uuid r :users/id)
+                                   '?v])))
+          ;; We can't do this yet because we don't keep track of eids except
+          ;; for the "id" value (which is why the previous test passes)
+          ;; To implement this, we could look up how many entities exist
+          ;; for the id attr, but we don't have that info in datalog yet
+          #_(is (= 1 (estimate-rows [:ea
+                                     #{(resolvers/->uuid r "eid-alex")}
+                                     (resolvers/->uuid r :users/handle)
+                                     '?v]))))
+
+        (testing "$not"
+          (is (= 3 (estimate-rows [:av '?e (resolvers/->uuid r :users/handle) {:$not "alex"}]))))
+
+        (testing "$gt"
+          ;; comparators just take 1/2 since we don't have a way to do real comparisons
+          (is (= 2 (estimate-rows [:av '?e (resolvers/->uuid r :users/handle) {:$comparator
+                                                                               {:op :$gt
+                                                                                :value "alex"
+                                                                                :data-type :string}}]))))
+
+        (testing "$isNull"
+          (doseq [{:keys [settings props]} isnull-cases]
+            (testing settings
+              (tool/def-locals)
+              (is (= 2 (estimate-rows [:ave
+                                       '?e
+                                       (:id-attr-id props)
+                                       {:$isNull (assoc props :nil? true)}])))
+              (is (= 1 (estimate-rows [:ave
+                                       '?e
+                                       (:id-attr-id props)
+                                       {:$isNull (assoc props :nil? false)}]))))))))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
When we do a count for `$isNull`, we do `(check sketch nil nil)`. That gets the count of triples that have `null` for their value. This works great for indexed blob fields because we always put a `nil` into the triples table for every indexed field. 

It doesn't work so well for unindexed fields and refs. If you create an entity and leave off the field, then there will be no triple for that field and we won't see it in the sketch.

This PR solves that problem by subtracting the count of the `id` triples from the count of the field's triples, to get the number of triples that are "undefined". We add the number of nulls and number of undefined's to get the total number of `$isNull`.