### PR TITLE
fix firebase auth title in docs

### DIFF
--- a/client/www/pages/docs/auth/firebase.md
+++ b/client/www/pages/docs/auth/firebase.md
@@ -1,3 +1,8 @@
+---
+title: Firebase Auth
+description: How to integrate Firebase's auth flow with Instant.
+---
+
 # Firebase Auth
 
 Instant supports delegating auth to Firebase Auth.


### PR DESCRIPTION
Noticed that we got an `undefined` in the title section on our docs for firebase. I updated the frontmatter with the title, and babam, no more undefined. 

@dwwoelfel @nezaj @drew-harris