### PR TITLE
[Dash] Hide app id in tooltip

### DIFF
--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -909,7 +909,7 @@ export function SmallCopyable({
               truncate: !multiline,
               'whitespace-pre-wrap break-all': multiline,
             })}
-            title={hideValue || hidden ? 'Copy App ID to Clipboard' : value}
+            title={hideValue || hidden ? 'Copy to clipboard' : value}
             onClick={(e) => {
               // Only copy if no text is selected
               const selection = window.getSelection();
@@ -995,7 +995,7 @@ export function Copyable({
           truncate: !multiline,
           'whitespace-pre-wrap break-all': multiline,
         })}
-        title={hideValue || hidden ? redactedValue(value) : value}
+        title={hideValue || hidden ? 'Copy to clipboard' : value}
         onClick={(e) => {
           const el = e.target as HTMLPreElement;
           const selection = window.getSelection();


### PR DESCRIPTION
Got a report about this from a user. We'll now show the redacted value in the tooltip when in a hidden state

**Before**

<img width="1364" height="356" alt="CleanShot 2025-10-20 at 09 32 12@2x" src="https://github.com/user-attachments/assets/a6a1f23a-61a0-4873-bfc4-90ed73a96919" />

**After**

<img width="1268" height="338" alt="CleanShot 2025-10-20 at 09 37 54@2x" src="https://github.com/user-attachments/assets/bec976de-978a-4a7a-a4fa-5af2948ccaf9" />