### PR TITLE
rename swr cache to descriptive key in localstorage

### DIFF
--- a/client/www/lib/swrCache.ts
+++ b/client/www/lib/swrCache.ts
@@ -2,13 +2,11 @@ export function localStorageProvider() {
   if (typeof window === 'undefined') {
     return new Map();
   }
-  const map = new Map(
-    JSON.parse(localStorage.getItem(`something-cache`) || '[]'),
-  );
+  const map = new Map(JSON.parse(localStorage.getItem(`swr-cache`) || '[]'));
 
   window.addEventListener('beforeunload', () => {
     const appCache = JSON.stringify(Array.from(map.entries()));
-    localStorage.setItem(`something-cache`, appCache);
+    localStorage.setItem(`swr-cache`, appCache);
   });
 
   return map;


### PR DESCRIPTION
I sloppily called it 'something-cache' for whatever reason during the org ui process. Let me know if i should write something to maybe migrate the key and transfer instead of just moving to this and leaving the old one. 