### PR TITLE
fix eslint error in vite react playground

### DIFF
--- a/client/sandbox/strong-init-vite/eslint.config.js
+++ b/client/sandbox/strong-init-vite/eslint.config.js
@@ -19,6 +19,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/no-empty-object-type': 'off',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },


### PR DESCRIPTION
<img width="1258" height="482" alt="image" src="https://github.com/user-attachments/assets/d4131b99-ea8b-450d-bb2f-79d15e06c9e2" />

Fixes these errors that pop up when you interact with the vite sandbox. 