### PR TITLE
Feature: Add webhook configuration types to schema definitions

### DIFF
--- a/client/packages/core/src/schemaTypes.ts
+++ b/client/packages/core/src/schemaTypes.ts
@@ -86,6 +86,26 @@ export class LinkAttrDef<
   ) {}
 }
 
+export type WebhookEvent = 'create' | 'update' | 'delete';
+
+export type WebhookFilter = {
+  [key: string]: any;
+};
+
+export type WebhookPayloadConfig = {
+  include?: string[];
+  exclude?: string[];
+};
+
+export class WebhookDef {
+  constructor(
+    public events: WebhookEvent[],
+    public url: string,
+    public filter?: WebhookFilter,
+    public payload?: WebhookPayloadConfig,
+  ) {}
+}
+
 export interface IContainEntitiesAndLinks<
   Entities extends EntitiesDef,
   Links extends LinksDef<Entities>,
@@ -111,14 +131,16 @@ export class EntityDef<
   Attrs extends AttrsDefs,
   Links extends Record<string, LinkAttrDef<any, any>>,
   AsType,
+  Webhooks extends Record<string, WebhookDef> = {},
 > {
   constructor(
     public attrs: Attrs,
     public links: Links,
+    public webhooks?: Webhooks,
   ) {}
 
   asType<_AsType extends Partial<MappedAttrs<Attrs, boolean>>>() {
-    return new EntityDef<Attrs, Links, _AsType>(this.attrs, this.links);
+    return new EntityDef<Attrs, Links, _AsType, Webhooks>(this.attrs, this.links, this.webhooks);
   }
 }
 


### PR DESCRIPTION
## Problem

Extend the schema type system to support webhook declarations on entities. Add types for webhook events (create/update/delete), webhook configuration objects, filtering conditions, and payload inclusion options. Update EntityDef to include an optional webhooks array.

**Severity**: `critical`
**File**: `client/packages/core/src/schemaTypes.ts`

## Solution

Add the following type definitions:

## Changes

- `client/packages/core/src/schemaTypes.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #2170