### PR TITLE
Fix error type

### DIFF
--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -66,7 +66,7 @@
                          ::validation-failed
 
                          ::session-missing
-                         ::machine-missing})
+                         ::member-missing})
 
 (comment
   (s/explain-data ::instant-exception {::type ::record-not-found

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -102,7 +102,7 @@
 
 ;; Exception types that we won't log an exception for
 (def silent-types #{::ex/session-missing
-                    ::ex/machine-missing})
+                    ::ex/member-missing})
 
 (defn wrap-errors
   "Captures exceptions thrown by the handler. We: 


### PR DESCRIPTION
I was using `::ex/machine-missing`, but it should have been `::ex/member-missing`