### PR TITLE
Move useLocalStorage to demo component, less noisy useLocalStorage hook

### DIFF
--- a/client/www/components/essays/EssayMarkdown.tsx
+++ b/client/www/components/essays/EssayMarkdown.tsx
@@ -55,10 +55,6 @@ export function EssayMarkdown({
   content: string;
   title: string;
 }) {
-  const [demoState, setDemoState] = useLocalStorage<DemoState>(
-    'architecture-essay-demo',
-    {},
-  );
   return (
     <ReactMarkdown
       rehypePlugins={[rehypeRaw, rehypeKatex]}
@@ -72,11 +68,7 @@ export function EssayMarkdown({
             return <SketchDemo demo={props.demo} />;
           },
           'architecture-demo': (props: { demo: string }) => (
-            <Demos
-              demo={props.demo}
-              demoState={demoState}
-              setDemoState={setDemoState}
-            />
+            <Demos demo={props.demo} />
           ),
           'gpt52-leaderboard': GPT52Leaderboard,
           'triple-demo': () => (

--- a/client/www/components/essays/EssayMarkdown.tsx
+++ b/client/www/components/essays/EssayMarkdown.tsx
@@ -14,10 +14,12 @@ import MuxPlayer from '@mux/mux-player-react';
 
 import { DemoIframe } from '@/components/DemoIframe';
 import { SketchDemo } from '@/components/essays/sketch/SketchDemo';
-import { Demos, type DemoState } from '@/components/essays/architecture/Demos';
+import {
+  Demos as ArchitectureDemos,
+  type DemoState,
+} from '@/components/essays/architecture/Demos';
 import { Fence } from '@/components/ui';
 import { muxPattern, youtubeParams, youtubePattern } from '@/lib/videos';
-import useLocalStorage from '@/lib/hooks/useLocalStorage';
 import { isValidElement, useState } from 'react';
 import ReactMarkdown, { Components } from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
@@ -64,12 +66,8 @@ export function EssayMarkdown({
           // Note if you change the custom component key, you
           // must also change all references in the markdown files
           'agents-essay-demo-section': AgentsEssayDemoSection,
-          'sketch-demo': (props: { demo: string }) => {
-            return <SketchDemo demo={props.demo} />;
-          },
-          'architecture-demo': (props: { demo: string }) => (
-            <Demos demo={props.demo} />
-          ),
+          'sketch-demo': SketchDemo,
+          'architecture-demo': ArchitectureDemos,
           'gpt52-leaderboard': GPT52Leaderboard,
           'triple-demo': () => (
             <div className="not-prose my-8 flex justify-center">

--- a/client/www/components/essays/architecture/Demos.tsx
+++ b/client/www/components/essays/architecture/Demos.tsx
@@ -3,6 +3,7 @@ import CreationTimeDemo from './CreationTimeDemo';
 import TodoIframeDemo from './TodoIframeDemo';
 import TodoCodeDemo, { TODO_CODE_LINE_COUNT } from './TodoCodeDemo';
 import FileUploadDemo from './FileUploadDemo';
+import useLocalStorage from '@/lib/hooks/useLocalStorage';
 
 export type DemoState = {
   app?: {
@@ -13,15 +14,11 @@ export type DemoState = {
   } | null;
 };
 
-export function Demos({
-  demo,
-  demoState,
-  setDemoState,
-}: {
-  demo: string;
-  demoState: DemoState;
-  setDemoState: (state: DemoState) => void;
-}) {
+export function Demos({ demo }: { demo: string }) {
+  const [demoState, setDemoState] = useLocalStorage<DemoState>(
+    'architecture-essay-demo',
+    {},
+  );
   switch (demo) {
     case 'create-app':
       return (

--- a/client/www/lib/hooks/useLocalStorage.tsx
+++ b/client/www/lib/hooks/useLocalStorage.tsx
@@ -33,17 +33,20 @@ export default function useLocalStorage<T>(
   saveDefaultValue = false,
 ): [T, (v: T | undefined) => void] {
   const snapshotRef = useRef<T>(getSnapshot<T>(k) || defaultValue);
-  const subscribe = useCallback((cb: Function) => {
-    const listener = (e: StorageEvent) => {
-      if (e.key !== k) return;
-      snapshotRef.current = getSnapshot<T>(k) || defaultValue;
-      cb();
-    };
-    window.addEventListener('storage', listener);
-    return () => {
-      window.removeEventListener('storage', listener);
-    };
-  }, []);
+  const subscribe = useCallback(
+    (cb: Function) => {
+      const listener = (e: StorageEvent) => {
+        if (e.key !== null && e.key !== k) return;
+        snapshotRef.current = getSnapshot<T>(k) || defaultValue;
+        cb();
+      };
+      window.addEventListener('storage', listener);
+      return () => {
+        window.removeEventListener('storage', listener);
+      };
+    },
+    [k, defaultValue],
+  );
   const state = useSyncExternalStore<T>(
     subscribe,
     () => snapshotRef.current,

--- a/client/www/lib/hooks/useLocalStorage.tsx
+++ b/client/www/lib/hooks/useLocalStorage.tsx
@@ -34,7 +34,8 @@ export default function useLocalStorage<T>(
 ): [T, (v: T | undefined) => void] {
   const snapshotRef = useRef<T>(getSnapshot<T>(k) || defaultValue);
   const subscribe = useCallback((cb: Function) => {
-    const listener = () => {
+    const listener = (e: StorageEvent) => {
+      if (e.key !== k) return;
       snapshotRef.current = getSnapshot<T>(k) || defaultValue;
       cb();
     };


### PR DESCRIPTION
Makes the architecture demos more self-contained. They now keep track of useLocalStorage instead of polluting the essay markdown component.

Also makes `useLocalStorage` only trigger the callback when the key we're watching changes.