### PR TITLE
Update system catalog to match db

### DIFF
--- a/server/src/instant/system_catalog.clj
+++ b/server/src/instant/system_catalog.clj
@@ -305,7 +305,8 @@
    (make-attr "$files" "size"
               :unique? false
               :index? true
-              :checked-data-type :number)
+              :checked-data-type :number
+              :required? true)
    (make-attr "$files" "content-type"
               :unique? false
               :index? true


### PR DESCRIPTION
Somehow we had size as required in the db, but not in the catalog. This updates it to match prod.