### PR TITLE
Update workflow with instant-cli login

### DIFF
--- a/client/www/pages/docs/workflow.md
+++ b/client/www/pages/docs/workflow.md
@@ -5,22 +5,35 @@ description: How to develop with Instant
 
 At a high level, here is the recommended workflow for developing with Instant:
 
-1. Create new projects via `npx create-instant-app`.
-2. Push changes to your schema and permissions via `npx instant-cli push`.
-3. Use the [Data Explorer](https://www.instantdb.com/dash?t=explorer) for
+1. Authenticate with Instant in your terminal via `npx instant-cli login`.
+2. Create new projects via `npx create-instant-app`.
+3. Push changes to your schema and permissions via `npx instant-cli push`.
+4. Use the [Data Explorer](https://www.instantdb.com/dash?t=explorer) for
    deleting namespaces and deleting/renaming attributes. Pull these changes in
    via `npx instant-cli pull`.
-4. Use the [Sandbox](https://www.instantdb.com/dash?t=sandbox) to debug queries,
+5. Use the [Sandbox](https://www.instantdb.com/dash?t=sandbox) to debug queries,
    transactions, and permissions.
-5. When you're ready for production, [restrict creating](/docs/patterns#restrict-creating-new-attributes) new attributes.
-6. If you need more help, check out our [patterns page](/docs/patterns) for common
+6. When you're ready for production, [restrict creating](/docs/patterns#restrict-creating-new-attributes) new attributes.
+7. If you need more help, check out our [patterns page](/docs/patterns) for common
    recipes or drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).
+
+## Authenticating with Instant in your terminal
+
+Use the [Instant CLI](/docs/instant-cli) to authenticate with Instant in your
+terminal. After authenticating you'll be able to create new projects
+and have them associated with your Instant account. This will also enable you to
+push and pull changes to your projects. To authenticate, run:
+
+```
+npx instant-cli login
+```
+
+This will open a browser window where you can log in or sign up for an account.
 
 ## Starting a new project
 
-If you're starting a new project, we recommend using
-[create-instant-app](/docs/create-instant-app) to get
-set up. This will give you some starter code, and set up rules for your LLM
+After authenticating, you can create a new project with
+[create-instant-app](/docs/create-instant-app). This will give you some starter code, and set up rules for your LLM
 agent. If your agent supports it, we also recommend setting up the [Instant MCP Server](/docs/using-llms#instant-mcp-server).
 
 The default rules cover the basics of using InstantDB. But if you want to add
@@ -31,7 +44,7 @@ page URL to get the raw markdown. For example, here are the docs for
 ## Updating schema and permissions
 
 As your project evolves, you'll likely need to update your schema and permissions. We
-recommend using the [Instant CLI](/docs/instant-cli) to do this. You can make
+recommend using the Instant CLI to do this. You can make
 edits to your local schema and permission files, and then run `npx instant-cli push` to push changes to your project.
 
 If you prefer a GUI, you can also make changes via the explorer in the [Instant


### PR DESCRIPTION
Figured it would be good to mention logging in as part of the recommended workflow. Mainly so that any apps a user makes with `create-instant-app` will be associated with their account by default