### PR TITLE
Add permissions for rooms

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -358,7 +358,7 @@ class Rooms<Schema extends InstantSchemaDef<any, any, any>> {
     this.config = config;
   }
 
-  async getPresence<RoomType extends keyof RoomsOf<Schema>>(
+  async getPresence<RoomType extends string & keyof RoomsOf<Schema>>(
     roomType: RoomType,
     roomId: string,
   ): Promise<PresenceResult<PresenceOf<Schema, RoomType>>> {

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -618,7 +618,8 @@ export default class Reactor {
 
         for (const roomId of Object.keys(this._rooms)) {
           const enqueuedUserPresence = this._presence[roomId]?.result?.user;
-          this._tryJoinRoom(roomId, enqueuedUserPresence);
+          const roomType = this._rooms[roomId]?.roomType;
+          this._tryJoinRoom(roomType, roomId, enqueuedUserPresence);
         }
         break;
       }
@@ -2227,15 +2228,17 @@ export default class Reactor {
   // Rooms
 
   /**
+   * @param {string} roomType
    * @param {string} roomId
    * @param {any | null | undefined} [initialPresence] -- initial presence data to send when joining the room
    * @returns () => void
    */
-  joinRoom(roomId, initialPresence) {
+  joinRoom(roomType, roomId, initialPresence) {
     let needsToSendJoin = false;
     if (!this._rooms[roomId]) {
       needsToSendJoin = true;
       this._rooms[roomId] = {
+        roomType,
         isConnected: false,
         error: undefined,
       };
@@ -2250,7 +2253,7 @@ export default class Reactor {
     }
 
     if (needsToSendJoin) {
-      this._tryJoinRoom(roomId, initialPresence);
+      this._tryJoinRoom(roomType, roomId, initialPresence);
     }
 
     return () => {
@@ -2284,6 +2287,15 @@ export default class Reactor {
   getPresence(roomType, roomId, opts = {}) {
     const room = this._rooms[roomId];
     const presence = this._presence[roomId];
+
+    if (room?.error) {
+      return {
+        ...buildPresenceSlice(presence?.result || {}, opts, this._sessionId),
+        isLoading: false,
+        error: room.error,
+      };
+    }
+
     if (!room || !presence || !presence.result) return null;
 
     return {
@@ -2326,8 +2338,13 @@ export default class Reactor {
     });
   }
 
-  _tryJoinRoom(roomId, data) {
-    this._trySendAuthed(uuid(), { op: 'join-room', 'room-id': roomId, data });
+  _tryJoinRoom(roomType, roomId, data) {
+    this._trySendAuthed(uuid(), {
+      op: 'join-room',
+      'room-type': roomType,
+      'room-id': roomId,
+      data,
+    });
     delete this._roomsPendingLeave[roomId];
   }
 
@@ -2345,6 +2362,7 @@ export default class Reactor {
   // TODO: look into typing again
   subscribePresence(roomType, roomId, opts, cb) {
     const leaveRoom = this.joinRoom(
+      roomType,
       roomId,
       // Oct 28, 2025
       // Note: initialData is deprecated.
@@ -2459,8 +2477,8 @@ export default class Reactor {
     });
   }
 
-  subscribeTopic(roomId, topic, cb) {
-    const leaveRoom = this.joinRoom(roomId);
+  subscribeTopic(roomType, roomId, topic, cb) {
+    const leaveRoom = this.joinRoom(roomType, roomId);
 
     this._broadcastSubs[roomId] = this._broadcastSubs[roomId] || {};
     this._broadcastSubs[roomId][topic] =

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -251,7 +251,7 @@ export default class Reactor {
   /** @type BroadcastChannel | undefined */
   _broadcastChannel;
 
-  /** @type {Record<string, {isConnected: boolean; error: any}>} */
+  /** @type {Record<string, {roomType: string; isConnected: boolean; error: any}>} */
   _rooms = {};
   /** @type {Record<string, boolean>} */
   _roomsPendingLeave = {};

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -689,7 +689,7 @@ class InstantCoreDatabase<
    * unsubscribeTopic();
    * room.leaveRoom();
    */
-  joinRoom<RoomType extends keyof RoomsOf<Schema>>(
+  joinRoom<RoomType extends string & keyof RoomsOf<Schema>>(
     roomType: RoomType = '_defaultRoomType' as RoomType,
     roomId: string = '_defaultRoomId',
     opts?: {

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -696,12 +696,16 @@ class InstantCoreDatabase<
       initialPresence?: Partial<PresenceOf<Schema, RoomType>>;
     },
   ): RoomHandle<PresenceOf<Schema, RoomType>, TopicsOf<Schema, RoomType>> {
-    const leaveRoom = this._reactor.joinRoom(roomId, opts?.initialPresence);
+    const leaveRoom = this._reactor.joinRoom(
+      roomType,
+      roomId,
+      opts?.initialPresence,
+    );
 
     return {
       leaveRoom,
       subscribeTopic: (topic, onEvent) =>
-        this._reactor.subscribeTopic(roomId, topic, onEvent),
+        this._reactor.subscribeTopic(roomType, roomId, topic, onEvent),
       subscribePresence: (opts, onChange) =>
         this._reactor.subscribePresence(roomType, roomId, opts, onChange),
       publishTopic: (topic, data) =>

--- a/client/packages/core/src/presence.ts
+++ b/client/packages/core/src/presence.ts
@@ -45,7 +45,7 @@ export type PresenceResponse<
   Keys extends keyof PresenceShape,
 > = PresenceSlice<PresenceShape, Keys> & {
   isLoading: boolean;
-  error?: string;
+  error?: { message: string; type: string };
 };
 
 export function buildPresenceSlice<

--- a/client/packages/core/src/rulesTypes.ts
+++ b/client/packages/core/src/rulesTypes.ts
@@ -8,6 +8,11 @@ type InstantRulesAttrsAllowBlock = {
   delete?: string | null | undefined;
 };
 
+type InstantRoomRulesAllowBlock = {
+  $default?: string | null | undefined;
+  join?: string | null | undefined;
+};
+
 export type InstantRulesAllowBlock = InstantRulesAttrsAllowBlock & {
   link?: { [key: string]: string } | null | undefined;
   unlink?: { [key: string]: string } | null | undefined;
@@ -23,6 +28,12 @@ export type InstantRules<
   attrs?: {
     bind?: string[] | Record<string, string>;
     allow: InstantRulesAttrsAllowBlock;
+  };
+  $rooms?: {
+    [RoomType: string]: {
+      bind?: string[] | Record<string, string>;
+      allow: InstantRoomRulesAllowBlock;
+    };
   };
 } & {
   [EntityName in keyof Schema['entities']]?: {

--- a/client/packages/react-common/src/InstantReactAbstractDatabase.tsx
+++ b/client/packages/react-common/src/InstantReactAbstractDatabase.tsx
@@ -137,7 +137,7 @@ export default abstract class InstantReactAbstractDatabase<
    *  const room = db.room('chat', roomId);
    *  const { peers } = db.rooms.usePresence(room);
    */
-  room<RoomType extends keyof Rooms>(
+  room<RoomType extends string & keyof Rooms>(
     type: RoomType = '_defaultRoomType' as RoomType,
     id: string = '_defaultRoomId',
   ) {

--- a/client/packages/react-common/src/InstantReactRoom.ts
+++ b/client/packages/react-common/src/InstantReactRoom.ts
@@ -76,6 +76,7 @@ export function useTopicEffect<
 
   useEffect(() => {
     const unsub = room.core._reactor.subscribeTopic(
+      room.type,
       room.id,
       topic,
       (event, peer) => {
@@ -110,7 +111,7 @@ export function usePublishTopic<
   room: InstantReactRoom<any, RoomSchema, RoomType>,
   topic: TopicType,
 ): (data: RoomSchema[RoomType]['topics'][TopicType]) => void {
-  useEffect(() => room.core._reactor.joinRoom(room.id), [room.id]);
+  useEffect(() => room.core._reactor.joinRoom(room.type, room.id), [room.id]);
 
   const publishTopic = useCallback(
     (data) => {
@@ -209,7 +210,10 @@ export function useSyncPresence<
   data: Partial<RoomSchema[RoomType]['presence']>,
   deps?: any[],
 ): void {
-  useEffect(() => room.core._reactor.joinRoom(room.id, data), [room.id]);
+  useEffect(
+    () => room.core._reactor.joinRoom(room.type, room.id, data),
+    [room.id],
+  );
   useEffect(() => {
     return room.core._reactor.publishPresence(room.type, room.id, data);
   }, [room.type, room.id, deps ?? JSON.stringify(data)]);

--- a/client/packages/react-common/src/InstantReactRoom.ts
+++ b/client/packages/react-common/src/InstantReactRoom.ts
@@ -61,7 +61,7 @@ export const defaultActivityStopTimeout = 1_000;
  */
 export function useTopicEffect<
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
   TopicType extends keyof RoomSchema[RoomType]['topics'],
 >(
   room: InstantReactRoom<any, RoomSchema, RoomType>,
@@ -105,7 +105,7 @@ export function useTopicEffect<
  */
 export function usePublishTopic<
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
   TopicType extends keyof RoomSchema[RoomType]['topics'],
 >(
   room: InstantReactRoom<any, RoomSchema, RoomType>,
@@ -147,7 +147,7 @@ export function usePublishTopic<
  */
 export function usePresence<
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
   Keys extends keyof RoomSchema[RoomType]['presence'],
 >(
   room: InstantReactRoom<any, RoomSchema, RoomType>,
@@ -204,7 +204,7 @@ export function usePresence<
  */
 export function useSyncPresence<
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
 >(
   room: InstantReactRoom<any, RoomSchema, RoomType>,
   data: Partial<RoomSchema[RoomType]['presence']>,
@@ -240,7 +240,7 @@ export function useSyncPresence<
  */
 export function useTypingIndicator<
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
 >(
   room: InstantReactRoom<any, RoomSchema, RoomType>,
   inputName: string,
@@ -324,7 +324,7 @@ export const rooms = {
 export class InstantReactRoom<
   Schema extends InstantSchemaDef<any, any, any>,
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
 > {
   core: InstantCoreDatabase<Schema, boolean>;
   /** @deprecated use `core` instead */

--- a/client/packages/react/src/Cursors.tsx
+++ b/client/packages/react/src/Cursors.tsx
@@ -10,7 +10,7 @@ import type { RoomSchemaShape } from '@instantdb/core';
 
 export function Cursors<
   RoomSchema extends RoomSchemaShape,
-  RoomType extends keyof RoomSchema,
+  RoomType extends string & keyof RoomSchema,
 >({
   as = 'div',
   spaceId: _spaceId,

--- a/client/sandbox/react-nextjs/pages/play/room-perms.tsx
+++ b/client/sandbox/react-nextjs/pages/play/room-perms.tsx
@@ -1,0 +1,146 @@
+import { i, InstantReactAbstractDatabase } from '@instantdb/react';
+import EphemeralAppPage from '../../components/EphemeralAppPage';
+import { useState } from 'react';
+
+const schema = i.schema({
+  entities: {},
+  rooms: {
+    chat: {
+      presence: i.entity({ name: i.string() }),
+    },
+    video: {
+      presence: i.entity({ name: i.string() }),
+    },
+  },
+});
+
+const perms = {
+  $rooms: {
+    chat: {
+      allow: {
+        join: 'auth.id != null',
+      },
+    },
+    $default: {
+      allow: {
+        join: 'false',
+      },
+    },
+  },
+};
+
+type DB = InstantReactAbstractDatabase<typeof schema>;
+
+function ChatRoomTest({ db }: { db: DB }) {
+  const room = db.room('chat', 'test-room');
+  const presence = db.rooms.usePresence(room, {
+    initialPresence: { name: 'guest' },
+  });
+
+  return (
+    <div className="rounded border p-2">
+      <p className="text-sm font-medium">chat room (should succeed)</p>
+      {presence.isLoading ? (
+        <p className="text-sm text-yellow-600">Joining...</p>
+      ) : presence.error ? (
+        <p className="text-sm text-red-600">
+          Error: {presence.error.message || JSON.stringify(presence.error)}
+        </p>
+      ) : (
+        <p className="text-sm text-green-600">Connected!</p>
+      )}
+    </div>
+  );
+}
+
+function VideoRoomTest({ db }: { db: DB }) {
+  const room = db.room('video', 'test-room-video');
+  const presence = db.rooms.usePresence(room, {
+    initialPresence: { name: 'guest' },
+  });
+
+  return (
+    <div className="rounded border p-2">
+      <p className="text-sm font-medium">video room (should fail - $default)</p>
+      {presence.isLoading ? (
+        <p className="text-sm text-yellow-600">Joining...</p>
+      ) : presence.error ? (
+        <p className="text-sm text-red-600">
+          Error: {presence.error.message || JSON.stringify(presence.error)}
+        </p>
+      ) : (
+        <p className="text-sm text-green-600">Connected!</p>
+      )}
+    </div>
+  );
+}
+
+function App({ db, appId }: { db: DB; appId: string }) {
+  const { isLoading: authLoading, user } = db.useAuth();
+  const [showChat, setShowChat] = useState(false);
+  const [showVideo, setShowVideo] = useState(false);
+
+  return (
+    <div className="mx-auto mt-10 max-w-lg space-y-4 p-4">
+      <h1 className="text-xl font-bold">Room Permissions Test</h1>
+      <p className="text-sm text-gray-600">
+        chat = <code>auth.id != null</code>, $default = <code>false</code>
+      </p>
+
+      <div className="space-y-2 rounded border p-3">
+        <h2 className="font-semibold">1. Auth</h2>
+        {authLoading ? (
+          <p>Loading...</p>
+        ) : user ? (
+          <div>
+            <p className="text-green-600">Signed in: {user.email || user.id}</p>
+            <button
+              className="mt-1 rounded bg-gray-200 px-2 py-1 text-sm"
+              onClick={() => db.auth.signOut()}
+            >
+              Sign Out
+            </button>
+          </div>
+        ) : (
+          <button
+            className="rounded bg-blue-500 px-3 py-1 text-white"
+            onClick={() => db.auth.signInAsGuest()}
+          >
+            Sign In as Guest
+          </button>
+        )}
+      </div>
+
+      {user && (
+        <div className="space-y-2 rounded border p-3">
+          <h2 className="font-semibold">2. Join Rooms</h2>
+          <div className="space-y-2">
+            <button
+              className="rounded bg-green-500 px-3 py-1 text-white"
+              onClick={() => setShowChat(true)}
+            >
+              Join "chat" Room
+            </button>
+            {showChat && <ChatRoomTest db={db} />}
+
+            <button
+              className="rounded bg-red-500 px-3 py-1 text-white"
+              onClick={() => setShowVideo(true)}
+            >
+              Join "video" Room
+            </button>
+            {showVideo && <VideoRoomTest db={db} />}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <div>
+      <EphemeralAppPage schema={schema} perms={perms} Component={App} />
+    </div>
+  );
+}

--- a/client/www/pages/docs/permissions.md
+++ b/client/www/pages/docs/permissions.md
@@ -233,6 +233,74 @@ But we would not be able to create goals with new attr types:
 db.transact(db.tx.goals[id()].update({title: "Hello World", priority: "high"})
 ```
 
+## Rooms
+
+You can define permissions for room joins using the `$rooms` key. Rules are keyed by room type, and each room type supports a `join` action. The CEL context for room rules exposes `auth` and `data.id`.
+
+```json
+{
+  "$rooms": {
+    "chat": {
+      "allow": {
+        "join": "auth.id != null"
+      }
+    }
+  }
+}
+```
+
+If `$rooms` is not defined, all room joins succeed. If `$rooms` is defined, room types not listed fall back to `$rooms.$default` if present, otherwise the join is allowed.
+
+```json
+{
+  "$rooms": {
+    "chat": {
+      "allow": {
+        "join": "auth.id != null"
+      }
+    },
+    "$default": {
+      "allow": {
+        "join": "false"
+      }
+    }
+  }
+}
+```
+
+In this example, authenticated users can join `chat` rooms, but all other room types are denied.
+
+You can use `bind` in room rules just like namespace rules:
+
+```json
+{
+  "$rooms": {
+    "chat": {
+      "allow": {
+        "join": "isMember"
+      },
+      "bind": {
+        "isMember": "auth.id != null"
+      }
+    }
+  }
+}
+```
+
+You can also use `auth.ref` to check relations:
+
+```json
+{
+  "$rooms": {
+    "chat": {
+      "allow": {
+        "join": "data.id in auth.ref('$user.chatRooms.id')"
+      }
+    }
+  }
+}
+```
+
 ## CEL expressions
 
 Inside each rule, you can write CEL code that evaluates to either `true` or `false`.

--- a/server/src/instant/db/cel.clj
+++ b/server/src/instant/db/cel.clj
@@ -410,6 +410,20 @@
   (-> (runtime-compiler-builder)
       (.build)))
 
+(def ^:private ^CelCompiler cel-join-compiler
+  (-> (CelCompilerFactory/standardCelCompilerBuilder)
+      (.addMessageTypes (ucoll/array-of Descriptors$Descriptor [proto/request-descriptor]))
+      (.addVar "data" type-obj)
+      (.addVar "auth" type-obj)
+      (.addVar "request" ^StructTypeReference request-cel-type)
+      (.addFunctionDeclarations (ucoll/array-of CelFunctionDecl custom-fn-decls))
+      (.setOptions cel-options)
+      (.setStandardMacros CelStandardMacro/STANDARD_MACROS)
+      (.addLibraries (ucoll/array-of CelCompilerLibrary [(CelExtensions/bindings)
+                                                         (CelExtensions/strings)
+                                                         (CelExtensions/math cel-options)]))
+      (.build)))
+
 (def ^:private ^CelCompiler cel-create-update-compiler
   (-> (runtime-compiler-builder)
       (.addVar "newData" type-obj)
@@ -443,6 +457,7 @@
 (defn action->compiler [action]
   (case (name action)
     ("view" "delete") cel-view-delete-compiler
+    "join"            cel-join-compiler
     "link"            cel-link-compiler
     "unlink"          cel-unlink-compiler
     #_else            cel-create-update-compiler))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -9,6 +9,7 @@
   (:require
    [clojure.main :refer [root-cause]]
    [instant.config :as config]
+   [instant.db.cel :as cel]
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
    [instant.db.permissioned-transaction :as permissioned-tx]
@@ -611,16 +612,60 @@
                                     (when (string? s)
                                       s))))
 
+(defn- assert-room-permission!
+  "Check room join permissions. If no $rooms rules exist, allow (backwards compat).
+   If $rooms rules exist but client didn't send room-type, deny."
+  [{:keys [app-id room-type room-id current-user admin?]}]
+  (when-not admin?
+    (let [rules (rule-model/get-by-app-id {:app-id app-id})
+          has-room-rules? (some? (get-in rules [:code "$rooms"]))]
+      (when has-room-rules?
+        (when-not room-type
+          (ex/assert-permitted!
+           :has-room-join-permission?
+           ["$rooms" nil "join"]
+           false))
+        (let [program (rule-model/get-room-program! rules room-type "join")]
+          (when program
+            (let [ctx {:current-user current-user
+                       :app-id app-id
+                       :db {:conn-pool (aurora/conn-pool :read)}
+                       :attrs (attr-model/get-by-app-id app-id)
+                       :datalog-query-fn d/query}]
+              (ex/assert-permitted!
+               :has-room-join-permission?
+               ["$rooms" room-type "join"]
+               (cel/eval-program! ctx program {:data {"id" room-id}})))))))))
+
 (defn- handle-join-room! [store sess-id {:keys [client-event-id data] :as event}]
   (let [auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
         current-user (-> auth :user)
-        room-id (validate-room-id event)]
-    (eph/join-room! app-id sess-id current-user room-id data)
-    (join-room-logger/log-join-room! app-id)
-    (rs/send-event! store app-id sess-id {:op :join-room-ok
-                                          :room-id room-id
-                                          :client-event-id client-event-id})))
+        room-id (validate-room-id event)
+        room-type (get event :room-type)]
+    (try
+      (assert-room-permission! {:app-id app-id
+                                :room-type room-type
+                                :room-id room-id
+                                :current-user current-user
+                                :admin? (:admin? auth)})
+      (eph/join-room! app-id sess-id current-user room-id data)
+      (join-room-logger/log-join-room! app-id)
+      (rs/send-event! store app-id sess-id {:op :join-room-ok
+                                            :room-id room-id
+                                            :client-event-id client-event-id})
+      (catch Exception e
+        (let [instant-ex (ex/find-instant-exception e)
+              err-data (when instant-ex (ex-data instant-ex))]
+          (if (#{::ex/permission-denied ::ex/permission-evaluation-failed}
+               (::ex/type err-data))
+            (rs/send-event! store app-id sess-id {:op :join-room-error
+                                                  :room-id room-id
+                                                  :error {:message (or (::ex/message err-data)
+                                                                       "Permission denied")
+                                                          :type :permission-denied}
+                                                  :client-event-id client-event-id})
+            (throw e)))))))
 
 (defn- handle-leave-room! [store sess-id {:keys [client-event-id] :as event}]
   (let [auth (get-auth! store sess-id)


### PR DESCRIPTION
Adds permission checks for room joins, gated by room type. Rules are defined under a `$rooms` key in permissions, keyed by room type, with a single `join` action. The CEL context exposes `data.id` and `auth`.

<img width="1018" height="944" alt="CleanShot 2026-02-10 at 15 23 55@2x" src="https://github.com/user-attachments/assets/5afe3ee9-6391-46bf-bc63-5c974dc8a1f4" />

### Default behavior

- If `$rooms` is **not defined** in rules, all joins succeed (backwards compatible)
- If `$rooms` is defined, room types not listed fall back to `$rooms.$default` if present, otherwise allow
- Admin sessions bypass room permission checks

### Rule syntax

```typescript
const rules = {
  $rooms: {
    chat: {
      allow: {
        join: 'auth.id != null',
      },
      bind: ['isMember', "data.id in auth.ref('$user.groups.id')"],
    },
    $default: {
      allow: {
        join: 'false',
      },
    },
  },
};
```

This pattern also let's us expand to other actions we may want to support like `broadcast` and `setPresence`

### How it works

**Client:** The client now sends `room-type` alongside `room-id` in the `join-room` WebSocket message. The room type is stored in the Reactor's room state so it persists across reconnects.

**Server:** When handling a `join-room` message, the server:

1. Looks up `$rooms` rules for the app
2. If no `$rooms` key exists → allow (backwards compat)
3. If `$rooms` exists but client didn't send `room-type` → deny (old clients must upgrade)
4. Finds the matching CEL program using fallback order: specific room type → `$default`
5. Evaluates the CEL expression with `{data: {id: "..."}, auth: ...}`
6. On denial, sends `join-room-error` instead of `join-room-ok`

### Files changed

| File                                                    | Change                                                                                                 |
| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| `client/packages/core/src/Reactor.js`                   | Thread `roomType` through `joinRoom`, `_tryJoinRoom`, reconnect, `subscribePresence`, `subscribeTopic` |
| `client/packages/core/src/index.ts`                     | Pass `roomType` to reactor                                                                             |
| `client/packages/react-common/src/InstantReactRoom.ts`  | Pass `room.type` in hooks                                                                              |
| `client/packages/core/src/rulesTypes.ts`                | Add `$rooms` type to `InstantRules`                                                                    |
| `server/src/instant/db/cel.clj`                         | Add `"join"` to `action->compiler`                                                                     |
| `server/src/instant/model/rule.clj`                     | Add `$rooms` validation, `get-room-program!` with fallback logic                                       |
| `server/src/instant/reactive/session.clj`               | Add `assert-room-permission!`, modify `handle-join-room!`                                              |
| `server/test/instant/model/rule_test.clj`               |   rule validation and program compilation                                                   |
| `server/test/instant/reactive/session_test.clj`         | permission enforcement                                                                     |
| `client/sandbox/react-nextjs/pages/play/room-perms.tsx` | E2E play page                                                                                          |
