### PR TITLE
Update moduleResolution for nextjs sandbox

### DIFF
--- a/client/sandbox/react-nextjs/tsconfig.json
+++ b/client/sandbox/react-nextjs/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Fixes this error:

 ```
 Cannot find module '@instantdb/react' or its corresponding type declarations.
  There are types at 
'~/instant/client/sandbox/react-nextjs/node_modules/@instantdb/react/dist/esm/index.d.ts', but 
this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 
'bundler'.ts(2307)
```

We use `bundler` in `www`, so this seems reasonable.