### PR TITLE
Quality: Add one-time query function for admin SDK

### DIFF
--- a/client/packages/admin/src/query.ts
+++ b/client/packages/admin/src/query.ts
@@ -1,0 +1,32 @@
+import {
+  InstantAPIError,
+  type Query,
+  type QueryResponse,
+} from '@instantdb/core';
+
+export interface QueryConfig {
+  appId: string;
+  adminToken: string;
+  apiURI: string;
+}
+
+export async function query<Q extends Query>(
+  config: QueryConfig,
+  query: Q
+): Promise<QueryResponse<Q>> {
+  const response = await fetch(`${config.apiURI}/admin/query`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${config.adminToken}`,
+      'Instant-App-Id': config.appId,
+    },
+    body: JSON.stringify({ query }),
+  });
+
+  if (!response.ok) {
+    throw new InstantAPIError(response);
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Problem

Create a new module that exports a `query` function for executing non-realtime (one-time) queries via HTTP. This complements the existing `subscribe` functionality by providing a simple Promise-based API for fetching data once without setting up a persistent subscription. The function should make a POST request to the admin query endpoint with proper authentication headers.

**Severity**: `high`
**File**: `client/packages/admin/src/query.ts`

## Solution

Create the file with the following implementation:

## Changes

- `client/packages/admin/src/query.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #2531