### PR TITLE
Force esm output in dev

### DIFF
--- a/client/packages/admin/tsconfig.dev.json
+++ b/client/packages/admin/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/packages/core/tsconfig.dev.json
+++ b/client/packages/core/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/packages/mcp/tsconfig.dev.json
+++ b/client/packages/mcp/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/packages/platform/tsconfig.dev.json
+++ b/client/packages/platform/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/packages/react-common/tsconfig.dev.json
+++ b/client/packages/react-common/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/packages/react/tsconfig.dev.json
+++ b/client/packages/react/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/packages/version/tsconfig.dev.json
+++ b/client/packages/version/tsconfig.dev.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
 
     "outDir": "./dist/esm",
 

--- a/client/turbo.json
+++ b/client/turbo.json
@@ -77,7 +77,7 @@
       "persistent": true
     },
     "clean": {
-      "outputs": []
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
Add more hints to the typescript compiler that we want it to emit esm instead of commonjs in dev. 

I ran into an issue where it was outputting commonjs for me locally. How typescript decides what to output when using nodenext is kind of murky, but this change to the tsconfig.json seems to work.