### PR TITLE
fix dark mode login page

### DIFF
--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -222,7 +222,7 @@ export default function Auth(props: {
     }));
   };
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center p-4">
+    <div className="flex min-h-[100dvh] items-center justify-center p-4 dark:bg-neutral-900">
       <div className="max-w-sm">
         <span className="inline-flex items-center space-x-2">
           <LogoIcon />


### PR DESCRIPTION
If a user has previously logged in and toggled the dark mode on the dashboard to be on. When they log out, they will see a bad light mode version when logging back in. Fixing this by adding a background dark mode variant. 

BEFORE:
<img width="1667" height="1326" alt="image" src="https://github.com/user-attachments/assets/b24ff795-74d2-4616-b414-8f20822f0413" />

AFTER:
<img width="1666" height="1328" alt="image" src="https://github.com/user-attachments/assets/11d585e0-63b4-4a17-ac24-8d571303f3f5" />
