### PR TITLE
[home] make it so you can't copy the $ from the npx create-instant-app command

### DIFF
--- a/client/www/pages/index.tsx
+++ b/client/www/pages/index.tsx
@@ -106,7 +106,10 @@ function CreateInstantApp() {
             <ClipboardDocumentIcon className="h-5 w-5" />
           )}
         </div>
-        $ {command}
+        <span className="mr-2 select-none" aria-hidden="true">
+          $
+        </span>
+        <span>{command}</span>
       </div>
     </CopyToClipboard>
   );


### PR DESCRIPTION
A user gave me some feedback that if you copy the create-instant-app command manually, the $ will come with it. 

Made it so the $ is select-none. 

@nezaj @dwwoelfel @drew-harris 