### PR TITLE
[CLI] Fix invalid args for push and pull

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -102,21 +102,13 @@ function convertArgToBagWithErrorLogging(arg) {
     return { ok: true, bag: arg };
   } else {
     error(
-      `${chalk.red(arg)} must be one of ${chalk.green(Array.from(PUSH_PULL_OPTIONS).join(', '))}`,
+      `${chalk.red(arg)} is not valid. Must be one of ${chalk.green(Array.from(PUSH_PULL_OPTIONS).join(', '))}`,
     );
     return { ok: false };
   }
 }
 
-// Note: Nov 20, 2024
-// We can eventually deprecate this
-// once we're confident that users no longer
-// provide app ID as their first argument
-function convertPushPullToCurrentFormat(cmdName, arg, opts) {
-  if (arg && !PUSH_PULL_OPTIONS.has(arg) && !opts.app) {
-    warnDeprecation(`${cmdName} ${arg}`, `${cmdName} --app ${arg}`);
-    return { ok: true, bag: 'all', opts: { ...opts, app: arg } };
-  }
+function convertPushPullToCurrentFormat(arg, opts) {
   const { ok, bag } = convertArgToBagWithErrorLogging(arg);
   if (!ok) return { ok: false };
   return { ok: true, bag, opts };
@@ -415,7 +407,7 @@ program
   )
   .description('Push schema and perm files to production.')
   .action(async function (arg, inputOpts) {
-    const ret = convertPushPullToCurrentFormat('push', arg, inputOpts);
+    const ret = convertPushPullToCurrentFormat(arg, inputOpts);
     if (!ret.ok) return process.exit(1);
     const { bag, opts } = ret;
     await handlePush(bag, opts);
@@ -462,7 +454,7 @@ program
   )
   .description('Pull schema and perm files from production.')
   .action(async function (arg, inputOpts) {
-    const ret = convertPushPullToCurrentFormat('pull', arg, inputOpts);
+    const ret = convertPushPullToCurrentFormat(arg, inputOpts);
     if (!ret.ok) return process.exit(1);
     const { bag, opts } = ret;
     await handlePull(bag, opts);

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.22.4';
+const version = 'v0.22.5';
 
 export { version };


### PR DESCRIPTION
We got an email from a user who was confused about a deprecation warning with our cli.

He meant to run `pnpx instant-cli push perms` but instead did `pnpx instant-cli push perm` (no plural). If you do the later right now you get the following error.

```
[warning] `instant-cli push perm` is deprecated. Use `instant-cli push --app perm` instead.
```

This is because we previously allowed folks to do `instant-cli push <APP_ID>`, but since Nov 2024 we changed it to `instant-cli push --app <APP_ID>`.

It's been long enough that we can probably remove this deprecation warning.

With this PR, if you use an incorrect command like `instant-cli push perm` or `instant-cli pull perm` You'll get the following error instead

```
[error] perm is not valid. Must be one of schema, perms, all
```