### PR TITLE
fix oauth inputs with password managers

### DIFF
--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -238,6 +238,7 @@ export function TextInput({
         data-lpignore={type === 'sensitive' ? 'true' : undefined}
         data-1p-ignore={type === 'sensitive' ? 'true' : undefined}
         data-bwignore={type === 'sensitive' ? 'true' : undefined}
+        data-form-type={type === 'sensitive' ? 'other' : undefined}
         ref={inputRef}
         inputMode={inputMode}
         placeholder={placeholder}

--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -233,9 +233,11 @@ export function TextInput({
         title={title}
         type={type === 'sensitive' ? 'password' : (type ?? 'text')}
         // Try to prevent password managers from trying to save
-        // sensitive input
+        // sensitive input, LastPass, 1password, BitWarden
         autoComplete={type === 'sensitive' ? 'off' : undefined}
         data-lpignore={type === 'sensitive' ? 'true' : undefined}
+        data-1p-ignore={type === 'sensitive' ? 'true' : undefined}
+        data-bwignore={type === 'sensitive' ? 'true' : undefined}
         ref={inputRef}
         inputMode={inputMode}
         placeholder={placeholder}


### PR DESCRIPTION
add new data-1p-ignore and data-bwignore tags for 1Password and Bitwarden

The bitwarden ignore tag still does not work for me 