### PR TITLE
Make @instantdb/admin work in the edge runtime

### DIFF
--- a/client/packages/admin/package.json
+++ b/client/packages/admin/package.json
@@ -61,7 +61,7 @@
     "@instantdb/core": "workspace:*",
     "@instantdb/version": "workspace:*",
     "cookie": "^1.1.1",
-    "@dww/eventsource": "4.1.0-0",
+    "@instantdb/eventsource": "4.1.0-2",
     "uuid": "^11.1.0"
   }
 }

--- a/client/packages/admin/package.json
+++ b/client/packages/admin/package.json
@@ -61,7 +61,7 @@
     "@instantdb/core": "workspace:*",
     "@instantdb/version": "workspace:*",
     "cookie": "^1.1.1",
-    "eventsource": "^4.0.0",
+    "@dww/eventsource": "4.1.0-0",
     "uuid": "^11.1.0"
   }
 }

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -91,7 +91,8 @@ import {
   SubscriptionReadyState,
 } from './subscribe.ts';
 import { parseCookie } from 'cookie';
-import { EventSource } from 'eventsource';
+import { EventSource } from '@dww/eventsource';
+import { MessageEventPolyfill } from './polyfill.ts';
 
 type DebugCheckResult = {
   /** The ID of the record. */
@@ -331,6 +332,7 @@ function makeEventSourceWrapper(opts: {
 
     #createEventSource(url: string): EventSource {
       const es = new EventSource(url, {
+        messageEvent: MessageEventPolyfill,
         fetch(input, init) {
           return fetch(input, {
             ...init,

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -111,6 +111,7 @@ type Config = {
   apiURI?: string;
   useDateObjects?: boolean;
   disableValidation?: boolean;
+  verbose?: boolean;
 };
 
 export type InstantConfig<

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -18,6 +18,7 @@ import {
   // core types
   type User,
   type Query,
+  InstantError,
 
   // query types
   type QueryResponse,
@@ -79,6 +80,7 @@ import {
   type WritableStreamCtor,
   type ReadableStreamCtor,
   InstantWritableStream,
+  InstantReadableStream,
 } from '@instantdb/core';
 
 import version from './version.ts';
@@ -1049,7 +1051,9 @@ class Streams {
    *     console.log(chunk);
    *   }
    */
-  createReadStream = (opts: CreateReadStreamOpts): ReadableStream<string> => {
+  createReadStream = (
+    opts: CreateReadStreamOpts,
+  ): InstantReadableStream<string> => {
     return this.#ensureInstantStream().createReadStream(opts);
   };
 
@@ -1611,6 +1615,7 @@ export {
   type InstaQLParams,
   type ValidQuery,
   type Query,
+  InstantError,
 
   // query types
   type QueryResponse,

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -93,7 +93,7 @@ import {
   SubscriptionReadyState,
 } from './subscribe.ts';
 import { parseCookie } from 'cookie';
-import { EventSource } from '@dww/eventsource';
+import { EventSource } from '@instantdb/eventsource';
 import { MessageEventPolyfill } from './polyfill.ts';
 
 type DebugCheckResult = {

--- a/client/packages/admin/src/polyfill.ts
+++ b/client/packages/admin/src/polyfill.ts
@@ -1,0 +1,39 @@
+// MessageEvent is not supported in the edge runtime, vercel
+// defines its own MessageEvent that throws. There is no easy
+// way to detect if MessageEvent is supported, so we just always
+// polyfill by passing it in to eventsource.
+export class MessageEventPolyfill<T = any> extends Event {
+  readonly data: T;
+  readonly origin: string;
+  readonly lastEventId: string;
+  readonly source: MessageEventSource | null;
+  readonly ports: ReadonlyArray<MessagePort>;
+  constructor(
+    type: string,
+    init?: {
+      data?: T;
+      origin?: string;
+      lastEventId?: string;
+      source?: MessageEventSource | null;
+      ports?: MessagePort[];
+    },
+  ) {
+    super(type);
+    this.data = init?.data ?? (null as T);
+    this.origin = init?.origin ?? '';
+    this.lastEventId = init?.lastEventId ?? '';
+    this.source = init?.source ?? null;
+    this.ports = init?.ports ?? [];
+  }
+  /** @deprecated */
+  initMessageEvent(
+    _type: string,
+    _bubbles?: boolean,
+    _cancelable?: boolean,
+    _data?: any,
+    _origin?: string,
+    _lastEventId?: string,
+    _source?: MessageEventSource | null,
+    _ports?: MessagePort[],
+  ) {}
+}

--- a/client/packages/admin/src/subscribe.ts
+++ b/client/packages/admin/src/subscribe.ts
@@ -1,4 +1,4 @@
-import { EventSource } from '@dww/eventsource';
+import { EventSource } from '@instantdb/eventsource';
 import version from './version.ts';
 import {
   id,

--- a/client/packages/admin/src/subscribe.ts
+++ b/client/packages/admin/src/subscribe.ts
@@ -1,4 +1,4 @@
-import { EventSource } from 'eventsource';
+import { EventSource } from '@dww/eventsource';
 import version from './version.ts';
 import {
   id,
@@ -10,6 +10,7 @@ import {
   ValidQuery,
   PageInfoResponse,
 } from '@instantdb/core';
+import { MessageEventPolyfill } from './polyfill.ts';
 
 export type SubscriptionReadyState = 'closed' | 'connecting' | 'open';
 
@@ -237,6 +238,7 @@ export function subscribe<
   const es = new EventSource(
     `${opts.apiURI}/admin/subscribe-query?local_connection_id=${localConnectionId}`,
     {
+      messageEvent: MessageEventPolyfill,
       fetch(input, init) {
         fetchErrorResponse = null;
         return fetch(input, {

--- a/client/packages/core/src/Stream.ts
+++ b/client/packages/core/src/Stream.ts
@@ -22,6 +22,10 @@ export interface InstantWritableStream<T> extends WritableStream<T> {
   streamId: () => Promise<string>;
 }
 
+export interface InstantReadableStream<T> extends ReadableStream<T> {
+  streamId: () => Promise<string>;
+}
+
 type WriteStreamStartResult =
   | { type: 'ok'; streamId: string; offset: number }
   | { type: 'disconnect' }
@@ -399,6 +403,7 @@ type ReadStreamUpdate =
       offset: number;
       files?: { url: string; size: number }[];
       content?: string;
+      streamId: string;
     }
   | { type: 'error'; error: InstantError }
   | { type: 'reconnect' };
@@ -476,7 +481,7 @@ function createReadStream({
   }) => StreamIterator<ReadStreamUpdate>;
   cancelStream: (opts: { eventId: string }) => void;
 }): {
-  stream: ReadableStream<string>;
+  stream: InstantReadableStream<string>;
   closed: () => boolean;
   addCloseCb: (cb: () => void) => void;
 } {
@@ -486,16 +491,20 @@ function createReadStream({
   const encoder = new TextEncoder();
   let eventId: string | null;
   let closed = false;
-  const closeCbs: (() => void)[] = [];
+  const closeCbs: ((error?: InstantError) => void)[] = [];
+  const streamIdCbs: ((streamId: string) => void)[] = [];
+  // Resolved stream id from the server
+  let streamId_: string | null = null;
+  let error_: InstantError | null = null;
 
-  function markClosed() {
+  function markClosed(error?: InstantError) {
     closed = true;
     for (const cb of closeCbs) {
-      cb();
+      cb(error);
     }
   }
 
-  function addCloseCb(cb: () => void) {
+  function addCloseCb(cb: (error?: InstantError) => void) {
     closeCbs.push(cb);
     return () => {
       const i = closeCbs.indexOf(cb);
@@ -505,12 +514,26 @@ function createReadStream({
     };
   }
 
+  function addStreamIdCb(cb: (streamId: string) => void) {
+    streamIdCbs.push(cb);
+    if (streamId_) {
+      cb(streamId_);
+    }
+    return () => {
+      const i = streamIdCbs.indexOf(cb);
+      if (i !== -1) {
+        streamIdCbs.splice(i, 1);
+      }
+    };
+  }
+
   function error(
     controller: ReadableStreamDefaultController<string>,
     e: InstantError,
   ) {
+    error_ = e;
     controller.error(e);
-    markClosed();
+    markClosed(e);
   }
 
   let fetchFailures = 0;
@@ -543,6 +566,12 @@ function createReadStream({
         error(controller, new InstantError('Stream is corrupted.'));
         canceled = true;
         return;
+      }
+
+      streamId_ = item.streamId;
+
+      for (const cb of streamIdCbs) {
+        cb(streamId_);
       }
 
       let discardLen = seenOffset - item.offset;
@@ -665,7 +694,51 @@ function createReadStream({
       markClosed();
     }
   }
-  const stream = new RStream<string>({
+
+  class RStreamEnhanced
+    extends RStream<string>
+    implements InstantReadableStream<string>
+  {
+    constructor(
+      source?: UnderlyingDefaultSource<string>,
+      strategy?: QueuingStrategy<string>,
+    ) {
+      super(source, strategy);
+    }
+
+    public async streamId(): Promise<string> {
+      if (streamId_) {
+        return streamId_;
+      }
+      if (error_) {
+        throw error_;
+      }
+      return new Promise((resolve, reject) => {
+        const cleanupFns: (() => void)[] = [];
+        const cleanup = () => {
+          for (const f of cleanupFns) {
+            f();
+          }
+        };
+        const resolveCb = (streamId: string) => {
+          resolve(streamId);
+          cleanup();
+        };
+        const rejectCb = (e?: InstantError) => {
+          console.log('REJECT');
+          reject(e || new InstantError('Stream is closed.'));
+          cleanup();
+        };
+
+        console.log('adding cbs');
+
+        cleanupFns.push(addStreamIdCb(resolveCb));
+        cleanupFns.push(addCloseCb(rejectCb));
+      });
+    }
+  }
+
+  const stream = new RStreamEnhanced({
     start(controller) {
       start(controller);
     },
@@ -1011,6 +1084,7 @@ export class InstantStream {
         offset: msg.offset,
         files: msg.files,
         content: msg.content,
+        streamId: msg['stream-id'],
       });
     }
 
@@ -1020,7 +1094,7 @@ export class InstantStream {
     }
   }
 
-  onConnectionStatusChange(status) {
+  onConnectionStatusChange(status: any) {
     // Tell the writers to retry:
     for (const cb of Object.values(this.startWriteStreamCbs)) {
       cb({ type: 'disconnect' });

--- a/client/packages/core/src/Stream.ts
+++ b/client/packages/core/src/Stream.ts
@@ -725,12 +725,9 @@ function createReadStream({
           cleanup();
         };
         const rejectCb = (e?: InstantError) => {
-          console.log('REJECT');
           reject(e || new InstantError('Stream is closed.'));
           cleanup();
         };
-
-        console.log('adding cbs');
 
         cleanupFns.push(addStreamIdCb(resolveCb));
         cleanupFns.push(addCloseCb(rejectCb));
@@ -1078,15 +1075,13 @@ export class InstantStream {
       return;
     }
 
-    if (msg.files?.length || msg.content) {
-      iterator.push({
-        type: 'append',
-        offset: msg.offset,
-        files: msg.files,
-        content: msg.content,
-        streamId: msg['stream-id'],
-      });
-    }
+    iterator.push({
+      type: 'append',
+      offset: msg.offset,
+      files: msg.files,
+      content: msg.content,
+      streamId: msg['stream-id'],
+    });
 
     if (msg.done) {
       iterator.close();

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -144,6 +144,7 @@ import type {
 import {
   InstantStream,
   InstantWritableStream,
+  InstantReadableStream,
   ReadableStreamCtor,
   WritableStreamCtor,
 } from './Stream.ts';
@@ -603,7 +604,9 @@ class Streams {
    *     console.log(chunk);
    *   }
    */
-  createReadStream = (opts: CreateReadStreamOpts): ReadableStream<string> => {
+  createReadStream = (
+    opts: CreateReadStreamOpts,
+  ): InstantReadableStream<string> => {
     return this.db.createReadStream(opts);
   };
 
@@ -1195,6 +1198,7 @@ export {
   type CreateReadStreamOpts,
   type CreateWriteStreamOpts,
   type InstantWritableStream,
+  type InstantReadableStream,
 
   // sync table types
   type SyncTableCallback,

--- a/client/packages/react-native/src/index.ts
+++ b/client/packages/react-native/src/index.ts
@@ -101,6 +101,7 @@ import {
   CreateReadStreamOpts,
   CreateWriteStreamOpts,
   InstantWritableStream,
+  InstantReadableStream,
 } from '@instantdb/core';
 
 /**
@@ -268,6 +269,7 @@ export {
   type CreateReadStreamOpts,
   type CreateWriteStreamOpts,
   type InstantWritableStream,
+  type InstantReadableStream,
 
   // custom store
   StoreInterface,

--- a/client/packages/react/src/InstantReactWebDatabase.ts
+++ b/client/packages/react/src/InstantReactWebDatabase.ts
@@ -1,6 +1,6 @@
 import type { InstantConfig, InstantSchemaDef } from '@instantdb/core';
 import { InstantReactAbstractDatabase } from '@instantdb/react-common';
-import { EventSource } from '@dww/eventsource';
+import { EventSource } from 'eventsource';
 
 export default class InstantReactWebDatabase<
   Schema extends InstantSchemaDef<any, any, any>,

--- a/client/packages/react/src/InstantReactWebDatabase.ts
+++ b/client/packages/react/src/InstantReactWebDatabase.ts
@@ -1,6 +1,6 @@
 import type { InstantConfig, InstantSchemaDef } from '@instantdb/core';
 import { InstantReactAbstractDatabase } from '@instantdb/react-common';
-import { EventSource } from 'eventsource';
+import { EventSource } from '@dww/eventsource';
 
 export default class InstantReactWebDatabase<
   Schema extends InstantSchemaDef<any, any, any>,

--- a/client/packages/react/src/index.ts
+++ b/client/packages/react/src/index.ts
@@ -94,6 +94,7 @@ import {
   createInstantRouteHandler,
   type StoreInterfaceStoreName,
   InstantWritableStream,
+  InstantReadableStream,
 } from '@instantdb/core';
 
 import { InstantReactAbstractDatabase } from '@instantdb/react-common';
@@ -194,6 +195,7 @@ export {
   type CreateReadStreamOpts,
   type CreateWriteStreamOpts,
   type InstantWritableStream,
+  type InstantReadableStream,
 
   // custom store
   StoreInterface,

--- a/client/packages/resumable-stream/src/index.ts
+++ b/client/packages/resumable-stream/src/index.ts
@@ -1,4 +1,4 @@
-import { Config, init } from '@instantdb/admin';
+import { Config, init, InstantError } from '@instantdb/admin';
 
 export interface CreateResumableStreamContextOptions {
   /**
@@ -167,6 +167,17 @@ export function createResumableStreamContext(
     skipCharacters?: number,
   ): Promise<ReadableStream<string> | null | undefined> {
     const readStream = db.streams.createReadStream({ clientId: streamId });
+    try {
+      await readStream.streamId();
+    } catch (e) {
+      if (
+        e instanceof InstantError &&
+        (e.hint as any)?.errors?.[0]?.message === 'Stream is missing.'
+      ) {
+        return undefined;
+      }
+      throw e;
+    }
     if (skipCharacters) {
       return readStream.pipeThrough(skipCharactersTransformer(skipCharacters));
     }

--- a/client/packages/resumable-stream/src/index.ts
+++ b/client/packages/resumable-stream/src/index.ts
@@ -21,6 +21,10 @@ export interface CreateResumableStreamContextOptions {
    * Optional apiURI for the instantdb server.
    */
   apiURI?: string;
+  /**
+   * Enable verbose logging from the underlying instant connection
+   */
+  verbose?: boolean;
 }
 
 export interface ResumableStreamContext {
@@ -119,6 +123,10 @@ export function createResumableStreamContext(
 
   if (apiURI) {
     config.apiURI = apiURI;
+  }
+
+  if (options.verbose) {
+    config.verbose = options.verbose;
   }
 
   const db = init(config);

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.1';
+const version = 'v1.0.2';
 
 export { version };

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -26,12 +26,12 @@ importers:
 
   packages/admin:
     dependencies:
-      '@dww/eventsource':
-        specifier: 4.1.0-0
-        version: 4.1.0-0
       '@instantdb/core':
         specifier: workspace:*
         version: link:../core
+      '@instantdb/eventsource':
+        specifier: 4.1.0-2
+        version: 4.1.0-2
       '@instantdb/version':
         specifier: workspace:*
         version: link:../version
@@ -2956,10 +2956,6 @@ packages:
       search-insights:
         optional: true
 
-  '@dww/eventsource@4.1.0-0':
-    resolution: {integrity: sha512-2Le2C5z9cCi6djWFvaBaxWIdJcfv8p/E4mwBnjEs7JNAAmnP+kSU5+qosmMfzCkwgFeu1ijr8cJjbyt7Mfq7fA==}
-    engines: {node: '>=20.0.0'}
-
   '@effect/cluster@0.56.1':
     resolution: {integrity: sha512-gnrsH6kfrUjn+82j/bw1IR4yFqJqV8tc7xZvrbJPRgzANycc6K1hu3LMg548uYbUkTzD8YYyqrSatMO1mkQpzw==}
     peerDependencies:
@@ -4721,6 +4717,10 @@ packages:
 
   '@instantdb/core@0.19.20':
     resolution: {integrity: sha512-v/lFVX2X3JdAwHFwQTthN/g72ta6Cc0X+TGIHHedbwLO6ryqGlQfaOn6vpuMPpdidemmEHhe59mwzdLaLa5rgA==}
+
+  '@instantdb/eventsource@4.1.0-2':
+    resolution: {integrity: sha512-k2uzhsRzdD7hzV3fv+eoCRNeluZcj4pDfUKKAhvIS6xshc7zHkaM9/m3vxBgaYoNVmvOyaGp84TcHG0/Bp7k4g==}
+    engines: {node: '>=20.0.0'}
 
   '@instantdb/platform@0.19.20':
     resolution: {integrity: sha512-qFPsV3AGRQKLGolNiAbrlqsIEEGlDCwgSHDYfgSRn19rM8MIqI8i5vqjvXYOljhEDyKm2lEEBMmrDZXrGw5O2w==}
@@ -19495,10 +19495,6 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@dww/eventsource@4.1.0-0':
-    dependencies:
-      eventsource-parser: 3.0.6
-
   '@effect/cluster@0.56.1(@effect/platform@0.94.1(effect@3.19.14))(@effect/rpc@0.73.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14)(ioredis@5.6.1))(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14)(ioredis@5.6.1))(@effect/platform@0.94.1(effect@3.19.14))(@effect/rpc@0.73.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14))(effect@3.19.14))(effect@3.19.14)':
     dependencies:
       '@effect/platform': 0.94.1(effect@3.19.14)
@@ -21221,6 +21217,10 @@ snapshots:
     dependencies:
       mutative: 1.1.0
       uuid: 9.0.1
+
+  '@instantdb/eventsource@4.1.0-2':
+    dependencies:
+      eventsource-parser: 3.0.6
 
   '@instantdb/platform@0.19.20':
     dependencies:

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   packages/admin:
     dependencies:
+      '@dww/eventsource':
+        specifier: 4.1.0-0
+        version: 4.1.0-0
       '@instantdb/core':
         specifier: workspace:*
         version: link:../core
@@ -35,9 +38,6 @@ importers:
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
-      eventsource:
-        specifier: ^4.0.0
-        version: 4.0.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -2955,6 +2955,10 @@ packages:
         optional: true
       search-insights:
         optional: true
+
+  '@dww/eventsource@4.1.0-0':
+    resolution: {integrity: sha512-2Le2C5z9cCi6djWFvaBaxWIdJcfv8p/E4mwBnjEs7JNAAmnP+kSU5+qosmMfzCkwgFeu1ijr8cJjbyt7Mfq7fA==}
+    engines: {node: '>=20.0.0'}
 
   '@effect/cluster@0.56.1':
     resolution: {integrity: sha512-gnrsH6kfrUjn+82j/bw1IR4yFqJqV8tc7xZvrbJPRgzANycc6K1hu3LMg548uYbUkTzD8YYyqrSatMO1mkQpzw==}
@@ -19491,6 +19495,10 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
+  '@dww/eventsource@4.1.0-0':
+    dependencies:
+      eventsource-parser: 3.0.6
+
   '@effect/cluster@0.56.1(@effect/platform@0.94.1(effect@3.19.14))(@effect/rpc@0.73.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14)(ioredis@5.6.1))(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14)(ioredis@5.6.1))(@effect/platform@0.94.1(effect@3.19.14))(@effect/rpc@0.73.0(@effect/platform@0.94.1(effect@3.19.14))(effect@3.19.14))(effect@3.19.14))(effect@3.19.14)':
     dependencies:
       '@effect/platform': 0.94.1(effect@3.19.14)
@@ -28068,7 +28076,7 @@ snapshots:
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.2
+      eventsource-parser: 3.0.6
 
   eventsource@4.0.0:
     dependencies:

--- a/client/www/pages/intern/emails/[slug].tsx
+++ b/client/www/pages/intern/emails/[slug].tsx
@@ -59,7 +59,7 @@ const HTMLView = ({
   htmlBody,
   useLocalImages,
 }: {
-  htmlBody: String;
+  htmlBody: string;
   useLocalImages: Boolean;
 }) => {
   const replaceUrl = getImgReplaceUrl();


### PR DESCRIPTION
This PR allows @instantdb/admin to work in vercel's edge runtime (should also work in Cloudflare, but I haven't tested).

The edge runtime supports almost everything that `eventsource` relies on, except for `MessageEvent`. And you can't just do a normal polyfill with `globalThis.MessageEvent = globalThis.MessageEvent || PolyFill`, because they define one that just throws at runtime. So I forked `eventsource` to [`@instantdb/eventsource`](https://github.com/instantdb/eventsource) and added a way to pass in our own `MessageEvent`.

I also added `streamId` to the read stream we return. We already had it on the writeStream, but not the readStream. I use that in resumable-stream to return undefined when the stream doesn't exist, matching vercel's behavior.