### PR TITLE
disable scrolling on number input

### DIFF
--- a/client/www/lib/patchBrowserEvents.ts
+++ b/client/www/lib/patchBrowserEvents.ts
@@ -25,17 +25,10 @@
  * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1556240
  * @see https://github.com/w3c/pointerevents/issues/356
  */
-export default function patchFirefoxClicks() {
+export function patchFirefoxClicks() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return;
   }
-
-  window.addEventListener('wheel', (event: WheelEvent) => {
-    const target = event.target;
-    if (target instanceof HTMLInputElement && target.type === 'number') {
-      event.preventDefault();
-    }
-  });
 
   if (!navigator.userAgent.includes('Firefox')) {
     return;
@@ -81,4 +74,13 @@ export default function patchFirefoxClicks() {
     document.removeEventListener('mouseup', handleMouseUp, { capture: true });
     document.removeEventListener('click', handleClick, { capture: true });
   };
+}
+
+export function patchNumberInputScroll() {
+  window.addEventListener('wheel', (event: WheelEvent) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement && target.type === 'number') {
+      event.preventDefault();
+    }
+  });
 }

--- a/client/www/pages/_app.tsx
+++ b/client/www/pages/_app.tsx
@@ -10,7 +10,10 @@ import { DocsPage } from '@/components/DocsPage';
 import { Button } from '@/components/ui';
 import { isDev } from '@/lib/config';
 import { Dev } from '@/components/Dev';
-import patchFirefoxClicks from '@/lib/patchFirefoxClicks';
+import {
+  patchFirefoxClicks,
+  patchNumberInputScroll,
+} from '@/lib/patchBrowserEvents';
 import { ReactElement, ReactNode, useEffect } from 'react';
 import { NextPage } from 'next';
 import { SWRConfig } from 'swr';
@@ -49,6 +52,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
     ),
   );
   useEffect(() => {
+    patchNumberInputScroll();
     return patchFirefoxClicks();
   }, []);
   return (


### PR DESCRIPTION
disables scrolling to change the number on a number input. 
tested in safari and chrome