### PR TITLE
Update type for admin sdk's `getUser` to omit the refresh token

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -491,7 +491,7 @@ class Auth {
    */
   getUser = async (
     params: { email: string } | { id: string } | { refresh_token: string },
-  ): Promise<User> => {
+  ): Promise<Omit<User, 'refresh_token'>> => {
     const qs = Object.entries(params)
       .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
       .join('&');


### PR DESCRIPTION
We don't expose the auth token when we fetch the user in the admin sdk. This updates the type to match what we actually do.

An alternative would be to generate a new refresh_token each time you call `getUser`, but that seems like a bad idea.