### PR TITLE
Pass through inference? for admin subscribe query

### DIFF
--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -83,8 +83,8 @@
                             ws/send-json!           (fn [_app-id msg fake-ws-conn]
                                                       (a/put! fake-ws-conn msg))
                             rq/instaql-query-reactive!
-                            (fn [store {:keys [session-id] :as base-ctx} instaql-query return-type]
-                              (let [res (query-reactive store base-ctx instaql-query return-type)]
+                            (fn [store {:keys [session-id] :as base-ctx} instaql-query return-type inference?]
+                              (let [res (query-reactive store base-ctx instaql-query return-type inference?)]
                                 (swap! *instaql-query-results* assoc-in [session-id instaql-query] res)
                                 res))]
                 (try


### PR DESCRIPTION
This fixes hasOne links in admin subscribe query. We weren't propagating the `inference?` field, so we were always returning an array.