### PR TITLE
Fix Hazelcast key serialization issues

### DIFF
--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -734,7 +734,8 @@
           close (some-> (rs/session store id)
                         :close)]
       (rs/remove-session! store app-id id)
-      (eph/leave-by-session-id! app-id id)
+      (when app-id
+        (eph/leave-by-session-id! app-id id))
       (when close (close)))))
 
 (defn undertow-config


### PR DESCRIPTION
We were trying to create the hazelcast key with a null app-id, which was causing it to throw a `com.hazelcast.nio.serialization.HazelcastSerializationException: Failed to serialize 'instant.util.hazelcast.RoomKeyV1'` error.

Now we check that the app-id exists before we try to call `eph/leave-by-session-id!`