### PR TITLE
[docs] remove duplicate title

### DIFF
--- a/client/www/pages/docs/auth/firebase.md
+++ b/client/www/pages/docs/auth/firebase.md
@@ -3,8 +3,6 @@ title: Firebase Auth
 description: How to integrate Firebase's auth flow with Instant.
 ---
 
-# Firebase Auth
-
 Instant supports delegating auth to Firebase Auth.
 
 ## Setup


### PR DESCRIPTION
Moved a biit to quick. Once we add the `title`, it causes the page to repeat "Firebase Auth" twice. 

@dwwoelfel @nezaj @drew-harris	