### PR TITLE
Sandbox and Query Inspector improvements

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -596,6 +596,7 @@ export function Sandbox({
             >
               <div className="flex-1">
                 <Editor
+                  key={app.id}
                   theme={darkMode ? 'vs-dark' : 'light'}
                   height={'100%'}
                   path="sandbox.ts"

--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   Checkbox,
   Dialog,
-  FullscreenLoading,
   IconButton,
   Label,
   Select,
@@ -36,12 +35,7 @@ import { InstantReactWebDatabase } from '@instantdb/react';
 import { Editor, Monaco, type OnMount } from '@monaco-editor/react';
 
 import clsx from 'clsx';
-import {
-  createParser,
-  createSerializer,
-  parseAsBoolean,
-  useQueryState,
-} from 'nuqs';
+import { createParser, createSerializer, parseAsBoolean } from 'nuqs';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { debounce } from 'lodash';
 import {
@@ -50,7 +44,7 @@ import {
   ResizablePanelGroup,
 } from '../resizable';
 import { useDarkMode } from './DarkModeToggle';
-import { ArrowUpToLine, Save } from 'lucide-react';
+import { Save } from 'lucide-react';
 import { infoToast } from '@/lib/toast';
 import { useSavedQueryState } from '@/lib/hooks/useSavedQueryState';
 import { addInstantLibs } from '@/lib/monaco';

--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -163,6 +163,7 @@ export function Sandbox({
 
   const { darkMode } = useDarkMode();
 
+  // Add the schema types your schema for better typesense
   useEffect(() => {
     const monaco = monacoRef.current;
     if (attrs && isMonacoLoaded && monaco) {
@@ -613,7 +614,6 @@ export function Sandbox({
             >
               <div className="flex-1">
                 <Editor
-                  key={app.id}
                   theme={darkMode ? 'vs-dark' : 'light'}
                   height={'100%'}
                   path="sandbox.ts"
@@ -1202,6 +1202,7 @@ declare global {
 export {};
 `.trim();
 
+// Generates the `instant.schema.ts` file from the attrs
 const schemaTs = (attrs: Record<string, DBAttr>) => {
   const schema = apiSchemaToInstantSchemaDef(
     attrsToSchema(Object.values(attrs)),

--- a/client/www/components/dash/Schema.tsx
+++ b/client/www/components/dash/Schema.tsx
@@ -15,60 +15,7 @@ import { useState } from 'react';
 
 import { attrsToSchema } from '@/lib/schema';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
-
-async function addInstantLibs(monaco: Monaco) {
-  const files = [
-    'index.d.ts',
-    'schema.d.ts',
-    'schemaTypes.d.ts',
-    'presence.d.ts',
-  ];
-
-  const fileContents = await Promise.all(
-    files.map(async (file) => {
-      const content = await fetch(
-        `https://unpkg.com/@instantdb/core@latest/dist/esm/${file}`,
-      ).then((r) => r.text());
-      return { file, content };
-    }),
-  );
-
-  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-    target: monaco.languages.typescript.ScriptTarget.ESNext,
-    module: monaco.languages.typescript.ModuleKind.ESNext,
-    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs, // Node-style lookup
-    baseUrl: 'file:///', // virtual project root
-    ...monaco.languages.typescript.typescriptDefaults.getCompilerOptions(),
-
-    paths: {
-      '@instantdb/core': ['file:///node_modules/@instantdb/core/index.d.ts'],
-      '@instantdb/admin': ['file:///node_modules/@instantdb/admin/index.d.ts'],
-      '@instantdb/react': ['file:///node_modules/@instantdb/react/index.d.ts'],
-      '@instantdb/react-native': [
-        'file:///node_modules/@instantdb/react-native/index.d.ts',
-      ],
-    },
-  });
-
-  for (const { file, content } of fileContents) {
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
-      content,
-      `file:///node_modules/@instantdb/core/${file}`,
-    );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
-      content,
-      `file:///node_modules/@instantdb/admin/${file}`,
-    );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
-      content,
-      `file:///node_modules/@instantdb/react/${file}`,
-    );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
-      content,
-      `file:///node_modules/@instantdb/react-native/${file}`,
-    );
-  }
-}
+import { addInstantLibs } from '@/lib/monaco';
 
 type Pkg =
   | '@instantdb/core'

--- a/client/www/components/dash/explorer/QueryInspector.tsx
+++ b/client/www/components/dash/explorer/QueryInspector.tsx
@@ -75,6 +75,7 @@ export function QueryInspector({
   const db = schema
     ? init({
         ...baseDb.core._reactor.config,
+        disableValidation: true,
         schema,
       })
     : baseDb;

--- a/client/www/lib/monaco.ts
+++ b/client/www/lib/monaco.ts
@@ -1,0 +1,60 @@
+import { Monaco } from '@monaco-editor/react';
+import { version } from '@instantdb/core';
+
+const bareVersion = version.replace(/^v/, '');
+
+export async function addInstantLibs(monaco: Monaco) {
+  const files = [
+    'index.d.ts',
+    'schema.d.ts',
+    'queryTypes.d.ts',
+    'schemaTypes.d.ts',
+    'presence.d.ts',
+    'instatx.d.ts',
+  ];
+
+  const fileContents = await Promise.all(
+    files.map(async (file) => {
+      const content = await fetch(
+        `https://unpkg.com/@instantdb/core@${bareVersion}/dist/esm/${file}`,
+      ).then((r) => r.text());
+      return { file, content };
+    }),
+  );
+
+  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    target: monaco.languages.typescript.ScriptTarget.ESNext,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs, // Node-style lookup
+    baseUrl: 'file:///', // virtual project root
+    ...monaco.languages.typescript.typescriptDefaults.getCompilerOptions(),
+
+    paths: {
+      '@instantdb/core': ['file:///node_modules/@instantdb/core/index.d.ts'],
+      '@instantdb/admin': ['file:///node_modules/@instantdb/admin/index.d.ts'],
+      '@instantdb/react': ['file:///node_modules/@instantdb/react/index.d.ts'],
+      '@instantdb/react-native': [
+        'file:///node_modules/@instantdb/react-native/index.d.ts',
+      ],
+    },
+  });
+
+  for (const { file, content } of fileContents) {
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/core/${file}`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/admin/${file}`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/react/${file}`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      content,
+      `file:///node_modules/@instantdb/react-native/${file}`,
+    );
+  }
+}

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -479,7 +479,7 @@ function DevtoolContent({
         />
       ) : tab === 'sandbox' ? (
         <div className="w-full min-w-[960px]">
-          <Sandbox app={app} db={connection.db} />
+          <Sandbox app={app} db={connection.db} attrs={schemaData.attrs} />
         </div>
       ) : tab === 'admin' ? (
         <div className="w-full min-w-[960px] p-4">

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -415,11 +415,12 @@ function Dashboard() {
       websocketURI: config.websocketURI,
       // @ts-expect-error
       __adminToken: app?.admin_token,
+      disableValidation: true,
     });
 
     setConnection({ db });
     return () => {
-      db._core.shutdown();
+      db.core.shutdown();
     };
   }, [app?.id, app?.admin_token]);
 

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -733,7 +733,7 @@ function Home({ appId, token }: { appId: string; token: string }) {
         <div className="pt-1">
           Use this App ID to connect to your database{' '}
           <a
-            className="hover:cursor-pointer dark:text-white underline"
+            className="underline hover:cursor-pointer dark:text-white"
             href="/docs/init"
             target="_blank"
           >
@@ -856,9 +856,15 @@ function DashboardContent({
           appId={appId}
           db={connection.db}
           namespaces={schemaData.namespaces}
+          attrs={schemaData.attrs}
         />
       ) : tab === 'sandbox' ? (
-        <Sandbox key={appId} app={app} db={connection.db} />
+        <Sandbox
+          key={appId}
+          app={app}
+          db={connection.db}
+          attrs={schemaData.attrs}
+        />
       ) : tab === 'perms' ? (
         <Perms
           app={app}


### PR DESCRIPTION
### Query Inspector

Passes a schema (generated from the attrs) to the query inspector so that users won't get arrays for `hasOne` links.

### Sandbox

1. Adds a generated `instant.schema.ts` to the monaco editor to give us better types for `db.query` and `db.transact`.

2. Runs prettier when you do `Opt+Shift+F`. It's even aware of how wide the pane is, so it will shrink or expand depending on the width. We delay loading the prettier library until you actually use the shortcut.

<img width="469" height="244" alt="image" src="https://github.com/user-attachments/assets/d71a7b65-158b-4cca-a56d-60d6e435e16e" />
<img width="396" height="259" alt="image" src="https://github.com/user-attachments/assets/f995ff41-ffcf-460a-bf71-a76c16270fb7" />
<img width="448" height="197" alt="image" src="https://github.com/user-attachments/assets/aadc65f0-a3f4-44a0-936a-35ca1b2b2803" />

