### PR TITLE
add clerk clients

### DIFF
--- a/client/packages/cli/__tests__/authClientAddClerk.test.ts
+++ b/client/packages/cli/__tests__/authClientAddClerk.test.ts
@@ -1,0 +1,104 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { NodeContext } from '@effect/platform-node';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import { InstantHttpAuthed } from '../src/lib/http.ts';
+
+// -- mocks --
+
+// Prevent src/index.ts side-effect (program.parse) from running.
+// add.ts has `import type` from index.ts, but vitest still evaluates it.
+vi.mock('../src/index.ts', () => ({}));
+
+let prompts: any[] = [];
+let mockPromptReturn: any = '';
+
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: (prompt: any) => {
+      prompts.push(prompt);
+      return Promise.resolve(mockPromptReturn);
+    },
+  };
+});
+
+let addedClients: any[] = [];
+
+vi.mock('../src/lib/oauth.ts', () => ({
+  getAppsAuth: () =>
+    Effect.succeed({
+      oauth_service_providers: [{ id: 'prov-1', provider_name: 'clerk' }],
+      oauth_clients: [],
+    }),
+  addOAuthProvider: () =>
+    Effect.succeed({
+      provider: { id: 'prov-1', provider_name: 'clerk' },
+    }),
+  addOAuthClient: (params: any) => {
+    addedClients.push(params);
+    return Effect.succeed({
+      client: {
+        id: 'client-1',
+        client_name: params.clientName,
+        client_id: params.clientId,
+      },
+    });
+  },
+}));
+
+// Lazy import so mocks are in place
+const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');
+// -- helpers --
+
+let logs: string[] = [];
+
+const run = (flags: Map<string, string>, { yes }: { yes: boolean }) =>
+  Effect.runPromise(
+    authClientAddCmd(Object.fromEntries(flags) as any).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(GlobalOpts, { yes }),
+          Layer.succeed(CurrentApp, { appId: 'test-app', source: 'env' }),
+          Layer.succeed(InstantHttpAuthed, {} as any),
+          // Provides FileSystem (required by the Apple handler).
+          NodeContext.layer,
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => {
+              logs.push(String(message));
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+const without = (flags: Map<string, string>, key: string) => {
+  const copy = new Map(flags);
+  copy.delete(key);
+  return copy;
+};
+
+const withEntry = (flags: Map<string, string>, key: string, value: string) =>
+  new Map([...flags, [key, value]]);
+
+beforeEach(() => {
+  prompts = [];
+  addedClients = [];
+  logs = [];
+  mockPromptReturn = '';
+});
+
+// -- flag sets --
+//
+const webFlags = new Map([
+  ['type', 'clerk'],
+  ['name', 'clerk-web'],
+  [
+    'publishable-key',
+    'pk_test_Z3VpZGluZy1wZWdhc3VzLTkzLmNsZXJrLmFjY291bnRzLmRldiQ',
+  ],
+]);

--- a/client/packages/cli/__tests__/authClientAddClerk.test.ts
+++ b/client/packages/cli/__tests__/authClientAddClerk.test.ts
@@ -27,16 +27,23 @@ vi.mock('../src/ui/lib.ts', async (importOriginal) => {
 
 let addedClients: any[] = [];
 
+let addedProviders: any[] = [];
+let mockHasExistingProvider = true;
+
 vi.mock('../src/lib/oauth.ts', () => ({
   getAppsAuth: () =>
     Effect.succeed({
-      oauth_service_providers: [{ id: 'prov-1', provider_name: 'clerk' }],
+      oauth_service_providers: mockHasExistingProvider
+        ? [{ id: 'prov-1', provider_name: 'clerk' }]
+        : [],
       oauth_clients: [],
     }),
-  addOAuthProvider: () =>
-    Effect.succeed({
-      provider: { id: 'prov-1', provider_name: 'clerk' },
-    }),
+  addOAuthProvider: (params: any) => {
+    addedProviders.push(params);
+    return Effect.succeed({
+      provider: { id: 'prov-new', provider_name: 'clerk' },
+    });
+  },
   addOAuthClient: (params: any) => {
     addedClients.push(params);
     return Effect.succeed({
@@ -44,6 +51,7 @@ vi.mock('../src/lib/oauth.ts', () => ({
         id: 'client-1',
         client_name: params.clientName,
         client_id: params.clientId,
+        discovery_endpoint: params.discoveryEndpoint,
       },
     });
   },
@@ -88,12 +96,14 @@ const withEntry = (flags: Map<string, string>, key: string, value: string) =>
 beforeEach(() => {
   prompts = [];
   addedClients = [];
+  addedProviders = [];
   logs = [];
   mockPromptReturn = '';
+  mockHasExistingProvider = true;
 });
 
 // -- flag sets --
-//
+
 const webFlags = new Map([
   ['type', 'clerk'],
   ['name', 'clerk-web'],
@@ -102,3 +112,107 @@ const webFlags = new Map([
     'pk_test_Z3VpZGluZy1wZWdhc3VzLTkzLmNsZXJrLmFjY291bnRzLmRldiQ',
   ],
 ]);
+
+// -- --yes: build-up errors on each missing required flag --
+
+describe('--yes errors on each missing required flag', () => {
+  test('missing --type', async () => {
+    await run(without(webFlags, 'type'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --type');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('missing --name', async () => {
+    await run(without(webFlags, 'name'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --name');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('missing --publishable-key', async () => {
+    await run(without(webFlags, 'publishable-key'), { yes: true });
+    expect(logs.join('\n')).toContain(
+      'Missing required value for --publishable-key',
+    );
+    expect(addedClients).toHaveLength(0);
+  });
+});
+
+// -- interactive prompts for each missing flag --
+
+describe('interactive prompts for each missing flag', () => {
+  test('missing --type → prompts type selector', async () => {
+    mockPromptReturn = 'clerk';
+    await run(without(webFlags, 'type'), { yes: false });
+    expect((prompts[0] as any).params.promptText).toBe('Select a client type:');
+  });
+
+  test('missing --name → prompts for name', async () => {
+    mockPromptReturn = 'clerk-web';
+    await run(without(webFlags, 'name'), { yes: false });
+    expect((prompts[0] as any).props.prompt).toBe('Client Name:');
+  });
+
+  test('missing --publishable-key → prompts for publishable key', async () => {
+    mockPromptReturn =
+      'pk_test_Z3VpZGluZy1wZWdhc3VzLTkzLmNsZXJrLmFjY291bnRzLmRldiQ';
+    await run(without(webFlags, 'publishable-key'), { yes: false });
+    expect((prompts[0] as any).props.prompt).toMatch(
+      /^Clerk publishable key.*https:\/\/dashboard\.clerk\.com/,
+    );
+  });
+});
+
+// -- provider creation --
+
+describe('provider creation', () => {
+  test('creates provider when none exists', async () => {
+    mockHasExistingProvider = false;
+    await run(webFlags, { yes: true });
+    expect(addedProviders).toHaveLength(1);
+    expect(addedProviders[0]).toMatchObject({ providerName: 'clerk' });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0].providerId).toBe('prov-new');
+  });
+
+  test('reuses existing provider', async () => {
+    mockHasExistingProvider = true;
+    await run(webFlags, { yes: true });
+    expect(addedProviders).toHaveLength(0);
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0].providerId).toBe('prov-1');
+  });
+});
+
+// -- success cases --
+
+describe('success', () => {
+  test('all required flags → creates client with correct discovery endpoint', async () => {
+    await run(webFlags, { yes: true });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({
+      clientName: 'clerk-web',
+      discoveryEndpoint:
+        'https://guiding-pegasus-93.clerk.accounts.dev/.well-known/openid-configuration',
+      meta: {
+        clerkPublishableKey:
+          'pk_test_Z3VpZGluZy1wZWdhc3VzLTkzLmNsZXJrLmFjY291bnRzLmRldiQ',
+      },
+    });
+    const output = logs.join('\n');
+    expect(output).toContain('Clerk OAuth client created: clerk-web');
+    expect(output).toContain('ID: client-1');
+    expect(output).toContain(
+      'Clerk Domain: https://guiding-pegasus-93.clerk.accounts.dev',
+    );
+  });
+
+  test('logs session token claim instructions', async () => {
+    await run(webFlags, { yes: true });
+    const output = logs.join('\n');
+    expect(output).toContain('Navigate to your Clerk dashboard');
+    expect(output).toContain('Sessions page');
+    expect(output).toContain('Customize session token');
+    expect(output).toContain('"email": "{{user.primary_email_address}}"');
+    expect(output).toContain('"email_verified": "{{user.email_verified}}"');
+  });
+});

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -796,6 +796,11 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
   }
 
   const domain = domainFromClerkKey(publishableKey);
+  if (!domain) {
+    return yield* BadArgsError.make({
+      message: 'Invalid publishable key. Could not extract domain.',
+    });
+  }
 
   // The backend infers GitHub's authorization/token endpoints from
   // meta.providerName === 'github', so we don't pass them here.
@@ -816,7 +821,7 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
       [
         `Clerk OAuth client created: ${response.client.client_name}`,
         `ID: ${response.client.id}`,
-        `Clerk Publishable Key: ${response.client.meta.clerkPublishableKey}`,
+        `Clerk Publishable Key: ${response.client.meta?.clerkPublishableKey}`,
         `Clerk Domain: ${clerkDomain}`,
       ].join('\n'),
       { dimBorder: true, padding: { right: 1, left: 1 } },

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -769,6 +769,8 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
     skipIf: false,
     prompt: {
       prompt: `Clerk publishable key ${chalk.dim('(from https://dashboard.clerk.com/last-active?path=api-keys)')}`,
+      placeholder:
+        'pk_********************************************************',
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
         UI.modifiers.dimOnComplete,
@@ -814,6 +816,7 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
       [
         `Clerk OAuth client created: ${response.client.client_name}`,
         `ID: ${response.client.id}`,
+        `Clerk Publishable Key: ${response.client.meta.clerkPublishableKey}`,
         `Clerk Domain: ${clerkDomain}`,
       ].join('\n'),
       { dimBorder: true, padding: { right: 1, left: 1 } },

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -802,8 +802,6 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
     });
   }
 
-  // The backend infers GitHub's authorization/token endpoints from
-  // meta.providerName === 'github', so we don't pass them here.
   const response = yield* addOAuthClient({
     providerId: provider.id,
     clientName,

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -830,14 +830,12 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
 
   yield* Effect.log(
     '\nNavigate to your Clerk dashboard. On the Sessions page, click the Edit button in the Customize session token section.\nEnsure your Claims field has the email claim:\n' +
-      chalk.bgBlack.white(
-        boxen(
-          `{
+      boxen(
+        `{
   "email": "{{user.primary_email_address}}",
   "email_verified": "{{user.email_verified}}"
 }`,
-          { borderStyle: 'none' },
-        ),
+        { borderStyle: 'none' },
       ),
   );
 });

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -36,7 +36,7 @@ const ClientTypeSchema = Schema.Literal(
   'github',
   'apple',
   'linkedin',
-  // 'clerk',
+  'clerk',
   // 'firebase',
 );
 
@@ -734,6 +734,106 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
   );
 });
 
+const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
+  const { auth, provider } = yield* getOrCreateProvider('clerk');
+  const usedClientNames = new Set(
+    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  );
+  const suggestedClientName = findName('clerk-web', usedClientNames);
+
+  const clientName = yield* optOrPrompt(opts.name, {
+    simpleName: '--name',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'Client Name:',
+      defaultValue: suggestedClientName,
+      placeholder: suggestedClientName,
+      validate: validateRequired,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  if (usedClientNames.has(clientName || '')) {
+    return yield* BadArgsError.make({
+      message: `The unique name '${clientName}' is already in use.`,
+    });
+  }
+
+  const publishableKey = yield* optOrPrompt(opts['publishable-key'], {
+    simpleName: '--publishable-key',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: `Clerk publishable key ${chalk.dim('(from https://dashboard.clerk.com/last-active?path=api-keys)')}`,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+      validate: (val) => {
+        if (!val) {
+          return 'Publishable key is required';
+        }
+        if (!val.startsWith('pk_')) {
+          return 'Invalid publishable key. It should start with "pk_".';
+        }
+      },
+    },
+  });
+
+  if (!clientName) {
+    return yield* BadArgsError.make({ message: 'Client name is required.' });
+  }
+  if (!publishableKey) {
+    return yield* BadArgsError.make({
+      message: 'Publishable key is required.',
+    });
+  }
+
+  const domain = domainFromClerkKey(publishableKey);
+
+  // The backend infers GitHub's authorization/token endpoints from
+  // meta.providerName === 'github', so we don't pass them here.
+  const response = yield* addOAuthClient({
+    providerId: provider.id,
+    clientName,
+    discoveryEndpoint: `https://${domain}/.well-known/openid-configuration`,
+    meta: { clerkPublishableKey: publishableKey },
+  });
+
+  const clerkDomain = response.client.discovery_endpoint?.replace(
+    '/.well-known/openid-configuration',
+    '',
+  );
+
+  yield* Effect.log(
+    boxen(
+      [
+        `Clerk OAuth client created: ${response.client.client_name}`,
+        `ID: ${response.client.id}`,
+        `Clerk Domain: ${clerkDomain}`,
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
+
+  yield* Effect.log(
+    '\nNavigate to your Clerk dashboard. On the Sessions page, click the Edit button in the Customize session token section.\nEnsure your Claims field has the email claim:\n' +
+      chalk.bgBlack.white(
+        boxen(
+          `{
+  "email": "{{user.primary_email_address}}",
+  "email_verified": "{{user.email_verified}}"
+}`,
+          { borderStyle: 'none' },
+        ),
+      ),
+  );
+});
+
 export const authClientAddCmd = Effect.fn(
   function* (
     opts: OptsFromCommand<typeof authClientAddDef> & Record<string, unknown>,
@@ -753,8 +853,8 @@ export const authClientAddCmd = Effect.fn(
               { label: 'GitHub', value: 'github' },
               { label: 'Apple', value: 'apple' },
               { label: 'LinkedIn', value: 'linkedin' },
+              { label: 'Clerk', value: 'clerk' },
               // TODO: implement
-              // { label: 'Clerk', value: 'clerk' },
               // { label: 'Firebase', value: 'firebase' },
             ],
             promptText: 'Select a client type:',
@@ -776,7 +876,7 @@ export const authClientAddCmd = Effect.fn(
       Match.when('github', () => handleGithubClient(opts)),
       Match.when('apple', () => handleAppleClient(opts)),
       Match.when('linkedin', () => handleLinkedInClient(opts)),
-      // Match.when('clerk', () => Effect.logError('Not Implemented')),
+      Match.when('clerk', () => handleClerkClient(opts)),
       // Match.when('firebase', () => Effect.logError('Not Implemented')),
       Match.exhaustive,
     );
@@ -792,3 +892,28 @@ export const authClientAddCmd = Effect.fn(
     }),
   ),
 );
+
+function domainFromClerkKey(key: string): string | null {
+  try {
+    const parts = key.split('_');
+    const domainPartB64 = parts[parts.length - 1];
+    const domainPart = base64Decode(domainPartB64);
+    return domainPart.replace('$', '');
+  } catch (e) {
+    console.error('Error getting domain from clerk key', e);
+    return null;
+  }
+}
+
+// Base64 decode, switching to url-safe decode if we hit an error
+// Can't be sure which method Clerk uses because you can't generate
+// `+` or `/` with characters that go in a normal host. Urls with
+// chinese characters exist, they might encode to `+` or `/`, and
+// Clerk might support them, so we'll be safe and do both.
+function base64Decode(s: string) {
+  try {
+    return Buffer.from(s, 'base64').toString('utf-8');
+  } catch (e) {
+    return Buffer.from(s, 'base64url').toString('utf-8');
+  }
+}

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -122,6 +122,8 @@ Provider Specific Options:
    --client-id
    --client-secret
    --custom-redirect-uri      (optional)
+  Clerk:
+   --publishable-key
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -123,7 +123,7 @@ Provider Specific Options:
    --client-secret
    --custom-redirect-uri      (optional)
   Clerk:
-   --publishable-key
+   --publishable-key    (Publishable Key from dashboard.clerk.com)
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/layer.ts
+++ b/client/packages/cli/src/layer.ts
@@ -16,6 +16,7 @@ import {
   InstantHttpLive,
 } from './lib/http.ts';
 import { SimpleLogLayer } from './logging.ts';
+import { RequestError } from '@effect/platform/HttpClientError';
 
 const runtime = ManagedRuntime.make(SimpleLogLayer);
 
@@ -38,6 +39,13 @@ export const printRedErrors = Effect.catchAllCause((cause) =>
       failure.value instanceof UnknownException
         ? failure.value.error
         : failure.value;
+
+    // Simplify "can't connect to url errors" instead of printing
+    // crazy stack trace
+    if (theError instanceof RequestError) {
+      yield* Effect.logError(theError.toString());
+      return process.exit(1);
+    }
 
     // Special error handling for specific error types
     if (theError instanceof InstantHttpError) {

--- a/client/packages/cli/src/lib/ui.ts
+++ b/client/packages/cli/src/lib/ui.ts
@@ -31,7 +31,10 @@ export const promptOk = Effect.fn('promptOk')(function* (
 export const runUIEffect = <P>(prompt: Prompt<P>) =>
   Effect.tryPromise({
     try: () => renderUnwrap(prompt),
-    catch: (error) => new UIError({ message: 'UI Error', cause: error }),
+    catch: (error) =>
+      new UIError({
+        message: error instanceof Error ? error.message : String(error),
+      }),
   });
 
 export const invalidFlagError = (flag: string, message: string) =>

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.14';
+const version = 'v1.0.15';
 
 export { version };


### PR DESCRIPTION
Adds an option to enable clerk oauth in the cli.
 - Adds tests for adding clerk via cli
 - Cleans up error message for when backend can't be reached. 
 - Passes through TUI lib error messages better ex: "UI Error" -> "User canceled prompt"


```zsh
#!/usr/bin/env zsh
cd sandbox/cli-nodejs

export INSTANT_CLI_DEV=true

# should show clerk specific flags
pnpm exec instant-cli auth client add --help

# Should fail without proper info
pnpm exec instant-cli auth client add -y
pnpm exec instant-cli auth client add --type clerk -y
pnpm exec instant-cli auth client add --type clerk --name clerk-app-9 -y

# Should work
pnpm exec instant-cli auth client add --type clerk --name clerk-app-9 --publishable-key "pk_test_Z3VpZGluZy1wZWdhc3VzLTkzLmNsZXJrLmFjY291bnRzLmRldiQ"

# Should work as expected
pnpm exec instant-cli auth client add
```