### PR TITLE
Ignore deleted attrs when doing db size calculation

### DIFF
--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -393,7 +393,8 @@
             WHEN pg_relation_size('triples') = 0 THEN 1
             ELSE pg_total_relation_size('triples')::numeric / pg_relation_size('triples')
         END) as num_bytes
-     FROM attr_sketches s WHERE s.app_id = ?::uuid" app-id])))
+     FROM attr_sketches s join attrs a on s.attr_id = a.id
+     WHERE a.deletion_marked_at is null and s.app_id = ?::uuid" app-id])))
 
 (defn decrypt-connection-string [app-id encrypted-connection-string]
   (-> (crypt-util/aead-decrypt {:ciphertext encrypted-connection-string

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -269,10 +269,12 @@
                                :0]
                               :num_bytes]]
                     :from [[:attr-sketches :s]]
-                    :join [[:apps :a] [:= :s.app_id :a.id]]
+                    :join [[:apps :app] [:= :s.app_id :app.id]
+                           [:attrs :attr] [:= :s.attr_id :attr.id]]
                     :where [:and
-                            [:= :a.org_id :?org-id]
-                            [:= nil :a.deletion-marked-at]]}))
+                            [:= :app.org_id :?org-id]
+                            [:= nil :app.deletion-marked-at]
+                            [:= nil :attr.deletion-marked-at]]}))
 
 (defn org-usage
   "Estimates amount of bytes used for an orgs's triples.


### PR DESCRIPTION
This way you'll immediately see your usage drop after you delete an attr.