### PR TITLE
[Dash] Tweak error message when restoring duplicate attr

### DIFF
--- a/client/www/components/dash/explorer/RecentlyDeletedAttrs.tsx
+++ b/client/www/components/dash/explorer/RecentlyDeletedAttrs.tsx
@@ -65,7 +65,13 @@ export const RecentlyDeletedAttrs: React.FC<{
     } catch (error) {
       console.error(error);
       if (error instanceof InstantAPIError) {
-        errorToast(error.message);
+        if (error.body?.type === 'record-not-unique') {
+          errorToast(
+            'Attribute already exists. Rename existing attribute first and then try again to restore.',
+          );
+        } else {
+          errorToast(error.message);
+        }
       } else {
         errorToast('Failed to restore attr');
       }


### PR DESCRIPTION
Thought it would be nicer to give a more explicit error message when trying to restore an existing attr.

**Before**
<img width="628" height="130" alt="CleanShot 2025-10-21 at 13 53 45@2x" src="https://github.com/user-attachments/assets/63ea2160-e403-4fdd-a098-118bb4782efd" />

**After**
<img width="622" height="200" alt="CleanShot 2025-10-21 at 13 53 27@2x" src="https://github.com/user-attachments/assets/db45f423-1baa-468e-846f-0f67f1e6d534" />
