### PR TITLE
Drop ave_index migration

### DIFF
--- a/server/resources/migrations/91_drop_ave_index.down.sql
+++ b/server/resources/migrations/91_drop_ave_index.down.sql
@@ -1,0 +1,2 @@
+-- Run in prod first `create index concurrently ave_index on triples(app_id, attr_id, value) where ave;`
+create index if not exists ave_index on triples(app_id, attr_id, value) where ave;

--- a/server/resources/migrations/91_drop_ave_index.up.sql
+++ b/server/resources/migrations/91_drop_ave_index.up.sql
@@ -1,0 +1,2 @@
+--  Run `drop index concurrently ave_index;` in production first
+drop index if exists ave_index;

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -786,11 +786,6 @@
           :cols [:e :a]
           :unique-cols #{:e}}
 
-         (when-not (flags/toggled? :remove-ave-index)
-           {:name :ave_index
-            :cols [:a :v]
-            :idx-key :ave})
-
          {:name :ave_with_e_index
           :cols [:a :v :e]
           :unique-cols #{:e}

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -2853,7 +2853,7 @@
               (is (= #{"0" "2" "3" "4"} (run-query :string {:etype {:$ {:where {:string {:$not "1"}}}}})))
 
               (testing "uses index"
-                (is (= "ave_index" (run-explain :string "2"))))
+                (is (= "ave_with_e_index" (run-explain :string "2"))))
 
               (testing "like uses index"
                 (is (= "triples_string_trgm_gist_idx" (run-explain :$like :string "%aaa")))))


### PR DESCRIPTION
Follow up to https://github.com/instantdb/instant/pull/1782, drops the ave_index from the database.

### Deploy plan
1. Merge PR
1. Run `drop index concurrently ave_index;`
2. Run the migration
3. Deploy the code change