### PR TITLE
[Tutorial] Fix add to cursor link

### DIFF
--- a/client/www/pages/tutorial.tsx
+++ b/client/www/pages/tutorial.tsx
@@ -548,7 +548,7 @@ const clientConfigs = {
         <p>Click this button to install the Instant MCP server in Cursor:</p>
         <div className="flex">
           <a
-            href="https://cursor.com/install-mcp?name=InstantDB&config=eyJ1cmwiOiJodHRwczovL21jcC5pbnN0YW50ZGIuY29tL21jcCJ9"
+            href="https://cursor.com/en/install-mcp?name=InstantDB&config=eyJ1cmwiOiJodHRwczovL21jcC5pbnN0YW50ZGIuY29tL21jcCJ9"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Got a report the "Add to Cursor" button was 404ing in the tutorial -- updating the link to match what we have in the docs (which works)!