### PR TITLE
Remove ave_index (part 1 of 2)

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -786,9 +786,10 @@
           :cols [:e :a]
           :unique-cols #{:e}}
 
-         {:name :ave_index
-          :cols [:a :v]
-          :idx-key :ave}
+         (when-not (flags/toggled? :remove-ave-index)
+           {:name :ave_index
+            :cols [:a :v]
+            :idx-key :ave})
 
          {:name :ave_with_e_index
           :cols [:a :v :e]


### PR DESCRIPTION
Now that the ave_with_e_index has been in production for a while, we can start the process to remove the `ave_index`. 

It will take two steps.

1. Stop using the index. That's this PR. It adds a flag to stop using the ave_index.
2. Run a migration to drop the ave_index from the db. That will be in a new PR if everything goes fine with this one.