### PR TITLE
Add error handling to the persister

### DIFF
--- a/client/packages/core/src/utils/PersistedObject.js
+++ b/client/packages/core/src/utils/PersistedObject.js
@@ -45,8 +45,18 @@ export class PersistedObject {
     this._load();
   }
 
+  async _getFromStorage() {
+    try {
+      return this.parse(await this._persister.getItem(this._key));
+    } catch (e) {
+      console.error(`Unable to read from storage for key=${this._key}`, e);
+      return null;
+    }
+  }
+
   async _load() {
-    const fromStorage = this.fromJSON(await this._persister.getItem(this._key));
+    const fromStorage = await this._getFromStorage();
+
     this._isLoading = false;
 
     this._onMerge(fromStorage, this.currentValue);

--- a/client/packages/core/src/utils/PersistedObject.js
+++ b/client/packages/core/src/utils/PersistedObject.js
@@ -47,7 +47,7 @@ export class PersistedObject {
 
   async _getFromStorage() {
     try {
-      return this.parse(await this._persister.getItem(this._key));
+      return this.fromJSON(await this._persister.getItem(this._key));
     } catch (e) {
       console.error(`Unable to read from storage for key=${this._key}`, e);
       return null;

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -1,6 +1,6 @@
 // This is the shared version for all of the js packages
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
-const version = 'v0.22.6';
+const version = 'v0.22.7';
 
 export { version };


### PR DESCRIPTION
Adds a try/catch when we fetch data from the store. This will prevent an error in the store from completely blocking an app from working.

Prerequisite for https://github.com/instantdb/instant/pull/1793, so that users can roll back to this version if there is something wrong with that version.