### PR TITLE
Fix prompt box mobile styles

### DIFF
--- a/client/www/components/docs/CopyPromptBox.tsx
+++ b/client/www/components/docs/CopyPromptBox.tsx
@@ -57,10 +57,10 @@ export function CopyPromptBox({
   };
 
   return (
-    <div className="relative flex items-center justify-between rounded-lg border border-orange-600 px-4 shadow-sm">
-      <p className="text-gray-700">{description}</p>
+    <div className="space-y-2 text-center md:text-start md:grid md:grid-cols-[1fr_auto] md:space-y-0 rounded-lg border border-orange-600 px-4 shadow-sm py-4">
+      <div className="text-gray-700">{description}</div>
 
-      <Button variant="cta" onClick={handleCopy}>
+      <Button size="mini" variant="cta" onClick={handleCopy}>
         {copyLabel}
       </Button>
     </div>


### PR DESCRIPTION
Noticed the prompt box looked a little off on mobile and wanted to fix it

**Before**

<img width="762" height="758" alt="CleanShot 2025-10-07 at 17 03 21@2x" src="https://github.com/user-attachments/assets/cdefb4a0-0b22-44a8-aaa3-4c8ac30ddcef" />

**After**

<img width="752" height="758" alt="CleanShot 2025-10-07 at 17 03 33@2x" src="https://github.com/user-attachments/assets/eb4bcb87-e9e8-47d2-996b-07a92f2b7246" />
