### PR TITLE
Add an `isGuest` field to user

### DIFF
--- a/client/packages/core/src/clientTypes.ts
+++ b/client/packages/core/src/clientTypes.ts
@@ -3,6 +3,7 @@ export type User = {
   refresh_token: string;
   email?: string | null | undefined;
   type?: 'user' | 'guest' | undefined;
+  isGuest: boolean;
 };
 
 export type AuthResult =

--- a/server/src/instant/system_catalog_ops.clj
+++ b/server/src/instant/system_catalog_ops.clj
@@ -19,51 +19,62 @@
 (defn lock-hash [^UUID app-id]
   (.getMostSignificantBits app-id))
 
+(def computed-columns
+  {"$users" {:isGuest (fn [u]
+                        (= "guest" (:type u)))}})
+
+(defn add-computed-columns [entity etype]
+  (reduce-kv (fn [ent computed-column f]
+               (assoc ent computed-column (f entity)))
+             entity
+             (get computed-columns etype)))
+
 (defn triples->db-format [app-id attrs etype triples]
-  (reduce (fn [acc [_e a v t]]
-            (let [attr (attr-model/seek-by-id a attrs)]
-              (if-not (= etype (attr-model/fwd-etype attr))
-                acc
-                (let [k (-> attr
-                            (attr-model/fwd-label)
-                            keyword)
+  (-> (reduce (fn [acc [_e a v t]]
+                (let [attr (attr-model/seek-by-id a attrs)]
+                  (if-not (= etype (attr-model/fwd-etype attr))
+                    acc
+                    (let [k (-> attr
+                                (attr-model/fwd-label)
+                                keyword)
 
-                      v (cond
-                          (string/starts-with? (name k) "$")
-                          (uuid-util/coerce v)
+                          v (cond
+                              (string/starts-with? (name k) "$")
+                              (uuid-util/coerce v)
 
-                          (= k :id) (uuid-util/coerce v)
+                              (= k :id) (uuid-util/coerce v)
 
-                          (= k :encryptedClientSecret)
-                          (when v
-                            (crypt-util/hex-string->bytes v))
-                          :else v)
+                              (= k :encryptedClientSecret)
+                              (when v
+                                (crypt-util/hex-string->bytes v))
+                              :else v)
 
-                      ;; Translate keywords
-                      k (case k
-                          :$user :user_id
-                          :$oauthProvider :provider_id
-                          :$oauthClient :client_id
-                          :clientId :client_id
-                          :encryptedClientSecret :client_secret
-                          :discoveryEndpoint :discovery_endpoint
-                          :codeChallengeMethod :code_challenge_method
-                          :codeChallenge :code_challenge
-                          :stateHash :state_hash
-                          :cooke-hash :cookie_hash
-                          :redirectUrl :redirect_url
-                          :authCode :auth_code
-                          :userInfo :user_info
-                          :name (case etype
-                                  "$oauthProviders" :provider_name
-                                  "$oauthClients" :client_name
-                                  k)
-                          k)]
-                  (cond-> acc
-                    true (assoc k v)
-                    (= k :id) (assoc :created_at (Date. (long t))))))))
-          {:app_id app-id}
-          triples))
+                          ;; Translate keywords
+                          k (case k
+                              :$user :user_id
+                              :$oauthProvider :provider_id
+                              :$oauthClient :client_id
+                              :clientId :client_id
+                              :encryptedClientSecret :client_secret
+                              :discoveryEndpoint :discovery_endpoint
+                              :codeChallengeMethod :code_challenge_method
+                              :codeChallenge :code_challenge
+                              :stateHash :state_hash
+                              :cooke-hash :cookie_hash
+                              :redirectUrl :redirect_url
+                              :authCode :auth_code
+                              :userInfo :user_info
+                              :name (case etype
+                                      "$oauthProviders" :provider_name
+                                      "$oauthClients" :client_name
+                                      k)
+                              k)]
+                      (cond-> acc
+                        true (assoc k v)
+                        (= k :id) (assoc :created_at (Date. (long t))))))))
+              {:app_id app-id}
+              triples)
+      (add-computed-columns etype)))
 
 (defn delete-entity!
   "Deletes and returns the deleted entity (if it was deleted)."

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -1021,7 +1021,8 @@
                       {:app_id app-id
                        :id louis-id
                        :created_at louis-created-at
-                       :email louis-email}}}}
+                       :email louis-email
+                       :isGuest false}}}}
                    body))))))))
 
 (deftest storage-impersonation-test

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -189,6 +189,7 @@
      (fn [{app-id :id :as app}]
        (let [guest  (sign-in-guest app)
              _      (is (= "guest" (:type guest)))
+             _      (is (:isGuest guest))
              _      (is (= nil (:email guest)))
              _      (is (some? (:refresh_token guest)))
 
@@ -207,16 +208,19 @@
              user   (verify-code app {:email         "1@b.c"
                                       :code          code
                                       :refresh-token (:refresh_token guest)})
+             _      (is (not (:isGuest user)))
              _      (is (= (:id guest) (:id user)))
              _      (is (= "user" (:type user)))
              _      (is (= "1@b.c" (:email user)))
 
              ;; can't convert guest to existing user
              guest2 (sign-in-guest app)
+             _ (is (:isGuest guest2))
              code2  (send-code app {:email "1@b.c"})
              user2  (verify-code app {:email         "1@b.c"
                                       :code          code2
                                       :refresh-token (:refresh_token guest2)})
+             _ (is (not (:isGuest user2)))
              _ (is (not= (:id guest2) (:id user2)))
              _ (testing "we link the guest user to the real user"
                  (is (= (parse-uuid (:id user2))


### PR DESCRIPTION
Adds an `isGuest` field to the user so that you don't have to check `user.type === 'guest'`. 

I decided to do it on the backend instead of the client because the user shows up in so many different places on the client that it would be very easy to miss one.