### PR TITLE
[codex-proposal] Add managed dev Google OAuth clients

### DIFF
--- a/client/www/components/dash/auth/Google.tsx
+++ b/client/www/components/dash/auth/Google.tsx
@@ -57,6 +57,23 @@ function isNative(appType: AppType) {
   return appType === 'ios' || appType === 'android';
 }
 
+function supportsDevCredentials(appType: AppType) {
+  return appType === 'web';
+}
+
+function usesDevCredentials(client: OAuthClient) {
+  return Boolean(client.meta?.useDevCredentials);
+}
+
+function DevCredentialsNotice() {
+  return (
+    <p className="text-sm text-gray-500 dark:text-neutral-400">
+      Works on localhost, preview URLs, and app schemes. Use your own Google
+      client ID and secret for production domains.
+    </p>
+  );
+}
+
 export function AddClientForm({
   app,
   provider,
@@ -82,6 +99,7 @@ export function AddClientForm({
   const [redirectTo, setRedirectTo] = useState<string>('');
   const [updatedRedirectURL, setUpdatedRedirectURL] = useState(false);
   const [skipNonceChecks, setSkipNonceChecks] = useState(isNative(appType));
+  const [useDevCredentials, setUseDevCredentials] = useState(appType === 'web');
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const onChangeAppType = (item: { id: string; label: string }) => {
@@ -89,6 +107,20 @@ export function AddClientForm({
     setAppType(newAppType);
     setClientName(findName(`google-${newAppType}`, usedClientNames));
     setSkipNonceChecks(isNative(newAppType));
+    setUseDevCredentials(supportsDevCredentials(newAppType));
+    if (!supportsDevCredentials(newAppType)) {
+      setUpdatedRedirectURL(false);
+    }
+  };
+
+  const onChangeUseDevCredentials = (nextValue: boolean) => {
+    setUseDevCredentials(nextValue);
+    if (nextValue) {
+      setClientId('');
+      setClientSecret('');
+      setRedirectTo('');
+      setUpdatedRedirectURL(false);
+    }
   };
 
   const validationError = () => {
@@ -98,10 +130,10 @@ export function AddClientForm({
     if (usedClientNames.has(clientName)) {
       return `The unique name '${clientName}' is already in use.`;
     }
-    if (!clientId) {
+    if (!useDevCredentials && !clientId) {
       return 'Missing client id';
     }
-    if (appType === 'web' && !clientSecret) {
+    if (appType === 'web' && !useDevCredentials && !clientSecret) {
       return 'Missing client secret';
     }
   };
@@ -120,16 +152,19 @@ export function AddClientForm({
         appId: app.id,
         providerId: provider.id,
         clientName,
-        clientId,
-        clientSecret: clientSecret ? clientSecret : undefined,
+        clientId: useDevCredentials ? undefined : clientId,
+        clientSecret:
+          useDevCredentials || !clientSecret ? undefined : clientSecret,
         authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
         tokenEndpoint: 'https://oauth2.googleapis.com/token',
         discoveryEndpoint:
           'https://accounts.google.com/.well-known/openid-configuration',
-        redirectTo,
+        redirectTo: useDevCredentials ? undefined : redirectTo,
         meta: {
+          providerName: 'google',
           skipNonceChecks: skipNonceChecks,
           appType,
+          useDevCredentials,
         },
       });
       onAddClient(resp.client);
@@ -174,28 +209,40 @@ export function AddClientForm({
         label="Client name"
         placeholder={`e.g. google-${appType}`}
       />
-
-      <TextInput
-        tabIndex={2}
-        value={clientId}
-        onChange={setClientId}
-        label={
-          <>
-            Client ID from{' '}
-            <a
-              className="underline"
-              target="_blank"
-              rel="noopener noreferer"
-              href="https://console.developers.google.com/apis/credentials"
-            >
-              Google console
-            </a>
-          </>
-        }
-        placeholder=""
-      />
-
       {appType === 'web' && (
+        <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <Checkbox
+            checked={useDevCredentials}
+            onChange={onChangeUseDevCredentials}
+            label="Use Instant dev credentials"
+          />
+          <DevCredentialsNotice />
+        </div>
+      )}
+
+      {!useDevCredentials && (
+        <TextInput
+          tabIndex={2}
+          value={clientId}
+          onChange={setClientId}
+          label={
+            <>
+              Client ID from{' '}
+              <a
+                className="underline"
+                target="_blank"
+                rel="noopener noreferer"
+                href="https://console.developers.google.com/apis/credentials"
+              >
+                Google console
+              </a>
+            </>
+          }
+          placeholder=""
+        />
+      )}
+
+      {appType === 'web' && !useDevCredentials && (
         <TextInput
           type="sensitive"
           tabIndex={3}
@@ -216,10 +263,10 @@ export function AddClientForm({
           }
         />
       )}
-      {appType === 'web' && (
+      {appType === 'web' && !useDevCredentials && (
         <RedirectUrlInput value={redirectTo} onChange={setRedirectTo} />
       )}
-      {appType === 'web' && (
+      {appType === 'web' && !useDevCredentials && (
         <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
           <p className="overflow-hidden">
             Add{' '}
@@ -363,6 +410,7 @@ export function Client({
   const { darkMode } = useDarkMode();
 
   const didSkipNonceChecks = client.meta?.skipNonceChecks;
+  const usesGoogleDevCredentials = usesDevCredentials(client);
 
   const handleDelete = async () => {
     try {
@@ -481,8 +529,10 @@ function Login() {
             <div className="">App Type: {appTypeLabel(appType)}</div>
 
             <Copyable label="Client name" value={client.client_name} />
-            <Copyable label="Google client ID" value={client.client_id || ''} />
-            {appType === 'web' && (
+            {!usesGoogleDevCredentials && client.client_id ? (
+              <Copyable label="Google client ID" value={client.client_id} />
+            ) : null}
+            {appType === 'web' && !usesGoogleDevCredentials && (
               <EditableRedirectUrl
                 app={app}
                 client={client}
@@ -501,7 +551,35 @@ function Login() {
                 <NonceCheckNotice />
               </div>
             ) : null}
-            {appType === 'web' && (
+            {appType === 'web' && usesGoogleDevCredentials && (
+              <>
+                <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
+                  <Checkbox
+                    checked={true}
+                    onChange={() => {}}
+                    label="Using Instant dev credentials"
+                  />
+                  <DevCredentialsNotice />
+                  <Content className="text-sm text-gray-500 dark:text-neutral-400">
+                    Custom Redirect URL is not supported in this mode. If you
+                    need production domains or a custom redirect URL, delete
+                    this client and create it again with your own Google client
+                    ID and secret.
+                  </Content>
+                </div>
+                <Content>
+                  Use the code below to generate a login link in your app.
+                </Content>
+                <div className="overflow-auto rounded-sm border text-sm dark:border-none">
+                  <Fence
+                    darkMode={darkMode}
+                    code={exampleCode}
+                    language="typescript"
+                  />
+                </div>
+              </>
+            )}
+            {appType === 'web' && !usesGoogleDevCredentials && (
               <>
                 <SubsectionHeading>
                   <a

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -235,13 +235,28 @@
   (-> @config-map :google-oauth-client))
 
 (defn get-google-oauth-client-dev []
-  (let [client-id (or (System/getenv "GOOGLE_OAUTH_CLIENT_ID_DEV")
-                      (-> @config-map :google-oauth-client-dev :client-id))
-        client-secret (or (System/getenv "GOOGLE_OAUTH_CLIENT_SECRET_DEV")
-                          (some-> @config-map
-                                  :google-oauth-client-dev
-                                  :client-secret
-                                  crypt-util/secret-value))]
+  (let [present-value (fn [v]
+                        (when-not (string/blank? v)
+                          v))
+        env-client-id (present-value (System/getenv "GOOGLE_OAUTH_CLIENT_ID_DEV"))
+        env-client-secret (present-value (System/getenv "GOOGLE_OAUTH_CLIENT_SECRET_DEV"))
+        config-client-id (present-value (-> @config-map
+                                            :google-oauth-client-dev
+                                            :client-id))
+        config-client-secret (some-> @config-map
+                                     :google-oauth-client-dev
+                                     :client-secret
+                                     crypt-util/secret-value
+                                     present-value)
+        [client-id client-secret] (cond
+                                    (and env-client-id env-client-secret)
+                                    [env-client-id env-client-secret]
+
+                                    (or env-client-id env-client-secret)
+                                    [nil nil]
+
+                                    :else
+                                    [config-client-id config-client-secret])]
     (when (and client-id client-secret)
       {:client-id client-id
        :client-secret (crypt-util/obfuscate client-secret)})))

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -234,6 +234,18 @@
 (defn get-google-oauth-client []
   (-> @config-map :google-oauth-client))
 
+(defn get-google-oauth-client-dev []
+  (let [client-id (or (System/getenv "GOOGLE_OAUTH_CLIENT_ID_DEV")
+                      (-> @config-map :google-oauth-client-dev :client-id))
+        client-secret (or (System/getenv "GOOGLE_OAUTH_CLIENT_SECRET_DEV")
+                          (some-> @config-map
+                                  :google-oauth-client-dev
+                                  :client-secret
+                                  crypt-util/secret-value))]
+    (when (and client-id client-secret)
+      {:client-id client-id
+       :client-secret (crypt-util/obfuscate client-secret)})))
+
 (def s3-bucket-name
   (case (get-env)
     :prod "instant-storage"

--- a/server/src/instant/config_edn.clj
+++ b/server/src/instant/config_edn.clj
@@ -46,6 +46,7 @@
 (s/def ::honeycomb-api-key ::config-value)
 (s/def ::posthog-api-key ::config-value)
 (s/def ::google-oauth-client ::oauth-client)
+(s/def ::google-oauth-client-dev ::oauth-client)
 (s/def ::instant-config-app-id uuid?)
 (s/def ::kms-key-url string?)
 
@@ -75,6 +76,7 @@
                                  ::honeycomb-api-key
                                  ::posthog-api-key
                                  ::google-oauth-client
+                                 ::google-oauth-client-dev
                                  ::hybrid-keyset]
                         :req-un [::aead-keyset]))
 
@@ -95,6 +97,7 @@
                                       ::google-oauth-client
                                       ::hybrid-keyset]
                              :opt-un [::instant-config-app-id
+                                      ::google-oauth-client-dev
                                       ::next-database-cluster-id]))
 
 (defn config-spec [prod?]

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -601,6 +601,64 @@
 
     (response/ok {:provider (select-keys provider [:id :provider_name :created_at])})))
 
+(defn- meta-value [m k]
+  (or (get m k)
+      (get m (keyword k))))
+
+(def ^:private missing-body-value ::missing-body-value)
+
+(defn- body-value [req k]
+  (let [body (:body req)]
+    (cond
+      (contains? body k) (get body k)
+      (contains? body (name k)) (get body (name k))
+      :else missing-body-value)))
+
+(defn- body-contains? [req k]
+  (not= missing-body-value (body-value req k)))
+
+(defn- get-optional-body-param! [req k coercer]
+  (let [param (body-value req k)]
+    (when-not (= missing-body-value param)
+      (if (nil? param)
+        nil
+        (if-some [coerced (coercer param)]
+          coerced
+          (ex/throw-malformed-param! [:body k] param))))))
+
+(defn- oauth-client-errors [{:keys [provider-name client-id client-secret redirect-to meta]}]
+  (let [use-dev-credentials? (true? (meta-value meta "useDevCredentials"))
+        app-type (meta-value meta "appType")]
+    (concat
+     (when (and use-dev-credentials?
+                (not= "google" provider-name))
+       [{:message "Instant dev credentials are only supported for Google clients."}])
+
+     (when (and use-dev-credentials?
+                (not= "web" app-type))
+       [{:message "Instant dev credentials are only supported for Google web redirect clients."}])
+
+     (when (and use-dev-credentials? redirect-to)
+       [{:message "Custom Redirect URL is not supported when using Instant dev credentials."}])
+
+     (when (and use-dev-credentials? client-id)
+       [{:message "Client ID must be blank when using Instant dev credentials."}])
+
+     (when (and use-dev-credentials? client-secret)
+       [{:message "Client secret must be blank when using Instant dev credentials."}])
+
+     (when (and (= "google" provider-name)
+                (= "web" app-type)
+                (not use-dev-credentials?)
+                (string/blank? client-id))
+       [{:message "Missing client id"}])
+
+     (when (and (= "google" provider-name)
+                (= "web" app-type)
+                (not use-dev-credentials?)
+                (string/blank? client-secret))
+       [{:message "Missing client secret"}]))))
+
 (defn oauth-clients-post [req]
   (let [coerce-optional-param!
         (fn [path]
@@ -610,10 +668,15 @@
 
         {{app-id :id} :app} (req->app-and-user! :collaborator req)
         provider-id (ex/get-param! req [:body :provider_id] uuid-util/coerce)
+        provider (app-oauth-service-provider-model/get-by-id {:app-id app-id
+                                                              :id provider-id})
         client-name (ex/get-param! req [:body :client_name] string-util/coerce-non-blank-str)
         client-id (coerce-optional-param! [:body :client_id])
         client-secret (coerce-optional-param! [:body :client_secret])
-        meta (ex/get-optional-param! req [:body :meta] (fn [x] (when (map? x) x)))
+        meta (ex/get-optional-param! req [:body :meta]
+                                     (fn [x]
+                                       (when (instance? java.util.Map x)
+                                         (into {} x))))
         redirect-to (-> req :body :redirect_to string-util/coerce-non-blank-str)
         _ (when redirect-to
             (ex/assert-valid!
@@ -621,11 +684,22 @@
              redirect-to
              (url-util/redirect-url-validation-errors
               redirect-to :allow-localhost? true)))
-        provider-name (ex/get-optional-param! meta [:providerName] string-util/coerce-non-blank-str)
+        _ (ex/assert-valid!
+           :oauth-client
+           {:provider-name (:provider_name provider)
+            :client-id client-id
+            :client-secret client-secret
+            :redirect-to redirect-to
+            :meta meta}
+           (oauth-client-errors {:provider-name (:provider_name provider)
+                                 :client-id client-id
+                                 :client-secret client-secret
+                                 :redirect-to redirect-to
+                                 :meta meta}))
 
         ;; GitHub doesn't need discovery endpoints
         ;; OIDC providers (Google, LinkedIn, Apple) need discovery endpoints
-        discovery-endpoint (when-not (= "github" provider-name)
+        discovery-endpoint (when-not (= "github" (:provider_name provider))
                              (ex/get-param! req [:body :discovery_endpoint] string-util/coerce-non-blank-str))
 
         client (app-oauth-client-model/create! {:app-id app-id
@@ -642,19 +716,49 @@
 (defn update-oauth-client [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         id (ex/get-param! req [:params :id] uuid-util/coerce)
-        meta (ex/get-optional-param! req [:body :meta] (fn [x] (when (map? x) x)))
-        redirect-to (-> req :body :redirect_to string-util/coerce-non-blank-str)
+        current-client (app-oauth-client-model/get-by-id {:app-id app-id
+                                                          :id id})
+        provider (app-oauth-service-provider-model/get-by-id {:app-id app-id
+                                                              :id (:provider_id current-client)})
+        meta (get-optional-body-param! req :meta
+                                       (fn [x]
+                                         (when (instance? java.util.Map x)
+                                           (into {} x))))
+        redirect-to (get-optional-body-param! req :redirect_to string-util/coerce-non-blank-str)
         _ (when redirect-to
             (ex/assert-valid!
              :redirect_to
              redirect-to
              (url-util/redirect-url-validation-errors
               redirect-to :allow-localhost? true)))
+        merged-meta (cond
+                      (body-contains? req :meta) (merge (:meta current-client) meta)
+                      :else (:meta current-client))
+        _ (ex/assert-valid!
+           :oauth-client
+           {:provider-name (:provider_name provider)
+            :redirect-to redirect-to
+            :meta merged-meta}
+           (concat
+            (when (and (body-contains? req :meta)
+                       (or (app-oauth-client-model/uses-dev-credentials? current-client)
+                           (contains? (or meta {}) "useDevCredentials")
+                           (contains? (or meta {}) :useDevCredentials)
+                           (nil? meta)))
+              [{:message "Delete and recreate the client to change Instant dev credentials mode."}])
+            (oauth-client-errors {:provider-name (:provider_name provider)
+                                  :client-id (:client_id current-client)
+                                  :client-secret (when (:client_secret current-client)
+                                                   "<existing>")
+                                  :redirect-to (if (body-contains? req :redirect_to)
+                                                 redirect-to
+                                                 (:redirect_to current-client))
+                                  :meta merged-meta})))
         params (cond-> {:app-id app-id
                         :id id}
                  ;; Distinguish between null and undefined
-                 (contains? (:body req) :meta) (assoc :meta meta)
-                 (contains? (:body req) :redirect_to) (assoc :redirect-to redirect-to))
+                 (body-contains? req :meta) (assoc :meta meta)
+                 (body-contains? req :redirect_to) (assoc :redirect-to redirect-to))
         client (app-oauth-client-model/update! params)]
     (response/ok {:client (select-keys client [:id :provider_id :client_name
                                                :client_id :created_at :meta :discovery_endpoint])})))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -749,13 +749,14 @@
            :oauth-client
            {:provider-name (:provider_name provider)
             :redirect-to redirect-to
-            :meta merged-meta}
+           :meta merged-meta}
            (concat
             (when (and (body-contains? req :meta)
-                       (or (app-oauth-client-model/uses-dev-credentials? current-client)
-                           (contains? (or meta {}) "useDevCredentials")
+                       (or (contains? (or meta {}) "useDevCredentials")
                            (contains? (or meta {}) :useDevCredentials)
-                           (nil? meta)))
+                           (and (nil? meta)
+                                (app-oauth-client-model/uses-dev-credentials?
+                                 current-client))))
               [{:message "Delete and recreate the client to change Instant dev credentials mode."}])
             (oauth-client-errors {:provider-name (:provider_name provider)
                                   :client-id (:client_id current-client)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -626,7 +626,7 @@
           coerced
           (ex/throw-malformed-param! [:body k] param))))))
 
-(defn- oauth-client-errors [{:keys [provider-name client-id client-secret redirect-to meta]}]
+(defn- oauth-client-errors [{:keys [provider-name client-id client-secret discovery-endpoint redirect-to meta]}]
   (let [use-dev-credentials? (true? (meta-value meta "useDevCredentials"))
         app-type (meta-value meta "appType")]
     (concat
@@ -646,6 +646,12 @@
 
      (when (and use-dev-credentials? client-secret)
        [{:message "Client secret must be blank when using Instant dev credentials."}])
+
+     (when (and use-dev-credentials?
+                (= "google" provider-name)
+                (not= app-oauth-client-model/google-discovery-endpoint
+                      discovery-endpoint))
+       [{:message "Instant dev credentials require Google's default discovery endpoint."}])
 
      (when (and (= "google" provider-name)
                 (= "web" app-type)
@@ -673,6 +679,10 @@
         client-name (ex/get-param! req [:body :client_name] string-util/coerce-non-blank-str)
         client-id (coerce-optional-param! [:body :client_id])
         client-secret (coerce-optional-param! [:body :client_secret])
+        ;; GitHub doesn't need discovery endpoints
+        ;; OIDC providers (Google, LinkedIn, Apple) need discovery endpoints
+        discovery-endpoint (when-not (= "github" (:provider_name provider))
+                             (ex/get-param! req [:body :discovery_endpoint] string-util/coerce-non-blank-str))
         meta (ex/get-optional-param! req [:body :meta]
                                      (fn [x]
                                        (when (instance? java.util.Map x)
@@ -689,18 +699,15 @@
            {:provider-name (:provider_name provider)
             :client-id client-id
             :client-secret client-secret
+            :discovery-endpoint discovery-endpoint
             :redirect-to redirect-to
             :meta meta}
            (oauth-client-errors {:provider-name (:provider_name provider)
                                  :client-id client-id
                                  :client-secret client-secret
+                                 :discovery-endpoint discovery-endpoint
                                  :redirect-to redirect-to
                                  :meta meta}))
-
-        ;; GitHub doesn't need discovery endpoints
-        ;; OIDC providers (Google, LinkedIn, Apple) need discovery endpoints
-        discovery-endpoint (when-not (= "github" (:provider_name provider))
-                             (ex/get-param! req [:body :discovery_endpoint] string-util/coerce-non-blank-str))
 
         client (app-oauth-client-model/create! {:app-id app-id
                                                 :provider-id provider-id
@@ -716,8 +723,12 @@
 (defn update-oauth-client [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         id (ex/get-param! req [:params :id] uuid-util/coerce)
-        current-client (app-oauth-client-model/get-by-id {:app-id app-id
-                                                          :id id})
+        current-client (ex/assert-record!
+                        (app-oauth-client-model/get-by-id {:app-id app-id
+                                                           :id id})
+                        :app-oauth-client
+                        {:app-id app-id
+                         :id id})
         provider (app-oauth-service-provider-model/get-by-id {:app-id app-id
                                                               :id (:provider_id current-client)})
         meta (get-optional-body-param! req :meta
@@ -750,6 +761,7 @@
                                   :client-id (:client_id current-client)
                                   :client-secret (when (:client_secret current-client)
                                                    "<existing>")
+                                  :discovery-endpoint (:discovery_endpoint current-client)
                                   :redirect-to (if (body-contains? req :redirect_to)
                                                  redirect-to
                                                  (:redirect_to current-client))

--- a/server/src/instant/model/app_oauth_client.clj
+++ b/server/src/instant/model/app_oauth_client.clj
@@ -1,6 +1,7 @@
 (ns instant.model.app-oauth-client
   (:require
    [instant.auth.oauth :as oauth]
+   [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
    [instant.system-catalog-ops :refer [query-op update-op]]
    [instant.util.crypt :as crypt-util]
@@ -11,6 +12,24 @@
    (java.util UUID)))
 
 (def etype "$oauthClients")
+
+(def google-discovery-endpoint
+  "https://accounts.google.com/.well-known/openid-configuration")
+
+(defn- meta-value [m k]
+  (or (get m k)
+      (get m (keyword k))))
+
+(defn uses-dev-credentials? [oauth-client]
+  (true? (meta-value (:meta oauth-client) "useDevCredentials")))
+
+(defn google-web-client? [oauth-client]
+  (and (= google-discovery-endpoint (:discovery_endpoint oauth-client))
+       (= "web" (meta-value (:meta oauth-client) "appType"))))
+
+(defn google-managed-dev-client? [oauth-client]
+  (and (uses-dev-credentials? oauth-client)
+       (google-web-client? oauth-client)))
 
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
@@ -121,6 +140,21 @@
 
 (defn ->OAuthClient [oauth-client]
   (cond
+    (google-managed-dev-client? oauth-client)
+    (let [{:keys [client-id client-secret]} (config/get-google-oauth-client-dev)]
+      (when-not (and client-id client-secret)
+        (ex/throw-validation-err!
+         :oauth-client
+         (:id oauth-client)
+         [{:message "Instant dev credentials for Google are not configured on the server."}]))
+      (oauth/generic-oauth-client-from-discovery-url
+       {:app-id (:app_id oauth-client)
+        :provider-id (:provider_id oauth-client)
+        :client-id client-id
+        :client-secret client-secret
+        :discovery-endpoint google-discovery-endpoint
+        :meta (:meta oauth-client)}))
+
     (:discovery_endpoint oauth-client)
     (oauth/generic-oauth-client-from-discovery-url
      {:app-id (:app_id oauth-client)

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -184,6 +184,18 @@
   (when (string/starts-with? v cookie-value-prefix)
     (uuid-util/coerce (subs v (count cookie-value-prefix)))))
 
+(defn- localhost-origin? [redirect-uri]
+  (contains? #{"localhost" "127.0.0.1"}
+             (some-> redirect-uri uri/uri :host)))
+
+(defn- managed-dev-origin? [matched-origin redirect-uri]
+  (case (:service matched-origin)
+    "netlify" true
+    "vercel" true
+    "custom-scheme" true
+    "generic" (localhost-origin? redirect-uri)
+    false))
+
 (defn oauth-start [{{:keys [state code_challenge code_challenge_method]} :params :as req}]
   (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
 
@@ -216,6 +228,18 @@
              :redirect-uri
              redirect-uri
              [{:message "Invalid redirect_uri. If you're the developer, make sure to add your website to the list of approved domains from the Dashboard."}]))
+        _ (when (and (app-oauth-client-model/google-managed-dev-client? client)
+                     (not (managed-dev-origin? matched-origin redirect-uri)))
+            (ex/throw-validation-err!
+             :redirect-uri
+             redirect-uri
+             [{:message "Instant dev credentials for Google only work on localhost, preview URLs, and custom app schemes. Add your own Google client ID and secret for production domains."}]))
+        _ (when (and (app-oauth-client-model/google-managed-dev-client? client)
+                     (:redirect_to client))
+            (ex/throw-validation-err!
+             :redirect-to
+             (:redirect_to client)
+             [{:message "Custom Redirect URL is not supported when using Instant dev credentials."}]))
 
         app-redirect-url
         (if state

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -185,8 +185,12 @@
     (uuid-util/coerce (subs v (count cookie-value-prefix)))))
 
 (defn- localhost-origin? [redirect-uri]
-  (contains? #{"localhost" "127.0.0.1"}
-             (some-> redirect-uri uri/uri :host)))
+  (let [host (some-> redirect-uri
+                     uri/uri
+                     :host
+                     (string/replace #"^\[(.*)\]$" "$1"))]
+    (contains? #{"localhost" "127.0.0.1" "::1"}
+               host)))
 
 (defn- managed-dev-origin? [matched-origin redirect-uri]
   (case (:service matched-origin)

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1109,6 +1109,14 @@
                 (is (= "Client secret must be blank when using Instant dev credentials."
                        (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))
 
+            (testing "managed dev credentials reject non-google discovery endpoints"
+              (let [resp (create-client (assoc managed-dev-body
+                                               :client_name "google-web-discovery"
+                                               :discovery_endpoint "https://example.com/.well-known/openid-configuration"))]
+                (is (= 400 (:status resp)))
+                (is (= "Instant dev credentials require Google's default discovery endpoint."
+                       (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))
+
             (testing "updating an existing client cannot toggle managed dev mode"
               (let [client-id (-> (create-client (assoc managed-dev-body
                                                         :client_name "google-web-update"))
@@ -1123,4 +1131,14 @@
                                      :throw-exceptions false})]
                 (is (= 400 (:status resp)))
                 (is (= "Delete and recreate the client to change Instant dev credentials mode."
-                       (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))))))))
+                       (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))
+
+            (testing "updating a missing client returns record not found"
+              (let [resp (http/post (str config/server-origin
+                                         "/dash/apps/" (:id app) "/oauth_clients/" (random-uuid))
+                                    {:headers headers
+                                     :body (->json {:meta {"theme" "light"}})
+                                     :throw-exceptions false})]
+                (is (= 400 (:status resp)))
+                (is (= "Record not found: app-oauth-client"
+                       (-> resp :body <-json (get "message"))))))))))))

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1133,6 +1133,23 @@
                 (is (= "Delete and recreate the client to change Instant dev credentials mode."
                        (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))
 
+            (testing "managed dev clients can update unrelated meta fields"
+              (let [client-id (-> (create-client (assoc managed-dev-body
+                                                        :client_name "google-web-theme"))
+                                  :body
+                                  <-json
+                                  (get "client")
+                                  (get "id"))
+                    resp (http/post (str config/server-origin
+                                         "/dash/apps/" (:id app) "/oauth_clients/" client-id)
+                                    {:headers headers
+                                     :body (->json {:meta {"theme" "light"}})
+                                     :throw-exceptions false})
+                    client (-> resp :body <-json (get "client"))]
+                (is (= 200 (:status resp)))
+                (is (= true (get-in client ["meta" "useDevCredentials"])))
+                (is (= "light" (get-in client ["meta" "theme"])))))
+
             (testing "updating a missing client returns record not found"
               (let [resp (http/post (str config/server-origin
                                          "/dash/apps/" (:id app) "/oauth_clients/" (random-uuid))

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1057,3 +1057,70 @@
               (is (= 400 (:status resp)))
               (is (= "admin-token-mismatch"
                      (-> resp :body <-json (get "hint") (get "reason")))))))))))
+
+(deftest google-managed-dev-oauth-client-validation
+  (with-user
+    (fn [u]
+      (with-empty-app
+        (:id u)
+        (fn [app]
+          (let [headers {:Authorization (str "Bearer " (:refresh-token u))
+                         :Content-Type "application/json"}
+                provider-resp (http/post (str config/server-origin
+                                              "/dash/apps/" (:id app) "/oauth_service_providers")
+                                         {:headers headers
+                                          :body (->json {:provider_name "google"})
+                                          :throw-exceptions false})
+                provider-id (-> provider-resp :body <-json (get "provider") (get "id"))
+                create-client (fn [body]
+                                (http/post (str config/server-origin
+                                                "/dash/apps/" (:id app) "/oauth_clients")
+                                           {:headers headers
+                                            :body (->json body)
+                                            :throw-exceptions false}))
+                managed-dev-body {:provider_id provider-id
+                                  :client_name "google-web"
+                                  :discovery_endpoint "https://accounts.google.com/.well-known/openid-configuration"
+                                  :meta {"providerName" "google"
+                                         "appType" "web"
+                                         "useDevCredentials" true}}]
+            (is (= 200 (:status provider-resp)))
+
+            (testing "managed dev credentials can create a Google web client without secrets"
+              (let [resp (create-client managed-dev-body)
+                    client (-> resp :body <-json (get "client"))]
+                (is (= 200 (:status resp)))
+                (is (= true (get-in client ["meta" "useDevCredentials"])))
+                (is (= "google-web" (get client "client_name")))))
+
+            (testing "managed dev credentials reject custom redirect urls"
+              (let [resp (create-client (assoc managed-dev-body
+                                               :client_name "google-web-redirect"
+                                               :redirect_to "http://localhost:3000/callback"))]
+                (is (= 400 (:status resp)))
+                (is (= "Custom Redirect URL is not supported when using Instant dev credentials."
+                       (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))
+
+            (testing "managed dev credentials reject custom secrets"
+              (let [resp (create-client (assoc managed-dev-body
+                                               :client_name "google-web-secret"
+                                               :client_secret "should-not-be-set"))]
+                (is (= 400 (:status resp)))
+                (is (= "Client secret must be blank when using Instant dev credentials."
+                       (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))
+
+            (testing "updating an existing client cannot toggle managed dev mode"
+              (let [client-id (-> (create-client (assoc managed-dev-body
+                                                        :client_name "google-web-update"))
+                                  :body
+                                  <-json
+                                  (get "client")
+                                  (get "id"))
+                    resp (http/post (str config/server-origin
+                                         "/dash/apps/" (:id app) "/oauth_clients/" client-id)
+                                    {:headers headers
+                                     :body (->json {:meta {"useDevCredentials" false}})
+                                     :throw-exceptions false})]
+                (is (= 400 (:status resp)))
+                (is (= "Delete and recreate the client to change Instant dev credentials mode."
+                       (-> resp :body <-json (get "hint") (get-in ["errors" 0 "message"]))))))))))))

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -1,6 +1,10 @@
 (ns instant.runtime.routes-test
   (:require
+   [clj-http.client :as clj-http]
+   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
+   [instant.auth.oauth :as oauth]
+   [instant.config :as config]
    [instant.core :as core]
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
@@ -11,6 +15,8 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
+   [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
+   [instant.model.app-oauth-client :as app-oauth-client-model]
    [instant.model.app-oauth-service-provider :as provider-model]
    [instant.model.app-user :as app-user-model]
    [instant.model.rule :as rule-model]
@@ -23,26 +29,70 @@
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [->json <-json]]
    [instant.util.test :as test-util]
-   [instant.util.tracer :as tracer])
+   [instant.util.tracer :as tracer]
+   [lambdaisland.uri :as uri])
   (:import
    (clojure.lang ExceptionInfo)
-   (java.io ByteArrayInputStream)))
+   (java.io ByteArrayInputStream)
+   (java.net URLDecoder)
+   (java.util Base64)))
+
+(defn- build-request [opts]
+  (let [[uri query-string] (string/split (:url opts) #"\?" 2)]
+    (merge-with merge
+                {:headers {"content-type" "application/json"}
+                 :request-method (:method opts)
+                 :uri uri}
+                (cond-> {}
+                  query-string (assoc :query-string query-string)
+                  (:body opts) (assoc :body (ByteArrayInputStream.
+                                             (.getBytes ^String (->json (:body opts))
+                                                        "UTF-8")))
+                  (:headers opts) (assoc :headers (:headers opts))))))
+
+(defn- maybe-json-body [body]
+  (if (string? body)
+    (try
+      (<-json body true)
+      (catch Exception _e
+        body))
+    body))
+
+(defn raw-request [opts]
+  (with-redefs [tracer/*silence-exceptions?* (atom true)]
+    (-> ((core/handler) (build-request opts))
+        (update :body maybe-json-body))))
 
 (defn request [opts]
-  (with-redefs [tracer/*silence-exceptions?* (atom true)]
-    (let [req (merge-with merge
-                          {:headers {"content-type" "application/json"}
-                           :request-method (:method opts)
-                           :uri (:url opts)}
-                          (-> opts
-                              (coll/update-when :body (fn [body]
-                                                        (ByteArrayInputStream. (.getBytes ^String (->json body) "UTF-8"))))))
-          resp (-> ((core/handler) req)
-                   (update :body (fn [body]
-                                   (<-json body true))))]
-      (if (not= 200 (:status resp))
-        (throw (ex-info (str "status " (:status resp)) resp))
-        resp))))
+  (let [resp (raw-request opts)]
+    (if (not= 200 (:status resp))
+      (throw (ex-info (str "status " (:status resp)) resp))
+      resp)))
+
+(defn- parse-query-params [url]
+  (let [query (.getQuery (java.net.URI. url))]
+    (into {}
+          (for [part (remove string/blank? (string/split (or query "") #"&"))
+                :let [[k v] (string/split part #"=" 2)]]
+            [k (URLDecoder/decode (or v "") "UTF-8")]))))
+
+(defn- first-set-cookie [resp]
+  (when-let [header (or (get-in resp [:headers "Set-Cookie"])
+                        (get-in resp [:headers "set-cookie"]))]
+    (let [cookie (if (sequential? header)
+                   (first header)
+                   header)]
+      (first (string/split cookie #";")))))
+
+(defn- base64url-encode [s]
+  (.encodeToString (.withoutPadding (Base64/getUrlEncoder))
+                   (.getBytes ^String s "UTF-8")))
+
+(defn- fake-jwt [payload]
+  (str (base64url-encode (->json {:alg "RS256" :typ "JWT"}))
+       "."
+       (base64url-encode (->json payload))
+       ".signature"))
 
 (defn send-code-runtime [app body]
   (let [letter (atom nil)]
@@ -440,6 +490,109 @@
         (is (not= (:id email-user) (:user_id anon-link)))
         (is (= (:id email-user) (:user_id revealed-link)))))))
 
+(deftest google-managed-dev-oauth-test
+  (with-empty-app
+    (fn [{app-id :id}]
+      (let [provider (provider-model/create! {:app-id app-id
+                                              :provider-name "google"})
+            discovery {:authorization_endpoint "https://accounts.google.com/o/oauth2/v2/auth"
+                       :token_endpoint "https://oauth2.googleapis.com/token"
+                       :jwks_uri "https://www.googleapis.com/oauth2/v3/certs"
+                       :issuer "https://accounts.google.com"
+                       :id_token_signing_alg_values_supported ["RS256"]}]
+        (app-authorized-redirect-origin-model/add! {:app-id app-id
+                                                    :service "generic"
+                                                    :params ["localhost:3000"]})
+        (app-authorized-redirect-origin-model/add! {:app-id app-id
+                                                    :service "generic"
+                                                    :params ["example.com"]})
+
+        (with-redefs [oauth/fetch-discovery (fn [_endpoint]
+                                              {:data discovery})
+                      config/get-google-oauth-client-dev
+                      (fn []
+                        {:client-id "managed-google-client-id"
+                         :client-secret (crypt-util/obfuscate
+                                         "managed-google-client-secret")})
+                      clj-http/post
+                      (fn [url opts]
+                        (is (= "https://oauth2.googleapis.com/token" url))
+                        (is (= "managed-google-client-id"
+                               (get-in opts [:form-params :client_id])))
+                        (is (= "managed-google-client-secret"
+                               (get-in opts [:form-params :client_secret])))
+                        {:status 200
+                         :body {:id_token (fake-jwt
+                                           {:email "google-dev@test.com"
+                                            :email_verified true
+                                            :sub "google-dev-sub"
+                                            :picture "https://example.com/avatar.png"})}})]
+          (let [client-name "google-web"
+                _client (app-oauth-client-model/create!
+                         {:app-id app-id
+                          :provider-id (:id provider)
+                          :client-name client-name
+                          :discovery-endpoint app-oauth-client-model/google-discovery-endpoint
+                          :meta {"appType" "web"
+                                 "providerName" "google"
+                                 "useDevCredentials" true}})]
+
+            (testing "managed dev clients reject production origins"
+              (let [resp (raw-request
+                          {:method :get
+                           :url (str "/runtime/oauth/start?app_id=" app-id
+                                     "&client_name=" client-name
+                                     "&redirect_uri="
+                                     (java.net.URLEncoder/encode
+                                      "https://example.com/callback"
+                                      "UTF-8"))})]
+                (is (= 400 (:status resp)))
+                (is (re-find #"localhost, preview URLs, and custom app schemes"
+                             (str (:body resp))))))
+
+            (testing "managed dev clients complete the redirect flow"
+              (let [start-resp (raw-request
+                                {:method :get
+                                 :url (str "/runtime/oauth/start?app_id=" app-id
+                                           "&client_name=" client-name
+                                           "&redirect_uri="
+                                           (java.net.URLEncoder/encode
+                                            "http://localhost:3000/callback"
+                                            "UTF-8"))})
+                    start-location (get-in start-resp [:headers "Location"])
+                    start-params (parse-query-params start-location)
+                    cookie (first-set-cookie start-resp)
+                    callback-resp (raw-request
+                                   {:method :get
+                                    :url (str "/runtime/oauth/callback?state="
+                                              (get start-params "state")
+                                              "&code=fake-google-code")
+                                    :headers {"cookie" cookie}})
+                    callback-location (get-in callback-resp [:headers "Location"])
+                    callback-params (parse-query-params callback-location)
+                    token-resp (request {:method :post
+                                         :url "/runtime/oauth/token"
+                                         :body {:app_id app-id
+                                                :code (get callback-params "code")}})
+                    user (get-in token-resp [:body :user])]
+                (is (= 302 (:status start-resp)))
+                (is (string/starts-with? start-location
+                                         "https://accounts.google.com/o/oauth2/v2/auth"))
+                (is (= "managed-google-client-id"
+                       (get start-params "client_id")))
+                (is (= route/oauth-redirect-url
+                       (get start-params "redirect_uri")))
+                (is (some? cookie))
+
+                (is (= 302 (:status callback-resp)))
+                (is (= "true" (get callback-params "_instant_oauth_redirect")))
+                (is (string/starts-with? callback-location
+                                         "http://localhost:3000/callback"))
+
+                (is (= "google-dev@test.com" (:email user)))
+                (is (some? (:refresh_token user)))
+                (is (true? (get-in token-resp [:body :created])))))))))))
+
 ;; -----
 ;; Extra fields on signup
 
@@ -796,4 +949,3 @@
                (permissioned-tx/transact!
                 ctx
                 [[:add-triple user-id (:id id-attr) user-id]]))))))))
-

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -29,8 +29,7 @@
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [->json <-json]]
    [instant.util.test :as test-util]
-   [instant.util.tracer :as tracer]
-   [lambdaisland.uri :as uri])
+   [instant.util.tracer :as tracer])
   (:import
    (clojure.lang ExceptionInfo)
    (java.io ByteArrayInputStream)
@@ -505,6 +504,9 @@
                                                     :params ["localhost:3000"]})
         (app-authorized-redirect-origin-model/add! {:app-id app-id
                                                     :service "generic"
+                                                    :params ["[::1]:3000"]})
+        (app-authorized-redirect-origin-model/add! {:app-id app-id
+                                                    :service "generic"
                                                     :params ["example.com"]})
 
         (with-redefs [oauth/fetch-discovery (fn [_endpoint]
@@ -528,6 +530,15 @@
                                             :sub "google-dev-sub"
                                             :picture "https://example.com/avatar.png"})}})]
           (let [client-name "google-web"
+                start-oauth (fn [redirect-uri]
+                              (raw-request
+                               {:method :get
+                                :url (str "/runtime/oauth/start?app_id=" app-id
+                                          "&client_name=" client-name
+                                          "&redirect_uri="
+                                          (java.net.URLEncoder/encode
+                                           redirect-uri
+                                           "UTF-8"))}))
                 _client (app-oauth-client-model/create!
                          {:app-id app-id
                           :provider-id (:id provider)
@@ -538,27 +549,13 @@
                                  "useDevCredentials" true}})]
 
             (testing "managed dev clients reject production origins"
-              (let [resp (raw-request
-                          {:method :get
-                           :url (str "/runtime/oauth/start?app_id=" app-id
-                                     "&client_name=" client-name
-                                     "&redirect_uri="
-                                     (java.net.URLEncoder/encode
-                                      "https://example.com/callback"
-                                      "UTF-8"))})]
+              (let [resp (start-oauth "https://example.com/callback")]
                 (is (= 400 (:status resp)))
                 (is (re-find #"localhost, preview URLs, and custom app schemes"
                              (str (:body resp))))))
 
             (testing "managed dev clients complete the redirect flow"
-              (let [start-resp (raw-request
-                                {:method :get
-                                 :url (str "/runtime/oauth/start?app_id=" app-id
-                                           "&client_name=" client-name
-                                           "&redirect_uri="
-                                           (java.net.URLEncoder/encode
-                                            "http://localhost:3000/callback"
-                                            "UTF-8"))})
+              (let [start-resp (start-oauth "http://localhost:3000/callback")
                     start-location (get-in start-resp [:headers "Location"])
                     start-params (parse-query-params start-location)
                     cookie (first-set-cookie start-resp)
@@ -591,7 +588,17 @@
 
                 (is (= "google-dev@test.com" (:email user)))
                 (is (some? (:refresh_token user)))
-                (is (true? (get-in token-resp [:body :created])))))))))))
+                (is (true? (get-in token-resp [:body :created])))))
+
+            (testing "managed dev clients allow IPv6 localhost origins"
+              (let [start-resp (start-oauth "http://[::1]:3000/callback")
+                    start-location (get-in start-resp [:headers "Location"])
+                    start-params (parse-query-params start-location)]
+                (is (= 302 (:status start-resp)))
+                (is (string/starts-with? start-location
+                                         "https://accounts.google.com/o/oauth2/v2/auth"))
+                (is (= "managed-google-client-id"
+                       (get start-params "client_id")))))))))))
 
 ;; -----
 ;; Extra fields on signup


### PR DESCRIPTION
## Summary

This implements a Clerk-style managed development credential mode for Google OAuth redirect clients.

The core UX is inside the existing Google client form rather than as a separate admin-page action:

- Web Google clients now default to `Use Instant dev credentials`
- When enabled, the dashboard hides custom client ID, client secret, and custom redirect URL inputs
- Existing managed-dev clients render as managed in the dashboard and make the limitation explicit
- Switching an existing client between managed-dev and custom-credential mode is intentionally rejected: delete and recreate instead

## Product / DX shape

The implementation is intentionally narrow.

What is supported:

- Google OAuth `web` redirect clients
- Localhost origins
- Preview origins already modeled by our authorized-origin system (`vercel`, `netlify`)
- Custom app schemes already modeled by our authorized-origin system

What is not supported:

- Google Button / One Tap style clients
- Native Google client types (`ios`, `android`)
- Production web domains on managed credentials
- Custom redirect URLs while managed credentials are enabled
- In-place mutation of an existing client from managed-dev to custom credentials, or vice versa

That scope is deliberate. Google redirect OAuth is a server-mediated flow where shared dev credentials are practical. Google Button / One Tap relies on Google client-side setup and origin registration, so trying to hide that behind shared backend credentials would be misleading and brittle.

## Backend changes

### Config

Added an optional managed-dev Google credential source in server config:

- `GOOGLE_OAUTH_CLIENT_ID_DEV`
- `GOOGLE_OAUTH_CLIENT_SECRET_DEV`
- optional config map fallback under `:google-oauth-client-dev`

### OAuth client resolution

When an OAuth client is:

- provider: Google
- app type: `web`
- `meta.useDevCredentials = true`

we now ignore stored app-specific credentials and instantiate the runtime OAuth client from the server-managed dev credentials plus Google's discovery document.

If the server is missing those managed credentials, we fail with a validation error rather than silently producing a broken flow.

### Dashboard validation

Added explicit validation so that managed-dev mode:

- only works for Google
- only works for Google `web` redirect clients
- requires client ID and secret to be blank
- rejects custom redirect URLs

I also tightened the update path so JSON body handling is robust for string-vs-keyword body keys and so managed-dev mode cannot be toggled in place. The delete-and-recreate requirement is now enforced server-side, not just implied by the UI.

### Runtime validation

At OAuth start time, managed-dev Google clients now reject production-style origins with a clear error. The runtime allows only:

- localhost generic origins
- preview origins matched through existing `vercel` / `netlify` origin types
- custom app schemes

This matters because even if someone manually creates a managed-dev client through the API, they still should not be able to use Instant's shared Google credentials against a production domain.

## Frontend changes

The Google dashboard UI now:

- defaults `web` clients into managed-dev mode
- renders a checkbox to opt out into custom credentials
- hides irrelevant inputs when managed-dev mode is active
- shows a persistent explanation of the scope and limitations
- avoids showing client ID / redirect editing affordances that do not apply to managed-dev clients

This keeps the happy path simple for local development while still letting someone opt into their own production-ready Google credentials from the same form.

## Tests

Added targeted end-to-end-ish server coverage in two places.

### Runtime flow test

`instant.runtime.routes-test/google-managed-dev-oauth-test`

Covers:

- production-origin rejection for managed-dev Google clients
- full `/runtime/oauth/start` -> `/runtime/oauth/callback` -> `/runtime/oauth/token` flow
- token exchange using managed server credentials
- user creation / refresh token issuance

This test stubs Google network edges but exercises the real route flow and state/cookie plumbing.

### Dashboard validation test

`instant.dash.routes-test/google-managed-dev-oauth-client-validation`

Covers:

- creating a managed-dev Google web client without secrets
- rejecting custom redirect URLs in managed-dev mode
- rejecting custom secrets in managed-dev mode
- rejecting in-place managed-dev mode changes on update

## Manual verification

I did not complete a live browser-based Google sign-in against Google's real consent screen in this environment. That would require an interactive browser login. I did verify the full server flow under test coverage and validated the dashboard behavior and server-side guards around the new mode.

## Why this shape

This is the smallest implementation that improves DX without creating an ambiguous production story.

A separate admin button would have made the model harder to reason about. Folding the behavior into the existing Google client form means the object the user creates is still just a Google OAuth client, with one explicit mode switch.

The runtime guard is also important. Without it, managed credentials would be too easy to accidentally carry into production setups.

## Follow-ups I would consider separately

- Apply the same managed-dev pattern to GitHub redirect OAuth if we want parity for another common dev provider
- Add docs copy that explicitly separates Google redirect OAuth from Google Button / One Tap
- Consider whether the dashboard should show a stronger warning badge when a managed-dev client exists alongside production origins
