### PR TITLE
Store objects in indexeddb, wait for requestIdleCallback

### DIFF
--- a/client/packages/core/src/IndexedDBStorage.ts
+++ b/client/packages/core/src/IndexedDBStorage.ts
@@ -1,11 +1,15 @@
 export default class IndexedDBStorage {
-  constructor(dbName) {
+  dbName: string;
+  _storeName: string;
+  _dbPromise: Promise<IDBDatabase>;
+
+  constructor(dbName: string) {
     this.dbName = dbName;
     this._storeName = 'kv';
     this._dbPromise = this._init();
   }
 
-  _init() {
+  _init(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, 1);
 
@@ -14,17 +18,19 @@ export default class IndexedDBStorage {
       };
 
       request.onsuccess = (event) => {
-        resolve(event.target.result);
+        const target = event.target as IDBOpenDBRequest;
+        resolve(target.result);
       };
 
       request.onupgradeneeded = (event) => {
-        const db = event.target.result;
+        const target = event.target as IDBOpenDBRequest;
+        const db = target.result;
         db.createObjectStore(this._storeName);
       };
     });
   }
 
-  async getItem(k) {
+  async getItem(k: string) {
     const db = await this._dbPromise;
     return new Promise((resolve, reject) => {
       const transaction = db.transaction([this._storeName], 'readonly');
@@ -43,8 +49,9 @@ export default class IndexedDBStorage {
     });
   }
 
-  async setItem(k, v) {
+  async setItem(k: string, v: string): Promise<void> {
     const db = await this._dbPromise;
+    globalThis.___db = db;
     return new Promise((resolve, reject) => {
       const transaction = db.transaction([this._storeName], 'readwrite');
       const objectStore = transaction.objectStore(this._storeName);

--- a/client/packages/core/src/IndexedDBStorage.ts
+++ b/client/packages/core/src/IndexedDBStorage.ts
@@ -30,7 +30,7 @@ export default class IndexedDBStorage {
     });
   }
 
-  async getItem(k: string) {
+  async getItem(k: string): Promise<any> {
     const db = await this._dbPromise;
     return new Promise((resolve, reject) => {
       const transaction = db.transaction([this._storeName], 'readonly');
@@ -49,9 +49,8 @@ export default class IndexedDBStorage {
     });
   }
 
-  async setItem(k: string, v: string): Promise<void> {
+  async setItem(k: string, v: any): Promise<void> {
     const db = await this._dbPromise;
-    globalThis.___db = db;
     return new Promise((resolve, reject) => {
       const transaction = db.transaction([this._storeName], 'readwrite');
       const objectStore = transaction.objectStore(this._storeName);

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -4,14 +4,14 @@ import instaql from './instaql.js';
 import * as instaml from './instaml.js';
 import * as s from './store.js';
 import uuid from './utils/uuid.ts';
-import IndexedDBStorage from './IndexedDBStorage.js';
+import IndexedDBStorage from './IndexedDBStorage.ts';
 import WindowNetworkListener from './WindowNetworkListener.js';
 import * as authAPI from './authAPI.ts';
 import * as StorageApi from './StorageAPI.ts';
 import * as flags from './utils/flags.ts';
 import { buildPresenceSlice, hasPresenceResponseChanged } from './presence.ts';
 import { Deferred } from './utils/Deferred.js';
-import { PersistedObject } from './utils/PersistedObject.js';
+import { PersistedObject } from './utils/PersistedObject.ts';
 import { extractTriples } from './model/instaqlResult.js';
 import {
   areObjectsDeepEqual,
@@ -78,8 +78,8 @@ const ignoreLogging = {
   'patch-presence': true,
 };
 
-function querySubsFromJSON(str, useDateObjects) {
-  const parsed = JSON.parse(str);
+function querySubsFromStorage(x, useDateObjects) {
+  const parsed = typeof x === 'string' ? JSON.parse(x) : x;
   for (const key in parsed) {
     const v = parsed[key];
     if (v?.result?.store) {
@@ -93,7 +93,7 @@ function querySubsFromJSON(str, useDateObjects) {
   return parsed;
 }
 
-function querySubsToJSON(querySubs) {
+function querySubsToStorage(querySubs) {
   const jsonSubs = {};
   for (const key in querySubs) {
     const sub = querySubs[key];
@@ -106,7 +106,7 @@ function querySubsToJSON(querySubs) {
     }
     jsonSubs[key] = jsonSub;
   }
-  return JSON.stringify(jsonSubs);
+  return jsonSubs;
 }
 
 function sortedMutationEntries(entries) {
@@ -278,8 +278,8 @@ export default class Reactor {
       'querySubs',
       {},
       this._onMergeQuerySubs,
-      querySubsToJSON,
-      (str) => querySubsFromJSON(str, this.config.useDateObjects),
+      querySubsToStorage,
+      (x) => querySubsFromStorage(x, this.config.useDateObjects),
     );
     this.pendingMutations = new PersistedObject(
       this._persister,
@@ -287,10 +287,10 @@ export default class Reactor {
       new Map(),
       this._onMergePendingMutations,
       (x) => {
-        return JSON.stringify([...x.entries()]);
+        return [...x.entries()];
       },
       (x) => {
-        return new Map(JSON.parse(x));
+        return new Map(typeof x === 'string' ? JSON.parse(x) : x);
       },
     );
     this._beforeUnloadCbs.push(() => {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -292,6 +292,8 @@ export default class Reactor {
       (x) => {
         return new Map(typeof x === 'string' ? JSON.parse(x) : x);
       },
+      100, // throttle
+      100, // idlecallback timeout, flush more often for mutations
     );
     this._beforeUnloadCbs.push(() => {
       this.pendingMutations.flush();

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -1663,7 +1663,7 @@ export default class Reactor {
   }
 
   async setCurrentUser(user) {
-    await this._persister.setItem(currentUserKey, JSON.stringify(user));
+    await this._persister.setItem(currentUserKey, user);
   }
 
   getCurrentUserCached() {
@@ -1672,7 +1672,7 @@ export default class Reactor {
 
   async _getCurrentUser() {
     const user = await this._persister.getItem(currentUserKey);
-    return JSON.parse(user);
+    return typeof user === 'string' ? JSON.parse(user) : user;
   }
 
   async getCurrentUser() {

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from './instatx.js';
 import weakHash from './utils/weakHash.js';
 import id from './utils/uuid.js';
-import IndexedDBStorage from './IndexedDBStorage.js';
+import IndexedDBStorage from './IndexedDBStorage.ts';
 import WindowNetworkListener from './WindowNetworkListener.js';
 import { i } from './schema.js';
 import { createDevtool } from './devtool.js';

--- a/client/packages/core/src/utils/PersistedObject.ts
+++ b/client/packages/core/src/utils/PersistedObject.ts
@@ -21,8 +21,6 @@ function safeIdleCallback(cb) {
   }
 }
 
-let i = 0;
-
 export class PersistedObject<T> {
   _subs = [];
   _persister: Storage;
@@ -130,11 +128,7 @@ export class PersistedObject<T> {
       return;
     }
     this._nextSave = setTimeout(() => {
-      let x = i++;
-      console.time(`idle callback ${x}`);
-
       safeIdleCallback(() => {
-        console.timeEnd(`idle callback ${x}`);
         this._nextSave = null;
         this._writeToStorage();
       });

--- a/client/packages/react-native/src/Storage.native.js
+++ b/client/packages/react-native/src/Storage.native.js
@@ -6,10 +6,11 @@ export default class Storage {
   }
 
   async getItem(k) {
-    return await AsyncStorage.getItem(`${this.dbName}_${k}`);
+    const res = await AsyncStorage.getItem(`${this.dbName}_${k}`);
+    return JSON.parse(res);
   }
 
   async setItem(k, v) {
-    await AsyncStorage.setItem(`${this.dbName}_${k}`, v);
+    await AsyncStorage.setItem(`${this.dbName}_${k}`, JSON.stringify(v));
   }
 }

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.22.7';
+const version = 'v0.22.8';
 
 export { version };

--- a/client/sandbox/react-native-expo/app/play/colors.tsx
+++ b/client/sandbox/react-native-expo/app/play/colors.tsx
@@ -2,8 +2,6 @@ import { init, tx } from '@instantdb/react-native';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import config from '../config';
 
-const { useQuery, transact } = init(config);
-
 function App() {
   return <Main />;
 }
@@ -11,7 +9,8 @@ function App() {
 const selectId = '4d39508b-9ee2-48a3-b70d-8192d9c5a059';
 
 function Main() {
-  const { isLoading, error, data } = useQuery({ colors: {} });
+  const db = init(config);
+  const { isLoading, error, data } = db.useQuery({ colors: {} });
 
   if (isLoading) return <Text>Loading...</Text>;
   if (error) return <Text>Error: {error.message}</Text>;
@@ -29,7 +28,7 @@ function Main() {
               <Button
                 title={c}
                 onPress={() => {
-                  transact(tx.colors[selectId].update({ color: c }));
+                  db.transact(tx.colors[selectId].update({ color: c }));
                 }}
                 key={c}
               />


### PR DESCRIPTION
Two changes in behavior:

1. We use `requestIdleCallback` to wait for things to simmer down before we persist to storage. We'll wait up to 1 second.
2. We store things directly as objects into indexeddb instead of serializing to JSON.


Also converted IndexedDBStorage and PersistedObject to typescript.

There's special handling for React native