### PR TITLE
Return a 401 when the token is bad

### DIFF
--- a/server/src/instant/model/instant_user.clj
+++ b/server/src/instant/model/instant_user.clj
@@ -122,7 +122,7 @@
      refresh-token])))
 
 (defn get-by-refresh-token! [params]
-  (ex/assert-record! (get-by-refresh-token params) :instant-user {}))
+  (ex/assert-record! (get-by-refresh-token params) :instant-user {:args [params]}))
 
 (defn get-by-personal-access-token
   ([params] (get-by-personal-access-token (aurora/conn-pool :read) params))

--- a/server/src/instant/model/instant_user.clj
+++ b/server/src/instant/model/instant_user.clj
@@ -122,7 +122,7 @@
      refresh-token])))
 
 (defn get-by-refresh-token! [params]
-  (ex/assert-record! (get-by-refresh-token params) :instant-user {:args [params]}))
+  (ex/assert-record! (get-by-refresh-token params) :instant-user {:args [(select-keys params [:auth?])]}))
 
 (defn get-by-personal-access-token
   ([params] (get-by-personal-access-token (aurora/conn-pool :read) params))


### PR DESCRIPTION
This fixes a bug where we would show "instant-user not found" on the homepage if the token was deleted on the server but not the client.

The client will delete the token if it gets a 401, but we were sending a 400. On the server, we rely on seeing `:auth? true` in the `args` hint to know that we should return a 401. That wasn't getting passed through. With this change, it gets passed through, we return a 401, and the user gets redirected to login instead of seeing an error page.