### PR TITLE
Fix push and pull for react native

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -1639,7 +1639,7 @@ async function promptOk(message, defaultAnswer = false) {
  */
 function transformImports(code) {
   return code.replace(
-    /"@instantdb\/react-native"/g,
+    /["']@instantdb\/react-native["']/g,
     '"@instantdb/react-native/dist/cli"',
   );
 }

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.22.3';
+const version = 'v0.22.4';
 
 export { version };


### PR DESCRIPTION
I noticed we had a bug with the following flow:

* `pnpx create-instant-app -b expo`
* Create a new project, no rules, create a new app
* cd into it
* `pnpx instant-cli pull` and/or `pnpx instant-cli push`

Would result in `Error: ParseError: Unexpected keyword 'typeof'`

The issue was `create-instant-app` would generate and import with single quotes which our `transform` didn't capture. This will now match on both single and double quotes