### PR TITLE
Add public app id section to home tab

### DIFF
--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -54,7 +54,9 @@ import OAuthApps from '@/components/dash/OAuthApps';
 import { Sandbox } from '@/components/dash/Sandbox';
 import {
   Badge,
+  Button,
   Content,
+  Copyable,
   SectionHeading,
   SmallCopyable,
   TabBar,
@@ -698,6 +700,7 @@ export function HomeButton({
 
 function Home({ appId, token }: { appId: string; token: string }) {
   const { stats, isLoading, error } = useAppConnectionStats(token, appId);
+  const [hideAppId, setHideAppId] = useLocalStorage('hide_app_id', false);
 
   // Sort origins by connection count (highest to lowest)
   const sortedOrigins = stats?.origins
@@ -722,6 +725,30 @@ function Home({ appId, token }: { appId: string; token: string }) {
           Join our Discord to meet like-minded hackers, and to give us feedback
           too!
         </HomeButton>
+      </div>
+
+      {/* Your Public App ID Section */}
+      <div className="mt-10">
+        <SectionHeading>Your Public App ID</SectionHeading>
+        <div className="pt-1">
+          Use this App ID to connect to your database{' '}
+          <a
+            className="hover:cursor-pointer dark:text-white underline"
+            href="/docs/init"
+            target="_blank"
+          >
+            via init
+          </a>
+          . This ID is safe to use in public-facing applications.
+        </div>
+        <div className="mt-4">
+          <Copyable
+            value={appId}
+            size="large"
+            hideValue={hideAppId}
+            onChangeHideValue={() => setHideAppId(!hideAppId)}
+          />
+        </div>
       </div>
 
       {/* Connection Count Display */}


### PR DESCRIPTION
I was going through a new user flow and felt like the location of the public app id might be non-obvious to new folks. This is specifically in response to something like this

<img width="3296" height="622" alt="CleanShot 2025-10-06 at 17 12 55@2x" src="https://github.com/user-attachments/assets/9e216fcd-6683-48c2-ab82-3e43c5a17b1f" />

This PR adds a new section to the home tab to make the public app id more visibile.

<img width="1364" height="724" alt="CleanShot 2025-10-06 at 17 13 44@2x" src="https://github.com/user-attachments/assets/43fa671a-cd40-4ada-8363-0e4aa76aee1d" />
