### PR TITLE
INSTANT_ADMIN_TOKEN -> INSTANT_APP_ADMIN_TOKEN

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -276,8 +276,8 @@ async function jsonFetch(
  *  import { init } from "@instantdb/admin"
  *
  *  const db = init({
- *    appId: "my-app-id",
- *    adminToken: process.env.INSTANT_ADMIN_TOKEN
+ *    appId: process.env.INSTANT_APP_ID!,
+ *    adminToken: process.env.INSTANT_APP_ADMIN_TOKEN
  *  })
  *
  *  // You can also provide a schema for type safety and editor autocomplete!
@@ -286,8 +286,8 @@ async function jsonFetch(
  *  import schema from ""../instant.schema.ts";
  *
  *  const db = init({
- *    appId: "my-app-id",
- *    adminToken: process.env.INSTANT_ADMIN_TOKEN,
+ *    appId: process.env.INSTANT_APP_ID!,
+ *    adminToken: process.env.INSTANT_APP_ADMIN_TOKEN,
  *    schema,
  *  })
  *  // To learn more: https://instantdb.com/docs/modeling-data

--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -546,7 +546,7 @@ async function handleEnvFile(pkgAndAuthInfo, { appId, appToken }) {
     `\nLooks like you don't have a ${chalk.green('`.env`')} file yet.`,
   );
   console.log(
-    `If we set ${chalk.green('`' + envName + '`')} & ${chalk.green('INSTANT_ADMIN_TOKEN')}, we can remember the app that you chose for all future commands.`,
+    `If we set ${chalk.green('`' + envName + '`')} & ${chalk.green('INSTANT_APP_ADMIN_TOKEN')}, we can remember the app that you chose for all future commands.`,
   );
   const ok = await promptOk(
     'Want us to create this env file for you?',


### PR DESCRIPTION
I was e2e testing the new admin changes, and realized the .env var that gets created is called `INSTANT_APP_ADMIN_TOKEN`. 

I went ahead and updated the chalk text, as well as a few docblocks where we use process.env.  

@dwwoelfel @nezaj @tonsky @drew-harris 