### PR TITLE
Fix nil? sketch check when nil attr has no sketch

### DIFF
--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -57,6 +57,8 @@
                    :total 0
                    :total-not-binned 0}))))
 
+(def default-empty (make-sketch))
+
 (defn data-type-for-hash [checked-data-type x]
   (if (nil? x)
     [:nil nil]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1188,8 +1188,9 @@
                                         (when (instance? java.time.Instant (:value vs))
                                           :date)
                                         (:value vs)))
-                     :nil? (if-let [sketch (:sketch (get sketches {:app-id app-id
-                                                                   :attr-id (:attr-id vs)}))]
+                     :nil? (let [sketch (or (:sketch (get sketches {:app-id app-id
+                                                                    :attr-id (:attr-id vs)}))
+                                            cms/default-empty)]
                              (let [nil-count (cms/check sketch nil nil)
                                    undefined-count (if (and (:indexed? vs)
                                                             (not (:ref? vs)))
@@ -1213,8 +1214,7 @@
                                                 (+ nil-count undefined-count)))]
                                (if (:nil? vs)
                                  (+ nil-count undefined-count)
-                                 (- total nil-count undefined-count)))
-                             0)
+                                 (- total nil-count undefined-count))))
                      ;; We don't have a good way to do comparisions, yet, so we'll
                      ;; just put a default of half the items.
                      :compare (long (/ (:total sketch) 2)))))]

--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1190,31 +1190,31 @@
                                         (:value vs)))
                      :nil? (let [sketch (or (:sketch (get sketches {:app-id app-id
                                                                     :attr-id (:attr-id vs)}))
-                                            cms/default-empty)]
-                             (let [nil-count (cms/check sketch nil nil)
-                                   undefined-count (if (and (:indexed? vs)
-                                                            (not (:ref? vs)))
-                                                     0
-                                                     (- (get-in sketches
-                                                                [{:app-id app-id
-                                                                  :attr-id (:id-attr-id vs)}
-                                                                 :sketch
-                                                                 :total]
-                                                                0)
-                                                        (:total sketch)))
-                                   total (if (and (:indexed? vs)
-                                                  (not (:ref? vs)))
-                                           (:total sketch)
-                                           (max (get-in sketches
-                                                        [{:app-id app-id
-                                                          :attr-id (:id-attr-id vs)}
-                                                         :sketch
-                                                         :total]
-                                                        0)
-                                                (+ nil-count undefined-count)))]
-                               (if (:nil? vs)
-                                 (+ nil-count undefined-count)
-                                 (- total nil-count undefined-count))))
+                                            cms/default-empty)
+                                 nil-count (cms/check sketch nil nil)
+                                 undefined-count (if (and (:indexed? vs)
+                                                          (not (:ref? vs)))
+                                                   0
+                                                   (- (get-in sketches
+                                                              [{:app-id app-id
+                                                                :attr-id (:id-attr-id vs)}
+                                                               :sketch
+                                                               :total]
+                                                              0)
+                                                      (:total sketch)))
+                                 total (if (and (:indexed? vs)
+                                                (not (:ref? vs)))
+                                         (:total sketch)
+                                         (max (get-in sketches
+                                                      [{:app-id app-id
+                                                        :attr-id (:id-attr-id vs)}
+                                                       :sketch
+                                                       :total]
+                                                      0)
+                                              (+ nil-count undefined-count)))]
+                             (if (:nil? vs)
+                               (+ nil-count undefined-count)
+                               (- total nil-count undefined-count)))
                      ;; We don't have a good way to do comparisions, yet, so we'll
                      ;; just put a default of half the items.
                      :compare (long (/ (:total sketch) 2)))))]


### PR DESCRIPTION
We fixed `isNull` on unindexed fields in https://github.com/instantdb/instant/pull/1745, but it was still returning 0 when the attr didn't have a sketch in the db (which can happen if you're never stored a triple for the attr).

Now we default to an empty sketch instead of just returning 0. That lets our logic for determining the count work.