### PR TITLE
Allow single-digit month in triple dates

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -1071,23 +1071,23 @@
    ;; 2025-03-01T16:08:53+0000
    (-> (DateTimeFormatterBuilder.)
        (.appendValue ChronoField/YEAR 1 19 SignStyle/NORMAL)
-       (.appendPattern "-MM-dd'T'HH:mm:ss")
+       (.appendPattern "-M-dd'T'HH:mm:ss")
        (.append optional-nano-or-milli)
        (.appendPattern "[Z][X]")
        (.toFormatter))
    (-> (DateTimeFormatterBuilder.)
        (.appendValue ChronoField/YEAR 1 19 SignStyle/NORMAL)
-       (.appendPattern "-MM-d'T'HH:mm:ss.SSSX")
+       (.appendPattern "-M-d'T'HH:mm:ss.SSSX")
        (.toFormatter))
    (-> (DateTimeFormatterBuilder.)
        (.appendValue ChronoField/YEAR 1 19 SignStyle/NORMAL)
-       (.appendPattern "-MM-dd HH:mm:ss")
+       (.appendPattern "-M-dd HH:mm:ss")
        (.append optional-nano-or-milli)
        (.appendOffset "+HHmm" "Z")
        (.toFormatter))
    (-> (DateTimeFormatterBuilder.)
        (.appendValue ChronoField/YEAR 1 19 SignStyle/NORMAL)
-       (.appendPattern "-MM-dd'T'HH:mm:ss")
+       (.appendPattern "-M-dd'T'HH:mm:ss")
        (.append pgtime/tz-abbrev-formatter)
        (.toFormatter))])
 
@@ -1165,7 +1165,6 @@
          (number? x)
          (Instant/ofEpochMilli x))))
 
-
 (comment
   (parse-date-value "3/12/4444")
   (parse-date-value "3/02/4444")
@@ -1179,6 +1178,7 @@
   (parse-date-value "2025-01-15 20:53:08")
   (parse-date-value "\"2025-01-15 20:53:08\"")
   (parse-date-value "8/4/2025, 11:02:31 PM")
+  (parse-date-value "2025-9-29T23:59:59.999Z")
 
   ;; These should throw an exception
   (parse-date-value "2025-01-0")

--- a/server/test/instant/db/model/triple_test.clj
+++ b/server/test/instant/db/model/triple_test.clj
@@ -49,7 +49,8 @@
              "2025-06-05T17:00:00PDT"
              "2025-06-05T17:00:00CETDST"
              "2025-06-05T17:00:00CET"
-             "3/12/4444"]]
+             "3/12/4444"
+             "2025-9-29T23:59:59.999Z"]]
     (testing (str "Date string `" s "` parses.")
       (let [pg-date (extract-pg-date s)]
         (is (= pg-date


### PR DESCRIPTION
Updates the date-time parsers to allow single digit month values, e.g. `2025-9-29T23:59:59.999Z`