### PR TITLE
Do size calc division with numeric so that we get a double back

### DIFF
--- a/server/src/instant/dash/admin.clj
+++ b/server/src/instant/dash/admin.clj
@@ -97,7 +97,7 @@
                                                           [:case
                                                            [:= [:pg_relation_size "triples"] 0] 1
                                                            :else [:/
-                                                                  [:pg_total_relation_size "triples"]
+                                                                  [:cast [:pg_total_relation_size "triples"] :numeric]
                                                                   [:pg_relation_size "triples"]]]]
                                                          0]]]
                                               :from [[:attr-sketches :s]]
@@ -123,7 +123,7 @@
                                                           [:case
                                                            [:= [:pg_relation_size "triples"] 0] 1
                                                            :else [:/
-                                                                  [:pg_total_relation_size "triples"]
+                                                                  [:cast [:pg_total_relation_size "triples"] :numeric]
                                                                   [:pg_relation_size "triples"]]]]
                                                          0]]]
                                               :from [[:attr-sketches :s]]

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -391,7 +391,7 @@
      (sum(s.triples_pg_size) *
         CASE
             WHEN pg_relation_size('triples') = 0 THEN 1
-            ELSE pg_total_relation_size('triples') / pg_relation_size('triples')
+            ELSE pg_total_relation_size('triples')::numeric / pg_relation_size('triples')
         END) as num_bytes
      FROM attr_sketches s WHERE s.app_id = ?::uuid" app-id])))
 

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -264,7 +264,7 @@
                                 [:case
                                  [:= :0 [:pg_relation_size [:inline "triples"]]] :1
                                  :else [:/
-                                        [:pg_total_relation_size [:inline "triples"]]
+                                        [:cast [:pg_total_relation_size [:inline "triples"]] :numeric]
                                         [:pg_relation_size [:inline "triples"]]]]]
                                :0]
                               :num_bytes]]


### PR DESCRIPTION
Fix for the index/total size calculation in usage. 

Previously we were getting an int back. If the ratio was 4.9, we would multiply by 4, then if the ratio jumped to 5.1, we would multiply by 5. So users will see a big jump instead of a slow growth.