### PR TITLE
[easy] add INSTANT_ADMIN_TOKEN to the note in cli

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -546,7 +546,7 @@ async function handleEnvFile(pkgAndAuthInfo, { appId, appToken }) {
     `\nLooks like you don't have a ${chalk.green('`.env`')} file yet.`,
   );
   console.log(
-    `If we set ${chalk.green('`' + envName + '`')}, we can remember the app that you chose for all future commands.`,
+    `If we set ${chalk.green('`' + envName + '`')} & ${chalk.green('INSTANT_ADMIN_TOKEN')}, we can remember the app that you chose for all future commands.`,
   );
   const ok = await promptOk(
     'Want us to create this env file for you?',

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.21.28';
+const version = 'v0.21.29';
 
 export { version };


### PR DESCRIPTION
I realized we didn't mention that we also set INSTANT_ADMIN_TOKEN. Updated the text to say that: 

<img width="2736" height="316" alt="image" src="https://github.com/user-attachments/assets/91958e1f-b3ef-4972-a1c6-72d9a892f9b8" />

@dwwoelfel @nezaj @tonsky @drew-harris 