### PR TITLE
Fix error message for first

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -384,7 +384,7 @@
      [{:expected 'supported-options?
        :in (conj (:in state) :first)
        :message (format "The first field must be a positive integer. Got %s."
-                        (->json first))}])))
+                        (->json limit))}])))
 
 (defn- coerce-last! [state limit]
   (if (and (int? limit) (pos? limit))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -285,7 +285,19 @@
                    :message "Only provide one of `first` or `last`."}
                  (validation-err ctx {:users
                                       {:$ {:last 10
-                                           :first 10}}}))))
+                                           :first 10}}})))
+
+          (is (= '{:expected supported-options?,
+                   :in [:users :$ :first],
+                   :message "The first field must be a positive integer. Got 0."}
+                 (validation-err ctx {:users
+                                      {:$ {:first 0}}})))
+
+          (is (= '{:expected supported-options?,
+                   :in [:users :$ :last],
+                   :message "The last field must be a positive integer. Got -1."}
+                 (validation-err ctx {:users
+                                      {:$ {:last -1}}}))))
 
         (testing "aggregate"
           (is (= '{:expected admin?


### PR DESCRIPTION
Fixes a bug where we were trying to encode the clojure function `first` instead of the field "first". Includes a test!