### PR TITLE
[admin] typecast ReadableStream

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -654,7 +654,7 @@ class Storage {
         );
       }
       headers['content-length'] = metadata.fileSize.toString();
-      body = Readable.toWeb(file) as ReadableStream;
+      body = Readable.toWeb(file) as unknown as ReadableStream;
       duplex = 'half'; // one-way stream
     } else {
       // File is a buffer, use directly


### PR DESCRIPTION
Related Issue: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65542 

I am not 100% sure why this is only happening to me, but I noticed @instantdb/admin was failing to build. 

Looking deeper, it's because of 

```
body = Readable.toWeb(file) as ReadableStream;
```

From what I understand, I think typescript thinks this is a different ReadableStream, and starts failing. 

Looking at what people suggest, I think we just typecast it as unknown as ReadableStream, we should be good to go. 

@nezaj @dwwoelfel @drew-harris 