### PR TITLE
Make self-hostable

### DIFF
--- a/.github/workflows/publish-self-hosted-images.yml
+++ b/.github/workflows/publish-self-hosted-images.yml
@@ -1,0 +1,110 @@
+name: Publish self-hosted Docker images
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-self-hosted-images-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/instantdb/dashboard
+            image_name: dashboard
+            context: ./client
+            file: ./client/Dockerfile.www
+            platform: linux/amd64
+            platform_tag: amd64
+            runner: ubuntu-latest
+          - image: ghcr.io/instantdb/server
+            image_name: server
+            context: ./server
+            file: ./server/Dockerfile.self-hosted
+            platform: linux/amd64
+            platform_tag: amd64
+            runner: ubuntu-latest
+          - image: ghcr.io/instantdb/dashboard
+            image_name: dashboard
+            context: ./client
+            file: ./client/Dockerfile.www
+            platform: linux/arm64
+            platform_tag: arm64
+            runner: ubuntu-24.04-arm
+          - image: ghcr.io/instantdb/server
+            image_name: server
+            context: ./server
+            file: ./server/Dockerfile.self-hosted
+            platform: linux/arm64
+            platform_tag: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ matrix.image }}:${{ github.sha }}-${{ matrix.platform_tag }}
+          cache-from: type=gha,scope=${{ matrix.image_name }}-${{ matrix.platform_tag }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}-${{ matrix.platform_tag }}
+
+  publish:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/instantdb/dashboard
+          - image: ghcr.io/instantdb/server
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish multi-arch image
+        run: |
+          docker buildx imagetools create \
+            -t ${{ matrix.image }}:latest \
+            -t ${{ matrix.image }}:${{ github.sha }} \
+            ${{ matrix.image }}:${{ github.sha }}-amd64 \
+            ${{ matrix.image }}:${{ github.sha }}-arm64

--- a/.github/workflows/publish-self-hosted-images.yml
+++ b/.github/workflows/publish-self-hosted-images.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
 
 permissions:
   contents: read
@@ -74,14 +68,13 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: |
             ${{ matrix.image }}:${{ github.sha }}-${{ matrix.platform_tag }}
           cache-from: type=gha,scope=${{ matrix.image_name }}-${{ matrix.platform_tag }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}-${{ matrix.platform_tag }}
 
   publish:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: build
     strategy:

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -2,9 +2,9 @@ node_modules
 .git
 .gitignore
 *.md
-dist
 .turbo
-www
+dist
 sandbox
 scripts
 .env
+www/_emails/replace-images

--- a/client/Dockerfile.www
+++ b/client/Dockerfile.www
@@ -1,0 +1,96 @@
+ARG NODE_VERSION=22.22.2-slim
+
+FROM node:${NODE_VERSION} AS dependencies
+
+WORKDIR /monorepo
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+
+
+# Install project dependencies with frozen lockfile for reproducible builds
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    --mount=type=cache,target=/root/.local/share/pnpm/store \
+    if [ -f package-lock.json ]; then \
+    npm ci --no-audit --no-fund; \
+    elif [ -f yarn.lock ]; then \
+    corepack enable yarn && yarn install --frozen-lockfile --production=false; \
+    elif [ -f pnpm-lock.yaml ]; then \
+    corepack enable pnpm && pnpm install --frozen-lockfile; \
+    else \
+    echo "No lockfile found." && exit 1; \
+    fi
+
+FROM node:${NODE_VERSION} AS pruner
+
+WORKDIR /monorepo
+
+COPY --from=dependencies /monorepo/node_modules ./node_modules
+
+COPY . .
+RUN corepack enable pnpm;
+RUN pnpm turbo prune instant-www --docker
+
+FROM node:${NODE_VERSION} AS builder
+WORKDIR /monorepo
+ARG NEXT_PUBLIC_SELF_HOSTED=true
+ENV NEXT_PUBLIC_SELF_HOSTED=${NEXT_PUBLIC_SELF_HOSTED}
+COPY --from=pruner /monorepo/out/json/ .
+RUN corepack enable pnpm
+RUN pnpm install --frozen-lockfile
+
+COPY --from=pruner /monorepo/out/full/ .
+COPY tsconfig.base.json ./
+
+RUN pnpm install --frozen-lockfile
+
+RUN pnpm turbo build
+
+# Production runner
+FROM node:${NODE_VERSION} AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV INSTANT_API_URI=
+ENV INSTANT_BACKEND_URL=
+ARG NEXT_PUBLIC_SELF_HOSTED=true
+ENV NEXT_PUBLIC_SELF_HOSTED=${NEXT_PUBLIC_SELF_HOSTED}
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy the standalone output
+COPY --from=builder /monorepo/www/.next/standalone ./
+# Copy static assets and public files
+COPY --from=builder /monorepo/www/.next/static ./www/.next/static
+COPY --from=builder /monorepo/www/public ./www/public
+
+COPY <<'EOF' /app/start.sh
+#!/bin/sh
+set -eu
+
+node <<'NODE'
+const fs = require('fs');
+
+const apiURI = process.env.INSTANT_API_URI || process.env.INSTANT_BACKEND_URL;
+const config = apiURI ? { apiURI } : {};
+
+fs.writeFileSync(
+  '/app/www/public/publicSelfHostedVariables.js',
+  `window.__instantConfig = ${JSON.stringify(config)};\n`,
+);
+NODE
+
+exec node www/server.js
+EOF
+
+RUN chmod +x /app/start.sh && chown -R nextjs:nodejs /app/www/public /app/start.sh
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["/app/start.sh"]

--- a/client/Dockerfile.www
+++ b/client/Dockerfile.www
@@ -11,15 +11,7 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=cache,target=/usr/local/share/.cache/yarn \
     --mount=type=cache,target=/root/.local/share/pnpm/store \
-    if [ -f package-lock.json ]; then \
-    npm ci --no-audit --no-fund; \
-    elif [ -f yarn.lock ]; then \
-    corepack enable yarn && yarn install --frozen-lockfile --production=false; \
-    elif [ -f pnpm-lock.yaml ]; then \
-    corepack enable pnpm && pnpm install --frozen-lockfile; \
-    else \
-    echo "No lockfile found." && exit 1; \
-    fi
+    corepack enable pnpm && pnpm install --frozen-lockfile;
 
 FROM node:${NODE_VERSION} AS pruner
 

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,8 @@
     "packages": [
       "sandbox/*",
       "packages/*",
-      "www"
+      "www",
+      "www/_emails/replace-images"
     ]
   },
   "scripts": {

--- a/client/packages/cli/src/lib/http.ts
+++ b/client/packages/cli/src/lib/http.ts
@@ -141,8 +141,15 @@ export const getBaseUrl = Effect.gen(function* () {
 });
 
 export const getDashUrl = Effect.gen(function* () {
+  const setEnv = yield* Config.string('INSTANT_CLI_DASH_URI').pipe(
+    Config.option,
+  );
   const dev = Option.getOrNull(
     yield* Config.boolean('INSTANT_CLI_DEV').pipe(Config.option),
   );
-  return dev ? 'http://localhost:3000' : 'https://instantdb.com';
+
+  return Option.match(setEnv, {
+    onSome: (url) => url,
+    onNone: () => (dev ? 'http://localhost:3000' : 'https://instantdb.com'),
+  });
 });

--- a/client/www/app/layout.tsx
+++ b/client/www/app/layout.tsx
@@ -4,6 +4,7 @@ import '../styles/docs/tailwind.css';
 import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import { Providers } from './providers';
+import { isSelfHosted } from '@/lib/config';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -103,6 +104,12 @@ export default async function RootLayout({
         />
       </head>
       <body>
+        {isSelfHosted && (
+          <Script
+            src="/publicSelfHostedVariables.js"
+            strategy="beforeInteractive"
+          />
+        )}
         <Providers>{children}</Providers>
         {!isDev && <GoogleScripts />}
       </body>

--- a/client/www/components/dash/TopBar.tsx
+++ b/client/www/components/dash/TopBar.tsx
@@ -10,7 +10,7 @@ import {
 import { useFetchedDash } from './MainDashLayout';
 import { DarkModeToggle } from './DarkModeToggle';
 import { useReadyRouter } from '../clientOnlyPage';
-import { areTeamsFree } from '@/lib/config';
+import { areTeamsFree, isSelfHosted } from '@/lib/config';
 import useLocalStorage from '@/lib/hooks/useLocalStorage';
 import { getRole, isMinRole } from '@/pages/dash';
 
@@ -24,7 +24,11 @@ export const TopBar: React.FC<{}> = () => {
     dash.data?.currentWorkspaceId !== 'personal'
       ? dash.data?.currentWorkspaceId
       : null;
-  const docsUrl = orgId ? `/docs?org=${orgId}` : '/docs';
+  const docsUrl = isSelfHosted
+    ? 'https://instantdb.com/docs'
+    : orgId
+      ? `/docs?org=${orgId}`
+      : '/docs';
 
   const hasInvites = (dash.data.invites || []).length > 0;
 

--- a/client/www/lib/config.ts
+++ b/client/www/lib/config.ts
@@ -3,6 +3,54 @@ export const isBrowser = typeof window != 'undefined';
 export const isDev = process.env.NODE_ENV === 'development';
 
 const isStaging = process.env.NEXT_PUBLIC_STAGING === 'true';
+export const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === 'true';
+
+type DashboardConfig = {
+  apiURI: string;
+  websocketURI: string;
+};
+
+type RuntimeDashboardConfig = Partial<DashboardConfig>;
+
+declare global {
+  interface Window {
+    __instantConfig?: RuntimeDashboardConfig;
+  }
+}
+
+function websocketURIFromApiURI(apiURI: string) {
+  const url = new URL(apiURI);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = '/runtime/session';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+function configFromApiURI(apiURI: string | undefined | null) {
+  if (!apiURI) {
+    return null;
+  }
+
+  return {
+    apiURI,
+    websocketURI: websocketURIFromApiURI(apiURI),
+  };
+}
+
+function getRuntimeConfig() {
+  try {
+    if (isBrowser) {
+      return configFromApiURI(window.__instantConfig?.apiURI);
+    }
+
+    return configFromApiURI(
+      process.env.INSTANT_API_URI || process.env.INSTANT_BACKEND_URL,
+    );
+  } catch (_e) {
+    return null;
+  }
+}
 
 const devBackend = getLocal('devBackend');
 
@@ -15,14 +63,14 @@ if (devBackend && isBrowser) {
   }
 }
 
-const config = {
-  apiURI: devBackend
-    ? `http://localhost:${localPort}`
-    : `https://${isStaging ? 'api-staging' : 'api'}.instantdb.com`,
-  websocketURI: devBackend
-    ? `ws://localhost:${localPort}/runtime/session`
-    : `wss://${isStaging ? 'api-staging' : 'api'}.instantdb.com/runtime/session`,
-};
+const defaultApiURI = devBackend
+  ? `http://localhost:${localPort}`
+  : `https://${isStaging ? 'api-staging' : 'api'}.instantdb.com`;
+
+export const config =
+  isSelfHosted && !devBackend
+    ? getRuntimeConfig() || configFromApiURI(defaultApiURI)!
+    : configFromApiURI(defaultApiURI)!;
 
 // In dev mode, sync the devBackend flag to a cookie so server components
 // can resolve the same apiURI as the client.
@@ -73,7 +121,7 @@ export const stripeCustomerPortalURI = isDev
   ? stripeDevCustomerPortalURI
   : stripeProdCustomerPortalURI;
 
-export function getLocal(k: string) {
+export function getLocal<T = any>(k: string): T | null {
   if (!isBrowser) {
     return null;
   }
@@ -87,7 +135,7 @@ export function getLocal(k: string) {
   }
 }
 
-export function setLocal(k: string, v: any) {
+export function setLocal<T = any>(k: string, v: T) {
   if (!isBrowser) {
     return;
   }

--- a/client/www/lib/locallySavedApp.tsx
+++ b/client/www/lib/locallySavedApp.tsx
@@ -10,7 +10,7 @@ export function getLocallySavedApp(
 ): LocallySavedApp | undefined {
   const effectiveOrgId = orgId || 'personal';
   const key = `${effectiveOrgId}-locally-saved-app`;
-  return getLocal(key);
+  return getLocal(key) ?? undefined;
 }
 
 export function setLocallySavedApp(app: LocallySavedApp) {

--- a/client/www/next.config.js
+++ b/client/www/next.config.js
@@ -24,6 +24,9 @@ async function fetchStarCount() {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  ...(process.env.NEXT_PUBLIC_SELF_HOSTED === 'true'
+    ? { output: 'standalone' }
+    : {}),
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md'],
   transpilePackages: ['@instantdb/components'],
@@ -54,7 +57,7 @@ const nextConfig = {
     return config;
   },
   async redirects() {
-    return [
+    const standardRedirects = [
       {
         permanent: false,
         source: '/',
@@ -123,6 +126,21 @@ const nextConfig = {
         destination: 'https://discord.com/invite/VU53p7uQcE',
       },
     ];
+
+    if (process.env.NEXT_PUBLIC_SELF_HOSTED === 'true') {
+      return [
+        ...standardRedirects,
+        // redirect any page that isn't /api, /dash, /docs, or /logout
+        {
+          permanent: false,
+          source:
+            '/((?!api(?:/.*)?|dash(?:/.*)?|docs(?:/.*)?|logout(?:/.*)?|.*\\.[^/]+$).*)',
+          destination: '/dash',
+        },
+      ];
+    }
+
+    return standardRedirects;
   },
   // Proxy to PostHog to avoid ad blockers
   async rewrites() {

--- a/client/www/pages/_document.tsx
+++ b/client/www/pages/_document.tsx
@@ -1,4 +1,6 @@
+import { isSelfHosted } from '@/lib/config';
 import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 export default function Document() {
   return (
@@ -48,6 +50,12 @@ export default function Document() {
         />
       </Head>
       <body>
+        {isSelfHosted && (
+          <Script
+            strategy="beforeInteractive"
+            src="/publicSelfHostedVariables.js"
+          />
+        )}
         <Main />
         <NextScript />
       </body>

--- a/client/www/public/publicSelfHostedVariables.js
+++ b/client/www/public/publicSelfHostedVariables.js
@@ -1,0 +1,1 @@
+window.__instantConfig = window.__instantConfig || {};

--- a/self-hosting/.env.example
+++ b/self-hosting/.env.example
@@ -1,6 +1,7 @@
 # Public URLs. Change these when deploying behind a domain or proxy.
 INSTANT_BACKEND_URL=http://localhost:8888
 INSTANT_DASHBOARD_URL=http://localhost:3000
+S3_PUBLIC_ENDPOINT=http://localhost:9000
 
 # Domains used by the Caddy compose file. For production, point DNS at this host
 # and update the public URLs above to use these domains with https://.
@@ -23,7 +24,6 @@ MINIO_ROOT_USER=pleasegenerateauserhere
 MINIO_ROOT_PASSWORD=pleasegenerateapasswordhere
 S3_BUCKET=instant-bucket
 S3_ENDPOINT=http://minio:9000
-S3_PUBLIC_ENDPOINT=http://localhost:9000
 AWS_REGION=us-east-1
 
 # Optional integrations.

--- a/self-hosting/.env.example
+++ b/self-hosting/.env.example
@@ -1,0 +1,42 @@
+# Public URLs. Change these when deploying behind a domain or proxy.
+INSTANT_BACKEND_URL=http://localhost:8888
+INSTANT_DASHBOARD_URL=http://localhost:3000
+
+# Domains used by the Caddy compose file. For production, point DNS at this host
+# and update the public URLs above to use these domains with https://.
+# These are only required if using docker-compose.with-caddy.yml
+DASHBOARD_DOMAIN=localhost
+BACKEND_DOMAIN=api.localhost
+STORAGE_DOMAIN=files.localhost
+
+# Database. DATABASE_URL is inferred from these values inside docker-compose.
+POSTGRES_USER=instant
+POSTGRES_PASSWORD=pleasegenerateapasswordhere
+POSTGRES_DB=instant
+
+# Object storage. Server AWS credentials are inferred from these MinIO values.
+# Replace these before deploying.
+# If using AWS S3, set MINIO_ROOT_USER to your AWS Access Key ID
+# and MINIO_ROOT_PASSWORD to your AWS Secret Access Key, and
+# leave S3_ENDPOINT and S3_PUBLIC_ENDPOINT blank.
+MINIO_ROOT_USER=pleasegenerateauserhere
+MINIO_ROOT_PASSWORD=pleasegenerateapasswordhere
+S3_BUCKET=instant-bucket
+S3_ENDPOINT=http://minio:9000
+S3_PUBLIC_ENDPOINT=http://localhost:9000
+AWS_REGION=us-east-1
+
+# Optional integrations.
+STRIPE_API_KEY=
+
+# Email. Provide the Postmark token to send login magic codes.
+# If omitted, one-time login codes will be printed to stdout
+# from the server container.
+POSTMARK_TOKEN=
+INSTANT_EMAIL_REPLY_TO=hello@example.com
+INSTANT_DASHBOARD_EMAIL_SENDER_NAME=Instant
+INSTANT_DASHBOARD_EMAIL_SENDER_EMAIL=verify@example.com
+INSTANT_APP_EMAIL_SENDER_NAME=Instant
+INSTANT_APP_EMAIL_SENDER_EMAIL=verify@example.com
+INSTANT_TEAM_EMAIL_SENDER_NAME=Instant
+INSTANT_TEAM_EMAIL_SENDER_EMAIL=teams@example.com

--- a/self-hosting/Caddyfile
+++ b/self-hosting/Caddyfile
@@ -1,0 +1,11 @@
+{$DASHBOARD_DOMAIN:localhost} {
+  reverse_proxy www:3000
+}
+
+{$BACKEND_DOMAIN:api.localhost} {
+  reverse_proxy server:8888
+}
+
+{$STORAGE_DOMAIN:files.localhost} {
+  reverse_proxy minio:9000
+}

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -1,0 +1,126 @@
+# Self Hosting InstantDB
+
+An InstantDB self hosted deployment consists of 3 urls (subdomains)
+1. Backend API
+2. Dashboard URL
+3. Files URL
+
+
+## Localhost Setup
+Use this setup if you want to self-host InstantDB while developing on your own machine. In most cases, it's more convenient to use our cloud service to spin up unlimited free apps.
+```bash
+git clone https://github.com/instantdb/instant.git
+cd instant/self-hosting
+docker compose --env-file .env.example up
+```
+
+The dashboard will be available on http://localhost:3000. 
+
+The server will be available on http://localhost:8888.
+
+If you are developing an app and would like to use port 3000 (for example: NextJS), you can modify the port assignment in the `docker-compose.yml` file like so:
+```yaml
+  www:
+    ports:
+      - "3001:3000"
+```
+Then you will need to change the value for `INSTANT_DASHBOARD_URL` in `.env.example`
+
+Apply changes with:
+```bash
+docker compose --env-file .env.example up -d
+```
+
+## Full Hetzner Setup Guide
+Create a new server on Hetzner. We tested on a server with 4vcpu, 8GB of RAM. For more memory constrained environments, the `JAVA_OPTIONS` env can be set to limit the memory the server container uses.
+
+This setup guide assumes that you have a domain name and can set DNS A records. 
+If you do not have a domain name, you can use [sslip.io](https://sslip.io/) to create a domain name on the fly that points to the IP address of your server.
+
+### Install Docker (optional if docker is already installed)
+The following Docker install instructions come from [docs.docker.com](https://docs.docker.com/engine/install/ubuntu/)
+```sh
+apt update
+sudo apt install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+```
+
+```sh
+sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+
+sudo apt update
+```
+
+```sh
+sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+### Clone the Instant DB Repo
+```sh
+git clone https://github.com/instantdb/instant.git
+```
+
+### Edit Environment Variables
+```sh
+cd instant/self-hosting
+cp .env.example .env
+nano .env
+```
+
+Example:
+```bash
+# Public URLs. Change these when deploying behind a domain or proxy.
+INSTANT_BACKEND_URL=https://api.myinstant.com
+INSTANT_DASHBOARD_URL=https://dash.myinstant.com
+S3_PUBLIC_ENDPOINT=https://files.myinstant.com
+
+# Domains used by the Caddy file. For production, point DNS at this host
+# and update the public URLs above to use these domains with https://.
+DASHBOARD_DOMAIN=dash.myinstant.com
+BACKEND_DOMAIN=api.myinstant.com
+STORAGE_DOMAIN=files.myinstant.com
+```
+
+The _DOMAIN variables are only used by the Caddy reverse proxy so if you are bringing your own reverse proxy, you can ignore them.
+
+The MinIO bucket is private by default. Files are accessed through Instant-generated signed URLs.
+
+### DNS 
+Before running Instant, make sure that you have pointed the subdomain DNS records to the IP address of the server so that when the Caddy reverse proxy starts, it is able to setup TLS certificates automatically.
+
+### Start!
+```sh
+docker compose -f docker-compose.with-caddy.yml --env-file .env up --build
+```
+
+After everything starts up, the dashboard will be available at wherever you set INSTANT_DASHBOARD_URL to.
+
+## Using Self-Hosted InstantDB
+
+Without a POSTMARK_TOKEN environment variable set, OTP codes will not be emailed. 
+You must read the console output of the server container, which will print the body of any emails that would get sent. 
+
+You can use this command to print out recent logs from the server (last 50 lines):
+```bash
+docker compose logs server -n 50
+```
+
+### Using the self-hosted instance with instant-cli
+
+To use the Instant CLI with your local backend, you can set the `INSTANT_CLI_API_URI` environment variable to `http://localhost:8888`. For example:
+```bash
+# Local Machine Deployment
+INSTANT_CLI_API_URI=http://localhost:8888 npx instant-cli@latest init 
+
+# Server Deployment
+INSTANT_CLI_API_URI=https://api.myinstant.com npx instant-cli@latest init 
+```

--- a/self-hosting/docker-compose.with-caddy.yml
+++ b/self-hosting/docker-compose.with-caddy.yml
@@ -1,0 +1,121 @@
+services:
+  postgres:
+    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
+      POSTGRES_USER: ${POSTGRES_USER:-instant}
+      POSTGRES_DB: ${POSTGRES_DB:-instant}
+    volumes:
+      - "backend-db:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-instant}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+      - "-c"
+      - "max_replication_slots=10"
+      - "-c"
+      - "max_wal_senders=10"
+      - "-c"
+      - "shared_preload_libraries=pg_hint_plan"
+      - "-c"
+      - "random_page_cost=1.1"
+
+  www:
+    image: "ghcr.io/instantdb/dashboard:latest"
+    depends_on:
+      - server
+    environment:
+      - INSTANT_BACKEND_URL=${INSTANT_BACKEND_URL:-http://localhost:8888}
+
+  minio:
+    image: minio/minio:latest
+    restart: always
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_BROWSER: "on"
+      MINIO_SKIP_CLIENT_CERT_VALIDATION: "on"
+    command: server /data --console-address ":9001" --address ":9000"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  createbuckets:
+    image: minio/mc
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      S3_BUCKET: ${S3_BUCKET:-instant-bucket}
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD;
+      /usr/bin/mc mb --ignore-existing local/$$S3_BUCKET;
+      exit"
+
+  server:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
+    image: "ghcr.io/instantdb/server:latest"
+    environment:
+      WAL_HISTORY_STORAGE: pg
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-instant}:${POSTGRES_PASSWORD:-pass}@postgres:5432/${POSTGRES_DB:-instant}?sslmode=disable"
+      INSTANT_BACKEND_URL: ${INSTANT_BACKEND_URL:-http://localhost:8888}
+      INSTANT_DASHBOARD_URL: ${INSTANT_DASHBOARD_URL:-http://localhost:3000}
+      STRIPE_API_KEY: ${STRIPE_API_KEY:-}
+      POSTMARK_TOKEN: ${POSTMARK_TOKEN:-}
+      INSTANT_EMAIL_REPLY_TO: ${INSTANT_EMAIL_REPLY_TO:-}
+      INSTANT_DASHBOARD_EMAIL_SENDER_NAME: ${INSTANT_DASHBOARD_EMAIL_SENDER_NAME:-}
+      INSTANT_DASHBOARD_EMAIL_SENDER_EMAIL: ${INSTANT_DASHBOARD_EMAIL_SENDER_EMAIL:-}
+      INSTANT_APP_EMAIL_SENDER_NAME: ${INSTANT_APP_EMAIL_SENDER_NAME:-}
+      INSTANT_APP_EMAIL_SENDER_EMAIL: ${INSTANT_APP_EMAIL_SENDER_EMAIL:-}
+      INSTANT_TEAM_EMAIL_SENDER_NAME: ${INSTANT_TEAM_EMAIL_SENDER_NAME:-}
+      INSTANT_TEAM_EMAIL_SENDER_EMAIL: ${INSTANT_TEAM_EMAIL_SENDER_EMAIL:-}
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      AWS_REGION: ${AWS_REGION:-}
+      S3_ENDPOINT: ${S3_ENDPOINT:-}
+      S3_PUBLIC_ENDPOINT: ${S3_PUBLIC_ENDPOINT:-}
+      S3_BUCKET: ${S3_BUCKET:-instant-bucket}
+    volumes:
+      - server_config:/app/resources/config
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - www
+      - server
+      - minio
+    environment:
+      DASHBOARD_DOMAIN: ${DASHBOARD_DOMAIN:-localhost}
+      BACKEND_DOMAIN: ${BACKEND_DOMAIN:-api.localhost}
+      STORAGE_DOMAIN: ${STORAGE_DOMAIN:-files.localhost}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  backend-db:
+  minio_data:
+  caddy_data:
+  caddy_config:
+  server_config:

--- a/self-hosting/docker-compose.yml
+++ b/self-hosting/docker-compose.yml
@@ -1,0 +1,110 @@
+services:
+  postgres:
+    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    ports:
+      - "8890:5432"
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
+      POSTGRES_USER: ${POSTGRES_USER:-instant}
+      POSTGRES_DB: ${POSTGRES_DB:-instant}
+    volumes:
+      - "backend-db:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-instant}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+      - "-c"
+      - "max_replication_slots=10"
+      - "-c"
+      - "max_wal_senders=10"
+      - "-c"
+      - "shared_preload_libraries=pg_hint_plan"
+      - "-c"
+      - "random_page_cost=1.1"
+
+  www:
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+    image: "ghcr.io/instantdb/dashboard:latest"
+    environment:
+      # Where the backend url will be available externally
+      - INSTANT_BACKEND_URL=${INSTANT_BACKEND_URL:-http://localhost:8888}
+
+  minio:
+    image: minio/minio:latest
+    restart: always
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_BROWSER: "on"
+      MINIO_SKIP_CLIENT_CERT_VALIDATION: "on"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: server /data --console-address ":9001" --address ":9000"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  createbuckets:
+    image: minio/mc
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      S3_BUCKET: ${S3_BUCKET:-instant-bucket}
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD;
+      /usr/bin/mc mb --ignore-existing local/$$S3_BUCKET;
+      exit"
+
+  server:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
+    image: "ghcr.io/instantdb/server:latest"
+    environment:
+      WAL_HISTORY_STORAGE: pg
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-instant}:${POSTGRES_PASSWORD:-pass}@postgres:5432/${POSTGRES_DB:-instant}?sslmode=disable"
+      INSTANT_BACKEND_URL: ${INSTANT_BACKEND_URL:-http://localhost:8888}
+      INSTANT_DASHBOARD_URL: ${INSTANT_DASHBOARD_URL:-http://localhost:3000}
+      STRIPE_API_KEY: ${STRIPE_API_KEY:-}
+      POSTMARK_TOKEN: ${POSTMARK_TOKEN:-}
+      INSTANT_EMAIL_REPLY_TO: ${INSTANT_EMAIL_REPLY_TO:-}
+      INSTANT_DASHBOARD_EMAIL_SENDER_NAME: ${INSTANT_DASHBOARD_EMAIL_SENDER_NAME:-}
+      INSTANT_DASHBOARD_EMAIL_SENDER_EMAIL: ${INSTANT_DASHBOARD_EMAIL_SENDER_EMAIL:-}
+      INSTANT_APP_EMAIL_SENDER_NAME: ${INSTANT_APP_EMAIL_SENDER_NAME:-}
+      INSTANT_APP_EMAIL_SENDER_EMAIL: ${INSTANT_APP_EMAIL_SENDER_EMAIL:-}
+      INSTANT_TEAM_EMAIL_SENDER_NAME: ${INSTANT_TEAM_EMAIL_SENDER_NAME:-}
+      INSTANT_TEAM_EMAIL_SENDER_EMAIL: ${INSTANT_TEAM_EMAIL_SENDER_EMAIL:-}
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      S3_ENDPOINT: ${S3_ENDPOINT:-}
+      S3_PUBLIC_ENDPOINT: ${S3_PUBLIC_ENDPOINT:-}
+      S3_BUCKET: ${S3_BUCKET:-instant-bucket}
+    ports:
+      - "8888:8888"
+    volumes:
+      - server_config:/app/resources/config
+
+volumes:
+  backend-db:
+  minio_data:
+  server_config:

--- a/server/Dockerfile.self-hosted
+++ b/server/Dockerfile.self-hosted
@@ -1,0 +1,70 @@
+FROM amazoncorretto:26 AS builder
+
+WORKDIR /app
+
+RUN yum -y install tar gzip git unzip
+
+RUN curl -L -O https://github.com/clojure/brew-install/releases/download/1.11.3.1463/linux-install.sh
+
+RUN echo '0c41063a2fefb53a31bc1bc236899955f759c5103dc0495489cdd74bf8f114bb  linux-install.sh' |  sha256sum -c
+
+RUN chmod +x linux-install.sh
+RUN ./linux-install.sh
+
+COPY deps.edn .
+
+RUN clojure -P
+
+COPY . .
+
+RUN clojure -X:deps tree
+
+RUN clojure -T:build uber
+
+FROM amazoncorretto:26
+
+WORKDIR /app
+
+# Install dependencies and golang-migrate
+RUN yum -y install tar gzip && \
+    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz && \
+    mv migrate /usr/local/bin/migrate && \
+    yum clean all
+
+COPY --from=builder /app/target/instant-standalone.jar ./target/instant-standalone.jar
+COPY --from=builder /app/resources/migrations ./resources/migrations
+RUN mkdir -p /app/resources/config
+
+# Startup script that bootstraps OSS config/migrations then starts the server
+COPY <<'EOF' /app/start.sh
+#!/bin/bash
+set -e
+
+JAVA_FLAGS="${JAVA_OPTS} \
+    --add-modules java.se \
+    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
+    --add-opens java.base/java.lang=ALL-UNNAMED \
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+    --add-opens java.management/sun.management=ALL-UNNAMED \
+    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+    -Djava.awt.headless=true \
+    -server"
+
+echo "Bootstrapping self-hosted server..."
+java ${JAVA_FLAGS} \
+    -cp resources:target/instant-standalone.jar \
+    clojure.main \
+    -e "(require 'tasks) (tasks/bootstrap-for-oss nil)"
+
+echo "Starting server..."
+exec java ${JAVA_FLAGS} \
+    -cp resources:target/instant-standalone.jar \
+    instant.core
+EOF
+
+RUN chmod +x /app/start.sh
+
+EXPOSE 8888
+EXPOSE 6005
+
+CMD ["/app/start.sh"]

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -93,9 +93,10 @@
 (defn s3-storage-secret-key []
   (some-> @config-map :s3-storage-secret-key crypt-util/secret-value))
 
-(defn s3-endpoint []
-  (or (System/getenv "S3_ENDPOINT")
-      (some-> @config-map :s3-endpoint)))
+(def s3-endpoint
+  (delay
+    (or (System/getenv "S3_ENDPOINT")
+        (some-> @config-map :s3-endpoint))))
 
 (defn s3-public-endpoint []
   (or (System/getenv "S3_PUBLIC_ENDPOINT")

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -93,14 +93,51 @@
 (defn s3-storage-secret-key []
   (some-> @config-map :s3-storage-secret-key crypt-util/secret-value))
 
+(defn s3-endpoint []
+  (or (System/getenv "S3_ENDPOINT")
+      (some-> @config-map :s3-endpoint)))
+
+(defn s3-public-endpoint []
+  (or (System/getenv "S3_PUBLIC_ENDPOINT")
+      (some-> @config-map :s3-public-endpoint)
+      (s3-endpoint)))
+
+(defn s3-region []
+  (or (System/getenv "AWS_REGION")
+      (some-> @config-map :s3-region)
+      "us-east-1"))
+
 (defn postmark-token []
-  (some-> @config-map :postmark-token crypt-util/secret-value))
+  (or (System/getenv "POSTMARK_TOKEN")
+      (some-> @config-map :postmark-token crypt-util/secret-value)))
 
 (defn sendgrid-token []
   (some-> @config-map :sendgrid-token crypt-util/secret-value))
 
 (defn postmark-account-token []
-  (some-> @config-map :postmark-account-token crypt-util/secret-value))
+  (or (System/getenv "POSTMARK_ACCOUNT_TOKEN")
+      (some-> @config-map :postmark-account-token crypt-util/secret-value)))
+
+(defn email-reply-to []
+  (or (System/getenv "INSTANT_EMAIL_REPLY_TO")
+      "hello@instantdb.com"))
+
+(defn dashboard-email-sender []
+  {:name (or (System/getenv "INSTANT_DASHBOARD_EMAIL_SENDER_NAME")
+             "Instant")
+   :email (or (System/getenv "INSTANT_DASHBOARD_EMAIL_SENDER_EMAIL")
+              "verify@dash-pm.instantdb.com")})
+
+(defn app-email-sender []
+  {:name (System/getenv "INSTANT_APP_EMAIL_SENDER_NAME")
+   :email (or (System/getenv "INSTANT_APP_EMAIL_SENDER_EMAIL")
+              "verify@auth-pm.instantdb.com")})
+
+(defn team-email-sender []
+  {:name (or (System/getenv "INSTANT_TEAM_EMAIL_SENDER_NAME")
+             "Instant")
+   :email (or (System/getenv "INSTANT_TEAM_EMAIL_SENDER_EMAIL")
+              "teams@pm.instantdb.com")})
 
 (defn sendgrid-send-disabled? []
   (not (string/blank? (sendgrid-token))))
@@ -197,10 +234,11 @@
 (defn dashboard-origin
   ([] (dashboard-origin {:env (get-env)}))
   ([{:keys [env]}]
-   (case env
-     :prod "https://www.instantdb.com"
-     :staging "https://staging.instantdb.com"
-     "http://localhost:3000")))
+   (or (System/getenv "INSTANT_DASHBOARD_URL")
+       (case env
+         :prod "https://www.instantdb.com"
+         :staging "https://staging.instantdb.com"
+         "http://localhost:3000"))))
 
 ;; ---
 ;; Stripe
@@ -262,10 +300,11 @@
   (-> @config-map :shared-oauth-clients))
 
 (def s3-bucket-name
-  (case (get-env)
-    :prod "instant-storage"
-    :staging "instant-storage-staging"
-    "instantdb-test-bucket"))
+  (or (System/getenv "S3_BUCKET")
+      (case (get-env)
+        :prod "instant-storage"
+        :staging "instant-storage-staging"
+        "instantdb-test-bucket")))
 
 (def s3-wal-history-bucket-name
   (when-not (= "pg" (System/getenv "WAL_HISTORY_STORAGE"))
@@ -319,10 +358,11 @@
         8887)))
 
 (def server-origin
-  (case (get-env)
-    :prod "https://api.instantdb.com"
-    :staging "https://api-staging.instantdb.com"
-    (str "http://localhost:" (get-server-port))))
+  (or (System/getenv "INSTANT_BACKEND_URL")
+      (case (get-env)
+        :prod "https://api.instantdb.com"
+        :staging "https://api-staging.instantdb.com"
+        (str "http://localhost:" (get-server-port)))))
 
 (defn get-nrepl-port []
   (or (env-integer "NREPL_PORT") 6005))

--- a/server/src/instant/config_edn.clj
+++ b/server/src/instant/config_edn.clj
@@ -41,6 +41,10 @@
 (s/def ::cloudfront-signing-key (s/keys :req-un [::key-id ::private-key]))
 (s/def ::s3-storage-access-key ::config-value)
 (s/def ::s3-storage-secret-key ::config-value)
+(s/def ::s3-endpoint string?)
+(s/def ::s3-public-endpoint string?)
+(s/def ::s3-region string?)
+(s/def ::s3-bucket-name string?)
 (s/def ::postmark-token ::config-value)
 (s/def ::sendgrid-token ::config-value)
 (s/def ::postmark-account-token ::config-value)
@@ -76,6 +80,10 @@
                                  ::cloudfront-signing-key
                                  ::s3-storage-access-key
                                  ::s3-storage-secret-key
+                                 ::s3-endpoint
+                                 ::s3-public-endpoint
+                                 ::s3-region
+                                 ::s3-bucket-name
                                  ::database-url
                                  ::next-database-cluster-id
                                  ::postmark-token

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -204,13 +204,15 @@
 ;; Magic Codes
 
 (defn magic-code-email [{:keys [user magic-code]}]
-  (let [title "Instant"
+  (let [{sender-name :name sender-email :email} (config/dashboard-email-sender)
+        title sender-name
         {:keys [email]} user
         {:keys [code]} magic-code]
-    {:from {:name title
-            :email "verify@dash-pm.instantdb.com"}
+    {:from {:name sender-name
+            :email sender-email}
      :to [{:email email}]
      :subject (str code " is your verification code for " title)
+     :reply-to sender-email
      :html
      (email/standard-body
       "<p><strong>Welcome,</strong></p>
@@ -704,9 +706,9 @@
                                                :client_id :created_at])})))
 
 (defn claim-app-post
-  "Users can claim two kinds of apps: 
-  
-  1. Ephemeral Apps 
+  "Users can claim two kinds of apps:
+
+  1. Ephemeral Apps
   2. Apps made by getadb.com"
   [req]
   (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
@@ -1072,12 +1074,15 @@
 
 (defn team-member-invite-email [{:keys [invitee-email inviter-id type foreign-key]}]
   (let [user (instant-user-model/get-by-id! {:id inviter-id})
+        {sender-name :name sender-email :email} (config/team-email-sender)
         title (case type
                 :org (:title (org-model/get-by-id! {:id foreign-key}))
-                :app (:title (app-model/get-by-id! {:id foreign-key})))]
-    {:from "Instant <teams@pm.instantdb.com>"
+                :app (:title (app-model/get-by-id! {:id foreign-key})))
+        invite-url (str (config/dashboard-origin) "/dash?s=invites")]
+    {:from (str sender-name " <" sender-email ">")
      :to invitee-email
      :subject (str "[Instant] You've been invited to collaborate on " title)
+     :reply-to sender-email
      :html
      (postmark/standard-body
       (h/html
@@ -1090,7 +1095,7 @@
           :app "app")
         " " title "."]
        [:p "Navigate to "
-        [:a {:href "https://instantdb.com/dash?s=invites"}
+        [:a {:href invite-url}
          "Instant"]
         " to accept the invite."]
        [:p "Note: this invite will expire in 3 days. "

--- a/server/src/instant/postmark.clj
+++ b/server/src/instant/postmark.clj
@@ -28,12 +28,12 @@
   (= 504
      (-> e ex-data :body :ErrorCode)))
 
-;; -------- 
+;; --------
 ;; API
 
 (defn send! [{:keys [from to cc bcc subject html text
                      reply-to]
-              :or {reply-to "hello@instantdb.com"}}]
+              :or {reply-to (config/email-reply-to)}}]
   (let [body (cond-> {:From from
                       :To to
                       :Cc cc
@@ -96,8 +96,8 @@
       (medley/update-existing :cc structured-emails->str)
       (medley/update-existing :bcc structured-emails->str)))
 
-;; XXX: Eventually we should make all callers use 
-;; this entry point. It will be easier to switch 
+;; XXX: Eventually we should make all callers use
+;; this entry point. It will be easier to switch
 ;; providers
 (defn send-structured! [req]
   (send! (structured->postmark-req req)))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -5,7 +5,7 @@
    [clojure.java.jmx :as jmx]
    [datascript.core :as ds]
    [editscript.core :as editscript]
-   [instant.config :as config]
+   [instant.config :as config :refer [aws-env?]]
    [instant.gauges :as gauges]
    [instant.rate-limit :as rate-limit]
    [instant.reactive.receive-queue :as receive-queue]
@@ -18,22 +18,19 @@
    [instant.util.uuid :as uuid-util]
    [medley.core :as medley])
   (:import
+   (com.hazelcast.cluster Cluster InitialMembershipListener Member)
    (com.hazelcast.config Config)
    (com.hazelcast.core Hazelcast HazelcastInstance)
-   (com.hazelcast.cluster Cluster Member InitialMembershipListener)
    (com.hazelcast.map IMap)
    (com.hazelcast.map.impl DataAwareEntryEvent)
-   (com.hazelcast.map.listener EntryAddedListener
-                               EntryRemovedListener
-                               EntryUpdatedListener)
+   (com.hazelcast.map.listener EntryAddedListener EntryRemovedListener EntryUpdatedListener)
    (com.hazelcast.spi.properties ClusterProperty HazelcastProperty)
-   (com.hazelcast.topic ITopic MessageListener Message)
-
+   (com.hazelcast.topic ITopic Message MessageListener)
    (io.github.bucket4j.grid.hazelcast HazelcastProxyManager)
    (java.time Duration Instant)
    (java.util Map Map$Entry)
+   (java.util.concurrent ConcurrentHashMap Future)
    (java.util.function BiFunction)
-   (java.util.concurrent Future ConcurrentHashMap)
    (javax.management ObjectName)))
 
 ;; ------
@@ -152,8 +149,8 @@
     (.setMemberAttributeConfig config member-attribute-config)
     (.setInstanceName config instance-name)
     (.setEnabled (.getMulticastConfig join-config) false)
-    (case env
-      (:prod :staging)
+    (cond
+      (aws-env?)
       (let [ip (aws-util/get-instance-ip)]
         (.setPublicAddress network-config ip)
         (.setPort network-config (config/get-hz-port))
@@ -164,13 +161,7 @@
           (.setProperty "tag-value" (aws-util/get-environment-tag)))
         (.setEnabled metrics-config true))
 
-      :dev
-      (do
-        (.setEnabled tcp-ip-config true)
-        (.setMembers tcp-ip-config (list "127.0.0.1"))
-        (.setEnabled metrics-config true))
-
-      :test
+      (= env :test)
       (do
         (.setEnabled (.getAutoDetectionConfig join-config) false)
         (.setEnabled aws-config false)
@@ -182,7 +173,13 @@
         (.setEnabled tcp-ip-config false)
         (.setPort network-config 0)
         (.setPortAutoIncrement network-config false)
-        (.setEnabled metrics-config false)))
+        (.setEnabled metrics-config false))
+
+      :else
+      (do
+        (.setEnabled tcp-ip-config true)
+        (.setMembers tcp-ip-config (list "127.0.0.1"))
+        (.setEnabled metrics-config true)))
 
     (.setClusterName config cluster-name)
 

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -126,8 +126,7 @@
                          :app_title (:title app)
                          :expiration (friendly-expiration app)}
 
-        {default-sender-name :name
-         default-sender-email :email} (config/app-email-sender)
+        {default-sender-email :email} (config/app-email-sender)
 
         sender-email    (or (:email template) default-sender-email)
         email-params    (if template
@@ -135,7 +134,7 @@
                            :sender-name (or (:name template) (:title app))
                            :subject (template-replace (:subject template) template-params)
                            :body (template-replace (:body template) template-params)}
-                          {:sender-name (or default-sender-name (:title app))
+                          {:sender-name (:title app)
                            :sender-email default-sender-email
                            :subject (str code " is your verification code for " (:title app))
                            :body (default-body template-params)})
@@ -150,7 +149,7 @@
                                 (tracer/record-info! {:name "magic-code/unconfirmed-or-unknown-sender" :attributes {:email sender-email :app-id app-id}})
                                 (postmark/send-structured! (magic-code-email email (assoc email-params :sender-email default-sender-email))))
 
-;; Don't throw if it's a test user, even if we can't send email to it
+                              ;; Don't throw if it's a test user, even if we can't send email to it
                               (and (= ::ex/validation-failed (-> e ex-data ::ex/type))
                                    (not (nil? (app-model/get-test-user req))))
                               false

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -1,6 +1,7 @@
 (ns instant.runtime.magic-code-auth
   (:require
    [clojure.string :as string]
+   [instant.config :as config]
    [instant.flags :as flags]
    [instant.model.app :as app-model]
    [instant.model.app-email-template :as app-email-template-model]
@@ -125,16 +126,17 @@
                          :app_title (:title app)
                          :expiration (friendly-expiration app)}
 
-        default-sender  "verify@auth-pm.instantdb.com"
+        {default-sender-name :name
+         default-sender-email :email} (config/app-email-sender)
 
-        sender-email    (or (:email template) default-sender)
+        sender-email    (or (:email template) default-sender-email)
         email-params    (if template
                           {:sender-email sender-email
                            :sender-name (or (:name template) (:title app))
                            :subject (template-replace (:subject template) template-params)
                            :body (template-replace (:body template) template-params)}
-                          {:sender-name (:title app)
-                           :sender-email default-sender
+                          {:sender-name (or default-sender-name (:title app))
+                           :sender-email default-sender-email
                            :subject (str code " is your verification code for " (:title app))
                            :body (default-body template-params)})
 
@@ -146,14 +148,12 @@
                               (invalid-sender? e)
                               (do
                                 (tracer/record-info! {:name "magic-code/unconfirmed-or-unknown-sender" :attributes {:email sender-email :app-id app-id}})
-                                (postmark/send-structured! (magic-code-email email (assoc email-params :sender-email default-sender))))
+                                (postmark/send-structured! (magic-code-email email (assoc email-params :sender-email default-sender-email))))
 
-
-                              ;; Don't throw if it's a test user, even if we can't send email to it
+;; Don't throw if it's a test user, even if we can't send email to it
                               (and (= ::ex/validation-failed (-> e ex-data ::ex/type))
                                    (not (nil? (app-model/get-test-user req))))
                               false
-
 
                               :else
                               (throw e))))]

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -22,7 +22,7 @@
 ;; ----------------------
 
 (defn- configure-s3-endpoint-client ^S3ClientBuilder [^S3ClientBuilder builder]
-  (if-let [endpoint (config/s3-endpoint)]
+  (if-let [endpoint @config/s3-endpoint]
     (doto builder
       (.endpointOverride (URI/create endpoint))
       (.region (Region/of (config/s3-region)))
@@ -30,7 +30,7 @@
     builder))
 
 (defn- configure-s3-endpoint-async-client ^S3CrtAsyncClientBuilder [^S3CrtAsyncClientBuilder builder]
-  (if-let [endpoint (config/s3-endpoint)]
+  (if-let [endpoint @config/s3-endpoint]
     (doto builder
       (.endpointOverride (URI/create endpoint))
       (.region (Region/of (config/s3-region)))

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -7,7 +7,9 @@
             [instant.util.tracer :as tracer])
   (:import
    [software.amazon.awssdk.auth.credentials DefaultCredentialsProvider]
-   [software.amazon.awssdk.services.s3 S3AsyncClient S3Client]
+   [software.amazon.awssdk.regions Region]
+   [software.amazon.awssdk.services.s3 S3AsyncClient S3Client S3ClientBuilder S3CrtAsyncClientBuilder]
+   [java.net URI]
    [java.time Duration Instant]
    [org.apache.tika Tika]
    [org.apache.tika.io TikaInputStream]
@@ -19,7 +21,25 @@
 ;; Configuration
 ;; ----------------------
 
-(def ^:private s3-client* (delay (.build (S3Client/builder))))
+(defn- configure-s3-endpoint-client ^S3ClientBuilder [^S3ClientBuilder builder]
+  (if-let [endpoint (config/s3-endpoint)]
+    (doto builder
+      (.endpointOverride (URI/create endpoint))
+      (.region (Region/of (config/s3-region)))
+      (.forcePathStyle Boolean/TRUE))
+    builder))
+
+(defn- configure-s3-endpoint-async-client ^S3CrtAsyncClientBuilder [^S3CrtAsyncClientBuilder builder]
+  (if-let [endpoint (config/s3-endpoint)]
+    (doto builder
+      (.endpointOverride (URI/create endpoint))
+      (.region (Region/of (config/s3-region)))
+      (.forcePathStyle Boolean/TRUE))
+    builder))
+
+(def ^:private s3-client* (delay (-> (S3Client/builder)
+                                     (configure-s3-endpoint-client)
+                                     (.build))))
 
 (defn s3-client
   "Standard blocking S3 client. We use this for most operations."
@@ -28,6 +48,7 @@
 
 (def ^:private s3-async-client* (delay
                                   (-> (S3AsyncClient/crtBuilder)
+                                      (configure-s3-endpoint-async-client)
                                       (.targetThroughputInGbps 20.0)
                                       (.build))))
 
@@ -40,23 +61,27 @@
   (delay
     (let [access-key (config/s3-storage-access-key)
           secret-key (config/s3-storage-secret-key)
-          region (.toString (.region (.serviceClientConfiguration (s3-client))))]
-      (if (and access-key secret-key)
-        {:access-key access-key
-         :secret-key secret-key
-         :region region}
-        (let [creds (.resolveCredentials (.build (DefaultCredentialsProvider/builder)))]
-          {:access-key (.accessKeyId creds)
-           :secret-key (.secretAccessKey creds)
-           :region region})))))
+          region (.toString (.region (.serviceClientConfiguration (s3-client))))
+          creds (if (and access-key secret-key)
+                  {:access-key access-key
+                   :secret-key secret-key
+                   :region region}
+                  (let [creds (.resolveCredentials (.build (DefaultCredentialsProvider/builder)))]
+                    {:access-key (.accessKeyId creds)
+                     :secret-key (.secretAccessKey creds)
+                     :region region}))]
+      (cond-> creds
+        (config/s3-public-endpoint)
+        (assoc :endpoint (config/s3-public-endpoint)
+               :path-style? true)))))
 
 (defn presign-creds
-  "Credentials to presign S3 URLs. We use special credentials, because 
-   the default credentials provider creates URLs that expire in 2 days. 
-   
+  "Credentials to presign S3 URLs. We use special credentials, because
+   the default credentials provider creates URLs that expire in 2 days.
+
    These are special credentials that can create URLs that expire in 7 days.
-   
-   Note: you need to make sure that both these credentials, and the default credentials, 
+
+   Note: you need to make sure that both these credentials, and the default credentials,
    have the necessary permissions to access the same S3 bucket."
   []
   @presign-creds*)
@@ -176,13 +201,13 @@
     (s3-util/delete-objects-paginated (s3-client) bucket-name location-keys)))
 
 (defn bucketed-signing-instant
-  "AWS URLs depend on the signing-instant.  
-  
-  We want to keep URLs stable: repeated calls to the same object should return 
-  the same URL, so that browsers can cache the object. 
+  "AWS URLs depend on the signing-instant.
 
-  To do this, we bucket dates to the start of the day. 
-  
+  We want to keep URLs stable: repeated calls to the same object should return
+  the same URL, so that browsers can cache the object.
+
+  To do this, we bucket dates to the start of the day.
+
   This gives about 24 hours where URLs are stable."
   []
   (let [now (date-util/utc-now)]

--- a/server/src/instant/util/aws_signature.clj
+++ b/server/src/instant/util/aws_signature.clj
@@ -1,12 +1,12 @@
 (ns instant.util.aws-signature
-  "Implements AWS' Signature Version 4. [1] 
-   
+  "Implements AWS' Signature Version 4. [1]
+
    We use these to generate S3 presigned URLs.
-   
-   Why not use the Java SDK directly to generate presigned URLs? 
-     We need a way to set the signing time. 
-     A consistent signing-time gives us stable URLs which browsers can cache. 
-   
+
+   Why not use the Java SDK directly to generate presigned URLs?
+     We need a way to set the signing time.
+     A consistent signing-time gives us stable URLs which browsers can cache.
+
    This code was originally imported from clj-aws-sign [2]
 
    [1] https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
@@ -15,14 +15,14 @@
    [clojure.string :as str]
    [instant.util.crypt :as crypt-util])
   (:import
-   (java.net URLEncoder)
+   (java.net URI URLEncoder)
    (java.time ZonedDateTime ZoneId Instant Duration)
    (java.time.format DateTimeFormatter)))
 
 (set! *warn-on-reflection* true)
 
 ;; ------------
-;; Constants 
+;; Constants
 
 (def sig-algorithm "AWS4-HMAC-SHA256")
 
@@ -31,7 +31,7 @@
 (def empty-sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 
 ;; ------------------------
-;; CanonicalRequest 
+;; CanonicalRequest
 
 (defn- url-encode
   "Percent encode the string to put in a URL."
@@ -43,17 +43,17 @@
       (.replace "%7E" "~")))
 
 (defn- ->canonical-path-str
-  "The `CanonicalURI` part of a CanonicalRequest string. 
-   
-   Note, though Amazon calls this a `CanonicalURI`, it is in fact _just_ 
-   the path component of a URI. 
+  "The `CanonicalURI` part of a CanonicalRequest string.
 
-   Rules: 
-    The URI-encoded version of the absolute path component URI, 
-    starting with the / that follows the domain name and up to 
+   Note, though Amazon calls this a `CanonicalURI`, it is in fact _just_
+   the path component of a URI.
+
+   Rules:
+    The URI-encoded version of the absolute path component URI,
+    starting with the / that follows the domain name and up to
     the end of the string or to the question mark character (?)
-    if you have query string parameters. 
-    
+    if you have query string parameters.
+
     If the absolute path is empty, use a forward slash character (/)."
   [^String path]
   (->> (.split path "/" -1)
@@ -66,12 +66,12 @@
     (compare v1 v2)))
 
 (defn- ->canonical-query-str
-  "Generates the `CanonicalQueryString` part of a CanonicalRequest string. 
-  
-  Rules:  
-   The URI-encoded query string parameters. 
-   You URI-encode each name and value individually. 
-   You must also sort the parameters in the canonical query string alphabetically by key name. 
+  "Generates the `CanonicalQueryString` part of a CanonicalRequest string.
+
+  Rules:
+   The URI-encoded query string parameters.
+   You URI-encode each name and value individually.
+   You must also sort the parameters in the canonical query string alphabetically by key name.
    The sorting occurs after encoding"
   [query]
   (->> query
@@ -81,12 +81,12 @@
        (str/join "&")))
 
 (defn- ->canonical-headers-str
-  "Generates the `CanonicalHeaders` part of a CanonicalRequest string. 
+  "Generates the `CanonicalHeaders` part of a CanonicalRequest string.
 
-   Note: The input `headers` _must_ already come sorted & transformed. 
-         see `create-sig-request`. 
+   Note: The input `headers` _must_ already come sorted & transformed.
+         see `create-sig-request`.
 
-   Rules: 
+   Rules:
     <headername>:<value>\n"
   [canonical-headers]
   (let [s (StringBuilder.)]
@@ -96,24 +96,24 @@
     (.toString s)))
 
 (defn- ->signed-headers-str
-  "Generates the `SignedHeaders` part of a CanonicalRequest. 
-   
-   Note: The input `headers` _must_ already come sorted & transformed. 
-         see `create-sig-request`. 
-   
-   Rules: 
+  "Generates the `SignedHeaders` part of a CanonicalRequest.
+
+   Note: The input `headers` _must_ already come sorted & transformed.
+         see `create-sig-request`.
+
+   Rules:
     <headername>;<headername>;..."
   [canonical-headers]
   (str/join ";" (keys canonical-headers)))
 
 (defn- ->hashed-payload-str
   "Generates the `HashedPayload` part of a CanonicalRequest string.
-  
-   Rules: 
-    Hex(SHA256Hash(<payload>)) 
-   
-    For Amazon S3, include the literal string UNSIGNED-PAYLOAD 
-    when constructing a canonical request, and set the same value as the x-amz-content-sha256 
+
+   Rules:
+    Hex(SHA256Hash(<payload>))
+
+    For Amazon S3, include the literal string UNSIGNED-PAYLOAD
+    when constructing a canonical request, and set the same value as the x-amz-content-sha256
     header value when sending the request."
   [{:keys [payload headers] :as _sig-request}]
   (let [content-sha-header (get headers "x-amz-content-sha256")]
@@ -128,23 +128,23 @@
                 crypt-util/bytes->hex-string))))
 
 (defn- ->canonical-method-str
-  "Generates the `HTTPMethod` part of a CanonicalRequest string. 
-  
-   Rules: 
+  "Generates the `HTTPMethod` part of a CanonicalRequest string.
+
+   Rules:
     GET | PUT ..."
   [method]
   (.toUpperCase (name method)))
 
 (defn ->canonical-request-str
-  "To create a signature, we first generate a CanonicalRequest string 
- 
-  
-   A `CanonicalRequest` is a deterministic string representation of your 
+  "To create a signature, we first generate a CanonicalRequest string
+
+
+   A `CanonicalRequest` is a deterministic string representation of your
    request. We format and sort it in the same way that AWS will.
-  
-   We use this string as an input to generate our signature. 
-   
-   Rules: 
+
+   We use this string as an input to generate our signature.
+
+   Rules:
     <HTTPMethod>\n
     <CanonicalURI>\n
     <CanonicalQueryString>\n
@@ -162,8 +162,8 @@
        (->signed-headers-str headers) \newline
        (->hashed-payload-str sig-request)))
 
-;; ------------- 
-;; StringToSign 
+;; -------------
+;; StringToSign
 
 (def ^DateTimeFormatter amz-date-pattern
   (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'"))
@@ -181,18 +181,18 @@
   (.format short-date-pattern (instant->utc-date-time instant)))
 
 (defn ->credential-scope-str
-  "Generates a `CredentialScope`. 
+  "Generates a `CredentialScope`.
    This restricts credentials to a specific region and service
-  
-   Rules: 
+
+   Rules:
     YYYYMMDD/region/service/aws4_request"
   [{:keys [signing-instant region service] :as _sig-request}]
   (str (instant->amz-short-date signing-instant) "/" region "/" service "/aws4_request"))
 
 (defn ->string-to-sign
-  "Generates the StringToSign. 
-  
-  Rules: 
+  "Generates the StringToSign.
+
+  Rules:
    Algorithm \n
    RequestDateTime \n
    CredentialScope  \n
@@ -207,13 +207,13 @@
        crypt-util/bytes->sha256
        crypt-util/bytes->hex-string)))
 
-;; ---------------- 
-;; SigningKey 
+;; ----------------
+;; SigningKey
 
 (defn ->signing-key-bytes
-  "Generates a `SigningKey`. 
-   
-   We do this by performing a succession of keyed hash operations 
+  "Generates a `SigningKey`.
+
+   We do this by performing a succession of keyed hash operations
    on the request date, region, and service"
   [{:keys [secret-key signing-instant region service] :as _sig-request}]
   (let [start-key (crypt-util/str->utf-8-bytes (str "AWS4" secret-key))
@@ -226,14 +226,14 @@
         signing-key-bytes (crypt-util/hmac-256 date-region-service-key (crypt-util/str->utf-8-bytes "aws4_request"))]
     signing-key-bytes))
 
-;; ------------- 
-;; Signature 
+;; -------------
+;; Signature
 
 (defn ->signature
-  "To generate a signature: 
-   1. We generate our SigningKey 
-   2. We generate our StringToSign 
-   
+  "To generate a signature:
+   1. We generate our SigningKey
+   2. We generate our StringToSign
+
    We then encrypt the StringToSign with our SigningKey, and voila!"
   [sig-request]
   (let [signing-key (->signing-key-bytes sig-request)
@@ -242,34 +242,44 @@
         sig-bytes (crypt-util/hmac-256 signing-key string-to-sign-bytes)]
     (crypt-util/bytes->hex-string sig-bytes)))
 
-;; ------------- 
-;; sig-request 
+;; -------------
+;; sig-request
 
 (defn- canonicalize-headers
-  "Generates a `CanonicalizedHeaders` sorted map. 
-  
-   Rules: 
+  "Generates a `CanonicalizedHeaders` sorted map.
+
+   Rules:
     Lowercase(<HeaderName1>):Trim(<value>)\n"
   [headers]
   (into (sorted-map)
         (map (fn [[k v]] [(str/lower-case k) (str/trim (or v ""))]) headers)))
 
 (defn create-sig-request
-  "Creates a signature request. 
+  "Creates a signature request.
 
    Main transformation: we sort and transform the `headers` map."
   [request]
   (-> request
       (update :headers canonicalize-headers)))
 
-;; -------------------- 
-;; presign-s3-url 
+;; --------------------
+;; presign-s3-url
 
 (defn s3-host [region bucket]
   (str bucket
        "."
        (if (= region "us-east-1") "s3" (str "s3-" region))
        ".amazonaws.com"))
+
+(defn- uri-port [^URI uri]
+  (let [port (.getPort uri)]
+    (when-not (= -1 port)
+      port)))
+
+(defn- uri-host-header [^URI uri]
+  (if-let [port (uri-port uri)]
+    (str (.getHost uri) ":" port)
+    (.getHost uri)))
 
 (defn amz-credential [{:keys [access-key signing-instant region service]}]
   (str access-key "/"
@@ -283,14 +293,21 @@
 
                               method
                               region
+                              endpoint
+                              path-style?
                               bucket
                               ^String path]}]
 
   (let [signing-instant (or signing-instant (Instant/now))
-        host (s3-host region bucket)
         path-with-slash (if (.startsWith path "/")
                           path
                           (str "/" path))
+        endpoint-uri (when endpoint (URI/create endpoint))
+        scheme (if endpoint-uri (.getScheme endpoint-uri) "https")
+        host (if endpoint-uri (uri-host-header endpoint-uri) (s3-host region bucket))
+        url-path (if path-style?
+                   (str "/" bucket path-with-slash)
+                   path-with-slash)
         amz-expires (str (.getSeconds expires-duration))
         query {"X-Amz-Algorithm" sig-algorithm
                "X-Amz-Credential" (amz-credential {:access-key access-key
@@ -309,7 +326,7 @@
                                          :method method
                                          :region region
                                          :service "s3"
-                                         :path path-with-slash
+                                         :path url-path
 
                                          :signing-instant signing-instant
                                          :query query
@@ -317,5 +334,4 @@
                                          :payload unsigned-payload})
         signature (->signature sig-request)
         all-query-params (assoc query "X-Amz-Signature" signature)]
-    (str "https://" host path-with-slash "?" (->canonical-query-str all-query-params))))
-
+    (str scheme "://" host url-path "?" (->canonical-query-str all-query-params))))

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -173,7 +173,7 @@
          (mapcat #(delete-objects s3-client bucket-name (vec %))))))
 
 (defn generate-presigned-url-get
-  [{:keys [access-key secret-key region] :as _signer-creds}
+  [{:keys [access-key secret-key region endpoint path-style?] :as _signer-creds}
    {:keys [app-id
            method
            bucket-name
@@ -198,6 +198,8 @@
      {:access-key access-key
       :secret-key secret-key
       :region region
+      :endpoint endpoint
+      :path-style? path-style?
       :method method
       :bucket bucket-name
       :signing-instant signing-instant
@@ -205,7 +207,7 @@
       :path key})))
 
 (defn generate-presigned-url-put
-  [{:keys [access-key secret-key region] :as _signer-creds}
+  [{:keys [access-key secret-key region endpoint path-style?] :as _signer-creds}
    {:keys [method bucket-name key ^Instant signing-instant ^Duration duration]}]
   (assert (= :put method)
           "put presigned urls are only implemented for :put requests")
@@ -213,6 +215,8 @@
    {:access-key access-key
     :secret-key secret-key
     :region region
+    :endpoint endpoint
+    :path-style? path-style?
     :method method
     :bucket bucket-name
     :signing-instant signing-instant
@@ -265,4 +269,3 @@
                                                (when content-length (long content-length))
                                                default-virtual-thread-executor)]
     (upload-body-to-s3 async-client bucket-name ctx body)))
-


### PR DESCRIPTION
Instructions for both localhost and hetzner setup at:
https://github.com/instantdb/instant/tree/drewh/self-hosting/self-hosting#readme

# Change Summary
 - Create a docker image for the dashboard.
   - Create a method for passing runtime environment variables to the dashboard client/server. Docker container creates a publicSelfHostedVariables.js file in /public that gets loaded before the client.
   - All non dashboard routes redirect to the dashboard. (i.e. you can't self-host our blog/docs)
 - Create a docker image for the server. 
 - On container startup runs the oss-bootstrap task to create a aead-keyset and webhook-keyset which gets stored in a volume to be persisted
 - Refactored s3.clj to allow for any S3 compatible filesystem. 
 - Created 2 docker compose files in self-hosting/
 - Created a github action workflow to publish images. 


# Review Instructions
Visit the instructions above and try to follow the instructions for setting up InstantDB on a fresh VPS. 
Should be able to use `create-instant-app` and `instant-cli` with the `INSTANT_CLI_API_URI` environment variable. 

Also try following the localhost/local dev instructions.

Would also appreciate a thorough review on the clojure code since that is what I'm least confident about. 

# Todos:
 - [x] Publish docker images manually so that the docker-compose files do not need to build them.
 - [x] Publish docker images on push to main. 

# Future Steps:
Make it easier to use create instant app and instant-cli with self hosted instances. 
	Example: create-instant-app should set the apiURI and websocketURI in the init config when scaffolding. 
    Example: instant-cli init should also save the backend api url when creating the .env with the app id and admin token.