### PR TITLE
Add prompt boxes

### DIFF
--- a/client/www/components/docs/CopyPromptBox.tsx
+++ b/client/www/components/docs/CopyPromptBox.tsx
@@ -1,0 +1,68 @@
+import { useState, useRef } from 'react';
+import { Button } from '@/components/ui';
+
+interface CopyPromptBoxProps {
+  id?: string;
+  description?: string;
+}
+
+const defaultFile = '/docs/index.md';
+const promptFiles: Record<string, string> = {
+  default: defaultFile,
+  react: '/docs/index.md',
+  expo: '/docs/start-rn.md',
+  vanilla: '/docs/start-vanilla.md',
+};
+
+// Cache for fetched content
+const contentCache: Record<string, string> = {};
+
+export function CopyPromptBox({
+  id = 'default',
+  description = 'Use this prompt to get started faster.',
+}: CopyPromptBoxProps) {
+  const [copyLabel, setCopyLabel] = useState('Copy prompt');
+  const fetchingRef = useRef(false);
+
+  const handleCopy = async () => {
+    if (fetchingRef.current) return;
+
+    try {
+      fetchingRef.current = true;
+
+      // Use cached content if available
+      let content = contentCache[id];
+
+      if (!content) {
+        const response = await fetch(promptFiles[id]);
+        content = await response.text();
+        contentCache[id] = content;
+      }
+
+      await navigator.clipboard.writeText(content);
+      setCopyLabel('Copied!');
+
+      setTimeout(() => {
+        setCopyLabel('Copy prompt');
+      }, 2000);
+    } catch (error) {
+      console.error('Failed to copy prompt:', error);
+      setCopyLabel('Failed');
+      setTimeout(() => {
+        setCopyLabel('Copy prompt');
+      }, 2000);
+    } finally {
+      fetchingRef.current = false;
+    }
+  };
+
+  return (
+    <div className="relative flex items-center justify-between rounded-lg border border-orange-600 px-4 shadow-sm">
+      <p className="text-gray-700">{description}</p>
+
+      <Button variant="cta" onClick={handleCopy}>
+        {copyLabel}
+      </Button>
+    </div>
+  );
+}

--- a/client/www/markdoc/tags.js
+++ b/client/www/markdoc/tags.js
@@ -9,6 +9,7 @@ import {
 import { Tag, transformer } from '@markdoc/markdoc';
 import { HasAppID } from '../components/docs/Fence';
 import { TabbedSingle } from '../components/docs/TabbedSingle';
+import { CopyPromptBox } from '../components/docs/CopyPromptBox';
 
 function CustomDiv({ className, children }) {
   return <div className={className}>{children}</div>;
@@ -143,6 +144,14 @@ const tags = {
       tabs: { type: Object, required: true },
       defaultTab: { type: String },
       storageKey: { type: String, required: true },
+    },
+  },
+
+  'copy-prompt-box': {
+    render: CopyPromptBox,
+    attributes: {
+      id: { type: String },
+      description: { type: String },
     },
   },
 };

--- a/client/www/pages/docs/index.md
+++ b/client/www/pages/docs/index.md
@@ -6,7 +6,7 @@ description: How to use Instant with React
 
 Instant is the easy to use backend for your frontend. With Instant you can build delightful apps in less than 10 minutes. Follow the quick start below to **build a live app!**
 
-## Quick start
+{% copy-prompt-box id="react" /%}
 
 To use Instant in a brand new project, fire up your terminal and run the following:
 

--- a/client/www/pages/docs/start-rn.md
+++ b/client/www/pages/docs/start-rn.md
@@ -3,7 +3,11 @@ title: Getting started with React Native
 description: How to use Instant with React Native
 ---
 
-You can use Instant in React Native projects too! Below is an example using Expo. Open up your terminal and do the following:
+You can use Instant in React Native projects too! Below is an example using Expo.
+
+{% copy-prompt-box id="expo" /%}
+
+Open up your terminal and do the following:
 
 ```shell {% showCopy=true %}
 # Create an app with expo

--- a/client/www/pages/docs/start-vanilla.md
+++ b/client/www/pages/docs/start-vanilla.md
@@ -5,6 +5,8 @@ description: How to use Instant with Vanilla JS
 
 You can use Instant with plain ol' Javascript/Typescript too. You may find this helpful to integrate Instant with a framework that doesn't have an official SDK yet.
 
+{% copy-prompt-box id="vanilla" /%}
+
 To use Instant in a brand new project fire up your terminal set up a new project with Vite.
 
 ```shell {% showCopy=true %}


### PR DESCRIPTION
We've been hearing asks to make it easier to copy docs for folks using agents. Following [Clerk's example](https://clerk.com/docs/nextjs/getting-started/quickstart), this PR adds a box for letting people copy the getting started docs via one click.

<img width="1212" height="818" alt="CleanShot 2025-10-06 at 17 27 34@2x" src="https://github.com/user-attachments/assets/845cada6-1663-4c51-90f3-670d583dd472" />
