### PR TITLE
Add dark mode for explorer links

### DIFF
--- a/client/www/components/dash/explorer/EditRowDialog.tsx
+++ b/client/www/components/dash/explorer/EditRowDialog.tsx
@@ -451,7 +451,7 @@ function LinkCombobox({
           portal={false}
           unmount={false}
           static={true}
-          className="fixed mt-1 max-h-[25vh] w-[var(--input-width)] divide-y overflow-scroll rounded-md border border-gray-300 bg-white shadow-lg empty:invisible"
+          className="fixed mt-1 max-h-[25vh] w-[var(--input-width)] divide-y overflow-scroll rounded-md border border-gray-300 bg-white shadow-lg empty:invisible dark:border-neutral-700"
           style={{ top: inputRef.current?.getBoundingClientRect().bottom }}
         >
           {(options || []).map((o) => (


### PR DESCRIPTION
Adds dark themes to the link box and it's tool tips

**Before**
<img width="1104" height="290" alt="CleanShot 2025-10-13 at 10 08 20@2x" src="https://github.com/user-attachments/assets/b6957a71-4103-429f-86c9-18aa8b2adb02" />
<img width="1086" height="350" alt="CleanShot 2025-10-13 at 10 08 32@2x" src="https://github.com/user-attachments/assets/aeda2519-98df-43f5-ae74-0cd5bcfce183" />
<img width="1128" height="366" alt="CleanShot 2025-10-13 at 10 09 06@2x" src="https://github.com/user-attachments/assets/468c4c44-b7bc-4e96-8c57-f7fc394e4c59" />

**After**
<img width="1016" height="288" alt="CleanShot 2025-10-13 at 10 10 35@2x" src="https://github.com/user-attachments/assets/f624f20f-b49e-4861-bff8-3fdae1af0b47" />
<img width="2932" height="1246" alt="CleanShot 2025-10-13 at 10 35 39@2x" src="https://github.com/user-attachments/assets/bbad81f2-ff52-441c-bfb0-ed4676aac1de" />
<img width="1036" height="402" alt="CleanShot 2025-10-13 at 10 10 08@2x" src="https://github.com/user-attachments/assets/2053014b-07b4-47ab-b20b-50d26a203a23" />
