### PR TITLE
Better error for invalid asUser token in admin api

### DIFF
--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -327,16 +327,19 @@
            ::message (format "Missing parameter: %s" (mapv safe-name ks))
            ::hint {:in ks}}))
 
+(defn throw-malformed-param! [ks input]
+  (throw+ {::type ::param-malformed
+           ::message (format "Malformed parameter: %s" (mapv safe-name ks))
+           ::hint {:in ks
+                   :original-input input}}))
+
 (defn get-param! [obj ks coercer]
   (let [param (get-in obj ks)
         _ (when-not param
             (throw-missing-param! ks))
         coerced (coercer param)
         _ (when-not coerced
-            (throw+ {::type ::param-malformed
-                     ::message (format "Malformed parameter: %s" (mapv safe-name ks))
-                     ::hint {:in ks
-                             :original-input param}}))]
+            (throw-malformed-param! ks param))]
     coerced))
 
 (defn get-optional-param! [obj ks coercer]


### PR DESCRIPTION
If you pass a malformed token right now, you'll get a `Something went wrong. Please ping `debug-uri` in #bug-and-questions, and we'll take a look. Sorry about this!` error.

This makes it a normal `param-malformed` error: 

<img width="599" height="123" alt="image" src="https://github.com/user-attachments/assets/02be128a-f458-4d90-9076-bb79199ae072" />
