### PR TITLE
Create Github OAuth clients from CLI

### DIFF
--- a/client/packages/cli/__tests__/authClientAddGithub.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGithub.test.ts
@@ -199,6 +199,9 @@ describe('success', () => {
     expect(output).toContain(
       'https://api.instantdb.com/runtime/oauth/callback',
     );
+    expect(output).toContain('GitHub OAuth client created: github-web');
+    expect(output).toContain('ID: client-1');
+    expect(output).toContain('GitHub Client ID: Iv1.abc123');
   });
 
   test('with custom-redirect-uri → uses it and prints forwarding instructions', async () => {

--- a/client/packages/cli/__tests__/authClientAddGithub.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGithub.test.ts
@@ -1,0 +1,220 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import { InstantHttpAuthed } from '../src/lib/http.ts';
+
+// -- mocks --
+
+// Prevent src/index.ts side-effect (program.parse) from running.
+// add.ts has `import type` from index.ts, but vitest still evaluates it.
+vi.mock('../src/index.ts', () => ({}));
+
+let prompts: any[] = [];
+let mockPromptReturn: any = '';
+
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: (prompt: any) => {
+      prompts.push(prompt);
+      return Promise.resolve(mockPromptReturn);
+    },
+  };
+});
+
+let addedClients: any[] = [];
+
+vi.mock('../src/lib/oauth.ts', () => ({
+  getAppsAuth: () =>
+    Effect.succeed({
+      oauth_service_providers: [{ id: 'prov-1', provider_name: 'github' }],
+      oauth_clients: [],
+    }),
+  addOAuthProvider: () =>
+    Effect.succeed({
+      provider: { id: 'prov-1', provider_name: 'github' },
+    }),
+  addOAuthClient: (params: any) => {
+    addedClients.push(params);
+    return Effect.succeed({
+      client: {
+        id: 'client-1',
+        client_name: params.clientName,
+        client_id: params.clientId,
+      },
+    });
+  },
+}));
+
+// Lazy import so mocks are in place
+const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');
+
+// -- helpers --
+
+let logs: string[] = [];
+
+const run = (flags: Map<string, string>, { yes }: { yes: boolean }) =>
+  Effect.runPromise(
+    authClientAddCmd(Object.fromEntries(flags) as any).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(GlobalOpts, { yes }),
+          Layer.succeed(CurrentApp, { appId: 'test-app', source: 'env' }),
+          Layer.succeed(InstantHttpAuthed, {} as any),
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => {
+              logs.push(String(message));
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+const without = (flags: Map<string, string>, key: string) => {
+  const copy = new Map(flags);
+  copy.delete(key);
+  return copy;
+};
+
+const withEntry = (flags: Map<string, string>, key: string, value: string) =>
+  new Map([...flags, [key, value]]);
+
+beforeEach(() => {
+  prompts = [];
+  addedClients = [];
+  logs = [];
+  mockPromptReturn = '';
+});
+
+// -- flag sets --
+
+const webFlags = new Map([
+  ['type', 'github'],
+  ['name', 'github-web'],
+  ['client-id', 'Iv1.abc123'],
+  ['client-secret', 'ghs_abc123'],
+]);
+
+// -- --yes: build-up errors on each missing required flag --
+
+describe('--yes errors on each missing required flag', () => {
+  test('missing --type', async () => {
+    await run(without(webFlags, 'type'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --type');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('missing --name', async () => {
+    await run(without(webFlags, 'name'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --name');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('missing --client-id', async () => {
+    await run(without(webFlags, 'client-id'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --client-id');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('missing --client-secret', async () => {
+    await run(without(webFlags, 'client-secret'), { yes: true });
+    expect(logs.join('\n')).toContain(
+      'Missing required value for --client-secret',
+    );
+    expect(addedClients).toHaveLength(0);
+  });
+});
+
+// -- interactive prompts for each missing flag --
+
+describe('interactive prompts for each missing flag', () => {
+  test('missing --type → prompts type selector', async () => {
+    mockPromptReturn = 'github';
+    await run(without(webFlags, 'type'), { yes: false });
+    expect((prompts[0] as any).params.promptText).toBe('Select a client type:');
+  });
+
+  test('missing --name → prompts for name', async () => {
+    mockPromptReturn = 'github-web';
+    await run(without(webFlags, 'name'), { yes: false });
+    expect((prompts[0] as any).props.prompt).toBe('Client Name:');
+  });
+
+  test('missing --client-id → prompts for client id', async () => {
+    mockPromptReturn = 'Iv1.abc123';
+    await run(without(webFlags, 'client-id'), { yes: false });
+    expect((prompts[0] as any).props.prompt).toContain('Client ID');
+    expect((prompts[0] as any).props.prompt).toContain(
+      'github.com/settings/developers',
+    );
+  });
+
+  test('missing --client-secret → prompts for client secret', async () => {
+    mockPromptReturn = 'ghs_abc123';
+    await run(without(webFlags, 'client-secret'), { yes: false });
+    expect((prompts[0] as any).props.prompt).toContain('Client Secret:');
+    expect((prompts[0] as any).props.sensitive).toBe(true);
+  });
+
+  test('custom-redirect-uri → prompts when omitted', async () => {
+    mockPromptReturn = '';
+    await run(webFlags, { yes: false });
+    expect(prompts).toHaveLength(1);
+    expect((prompts[0] as any).props.placeholder).toBe(
+      'https://yoursite.com/oauth/callback',
+    );
+  });
+
+  test('custom-redirect-uri → skipped with --yes', async () => {
+    await run(webFlags, { yes: true });
+    expect(prompts).toHaveLength(0);
+    expect(addedClients).toHaveLength(1);
+  });
+});
+
+// -- success cases --
+
+describe('success', () => {
+  test('all required flags → creates client and prints callback URL', async () => {
+    await run(webFlags, { yes: true });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({
+      clientName: 'github-web',
+      clientId: 'Iv1.abc123',
+      clientSecret: 'ghs_abc123',
+      redirectTo: 'https://api.instantdb.com/runtime/oauth/callback',
+      meta: { providerName: 'github' },
+    });
+    expect(addedClients[0].authorizationEndpoint).toBeUndefined();
+    expect(addedClients[0].tokenEndpoint).toBeUndefined();
+    expect(addedClients[0].discoveryEndpoint).toBeUndefined();
+    const output = logs.join('\n');
+    expect(output).toContain(
+      'Add this callback URL in your GitHub OAuth App settings:',
+    );
+    expect(output).toContain(
+      'https://api.instantdb.com/runtime/oauth/callback',
+    );
+  });
+
+  test('with custom-redirect-uri → uses it and prints forwarding instructions', async () => {
+    await run(
+      withEntry(webFlags, 'custom-redirect-uri', 'https://myapp.com/cb'),
+      { yes: true },
+    );
+    expect(addedClients[0].redirectTo).toBe('https://myapp.com/cb');
+    const output = logs.join('\n');
+    expect(output).toContain(
+      'Add this callback URL in your GitHub OAuth App settings:',
+    );
+    expect(output).toContain('https://myapp.com/cb');
+    expect(output).toContain(
+      'https://api.instantdb.com/runtime/oauth/callback with all query parameters',
+    );
+    expect(output).toContain('https://myapp.com/cb?test-redirect=true');
+  });
+});

--- a/client/packages/cli/__tests__/authClientAddGoogle.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGoogle.test.ts
@@ -211,6 +211,12 @@ describe('web: success', () => {
     expect(output).toContain(
       'https://api.instantdb.com/runtime/oauth/callback',
     );
+    expect(output).toContain('Google OAuth client created: google-web');
+    expect(output).toContain('App type: web');
+    expect(output).toContain('ID: client-1');
+    expect(output).toContain(
+      'Google Client ID: 123456.apps.googleusercontent.com',
+    );
   });
 
   test('with custom-redirect-uri → uses it and prints forwarding instructions', async () => {
@@ -256,6 +262,13 @@ describe('ios', () => {
       clientId: '123456.apps.googleusercontent.com',
     });
     expect(addedClients[0].clientSecret).toBeUndefined();
-    expect(logs.join('\n')).not.toContain('Add this redirect URI');
+    const output = logs.join('\n');
+    expect(output).not.toContain('Add this redirect URI');
+    expect(output).toContain('Google OAuth client created: google-ios');
+    expect(output).toContain('App type: ios');
+    expect(output).toContain('ID: client-1');
+    expect(output).toContain(
+      'Google Client ID: 123456.apps.googleusercontent.com',
+    );
   });
 });

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -239,8 +239,8 @@ ${chalk.dim('Your URI must forward to https://api.instantdb.com/runtime/oauth/ca
       [
         `Google OAuth client created: ${response.client.client_name}`,
         `App type: ${appType}`,
-        `Client database id: ${response.client.id}`,
-        `Google client id: ${response.client.client_id ?? clientId}`,
+        `ID: ${response.client.id}`,
+        `Google Client ID: ${response.client.client_id ?? clientId}`,
         ...redirectMessages,
       ].join('\n'),
       { dimBorder: true, padding: { right: 1, left: 1 } },
@@ -365,8 +365,8 @@ ${chalk.dim('Your URI must forward to https://api.instantdb.com/runtime/oauth/ca
     boxen(
       [
         `GitHub OAuth client created: ${response.client.client_name}`,
-        `Client database id: ${response.client.id}`,
-        `GitHub client id: ${response.client.client_id ?? clientId}`,
+        `ID: ${response.client.id}`,
+        `GitHub Client ID: ${response.client.client_id ?? clientId}`,
         ...redirectMessages,
       ].join('\n'),
       { dimBorder: true, padding: { right: 1, left: 1 } },

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -22,12 +22,11 @@ import {
 import { UI } from '../../../ui/index.ts';
 import chalk from 'chalk';
 import boxen from 'boxen';
-import { redirect } from '@effect/platform/HttpServerResponse';
 
 const ClientTypeSchema = Schema.Literal(
   'google',
+  'github',
   // 'apple',
-  // 'github',
   // 'linkedin',
   // 'clerk',
   // 'firebase',
@@ -249,6 +248,132 @@ ${chalk.dim('Your URI must forward to https://api.instantdb.com/runtime/oauth/ca
   );
 });
 
+const GITHUB_DEFAULT_CALLBACK_URL =
+  'https://api.instantdb.com/runtime/oauth/callback';
+
+const handleGithubClient = Effect.fn(function* (opts: Record<string, unknown>) {
+  const { auth, provider } = yield* getOrCreateProvider('github');
+  const usedClientNames = new Set(
+    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  );
+  const suggestedClientName = findName('github-web', usedClientNames);
+
+  const clientName = yield* optOrPrompt(opts.name, {
+    simpleName: '--name',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'Client Name:',
+      defaultValue: suggestedClientName,
+      placeholder: suggestedClientName,
+      validate: validateRequired,
+      modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
+    },
+  });
+
+  if (usedClientNames.has(clientName || '')) {
+    return yield* BadArgsError.make({
+      message: `The unique name '${clientName}' is already in use.`,
+    });
+  }
+
+  const clientId = yield* optOrPrompt(opts['client-id'], {
+    simpleName: '--client-id',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: `Client ID ${chalk.dim('(from https://github.com/settings/developers)')}`,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+      validate: validateRequired,
+    },
+  });
+
+  const clientSecret = yield* optOrPrompt(opts['client-secret'], {
+    required: true,
+    skipIf: false,
+    simpleName: '--client-secret',
+    prompt: {
+      prompt: `Client Secret: ${chalk.dim('(from https://github.com/settings/developers)')}`,
+      validate: validateRequired,
+      sensitive: true,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  const customRedirectUri = yield* optOrPrompt(opts['custom-redirect-uri'], {
+    required: false,
+    simpleName: '--custom-redirect-uri',
+    skipIf: false,
+    prompt: {
+      prompt: '',
+      placeholder: 'https://yoursite.com/oauth/callback',
+      modifyOutput: UI.modifiers.piped([
+        (output, status) => {
+          if (status === 'idle') {
+            return (
+              `\nCustom redirect URI (optional):
+${chalk.dim('With a custom redirect URI, users will see "Redirecting to yoursite.com..." for a more branded experience.')}
+${chalk.dim('Your URI must forward to https://api.instantdb.com/runtime/oauth/callback with all query parameters preserved.')}\n\n` +
+              stripFirstBlankLine(output)
+            );
+          }
+          return `\nCustom redirect URI (optional):\n${stripFirstBlankLine(output)}`;
+        },
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  if (!clientName) {
+    return yield* BadArgsError.make({ message: 'Client name is required.' });
+  }
+
+  const redirectUri = customRedirectUri || GITHUB_DEFAULT_CALLBACK_URL;
+
+  // The backend infers GitHub's authorization/token endpoints from
+  // meta.providerName === 'github', so we don't pass them here.
+  const response = yield* addOAuthClient({
+    providerId: provider.id,
+    clientName,
+    clientId,
+    clientSecret,
+    redirectTo: redirectUri,
+    meta: { providerName: 'github' },
+  });
+
+  const redirectMessages: string[] = [
+    chalk.bold(
+      `\nAdd this callback URL in your GitHub OAuth App settings:\n${redirectUri}\n`,
+    ),
+  ];
+  if (customRedirectUri) {
+    redirectMessages.push(
+      `Your custom redirect must forward to ${chalk.bold(GITHUB_DEFAULT_CALLBACK_URL)} with all query parameters preserved.`,
+    );
+    redirectMessages.push(
+      `You can test it by visiting: ${chalk.bold(redirectUri + '?test-redirect=true')}`,
+    );
+  }
+
+  yield* Effect.log(
+    boxen(
+      [
+        `GitHub OAuth client created: ${response.client.client_name}`,
+        `Client database id: ${response.client.id}`,
+        `GitHub client id: ${response.client.client_id ?? clientId}`,
+        ...redirectMessages,
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
+});
+
 export const authClientAddCmd = Effect.fn(
   function* (
     opts: OptsFromCommand<typeof authClientAddDef> & Record<string, unknown>,
@@ -265,9 +390,9 @@ export const authClientAddCmd = Effect.fn(
           new UI.Select({
             options: [
               { label: 'Google', value: 'google' },
+              { label: 'GitHub', value: 'github' },
               // TODO: implement
               // { label: 'Apple', value: 'apple' },
-              // { label: 'GitHub', value: 'github' },
               // { label: 'LinkedIn', value: 'linkedin' },
               // { label: 'Clerk', value: 'clerk' },
               // { label: 'Firebase', value: 'firebase' },
@@ -289,9 +414,9 @@ export const authClientAddCmd = Effect.fn(
     yield* Match.value(clientType).pipe(
       Match.withReturnType<Effect.Effect<void, any, any>>(),
       Match.when('google', () => handleGoogleClient(opts)),
+      Match.when('github', () => handleGithubClient(opts)),
       // Match.when('apple', () => Effect.logError('Not Implemented')),
       // Match.when('clerk', () => Effect.logError('Not Implemented')),
-      // Match.when('github', () => Effect.logError('Not Implemented')),
       // Match.when('firebase', () => Effect.logError('Not Implemented')),
       // Match.when('linkedin', () => Effect.logError('Not Implemented')),
       Match.exhaustive,

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -87,7 +87,7 @@ export const authClientAddDef = authClient
   .command('add')
   .allowExcessArguments(true)
   .allowUnknownOption(true)
-  .option('--type <google>', 'Type of oauth client to add')
+  .option('--type <google|github>', 'Type of oauth client to add')
   .option(
     '--name <client name>',
     'Custom name to identify the OAuth client (ex: google-web)',
@@ -105,6 +105,11 @@ Provider Specific Options:
    --client-id
    --client-secret                      (web only)
    --custom-redirect-uri       (optional, web only)
+
+  GitHub:
+   --client-id
+   --client-secret
+   --custom-redirect-uri                  (optional)
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -105,7 +105,6 @@ Provider Specific Options:
    --client-id
    --client-secret                      (web only)
    --custom-redirect-uri       (optional, web only)
-
   GitHub:
    --client-id
    --client-secret

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.6';
+const version = 'v1.0.7';
 
 export { version };


### PR DESCRIPTION
Adds github as a provider for cli auth client commands



Tested commands manually:
```nushell
#@ help
cd ~/testing
do -i {INSTANT_CLI_DEV=true instant-cli auth client add --help}

#@ run it
cd ~/testing
print "SHOULD PASS"
do -i {INSTANT_CLI_DEV=true instant-cli auth client add --type github --name (random chars) --client-id lsjkdfj --client-secret (random chars) --custom-redirect-uri https://www.example/com/redirect --yes}

print "SHOULD FAIL"
do -i {INSTANT_CLI_DEV=true instant-cli auth client add --type github --name (random chars) --client-id lsjkdfj  --yes}
print "SHOULD FAIL"
do -i {INSTANT_CLI_DEV=true instant-cli auth client add  --name (random chars) --yes}

#@ stopas
cd ~/testing
do -i {INSTANT_CLI_DEV=1 instant-cli auth client add --type github --name (random chars) --client-id 1 --client-secret 2}

#@ create then delete
cd ~/testing
let name = random chars;
print "SHOULD PASS"
do -i {INSTANT_CLI_DEV=true instant-cli auth client add --client-secret lskdjfkl --type github --name $name --client-id lsjkdfj --yes}
sleep 1sec
do -i {INSTANT_CLI_DEV=true instant-cli auth client delete --name $name}


#@ delete all auth clients
cd ~/testing
let clients = INSTANT_CLI_DEV=true instant-cli auth client list --json | from json
$clients | each {|client| INSTANT_CLI_DEV=true instant-cli auth client delete --name $client.client_name}
```