### PR TITLE
[sm] Distinguish between namespace and attribute

### DIFF
--- a/client/www/components/dash/explorer/EditNamespaceDialog.tsx
+++ b/client/www/components/dash/explorer/EditNamespaceDialog.tsx
@@ -281,6 +281,7 @@ export function EditNamespaceDialog({
       ) : screen.type === 'delete' ? (
         <DeleteForm
           name={namespace.name}
+          type="namespace"
           onClose={onClose}
           onConfirm={deleteNs}
         />
@@ -304,10 +305,12 @@ export function EditNamespaceDialog({
 
 function DeleteForm({
   name,
+  type,
   onClose,
   onConfirm,
 }: {
   name: string;
+  type: 'namespace' | 'attribute';
   onClose: () => void;
   onConfirm: () => void;
 }) {
@@ -324,7 +327,7 @@ function DeleteForm({
 
       <div className="flex flex-col gap-2">
         <p className="pb-2">
-          Are you sure you want to delete the <strong>{name}</strong> attribute?
+          Are you sure you want to delete the <strong>{name}</strong> {type}?
         </p>
         <ActionButton
           variant="destructive"
@@ -1697,7 +1700,12 @@ function EditAttrForm({
 
   if (screen.type === 'delete') {
     return (
-      <DeleteForm onConfirm={deleteAttr} onClose={onClose} name={attr.name} />
+      <DeleteForm
+        onConfirm={deleteAttr}
+        onClose={onClose}
+        name={attr.name}
+        type="attribute"
+      />
     );
   }
   return (


### PR DESCRIPTION
When deleting a namespace I noticed we said delete attribute instead -- updating the copy to make it more explicit when we are deleting a namespace or an attribute.

**Before**
<img width="1210" height="318" alt="CleanShot 2025-11-10 at 11 28 59@2x" src="https://github.com/user-attachments/assets/dc1e3695-e86f-4c8a-a492-8ccbbe06a1ca" />

**After**
<img width="1202" height="310" alt="CleanShot 2025-11-10 at 11 27 20@2x" src="https://github.com/user-attachments/assets/089ae2e9-1399-43d9-b594-dddadddbadcb" />
