### PR TITLE
Remove global ISR

### DIFF
--- a/client/www/app/docs/layout.tsx
+++ b/client/www/app/docs/layout.tsx
@@ -1,3 +1,5 @@
+export const revalidate = false;
+
 export default function DocsLayout({
   children,
 }: {

--- a/client/www/app/docs/layout.tsx
+++ b/client/www/app/docs/layout.tsx
@@ -1,5 +1,3 @@
-export const revalidate = false;
-
 export default function DocsLayout({
   children,
 }: {

--- a/client/www/app/layout.tsx
+++ b/client/www/app/layout.tsx
@@ -7,7 +7,6 @@ import { Providers } from './providers';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-
 export const metadata: Metadata = {
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_VERCEL_URL

--- a/client/www/app/layout.tsx
+++ b/client/www/app/layout.tsx
@@ -7,7 +7,6 @@ import { Providers } from './providers';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-export const revalidate = 3600;
 
 export const metadata: Metadata = {
   metadataBase: new URL(


### PR DESCRIPTION
We had revalidate set to 3600 on the app layout, which causes everything in the app router to use ISR. I don't think we need it and it should solve our transient `/docs` 404.

https://instant-www-js-no-docs-revalidate-jsv.vercel.app/docs