### PR TITLE
Update cia docs

### DIFF
--- a/client/www/pages/docs/create-instant-app.md
+++ b/client/www/pages/docs/create-instant-app.md
@@ -15,7 +15,7 @@ If you haven't already, authenticate with the [Instant CLI](/docs/cli) in your
 terminal.
 
 ```shell {% showCopy=true %}
-npx instant login
+npx instant-cli login
 ```
 
 This will open a browser window where you can log in or sign up for an account.


### PR DESCRIPTION
Adds instructions about `npx instant-cli login` for create-instant-app. Also update that create-instant-app --ai can be used for Expo