### PR TITLE
Fix on delete direction for linked guest users

### DIFF
--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -154,7 +154,7 @@
   (make-attr "$users" "linkedPrimaryUser"
              :reverse-identity (get-ident-spec "$users" "linkedGuestUsers")
              :value-type :ref
-             :on-delete-reverse :cascade
+             :on-delete :cascade
              :cardinality :one))
 
 (def $users-attrs

--- a/server/src/instant/system_catalog_migration.clj
+++ b/server/src/instant/system_catalog_migration.clj
@@ -5,7 +5,6 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.system-catalog :as system-catalog]
-   [instant.util.json :refer [->json]]
    [instant.util.tracer :as tracer]
    [lambdaisland.deep-diff2 :as ddiff]))
 
@@ -64,7 +63,7 @@
        (when (seq mismatches)
          (tracer/record-info! {:name "system-catalog/mismatched-attrs"
                                :attributes {:mismatches (map (fn [m]
-                                                               (update m :diff ->json))
+                                                               (update m :diff vec))
                                                              mismatches)}}))
 
        (when (seq extras)


### PR DESCRIPTION
Had the on-delete direction reversed. It should delete the guest users when you delete the primary user, but it shouldn't delete the primary user if you delete the guest user.

Already updated the attr in production. Includes a test.