### PR TITLE
Add client-id and auth-code to $oauthCodes

### DIFF
--- a/server/src/instant/model/app_oauth_code.clj
+++ b/server/src/instant/model/app_oauth_code.clj
@@ -17,7 +17,9 @@
                  user-id
                  app-id
                  code-challenge-method
-                 code-challenge]}]
+                 code-challenge
+                 client-id
+                 auth-code]}]
    (update-op
     conn
     {:app-id app-id
@@ -29,9 +31,11 @@
                           crypt-util/bytes->hex-string)]
         (transact! [[:add-triple eid (resolve-id :id) eid]
                     [:add-triple eid (resolve-id :codeHash) code-hash]
-                    [:add-triple eid (resolve-id :$user) user-id]
+                    [:add-triple eid (resolve-id :$user) user-id] ;; TODO remove
                     [:add-triple eid (resolve-id :codeChallengeMethod) code-challenge-method]
-                    [:add-triple eid (resolve-id :codeChallenge) code-challenge]])
+                    [:add-triple eid (resolve-id :codeChallenge) code-challenge]
+                    [:add-triple eid (resolve-id :$oauthClient) client-id]
+                    [:add-triple eid (resolve-id :authCode) auth-code]])
         (get-entity eid))))))
 
 (defn expired?

--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -52,6 +52,7 @@
    "email" "email"
    "type" "type"
    "codeHash" "codehash"
+   "authCode" "authcode"
    "$user" "user"
    "hashedToken" "hashedtok"
    "name" "name"
@@ -245,6 +246,7 @@
               :unique? true
               :index? true
               :checked-data-type :string)
+   ;; TODO remove "$user"
    (make-attr "$oauthCodes" "$user"
               :reverse-identity (get-ident-spec "$users" "$oauthCodes")
               :value-type :ref
@@ -252,7 +254,13 @@
    (make-attr "$oauthCodes" "codeChallengeMethod"
               :checked-data-type :string)
    (make-attr "$oauthCodes" "codeChallenge"
-              :checked-data-type :string)])
+              :checked-data-type :string)
+   (make-attr "$oauthCodes" "authCode"
+              :checked-data-type :string)
+   (make-attr "$oauthCodes" "$oauthClient"
+              :reverse-identity (get-ident-spec "$oauthClients" "$oauthCodes")
+              :value-type :ref
+              :on-delete :cascade)])
 
 (def $oauth-redirect-attrs
   [(make-attr "$oauthRedirects" "id"

--- a/server/src/instant/system_catalog_ops.clj
+++ b/server/src/instant/system_catalog_ops.clj
@@ -52,6 +52,7 @@
                           :stateHash :state_hash
                           :cooke-hash :cookie_hash
                           :redirectUrl :redirect_url
+                          :authCode :auth_code
                           :name (case etype
                                   "$oauthProviders" :provider_name
                                   "$oauthClients" :client_name


### PR DESCRIPTION
Pre-requisite for #1750

We want to postpone user creation from `/oauth/callback` to `/oauth/token`. To do that, we need to store `$oauthClient` and `$authCode` in `$oauthCodes` and wait for all in-flight requests to expire (10-60 minutes)

Needs to be deployed before #1750