### PR TITLE
Fix dashboard log out not logging users out

### DIFF
--- a/client/www/lib/auth.ts
+++ b/client/www/lib/auth.ts
@@ -199,10 +199,19 @@ export async function verifyMagicCode({
   return res;
 }
 
-export async function signOut() {
-  try {
-    const token = _AUTH_INFO.token;
-    if (token) {
+export async function signOut({ navigating = false } = {}) {
+  const token = _AUTH_INFO.token;
+  if (navigating) {
+    // Skip subscriber notification so the current page doesn't flash the Auth
+    // screen before the browser unloads.
+    _AUTH_INFO.token = undefined;
+    _AUTH_INFO.user = undefined;
+    saveAuthInfo(_AUTH_INFO);
+  } else {
+    clearAuthInfo();
+  }
+  if (token) {
+    try {
       await jsonFetch(`${config.apiURI}/dash/signout`, {
         method: 'POST',
         headers: {
@@ -211,11 +220,10 @@ export async function signOut() {
         },
         body: JSON.stringify({}),
       });
+    } catch (e) {
+      console.error('Error signing out', e);
     }
-  } catch (e) {
-    console.error('Error signing out', e);
   }
-  clearAuthInfo();
 }
 
 // ---------

--- a/client/www/pages/dash/user-settings.tsx
+++ b/client/www/pages/dash/user-settings.tsx
@@ -41,12 +41,8 @@ const UserSettingsPage: NextPageWithLayout = () => {
           </div>
           <Button
             onClick={() => {
+              signOut({ navigating: true });
               router.push('/');
-              // delay sign out to allow the router to change the page
-              // and avoid a flash of the unauthenticated dashboard
-              setTimeout(() => {
-                signOut();
-              }, 150);
             }}
             variant="destructive"
           >


### PR DESCRIPTION
Clicking Log Out in `dash/user-settings` navigated to `/` but left the user logged in. The home page is in the App Router (`app/page.tsx`), while `dash/user-settings` is in the Pages Router, so `router.push('/')` does a hard navigation between them. The old handler was:

```ts
router.push('/');
setTimeout(() => signOut(), 150);
```

The hard nav tore down the JS context before the 150ms timeout fired, so `signOut` never ran. The token stayed in localStorage, the `loggedIn` cookie stayed at `1`, and `/dash/signout` was never called.

### Fix

Two changes:

1. `lib/auth.ts`: `signOut()` clears `_AUTH_INFO` + localStorage + cookie *before* awaiting the API call. Previously it only cleared after the `await`, which doesn't help if the JS context dies mid-flight.
2. `pages/dash/user-settings.tsx`: dropped the `setTimeout`. Now calls `signOut({ navigating: true })` then `router.push('/')`. The `navigating: true` option clears state but skips notifying React subscribers, so the dashboard keeps rendering until the browser unloads, avoiding a flash of the Auth screen.

### Why it works

Local state is cleared synchronously before navigation, so even if the hard nav kills the in-flight `/dash/signout` request, the client is already logged out. The new page boots from empty localStorage. Skipping subscriber notification preserves the outgoing view in the tiny window before unload.

### Test

- Click Log Out from `/dash/user-settings`, verify you land on `/` and `/dash` now shows the login screen.
- Verify no flash of the Auth screen during the transition.
- Verify server `instant_user_refresh_tokens` row for the token is deleted.