### PR TITLE
Guest auth part 2

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1682,7 +1682,7 @@ export default class Reactor {
       this._currentUserCached = { isLoading: false, ...errorV };
       return errorV;
     }
-    const user = await this._getCurrentUser()
+    const user = await this._getCurrentUser();
     const userV = { user: user, error: undefined };
     this._currentUserCached = {
       isLoading: false,

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1794,6 +1794,9 @@ export default class Reactor {
 
   /**
    * Creates an OAuth authorization URL.
+   *
+   * Note: this version doesn't support promotion of guest users. Use createAuthorizationURLAsync instead
+   *
    * @param {Object} params - The parameters to create the authorization URL.
    * @param {string} params.clientName - The name of the client requesting authorization.
    * @param {string} params.redirectURL - The URL to redirect users to after authorization.
@@ -1802,6 +1805,24 @@ export default class Reactor {
   createAuthorizationURL({ clientName, redirectURL }) {
     const { apiURI, appId } = this.config;
     return `${apiURI}/runtime/oauth/start?app_id=${appId}&client_name=${clientName}&redirect_uri=${redirectURL}`;
+  }
+
+  /**
+   * Creates an OAuth authorization URL.
+   * @param {Object} params - The parameters to create the authorization URL.
+   * @param {string} params.clientName - The name of the client requesting authorization.
+   * @param {string} params.redirectURL - The URL to redirect users to after authorization.
+   * @returns {Promise<string>} The created authorization URL.
+   */
+  async createAuthorizationURLAsync({ clientName, redirectURL }) {
+    const { apiURI, appId } = this.config;
+    let url = `${apiURI}/runtime/oauth/start?app_id=${appId}&client_name=${clientName}&redirect_uri=${redirectURL}`;
+    const currentUser = await this.getCurrentUser();
+    const isGuest = currentUser?.user?.type === 'guest';
+    if (isGuest) {
+      url = `${url}&refresh_token=${currentUser.user.refresh_token}`;
+    }
+    return url;
   }
 
   /**

--- a/client/packages/core/src/authAPI.ts
+++ b/client/packages/core/src/authAPI.ts
@@ -85,6 +85,7 @@ export async function signInAsGuest({
 export type ExchangeCodeForTokenParams = {
   code: string;
   codeVerifier?: string;
+  refreshToken?: string | undefined;
 };
 
 export async function exchangeCodeForToken({
@@ -92,6 +93,7 @@ export async function exchangeCodeForToken({
   appId,
   code,
   codeVerifier,
+  refreshToken,
 }: SharedInput & ExchangeCodeForTokenParams): Promise<VerifyResponse> {
   const res = await jsonFetch(`${apiURI}/runtime/oauth/token`, {
     method: 'POST',
@@ -100,6 +102,7 @@ export async function exchangeCodeForToken({
       app_id: appId,
       code: code,
       code_verifier: codeVerifier,
+      refresh_token: refreshToken,
     }),
   });
   return res;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -328,9 +328,6 @@ class Auth {
   /**
    * Create an authorization url to sign in with an external provider.
    *
-   * Note: this version doesn't support promoting guest users. Use
-   * createAuthorizationURLAsync instead
-   *
    * @see https://instantdb.com/docs/auth
    *
    * @example
@@ -348,32 +345,6 @@ class Auth {
     redirectURL: string;
   }): string => {
     return this.db.createAuthorizationURL(params);
-  };
-
-  /**
-   * Create an authorization url to sign in with an external provider
-   *
-   * @see https://instantdb.com/docs/auth
-   *
-   * @example
-   *   const [url, setUrl] = useState<string | null>(null);
-   *
-   *   useEffect(() => {
-   *     // Get the authorization url from your backend
-   *     auth.createAuthorizationURLAsync({
-   *       clientName: 'google',
-   *       redirectURL: window.location.href,
-   *     }).then(setUrl);
-   *   }, []);
-   *
-   *   // Put it in a sign in link
-   *   <a href={url}>Log in with Google</a>
-   */
-  createAuthorizationURLAsync = (params: {
-    clientName: string;
-    redirectURL: string;
-  }): Promise<string> => {
-    return this.db.createAuthorizationURLAsync(params);
   };
 
   /**

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -326,7 +326,10 @@ class Auth {
   };
 
   /**
-   * Create an authorization url to sign in with an external provider
+   * Create an authorization url to sign in with an external provider.
+   *
+   * Note: this version doesn't support promoting guest users. Use
+   * createAuthorizationURLAsync instead
    *
    * @see https://instantdb.com/docs/auth
    *
@@ -345,6 +348,32 @@ class Auth {
     redirectURL: string;
   }): string => {
     return this.db.createAuthorizationURL(params);
+  };
+
+  /**
+   * Create an authorization url to sign in with an external provider
+   *
+   * @see https://instantdb.com/docs/auth
+   *
+   * @example
+   *   const [url, setUrl] = useState<string | null>(null);
+   *
+   *   useEffect(() => {
+   *     // Get the authorization url from your backend
+   *     auth.createAuthorizationURLAsync({
+   *       clientName: 'google',
+   *       redirectURL: window.location.href,
+   *     }).then(setUrl);
+   *   }, []);
+   *
+   *   // Put it in a sign in link
+   *   <a href={url}>Log in with Google</a>
+   */
+  createAuthorizationURLAsync = (params: {
+    clientName: string;
+    redirectURL: string;
+  }): Promise<string> => {
+    return this.db.createAuthorizationURLAsync(params);
   };
 
   /**

--- a/client/sandbox/react-nextjs/pages/play/guest.tsx
+++ b/client/sandbox/react-nextjs/pages/play/guest.tsx
@@ -158,7 +158,8 @@ function GoogleLoginRedirect() {
     auth.createAuthorizationURL({
       clientName: 'google',
       redirectURL: window.location.href,
-  }));
+    }),
+  );
   return (
     <div className="flex">
       <div className="w-[200px] flex items-center">
@@ -184,11 +185,10 @@ function GoogleLoginRedirect() {
 
 function LinkedInLoginRedirect() {
   const [url] = useState<string>(() =>
-    auth
-      .createAuthorizationURL({
-        clientName: 'linkedin-web',
-        redirectURL: window.location.href,
-      })
+    auth.createAuthorizationURL({
+      clientName: 'linkedin-web',
+      redirectURL: window.location.href,
+    }),
   );
 
   return (
@@ -293,11 +293,10 @@ function AppleLoginPopup() {
 
 function AppleLoginRedirect() {
   const [url] = useState<string>(() =>
-    auth
-      .createAuthorizationURL({
-        clientName: 'apple',
-        redirectURL: window.location.href,
-      })
+    auth.createAuthorizationURL({
+      clientName: 'apple',
+      redirectURL: window.location.href,
+    }),
   );
 
   return (

--- a/client/sandbox/react-nextjs/pages/play/guest.tsx
+++ b/client/sandbox/react-nextjs/pages/play/guest.tsx
@@ -157,10 +157,12 @@ function GoogleLoginRedirect() {
   const [url, setUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    auth.createAuthorizationURLAsync({
-      clientName: 'google',
-      redirectURL: window.location.href,
-    }).then(setUrl);
+    auth
+      .createAuthorizationURLAsync({
+        clientName: 'google',
+        redirectURL: window.location.href,
+      })
+      .then(setUrl);
   }, []);
 
   return (
@@ -190,10 +192,12 @@ function LinkedInLoginRedirect() {
   const [url, setUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    auth.createAuthorizationURLAsync({
-      clientName: 'linkedin-web',
-      redirectURL: window.location.href,
-    }).then(setUrl);
+    auth
+      .createAuthorizationURLAsync({
+        clientName: 'linkedin-web',
+        redirectURL: window.location.href,
+      })
+      .then(setUrl);
   }, []);
 
   return (
@@ -300,10 +304,12 @@ function AppleLoginRedirect() {
   const [url, setUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    auth.createAuthorizationURLAsync({
-      clientName: 'apple',
-      redirectURL: window.location.href,
-    }).then(setUrl);
+    auth
+      .createAuthorizationURLAsync({
+        clientName: 'apple',
+        redirectURL: window.location.href,
+      })
+      .then(setUrl);
   }, []);
 
   return (
@@ -317,7 +323,8 @@ function AppleLoginRedirect() {
             href={url}
             className="inline-block px-4 py-2 bg-black text-white rounded hover:bg-gray-800 no-underline"
             style={{
-              fontFamily: 'SF Pro, -apple-system, BlinkMacSystemFont, sans-serif',
+              fontFamily:
+                'SF Pro, -apple-system, BlinkMacSystemFont, sans-serif',
             }}
           >
             􀣺 Sign in with Apple Redirect
@@ -375,7 +382,8 @@ function ClerkLoginInternal() {
 }
 
 function ClerkLogin() {
-  const clerkPublishableKey = 'pk_test_Z3Jvd24tY2FyaWJvdS04NC5jbGVyay5hY2NvdW50cy5kZXYk';
+  const clerkPublishableKey =
+    'pk_test_Z3Jvd24tY2FyaWJvdS04NC5jbGVyay5hY2NvdW50cy5kZXYk';
 
   return (
     <ClerkProvider publishableKey={clerkPublishableKey}>
@@ -414,7 +422,7 @@ function SignedOut() {
 function SignedInAsGuest({ user }: { user: any }) {
   return (
     <div className="max-w-4xl mx-auto">
-      <SignedIn user={ user } />
+      <SignedIn user={user} />
 
       <h2 className="text-lg font-semibold mb-4">Upgrade your account</h2>
       <div className="space-y-4">

--- a/client/sandbox/react-nextjs/pages/play/guest.tsx
+++ b/client/sandbox/react-nextjs/pages/play/guest.tsx
@@ -154,17 +154,11 @@ function GoogleLoginPopup() {
 }
 
 function GoogleLoginRedirect() {
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    auth
-      .createAuthorizationURLAsync({
-        clientName: 'google',
-        redirectURL: window.location.href,
-      })
-      .then(setUrl);
-  }, []);
-
+  const [url] = useState<string>(() =>
+    auth.createAuthorizationURL({
+      clientName: 'google',
+      redirectURL: window.location.href,
+  }));
   return (
     <div className="flex">
       <div className="w-[200px] flex items-center">
@@ -189,16 +183,13 @@ function GoogleLoginRedirect() {
 }
 
 function LinkedInLoginRedirect() {
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
+  const [url] = useState<string>(() =>
     auth
-      .createAuthorizationURLAsync({
+      .createAuthorizationURL({
         clientName: 'linkedin-web',
         redirectURL: window.location.href,
       })
-      .then(setUrl);
-  }, []);
+  );
 
   return (
     <div className="flex">
@@ -301,16 +292,13 @@ function AppleLoginPopup() {
 }
 
 function AppleLoginRedirect() {
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
+  const [url] = useState<string>(() =>
     auth
-      .createAuthorizationURLAsync({
+      .createAuthorizationURL({
         clientName: 'apple',
         redirectURL: window.location.href,
       })
-      .then(setUrl);
-  }, []);
+  );
 
   return (
     <div className="flex">

--- a/client/sandbox/react-nextjs/pages/play/guest.tsx
+++ b/client/sandbox/react-nextjs/pages/play/guest.tsx
@@ -178,12 +178,46 @@ function GoogleLoginRedirect() {
   );
 }
 
+function LinkedInLoginRedirect() {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    auth.createAuthorizationURLAsync({
+      clientName: 'linkedin-web',
+      redirectURL: window.location.href,
+    }).then(setUrl);
+  }, []);
+
+  return (
+    <div className="flex">
+      <div className="w-[200px] flex items-center">
+        <span className="text-sm font-medium">LinkedIn Redirect</span>
+      </div>
+      <div className="w-[500px]">
+        {url ? (
+          <a
+            href={url}
+            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 no-underline"
+          >
+            Sign in with LinkedIn
+          </a>
+        ) : (
+          <div className="inline-block px-4 py-2 bg-gray-400 text-white rounded">
+            Loading...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function UserSignIns() {
   return (
     <>
       <SignInWithMagicCode />
       <GoogleLoginPopup />
       <GoogleLoginRedirect />
+      <LinkedInLoginRedirect />
     </>
   );
 }

--- a/client/sandbox/react-nextjs/pages/play/guest.tsx
+++ b/client/sandbox/react-nextjs/pages/play/guest.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { init } from '@instantdb/react';
 import config from '../../config';
 // Import Google OAuth components
@@ -146,24 +146,33 @@ function GoogleLoginPopup() {
 }
 
 function GoogleLoginRedirect() {
-  const [url] = useState(() =>
-    auth.createAuthorizationURL({
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    auth.createAuthorizationURLAsync({
       clientName: 'google',
       redirectURL: window.location.href,
-    }),
-  );
+    }).then(setUrl);
+  }, []);
+
   return (
     <div className="flex">
       <div className="w-[200px] flex items-center">
         <span className="text-sm font-medium">Google Redirect</span>
       </div>
       <div className="w-[500px]">
-        <a
-          href={url}
-          className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 no-underline"
-        >
-          Sign in with Google Redirect
-        </a>
+        {url ? (
+          <a
+            href={url}
+            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 no-underline"
+          >
+            Sign in with Google Redirect
+          </a>
+        ) : (
+          <div className="inline-block px-4 py-2 bg-gray-400 text-white rounded">
+            Loading...
+          </div>
+        )}
       </div>
     </div>
   );

--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -38,7 +38,7 @@
                                userinfo-endpoint]
   OAuthClient
   (create-authorization-url [_ state redirect-url extra-params]
-    (let [base-params {:scope "email"
+    (let [base-params {:scope "email openid"
                        :response_type "code"
                        :response_mode "form_post"
                        :state state

--- a/server/src/instant/model/app_oauth_code.clj
+++ b/server/src/instant/model/app_oauth_code.clj
@@ -14,7 +14,6 @@
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [code
-                 user-id
                  app-id
                  code-challenge-method
                  code-challenge
@@ -31,7 +30,6 @@
                           crypt-util/bytes->hex-string)]
         (transact! [[:add-triple eid (resolve-id :id) eid]
                     [:add-triple eid (resolve-id :codeHash) code-hash]
-                    [:add-triple eid (resolve-id :$user) user-id] ;; TODO remove
                     [:add-triple eid (resolve-id :codeChallengeMethod) code-challenge-method]
                     [:add-triple eid (resolve-id :codeChallenge) code-challenge]
                     [:add-triple eid (resolve-id :$oauthClient) client-id]

--- a/server/src/instant/model/app_oauth_redirect.clj
+++ b/server/src/instant/model/app_oauth_redirect.clj
@@ -17,20 +17,24 @@
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id state cookie redirect-url oauth-client-id
-                 code-challenge-method code-challenge]}]
+                 code-challenge-method code-challenge user-id]}]
    (update-op
     conn
     {:app-id app-id
      :etype etype}
     (fn [{:keys [transact! resolve-id get-entity]}]
       (let [eid (random-uuid)]
-        (transact! [[:add-triple eid (resolve-id :id) eid]
-                    [:add-triple eid (resolve-id :stateHash) (hash-uuid state)]
-                    [:add-triple eid (resolve-id :cookieHash) (hash-uuid cookie)]
-                    [:add-triple eid (resolve-id :redirectUrl) redirect-url]
-                    [:add-triple eid (resolve-id :$oauthClient) oauth-client-id]
-                    [:add-triple eid (resolve-id :codeChallengeMethod) code-challenge-method]
-                    [:add-triple eid (resolve-id :codeChallenge) code-challenge]])
+        (transact!
+         (concat
+          [[:add-triple eid (resolve-id :id) eid]
+           [:add-triple eid (resolve-id :stateHash) (hash-uuid state)]
+           [:add-triple eid (resolve-id :cookieHash) (hash-uuid cookie)]
+           [:add-triple eid (resolve-id :redirectUrl) redirect-url]
+           [:add-triple eid (resolve-id :$oauthClient) oauth-client-id]
+           [:add-triple eid (resolve-id :codeChallengeMethod) code-challenge-method]
+           [:add-triple eid (resolve-id :codeChallenge) code-challenge]]
+          (when user-id
+            [[:add-triple eid (resolve-id :$user) user-id]])))
         (get-entity eid))))))
 
 (defn consume!

--- a/server/src/instant/model/app_user_refresh_token.clj
+++ b/server/src/instant/model/app_user_refresh_token.clj
@@ -37,7 +37,8 @@
     {:app-id app-id
      :etype etype}
     (fn [{:keys [transact! resolve-id get-entity]}]
-      (let [entity-id (random-uuid)]
+      (let [id        (or id (random-uuid))
+            entity-id (random-uuid)]
         (transact! [[:add-triple entity-id (resolve-id :id) entity-id]
                     [:add-triple entity-id (resolve-id :hashedToken) (hash-token id)]
                     [:add-triple entity-id (resolve-id :$user) user-id]])

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -463,10 +463,16 @@
                                 (throw (ex-info "Invalid email" {:type  :oauth-error
                                                                  :email (:email user-info)})))
 
+        guest-user          (when-some [refresh-token (ex/get-optional-param! req [:body :refresh-token] uuid-util/coerce)]
+                              (app-user-model/get-by-refresh-token!
+                               {:app-id        app-id
+                                :refresh-token refresh-token}))
+
         {user-id :user_id}  (upsert-oauth-link! {:email       email
                                                  :sub         (:sub user-info)
                                                  :app-id      app-id
-                                                 :provider-id (:provider_id client)})
+                                                 :provider-id (:provider_id client)
+                                                 :user-id     (:id guest-user)})
 
         refresh-token-id    (random-uuid)
 

--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -246,11 +246,6 @@
               :unique? true
               :index? true
               :checked-data-type :string)
-   ;; TODO remove "$user"
-   (make-attr "$oauthCodes" "$user"
-              :reverse-identity (get-ident-spec "$users" "$oauthCodes")
-              :value-type :ref
-              :on-delete :cascade)
    (make-attr "$oauthCodes" "codeChallengeMethod"
               :checked-data-type :string)
    (make-attr "$oauthCodes" "codeChallenge"

--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -280,7 +280,11 @@
    (make-attr "$oauthRedirects" "codeChallengeMethod"
               :checked-data-type :string)
    (make-attr "$oauthRedirects" "codeChallenge"
-              :checked-data-type :string)])
+              :checked-data-type :string)
+   (make-attr "$oauthRedirects" "$user"
+              :reverse-identity (get-ident-spec "$users" "$oauthRedirects")
+              :value-type :ref
+              :on-delete :cascade)])
 
 (def $files-attrs
   [(make-attr "$files" "id"


### PR DESCRIPTION
Before: #1723

Other types of sign in should support promoting from guest user

- [x] Google Popup
- [x] Google Redirect
- [x] LinkedIn Redirect
- [x] Apple Popup
- [x] Apple Redirect
- [x] Clerk

This PR also adds `createAuthorizationURLAsync` because guest promotion needs refreshToken and that lives in `getCurrentUser` which is async :( If anyone have better ideas how to work around that I’m all ears

We also changed scope to GenericOAuthClient from `email` to `email openid` which fixes LinkedIn and seem to not affect other providers

Finally, an uber Sign In page that collects everything:

<img width="1606" height="1254" alt="Screenshot 2025-09-30 at 21 21 58" src="https://github.com/user-attachments/assets/3e2fef5a-0e42-410b-bec5-92d600c3b98c" />

I’ll look into native sign in tomorrow, chances are they also need massaging, perhaps in next PR (+ docs)