### PR TITLE
Fix the algolia index script

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -225,7 +225,7 @@ jobs:
     name: Publish algolia changes
     runs-on: ubuntu-latest
     needs: [ build, detect_changes ]
-    if: github.ref == 'refs/heads/main' && needs.detect_changes.outputs.docs_did_change == 'true'
+    if: needs.detect_changes.outputs.docs_did_change == 'true'
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -263,7 +263,19 @@ jobs:
       env:
         ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
       working-directory: 'client'
-      run: pnpm exec tsx ./www/scripts/index-docs.ts
+      run: |
+        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          pnpm exec tsx ./www/scripts/index-docs.ts
+        else
+          pnpm exec tsx ./www/scripts/index-docs.ts --dry-run
+        fi
+
+    - name: Upload algolia objects
+      if: github.ref != 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: algolia-objects
+        path: client/www/scripts/algolia-objects.json
 
   deploy-remote-mcp:
     name: Deploy remote MCP

--- a/client/www/scripts/index-docs.ts
+++ b/client/www/scripts/index-docs.ts
@@ -127,8 +127,17 @@ function toAlgoliaObjects(pages: PageInfo[]): AlgoliaObject[] {
 function getPageInfos(): PageInfo[] {
   return navigation.flatMap(({ title: groupTitle, links }) => {
     return links.map(({ title: pageTitle, href }) => {
-      const mdPath = href === '/docs' ? '/docs/index' : href;
-      const page = path.join(__dirname, '../pages', mdPath + '.md');
+      const basePath = path.join(__dirname, '..', 'app', href);
+      const candidates = [
+        path.join(basePath, 'page.md'),
+        path.join(basePath, '[[...tab]]', 'page.md'),
+      ];
+      const page = candidates.find((p) => fs.existsSync(p));
+      if (!page) {
+        throw new Error(
+          `Could not find markdown for ${href}. Looked in: ${candidates.join(', ')}`,
+        );
+      }
       const fileContents = fs.readFileSync(page, 'utf8');
       const ast = Markdoc.parse(fileContents);
 


### PR DESCRIPTION
Our docs files moved and the script that indexes our docs for algolia failed.

Updates the script to look in the correct place for docs.

Also runs the script in --dry-run mode on non-main branches to make sure we catch regressions before they make it into main.