### PR TITLE
Small CLI docs fix

### DIFF
--- a/client/www/pages/docs/cli.md
+++ b/client/www/pages/docs/cli.md
@@ -17,7 +17,7 @@ This will open a browser window where you can authenticate with your Instant acc
 
 ## Init
 
-To get started, head on over to your project's root repository, and write:
+After logging in, head on over to your project's root repository, and write:
 
 ```shell {% showCopy=true %}
 npx instant-cli@latest init


### PR DESCRIPTION
We had "to get started" twice (both in `init` and `login`), wanted to make this little doc tweak