### PR TITLE
Guard against the case where etype is missing

### DIFF
--- a/server/src/instant/db/permissioned_transaction.clj
+++ b/server/src/instant/db/permissioned_transaction.clj
@@ -36,7 +36,8 @@
   [{:keys [admin?]} tx-step-maps]
   (doseq [{:keys [op etype] :as tx-step} tx-step-maps
           :when (#{:add-triple :deep-merge-triple :retract-triple :delete-entity} op)
-          :when (and (string/starts-with? etype "$")
+          :when (and etype
+                     (string/starts-with? etype "$")
                      (not admin?)
                      ;; checking admin? is not enough for $files so we handle
                      ;; validations later


### PR DESCRIPTION
Not sure how this happens and there's not enough info in the logs to reproduce. Hopefully this will get us further along to a better error message (right now it just throws `Cannot invoke "Object.toString()" because "s" is null`.