### PR TITLE
Fix stripe test

### DIFF
--- a/server/src/instant/fixtures.clj
+++ b/server/src/instant/fixtures.clj
@@ -213,7 +213,10 @@
      (fn [app#]
        (run-zeneca-byop app# ~f))))
 
-(defn with-pro-app [{:keys [create-fake-objects? free?]} owner f]
+(defn with-pro-app [{:keys [create-fake-objects? free?
+                            skip-billing-cycle-anchor?]}
+                    owner
+                    f]
   (binding [stripe/*create-fake-objects* create-fake-objects?]
     (let [app-id (random-uuid)
           app (app-model/create!
@@ -226,7 +229,8 @@
           stripe-subscription-id (:id (stripe/create-pro-subscription {:customer-id (:id stripe-customer)
                                                                        :app app
                                                                        :user owner
-                                                                       :free? free?}))
+                                                                       :free? free?
+                                                                       :skip-billing-cycle-anchor? skip-billing-cycle-anchor?}))
           owner-req (mock-app-req app owner)
           _ (instant-subscription-model/create!
              {:user-id (:id owner)

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -842,7 +842,8 @@
       (fn [{:keys [org owner]}]
         (testing "the org gets a credit for the amount they have paid"
           (with-pro-app
-            {:create-fake-objects? false}
+            {:create-fake-objects? false
+             :skip-billing-cycle-anchor? true}
             owner
             (fn [{:keys [app stripe-subscription-id]}]
 

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -857,17 +857,16 @@
                 (is (neg? (-> resp
                               :body
                               :credit)))
-              ;; is app transfered
+                ;; is app transfered
                 (is (nil? (:creator_id (app-model/get-by-id! {:id (:id app)}))))
                 (is (= (:id org) (:org_id (app-model/get-by-id! {:id (:id app)}))))
 
                 (is (= "canceled" (.getStatus (stripe/subscription stripe-subscription-id))))
 
-              ;; does the customer have a credit
+                ;; does the customer have a credit
                 (let [sub-id (:stripe_subscription_id
                               (sql/select-one (aurora/conn-pool :read)
                                               ["select * from instant_subscriptions s join orgs o on o.subscription_id = s.id where o.id = ?::uuid" (:id org)]))]
-                ;; If this fails around midnight on the last day of the month, just try again
                   (is (neg? (stripe/customer-balance-by-subscription sub-id))))))))
         (testing "the org gets no credit if they haven't paid anything"
           (with-pro-app
@@ -886,17 +885,16 @@
                 (is (nil? (-> resp
                               :body
                               :credit)))
-              ;; is app transfered
+                ;; is app transfered
                 (is (nil? (:creator_id (app-model/get-by-id! {:id (:id app)}))))
                 (is (= (:id org) (:org_id (app-model/get-by-id! {:id (:id app)}))))
 
                 (is (= "canceled" (.getStatus (stripe/subscription stripe-subscription-id))))
 
-              ;; does the customer have a credit
+                ;; does the customer have a credit
                 (let [sub-id (:stripe_subscription_id
                               (sql/select-one (aurora/conn-pool :read)
                                               ["select * from instant_subscriptions s join orgs o on o.subscription_id = s.id where o.id = ?::uuid" (:id org)]))]
-                ;; If this fails around midnight on the last day of the month, just try again
                   (is (neg? (stripe/customer-balance-by-subscription sub-id))))))))))))
 
 (deftest members-transfer-for-paid-orgs


### PR DESCRIPTION
The stripe test was failing because it expected a refund, but since the subscription was started so close to the end of the month, there was no refund.

This changes the subscription not to anchor to the first of the month for the failing test. Then we'll always get a refund when we transfer the app to an org.