### PR TITLE
Publish our postgres image to github's container registry

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -102,7 +102,7 @@ jobs:
 
     services:
       postgres:
-        image: public.ecr.aws/z9j8u5b3/instant-public:postgresql-16-pg-hint-plan
+        image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
         ports:
           - 5432:5432
         env:

--- a/server/dev-postgres/Makefile
+++ b/server/dev-postgres/Makefile
@@ -1,16 +1,9 @@
 MAKEFLAGS = --no-print-directory --always-make --silent
 MAKE = make $(MAKEFLAGS)
 
-ecr-login:
-	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-
-build-and-push-image:
-	docker buildx build --platform linux/amd64,linux/arm64 --push \
-		-t public.ecr.aws/z9j8u5b3/instant-public:postgresql-16-pg-hint-plan .
-
 github-login:
 	echo "Follow instructions at https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry"
 
-build-and-push-github:
+build-and-push-image:
 	docker buildx build --platform linux/amd64,linux/arm64 --push \
 		-t ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan .

--- a/server/dev-postgres/Makefile
+++ b/server/dev-postgres/Makefile
@@ -7,3 +7,10 @@ ecr-login:
 build-and-push-image:
 	docker buildx build --platform linux/amd64,linux/arm64 --push \
 		-t public.ecr.aws/z9j8u5b3/instant-public:postgresql-16-pg-hint-plan .
+
+github-login:
+	echo "Follow instructions at https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry"
+
+build-and-push-github:
+	docker buildx build --platform linux/amd64,linux/arm64 --push \
+		-t ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan .

--- a/server/dev-postgres/README.md
+++ b/server/dev-postgres/README.md
@@ -1,11 +1,18 @@
 Builds the image for postgres that is used in the local docker compose setup.
 
-Log in to the instant public ecr registry:
+Log in to GitHub's container registry:
 
-```sh
-make ecr-login
+[Check the docs to see if GitHub has improved the signin process](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
+
+1. Create a new personal access token (classic) with the write:packages scope
+2. Save your personal access token (classic). We recommend saving your token as an environment variable.
+```bash
+export CR_PAT=YOUR_TOKEN
 ```
-
+3. Sign in to the Container registry service at ghcr.io.
+```bash
+echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin
+```
 Build and push the image:
 
 ```sh

--- a/server/docker-compose-dev.yml
+++ b/server/docker-compose-dev.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: public.ecr.aws/z9j8u5b3/instant-public:postgresql-16-pg-hint-plan
+    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
     ports:
       - '8890:5432'
     environment:


### PR DESCRIPTION
We get occasional rate-limit errors when we pull the image from amazon's container registry. It doesn't fail the build, because we retry and start again, but it slows it down.


With this change, we'll push the image to the github container registry, which seems to be a bit faster.

It's also nice that we can have multiple package names--with the amazon registry, everything went into the `instantdb` package, and we just had to give it different tags.