### PR TITLE
Add `@instantdb/version` to make dev

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "turbo run build --cache-dir=.turbo --no-update-notifier",
-    "dev": "turbo run dev --filter=@instantdb/core --filter=@instantdb/react --filter=@instantdb/react-native --filter=@instantdb/admin --filter=instant-www --filter=sb-react-nextjs --filter=sb-admin-sdk-express --parallel --concurrency=20 --no-update-notifier",
+    "dev": "turbo run dev --filter=@instantdb/version --filter=@instantdb/core --filter=@instantdb/react --filter=@instantdb/react-native --filter=@instantdb/admin --filter=instant-www --filter=sb-react-nextjs --filter=sb-admin-sdk-express --parallel --concurrency=20 --no-update-notifier",
     "test": "turbo run test:ci --no-update-notifier",
     "bench": "turbo run bench:ci --no-update-notifier",
     "format": "prettier --write --ignore-path .prettierignore --ignore-path ../.gitignore --config ./.prettierrc \"**/*.{ts,tsx,js,jsx,json,md}\"",


### PR DESCRIPTION
While playing I realized that our `version` would get stuck in the past in dev. This is because we stopped building `@instantdb/version` locally when I introduced the changes in make dev. This adds it to our filters. 

@dwwoelfel @nezaj @tonsky @drew-harris 