### PR TITLE
Add better hint for incorrect admin token

### DIFF
--- a/server/src/instant/model/app_admin_token.clj
+++ b/server/src/instant/model/app_admin_token.clj
@@ -12,7 +12,8 @@
                     token app-id])))
 
 (defn fetch! [params]
-  (ex/assert-record! (fetch params) :app-admin-token {:args [params]}))
+  (ex/assert-record! (fetch params) :app-admin-token {:args [params]
+                                                      :message "This admin token may be expired or invalid. Or you may have provided an incorrect app ID."}))
 
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))


### PR DESCRIPTION
Got an email from a user who was having a hard time using the admin sdk. They kept getting `InstantAPIError: Record not found: app-admin-token`

The actual error was because they had a typo in their app id. Thought it would be nicer to include a more helpful hint message