### PR TITLE
Fix cascade-delete when items share an entity_id

### DIFF
--- a/client/sandbox/react-nextjs/pages/bugs/cascade-delete.tsx
+++ b/client/sandbox/react-nextjs/pages/bugs/cascade-delete.tsx
@@ -55,13 +55,13 @@ function App({ db }: AppProps) {
       db.tx.publicEnts[p2].create({ name: 'Sally' }),
       db.tx.publicEnts[p3].create({ name: 'Doug' }),
       db.tx.privateEnts[p1]
-        .create({ email: 'red@example.com' })
+        .create({ email: 'bob@example.com' })
         .link({ publicEnts: p1 }),
       db.tx.privateEnts[p2]
-        .create({ email: 'green@example.com' })
+        .create({ email: 'sally@example.com' })
         .link({ publicEnts: p2 }),
       db.tx.privateEnts[p3]
-        .create({ email: 'blue@example.com' })
+        .create({ email: 'doug@example.com' })
         .link({ publicEnts: p3 }),
     ]);
   }, [data, isLoading, db]);

--- a/server/src/instant/util/test.clj
+++ b/server/src/instant/util/test.clj
@@ -13,11 +13,13 @@
    [instant.jdbc.aurora :as aurora]
    [instant.model.rule :as rule-model]
    [instant.reactive.aggregator :as aggregator]
+   [instant.system-catalog :refer [encode-string->long]]
    [instant.util.coll :as coll]
    [instant.util.exception :as ex]
    [instant.util.instaql :refer [instaql-nodes->object-tree]]
    [next.jdbc])
   (:import
+   (java.util UUID)
    (java.time Duration Instant)))
 
 (defmacro instant-ex-data [& body]
@@ -198,6 +200,17 @@
   [s]
   (parse-uuid
     (str s (subs "00000000-0000-0000-0000-000000000000" (count s)))))
+
+(defn stuid
+  "Stable uuid, can just specify prefix, rest will be filled with 0s
+   Like suid, but accepts any string. Must be less than 24 characters.
+
+     (stuid \"hello\") ; => #uuid \"3916b77f-ffff-ffff-ffff-ffffffffffff\""
+  [s]
+  (UUID. (encode-string->long (subs s 0 (min 12 (count s))))
+         (encode-string->long (if (> (count s) 12)
+                                (subs s 12)
+                                ""))))
 
 (defn rand-string
   ([]


### PR DESCRIPTION
Fixes a bug where cascade delete would filter out entities that had the same entity_id as the parent. Now we check that the etypes match.