### PR TITLE
Fix inference in query inspector

### DIFF
--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -954,7 +954,11 @@ function init<
   versions?: { [key: string]: string },
   EventSourceImpl?: any,
 ): InstantCoreDatabase<Schema, UseDates> {
-  const cardinalityInference = config.cardinalityInference ?? !!config.schema;
+  const cardinalityInference =
+    Boolean(config.schema) &&
+    ('cardinalityInference' in config
+      ? Boolean(config.cardinalityInference)
+      : true);
 
   const configStrict = {
     ...config,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -981,7 +981,6 @@ function init<
     {
       ...defaultConfig,
       ...configStrict,
-      cardinalityInference: configStrict.schema ? true : false,
     },
     Store || IndexedDBStorage,
     NetworkListener || WindowNetworkListener,

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -179,6 +179,7 @@ export type InstantConfig<
 > = {
   appId: string;
   schema?: S;
+  cardinalityInference?: boolean;
   websocketURI?: string;
   firstPartyPath?: string;
   apiURI?: string;
@@ -303,7 +304,9 @@ function reactorKey(config: InstantConfig<any, boolean>): string {
     '_' +
     (adminToken || 'client_only') +
     '_' +
-    config.useDateObjects
+    config.useDateObjects +
+    '_' +
+    String(!!config.cardinalityInference)
   );
 }
 
@@ -951,10 +954,13 @@ function init<
   versions?: { [key: string]: string },
   EventSourceImpl?: any,
 ): InstantCoreDatabase<Schema, UseDates> {
+  const cardinalityInference = config.cardinalityInference ?? !!config.schema;
+
   const configStrict = {
     ...config,
     appId: config.appId?.trim(),
     useDateObjects: (config.useDateObjects ?? false) as UseDates,
+    cardinalityInference,
   };
   const existingClient = globalInstantCoreStore[
     reactorKey(configStrict)


### PR DESCRIPTION
The cardinality inference in the query inspector is not working. We create a separate db with the schema in the query inspector component. But then we just end up using the existing db because it has the same reactor cache key.

This updates the reactor cache key so that it changes when inference is disabled/enabled.