### PR TITLE
Add title input to create-app option

### DIFF
--- a/client/packages/cli/src/index.js
+++ b/client/packages/cli/src/index.js
@@ -61,7 +61,7 @@ function error(firstArg, ...rest) {
   console.error(chalk.red('[error]') + ' ' + firstArg, ...rest);
 }
 
-// consts
+// constss
 
 const potentialEnvs = {
   catchall: 'INSTANT_APP_ID',
@@ -342,7 +342,7 @@ program
 program
   .command('create-app')
   .description('Generate an app ID and admin token for a new app.')
-  .option('-t --title', 'Title for the created app')
+  .option('-t --title <title>', 'Title for the created app')
   .option(
     '-o --org <org-id>',
     'The (optional) id of the organization to create the app in.',


### PR DESCRIPTION
I intentionally returned to a02c847a (0.22.20) because it seems like `create-app` was removed since then, and I don't know what's up with that.

But this small change would allow a title to be passed in.