### PR TITLE
Prepare wal records for serialization

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -334,10 +334,10 @@
         (ensure-attrs-on-system-catalog-app))
       (with-log-init :reactive-store
         (rs/start))
-      (with-log-init :ephemeral
-        (eph/start))
       (with-log-init :grpc-server
         (grpc-server/start-global))
+      (with-log-init :ephemeral
+        (eph/start))
       (with-log-init :stripe
         (stripe/init))
       (with-log-init :session

--- a/server/src/instant/grpc.clj
+++ b/server/src/instant/grpc.clj
@@ -10,7 +10,6 @@
    (java.io ByteArrayInputStream DataInputStream)
    (java.time Instant)
    (java.util UUID)
-   (java.util.concurrent Executors)
    (org.postgresql.replication LogSequenceNumber)))
 
 ;; These defrecords are used to transfer messages between machines.

--- a/server/src/instant/grpc.clj
+++ b/server/src/instant/grpc.clj
@@ -1,33 +1,52 @@
 (ns instant.grpc
   (:require
    [clojure.set]
+   [instant.isn]
+   [instant.util.defrecord :refer [defrecord-once]]
    [taoensso.nippy :as nippy])
   (:import
+   (instant.isn ISN)
    (io.grpc MethodDescriptor MethodDescriptor$Marshaller MethodDescriptor$MethodType)
    (java.io ByteArrayInputStream DataInputStream)
-   (java.util UUID)))
+   (java.time Instant)
+   (java.util UUID)
+   (java.util.concurrent Executors)
+   (org.postgresql.replication LogSequenceNumber)))
 
 ;; These defrecords are used to transfer messages between machines.
 ;; If you need to change anything or add new ones, you must do a 2-phase deploy.
 ;; Also update the encoders in instant.nippy
 
-(defrecord StreamRequest [^UUID app-id ^UUID stream-id ^long offset])
+(defrecord-once StreamRequest [^UUID app-id ^UUID stream-id ^long offset])
 
-(defrecord StreamFile [^UUID id ^String location-id ^long size])
+(defrecord-once StreamFile [^UUID id ^String location-id ^long size])
 
-(defrecord StreamInit [^long offset files chunks])
+(defrecord-once StreamInit [^long offset files chunks])
 
-(defrecord StreamContent [^long offset chunks])
+(defrecord-once StreamContent [^long offset chunks])
 
-(defrecord StreamComplete [])
-(defrecord StreamAborted [^String abort-reason])
+(defrecord-once StreamComplete [])
+(defrecord-once StreamAborted [^String abort-reason])
 
 ;; Stream errors take a single keyword to indicate the error type
 ;; make sure to add the key to the stream-error-map so that nippy
 ;; can serialize/deserialize it
 
-(defrecord StreamError [error])
+(defrecord-once StreamError [error])
 
+
+(defrecord-once WalRecord [^UUID app-id
+                           ^long tx-id
+                           ^ISN isn
+                           ^ISN previous-isn
+                           ^Instant tx-created-at
+                           ^long tx-bytes
+                           ^LogSequenceNumber nextlsn
+                           attr-changes
+                           ident-changes
+                           triple-changes
+                           messages
+                           wal-logs])
 (def stream-error-map
   {:unknown -1
    :rate-limit 1
@@ -48,7 +67,6 @@
 (def nippy-marshaller
   (reify MethodDescriptor$Marshaller
     (stream [_ value]
-      value
       (ByteArrayInputStream. (nippy/fast-freeze value)))
     (parse [_ stream]
       (nippy/thaw-from-in! (DataInputStream. stream)))))

--- a/server/src/instant/isn.clj
+++ b/server/src/instant/isn.clj
@@ -23,7 +23,16 @@
    (java.util.concurrent.atomic AtomicReference)
    (org.postgresql.replication LogSequenceNumber)))
 
+(defprotocol ISNProto
+  (lsn [this])
+  (slotNum [this]))
+
 (deftype ISN [^Integer slot-num ^LogSequenceNumber lsn]
+  ISNProto
+  (lsn [_]
+    lsn)
+  (slotNum [_]
+    slot-num)
   Comparable
   (compareTo [_ other]
     (let [other ^ISN other]
@@ -62,11 +71,27 @@
 (defn get-max-seen-isn ^ISN []
   (.get ^AtomicReference -max-seen-isn))
 
-(defn isn-max [^ISN a ^ISN b]
-  (case (compare a b)
-    0 a
-    -1 b
-    1 a))
+(defn isn-max
+  ([^ISN a]
+   a)
+  ([^ISN a ^ISN b]
+   (case (compare a b)
+     0 a
+     -1 b
+     1 a))
+  ([^ISN a ^ISN b & more]
+   (reduce isn-max (isn-max a b) more)))
+
+(defn isn-min
+  ([^ISN a]
+   a)
+  ([^ISN a ^ISN b]
+   (case (compare a b)
+     0 a
+     -1 a
+     1 b))
+  ([^ISN a ^ISN b & more]
+   (reduce isn-min (isn-min a b) more)))
 
 (defn test-isn
   "Generates an isn. (test-isn i) will be less than (test-isn (inc i))"

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -35,6 +35,7 @@
    [instant.jdbc.cache-evict :as cache-evict]
    [instant.jdbc.pgerrors :as pgerrors]
    [instant.jdbc.sql :as sql]
+   [instant.jdbc.wal-entry :as wal-entry]
    [instant.util.async :as ua]
    [instant.util.json :refer [<-json-big]]
    [instant.util.lang :as lang]
@@ -199,7 +200,8 @@
 (defn ensure-slot [db-config slot-name]
   (with-open [conn (get-pg-replication-conn db-config)]
     (try
-      (create-slot-with-snapshot! conn slot-name "wal2json")
+      (when-not (get-logical-replication-slot conn slot-name)
+        (create-slot-with-snapshot! conn slot-name "wal2json"))
       (catch PSQLException e
         (when (not= :duplicate-object (:condition (pgerrors/extract-data e)))
           (throw e))))))
@@ -328,18 +330,22 @@
                         :attributes {:action action}}
       action)))
 
+(def use-wal-entry? (not (config/prod?)))
+
 (defn- wal-buffer->record
   "PGReplicationStream returns a ByteBuffer. This
    function converts it to a clojure map."
   [^ByteBuffer buffer]
-  (let [src (.array buffer)
-        offset (.arrayOffset buffer)
-        record-len (- (count src) offset)
-        json-str (String. src offset record-len)
-        record (<-json-big json-str true)]
-    (-> record
-        (update :action kw-action)
-        (assoc :tx-bytes record-len))))
+  (if use-wal-entry?
+    (wal-entry/parse-buffer buffer)
+    (let [src (.array buffer)
+          offset (.arrayOffset buffer)
+          record-len (- (count src) offset)
+          json-str (String. src offset record-len)
+          record (<-json-big json-str true)]
+      (-> record
+          (update :action kw-action)
+          (assoc :tx-bytes record-len)))))
 
 (comment
   (wal-buffer->record (ByteBuffer/wrap (.getBytes "{\"x\": 1}"))))
@@ -366,7 +372,8 @@
    We do some book-keeping for the replication stream, by recording the LSN
    for the last record that was pushed to `to`."
   [^PGReplicationStream stream to close-signal-chan slot-num {:keys [auto-flush?
-                                                                     evict-cache?]}]
+                                                                     evict-cache?
+                                                                     previous-isn]}]
   ;; :next-action is either:
   ;;   :begin, we're waiting for a :begin record
   ;;     :tx, we got :begin and we're waiting to see if the first insert is to the transactions table
@@ -377,10 +384,11 @@
   ;;     :advance, we got :close and we need to reset for the next db transaction
 
   (loop [buffer (.read stream)
-         state produce-start-state]
+         state produce-start-state
+         previous-isn previous-isn]
     (if-not buffer
       (when-not (.isClosed stream)
-        (recur (.read stream) state))
+        (recur (.read stream) state previous-isn))
       (let [record (wal-buffer->record buffer)
             _ (when evict-cache? (cache-evict/evict-cache! record))
             next-state (-> (case (:next-action state)
@@ -418,7 +426,6 @@
                                                             record
                                                             {:next-action :tx
                                                              :records []})
-
 
                                    (unexpected-state state
                                                      record
@@ -467,17 +474,22 @@
                        (when auto-flush?
                          (.setAppliedLSN stream last-receive-lsn)
                          (.setFlushedLSN stream last-receive-lsn))
-                       (recur (.read stream) produce-start-state)))
+                       (recur (.read stream) produce-start-state previous-isn)))
           :deliver (let [last-receive-lsn ^LogSequenceNumber (.getLastReceiveLSN stream)
-                         nextlsn (LogSequenceNumber/valueOf ^String (:nextlsn record))
+                         nextlsn (if (string? (:nextlsn record))
+                                   (LogSequenceNumber/valueOf ^String (:nextlsn record))
+                                   (:nextlsn record))
                          isn (->ISN slot-num nextlsn)
                          _ (when evict-cache?
                              (set-max-seen-isn isn))
                          msg {:changes (:records state)
                               :messages (:messages state)
-                              :lsn (LogSequenceNumber/valueOf ^String (:lsn record))
+                              :lsn (if (string? (:lsn record))
+                                     (LogSequenceNumber/valueOf ^String (:lsn record))
+                                     (:lsn record))
                               :nextlsn nextlsn
                               :isn isn
+                              :previous-isn previous-isn
                               :tx-bytes (:tx-bytes state)}
                          put-result (a/alt!! [[to msg]] :put
                                              ;; The close signal chan keeps us from
@@ -490,8 +502,8 @@
                        (when auto-flush?
                          (.setAppliedLSN stream last-receive-lsn)
                          (.setFlushedLSN stream last-receive-lsn))
-                       (recur (.read stream) produce-start-state)))
-          (recur (.read stream) next-state))))))
+                       (recur (.read stream) produce-start-state isn)))
+          (recur (.read stream) next-state previous-isn))))))
 
 (defn- produce-aggregate
   "Repeatedly read from the stream and puts records on the `to` channel.
@@ -637,7 +649,8 @@
                                   (health/mark-wal-healthy-async)))
       (let [produce-error (try
                             (produce stream to close-signal-chan slot-num {:auto-flush? true
-                                                                           :evict-cache? true})
+                                                                           :evict-cache? true
+                                                                           :previous-isn (->ISN slot-num lsn)})
                             (catch Exception e
                               (tracer/with-span! {:name "wal-worker/produce-error"
                                                   :attributes {:exception e}}
@@ -693,6 +706,8 @@
                                     (close-nicely stream)
                                     (close-nicely replication-conn)))
         (let [stream ^PGReplicationStream stream
+              lsn (with-open [conn (get-pg-replication-conn (get-conn-config))]
+                    (:lsn (get-logical-replication-slot conn slot-name)))
               flush-interrupt (a/chan)
               flush-process (a/go
                               (loop []
@@ -708,7 +723,8 @@
                                     (tracer/record-info! {:name "wal-worker/flush-lsn-exit"})))))
               produce-error (try
                               (produce stream to close-signal-chan slot-num {:auto-flush? false
-                                                                             :evict-cache? true})
+                                                                             :evict-cache? true
+                                                                             :previous-isn (->ISN slot-num lsn)})
                               (catch Exception e
                                 (tracer/with-span! {:name "wal-worker/produce-error"
                                                     :attributes {:exception e}}

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -331,6 +331,21 @@
       action)))
 
 (def use-wal-entry? (not (config/prod?)))
+(def try-wal-entry? false)
+
+(defn test-wal-entry-parse
+  "Tests that the wal entries parse. We'll run this on one machine
+   for a bit to make sure there are no errors before trying to flip
+   the use-wal-entry? flag."
+  [^ByteBuffer buffer]
+  (try
+    (wal-entry/parse-buffer buffer)
+    (catch Throwable t
+      (tracer/with-new-trace-root
+        (tracer/record-exception-span! t {:name "wal/new-wal-record-parse-error"}))
+      (def -t t)
+      (def -buffer buffer)
+      nil)))
 
 (defn- wal-buffer->record
   "PGReplicationStream returns a ByteBuffer. This
@@ -343,6 +358,8 @@
           record-len (- (count src) offset)
           json-str (String. src offset record-len)
           record (<-json-big json-str true)]
+      (when try-wal-entry?
+        (test-wal-entry-parse buffer))
       (-> record
           (update :action kw-action)
           (assoc :tx-bytes record-len)))))

--- a/server/src/instant/jdbc/wal_entry.clj
+++ b/server/src/instant/jdbc/wal_entry.clj
@@ -1,0 +1,28 @@
+(ns instant.jdbc.wal-entry
+  "Parses a PGReplicationStream ByteBuffer containing a single wal2json
+   format-version 2 entry directly into an `instant.jdbc.WalEntry`."
+  (:import
+   (com.fasterxml.jackson.core StreamReadConstraints)
+   (com.fasterxml.jackson.databind DeserializationFeature ObjectMapper)
+   (instant.jdbc WalEntry)
+   (java.nio ByteBuffer)))
+
+(def ^:private ^ObjectMapper object-mapper
+  (let [mapper (ObjectMapper.)]
+    (.setStreamReadConstraints (.getFactory mapper)
+                               (-> (StreamReadConstraints/builder)
+                                   (.maxStringLength 200000000)
+                                   (.build)))
+    (.configure mapper DeserializationFeature/FAIL_ON_UNKNOWN_PROPERTIES false)
+    mapper))
+
+(defn parse-buffer
+  "Decodes a single wal2json format-version 2 entry from `buffer` into a
+   fully-populated `instant.jdbc.WalEntry`."
+  ^WalEntry [^ByteBuffer buffer]
+  (let [src ^bytes (.array buffer)
+        offset (.arrayOffset buffer)
+        record-len (- (alength src) offset)
+        ^WalEntry e (.readValue object-mapper src offset record-len WalEntry)]
+    (set! (.txBytes e) record-len)
+    e))

--- a/server/src/instant/nippy.clj
+++ b/server/src/instant/nippy.clj
@@ -247,18 +247,3 @@
                               (nippy/thaw-from-in! data-input)
                               (nippy/thaw-from-in! data-input)
                               (nippy/thaw-from-in! data-input))))
-
-;; ;; 11 is our custom identifier for InvalidatorAck, no other type can use it and
-;; ;; it must be the same across all machines.
-;; (nippy/extend-freeze InvalidatorAck 11 [^InvalidatorAck {:keys [isn]} data-output]
-;;   (write-isn isn data-output))
-
-;; (nippy/extend-thaw 11 [data-input]
-;;   (instant.grpc/->InvalidatorAck (read-isn data-input)))
-
-;; ;; 12 is our custom identifier for SlotDisconnect, no other type can use it and
-;; ;; it must be the same across all machines.
-;; (nippy/extend-freeze SlotDisconnect 12 [^SlotDisconnect _ _data-output])
-
-;; (nippy/extend-thaw 12 [_data-input]
-;;   (instant.grpc/->SlotDisconnect))

--- a/server/src/instant/nippy.clj
+++ b/server/src/instant/nippy.clj
@@ -4,9 +4,11 @@
    [instant.isn]
    [taoensso.nippy :as nippy])
   (:import
-   (instant.grpc StreamAborted StreamComplete StreamContent StreamError StreamFile StreamInit StreamRequest)
+   (instant.grpc StreamAborted StreamComplete StreamContent StreamError StreamFile StreamInit StreamRequest WalRecord)
    (instant.isn ISN)
+   (instant.jdbc WalColumn WalEntry)
    (java.io DataInput DataOutput)
+   (java.time Instant)
    (java.util UUID)
    (org.postgresql.replication LogSequenceNumber)))
 
@@ -35,15 +37,21 @@
 (nippy/extend-thaw 1 [data-input]
   (LogSequenceNumber/valueOf (.readLong data-input)))
 
-;; 2 is our custom identifier for ISN, no other type can use it and
-;; it must be the same across all machines.
-(nippy/extend-freeze ISN 2 [^ISN isn data-output]
+(defn write-isn [^ISN isn ^DataOutput data-output]
   (.writeInt data-output (.slot_num isn))
   (.writeLong data-output (.asLong ^LogSequenceNumber (.lsn isn))))
 
-(nippy/extend-thaw 2 [data-input]
+(defn read-isn ^ISN [^DataInput data-input]
   (instant.isn/->ISN (.readInt data-input)
                      (LogSequenceNumber/valueOf (.readLong data-input))))
+
+;; 2 is our custom identifier for ISN, no other type can use it and
+;; it must be the same across all machines.
+(nippy/extend-freeze ISN 2 [^ISN isn data-output]
+  (write-isn isn data-output))
+
+(nippy/extend-thaw 2 [data-input]
+  (read-isn data-input))
 
 ;; 3 is our custom identifier for StreamRequest, no other type can use it and
 ;; it must be the same across all machines.
@@ -159,3 +167,98 @@
 
 (nippy/extend-thaw 9 [data-input]
   (instant.grpc/->StreamAborted (nippy/thaw-from-in! data-input)))
+
+;; 10 is our custom identifier for WalColumn, no other type can use it and
+;; it must be the same across all machines.
+
+(nippy/extend-freeze WalColumn 10 [^WalColumn c data-output]
+  (nippy/freeze-to-out! data-output (.name c))
+  (nippy/freeze-to-out! data-output (.value c)))
+
+(nippy/extend-thaw 10 [data-input]
+  (WalColumn. (nippy/thaw-from-in! data-input) ; name
+              (nippy/thaw-from-in! data-input))) ; value
+
+;; 11 is our custom identifier for WalEntry, no other type can use it and
+;; it must be the same across all machines.
+
+(nippy/extend-freeze WalEntry 11 [^WalEntry c data-output]
+  (nippy/freeze-to-out! data-output (.action c))
+  (nippy/freeze-to-out! data-output (.txBytes c))
+  (nippy/freeze-to-out! data-output (.table c))
+  (nippy/freeze-to-out! data-output (.columns c))
+  (nippy/freeze-to-out! data-output (.identity c))
+  (nippy/freeze-to-out! data-output (.prefix c))
+  (nippy/freeze-to-out! data-output (.content c))
+  (nippy/freeze-to-out! data-output (.lsn c))
+  (nippy/freeze-to-out! data-output (.nextlsn c)))
+
+(nippy/extend-thaw 11 [data-input]
+  (WalEntry. (nippy/thaw-from-in! data-input) ; action
+             (nippy/thaw-from-in! data-input) ; txBytes
+             (nippy/thaw-from-in! data-input) ; table
+             (nippy/thaw-from-in! data-input) ; columns
+             (nippy/thaw-from-in! data-input) ; identity
+             (nippy/thaw-from-in! data-input) ; prefix
+             (nippy/thaw-from-in! data-input) ; content
+             (nippy/thaw-from-in! data-input) ; lsn
+             (nippy/thaw-from-in! data-input))) ; nextlsn
+
+;; 12 is our custom identifier for WalRecord, no other type can use it and
+;; it must be the same across all machines.
+(nippy/extend-freeze WalRecord 12 [^WalRecord {:keys [^UUID app-id
+                                                      ^long tx-id
+                                                      ^ISN isn
+                                                      ^ISN previous-isn
+                                                      ^Instant tx-created-at
+                                                      ^long tx-bytes
+                                                      ^LogSequenceNumber nextlsn
+                                                      attr-changes
+                                                      ident-changes
+                                                      triple-changes
+                                                      messages
+                                                      wal-logs]}
+                                   data-output]
+  (nippy/with-cache
+    (write-uuid data-output app-id)
+    (nippy/freeze-to-out! data-output tx-id)
+    (write-isn isn data-output)
+    (write-isn previous-isn data-output)
+    (nippy/freeze-to-out! data-output tx-created-at)
+    (nippy/freeze-to-out! data-output tx-bytes)
+    (nippy/freeze-to-out! data-output (.asLong nextlsn))
+    (nippy/freeze-to-out! data-output attr-changes)
+    (nippy/freeze-to-out! data-output ident-changes)
+    (nippy/freeze-to-out! data-output triple-changes)
+    (nippy/freeze-to-out! data-output messages)
+    (nippy/freeze-to-out! data-output wal-logs)))
+
+(nippy/extend-thaw 12 [data-input]
+  (nippy/with-cache
+    (instant.grpc/->WalRecord (read-uuid data-input)
+                              (nippy/thaw-from-in! data-input)
+                              (read-isn data-input)
+                              (read-isn data-input)
+                              (nippy/thaw-from-in! data-input)
+                              (nippy/thaw-from-in! data-input)
+                              (LogSequenceNumber/valueOf ^long (nippy/thaw-from-in! data-input))
+                              (nippy/thaw-from-in! data-input)
+                              (nippy/thaw-from-in! data-input)
+                              (nippy/thaw-from-in! data-input)
+                              (nippy/thaw-from-in! data-input)
+                              (nippy/thaw-from-in! data-input))))
+
+;; ;; 11 is our custom identifier for InvalidatorAck, no other type can use it and
+;; ;; it must be the same across all machines.
+;; (nippy/extend-freeze InvalidatorAck 11 [^InvalidatorAck {:keys [isn]} data-output]
+;;   (write-isn isn data-output))
+
+;; (nippy/extend-thaw 11 [data-input]
+;;   (instant.grpc/->InvalidatorAck (read-isn data-input)))
+
+;; ;; 12 is our custom identifier for SlotDisconnect, no other type can use it and
+;; ;; it must be the same across all machines.
+;; (nippy/extend-freeze SlotDisconnect 12 [^SlotDisconnect _ _data-output])
+
+;; (nippy/extend-thaw 12 [_data-input]
+;;   (instant.grpc/->SlotDisconnect))

--- a/server/src/instant/nippy.clj
+++ b/server/src/instant/nippy.clj
@@ -222,11 +222,11 @@
   (nippy/with-cache
     (write-uuid data-output app-id)
     (nippy/freeze-to-out! data-output tx-id)
-    (write-isn isn data-output)
-    (write-isn previous-isn data-output)
+    (nippy/freeze-to-out! data-output isn)
+    (nippy/freeze-to-out! data-output previous-isn)
     (nippy/freeze-to-out! data-output tx-created-at)
     (nippy/freeze-to-out! data-output tx-bytes)
-    (nippy/freeze-to-out! data-output (.asLong nextlsn))
+    (nippy/freeze-to-out! data-output nextlsn)
     (nippy/freeze-to-out! data-output attr-changes)
     (nippy/freeze-to-out! data-output ident-changes)
     (nippy/freeze-to-out! data-output triple-changes)
@@ -235,15 +235,15 @@
 
 (nippy/extend-thaw 12 [data-input]
   (nippy/with-cache
-    (instant.grpc/->WalRecord (read-uuid data-input)
-                              (nippy/thaw-from-in! data-input)
-                              (read-isn data-input)
-                              (read-isn data-input)
-                              (nippy/thaw-from-in! data-input)
-                              (nippy/thaw-from-in! data-input)
-                              (LogSequenceNumber/valueOf ^long (nippy/thaw-from-in! data-input))
-                              (nippy/thaw-from-in! data-input)
-                              (nippy/thaw-from-in! data-input)
-                              (nippy/thaw-from-in! data-input)
-                              (nippy/thaw-from-in! data-input)
-                              (nippy/thaw-from-in! data-input))))
+    (instant.grpc/->WalRecord (read-uuid data-input) ; app-id
+                              (nippy/thaw-from-in! data-input) ; tx-id
+                              (nippy/thaw-from-in! data-input) ; isn
+                              (nippy/thaw-from-in! data-input) ; previous-isn
+                              (nippy/thaw-from-in! data-input) ; tx-created-at
+                              (nippy/thaw-from-in! data-input) ; tx-bytes
+                              (nippy/thaw-from-in! data-input) ; nextlsn
+                              (nippy/thaw-from-in! data-input) ; attr-changes
+                              (nippy/thaw-from-in! data-input) ; ident-changes
+                              (nippy/thaw-from-in! data-input) ; triple-changes
+                              (nippy/thaw-from-in! data-input) ; messages
+                              (nippy/thaw-from-in! data-input)))) ; wal-logs

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -230,7 +230,9 @@
 
    Returns a list of changes and the lsn."
   [start-lsn skip-empty-updates change]
-  (let [lsn (LogSequenceNumber/valueOf ^String (:lsn change))
+  (let [lsn (if (string? (:lsn change))
+              (LogSequenceNumber/valueOf ^String (:lsn change))
+              (:lsn change))
         sketch-changes
         (test-filter
           (when (= "triples" (:table change))

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -16,7 +16,6 @@
    [instant.reactive.topics :as topics]
    [instant.util.async :as ua]
    [instant.util.e2e-tracer :as e2e-tracer]
-   [instant.util.hazelcast :refer [->WalRecord]]
    [instant.util.tracer :as tracer]
    [clojure.set :as set])
   (:import
@@ -24,7 +23,6 @@
    (com.hazelcast.ringbuffer Ringbuffer)
    (com.hazelcast.ringbuffer.impl RingbufferService)
    (com.hazelcast.topic Message ITopic ReliableMessageListener TopicOverloadPolicy)
-   (instant.util.hazelcast WalRecord)
    (java.sql Timestamp)
    (java.time Instant)
    (java.time.temporal ChronoUnit)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -300,7 +300,8 @@
                         (when-not (and stop-lsn
                                        (= -1 (compare stop-lsn (:nextlsn wal-record))))
                           (try
-                            (.publish hz-topic (->WalRecord wal-record))
+                            ;; Remove while we prepare to switch from hazelcast to grpc
+                            ;;(.publish hz-topic (->WalRecord wal-record))
                             (ua/>!-close-safe close-signal-chan flush-lsn-chan (:nextlsn wal-record))
                             (catch Exception e
                               (on-error e)))
@@ -535,7 +536,7 @@
                                                   (hz-gauges topic)))
         on-msg (fn [^Message m]
                  (let [msg (.getMessageObject m)]
-                   (if (instance? WalRecord msg)
+                   (if true ;; remove while we switch to grpc (instance? WalRecord msg)
                      (grouped-queue/put! queue (:record msg))
                      ;; We should try to reconnect, but only if we weren't
                      ;; the ones that sent the message to reconnect (if there

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -287,7 +287,7 @@
 (defn start-singleton-worker [{:keys [wal-chan
                                       close-signal-chan
                                       flush-lsn-chan
-                                      ^ITopic hz-topic
+                                      ^ITopic _hz-topic
                                       on-error
                                       stop-lsn
                                       check-disabled]}]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -7,6 +7,7 @@
    [instant.flags :as flags]
    [instant.gauges :as gauges]
    [instant.grouped-queue :as grouped-queue]
+   [instant.grpc :as grpc]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
    [instant.reactive.ephemeral :as eph]
@@ -105,7 +106,7 @@
   (when-let [^String created-at (topics/get-column columns "created_at")]
     (.toInstant (Timestamp/valueOf created-at))))
 
-(defn transform-wal-record [{:keys [changes messages tx-bytes nextlsn isn] :as _record}]
+(defn transform-wal-record [{:keys [changes messages tx-bytes nextlsn isn previous-isn] :as _record}]
   ;; n.b. Add the table to the `add-tables` setting in create-replication-stream
   ;;      or else we will never be notified about it.
   (let [{:strs [idents triples attrs transactions
@@ -126,18 +127,19 @@
                                                 :name "transform-wal-record"})
         ;; n.b. make sure to update combine-wal-records below if new
         ;;      items are added to this map
-        {:nextlsn nextlsn
-         :isn isn
-         :attr-changes attrs
-         :ident-changes idents
-         :triple-changes triples
-         :app-id app-id
-         :tx-created-at tx-created-at
-         :tx-id tx-id
-         :tx-bytes tx-bytes
-         :messages messages
-         :wal-logs (concat wal_logs wal_logs_0 wal_logs_1 wal_logs_2 wal_logs_3
-                           wal_logs_4 wal_logs_5 wal_logs_6 wal_logs_7)}))))
+        (grpc/->WalRecord app-id
+                          tx-id
+                          isn
+                          previous-isn
+                          tx-created-at
+                          tx-bytes
+                          nextlsn
+                          attrs
+                          idents
+                          triples
+                          messages
+                          (concat wal_logs wal_logs_0 wal_logs_1 wal_logs_2 wal_logs_3
+                                  wal_logs_4 wal_logs_5 wal_logs_6 wal_logs_7))))))
 
 (defn wal-record-xf
   "Filters wal records for supported changes. Returns [app-id changes]"

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -42,7 +42,6 @@
 (def task-type-id 7)
 (def join-room-v3-type-id 9)
 (def sse-message-type-id 10)
-(def wal-record-type-id 11)
 
 ;; --------
 ;; Room key
@@ -297,26 +296,6 @@
   (make-serializer-config Task
                           task-serializer))
 
-;; ----------
-;; Wal record
-
-;; Expects a var that takes no arguments
-(defrecord WalRecord [record])
-
-(def ^ByteArraySerializer wal-record-serializer
-  (reify ByteArraySerializer
-    (getTypeId [_]
-      wal-record-type-id)
-    (write ^bytes [_ {:keys [record]}]
-      (nippy/fast-freeze record))
-    (read [_ ^bytes in]
-      (->WalRecord (nippy/fast-thaw in)))
-    (destroy [_])))
-
-(def wal-record-config
-  (make-serializer-config WalRecord
-                          wal-record-serializer))
-
 ;; -----------------
 ;; Global serializer
 
@@ -341,5 +320,4 @@
    set-presence-config
    room-key-config
    task-config
-   sse-message-config
-   wal-record-config])
+   sse-message-config])

--- a/server/src/java/instant/jdbc/WalColumn.java
+++ b/server/src/java/instant/jdbc/WalColumn.java
@@ -1,0 +1,61 @@
+package instant.jdbc;
+
+import clojure.lang.ILookup;
+import clojure.lang.Keyword;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import java.util.Objects;
+
+/**
+ * A single column entry from a wal2json format-version 2 row (inside
+ * {@code columns} or {@code identity}). Deserialized by Jackson from JSON
+ * {@code {"name": ..., "value": ..., ...}} objects.
+ *
+ * Implements ILookup so existing Clojure consumers can use
+ * {@code (:name col)} / {@code (:value col)} and
+ * {@code {:keys [name value]}} destructuring without conversion.
+ */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public final class WalColumn implements ILookup {
+  private static final Keyword KW_NAME = Keyword.intern("name");
+  private static final Keyword KW_VALUE = Keyword.intern("value");
+
+  public String name;
+  public Object value;
+
+  public WalColumn() {}
+
+  public WalColumn(String name, Object value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  @Override
+  public Object valAt(Object key) {
+    return valAt(key, null);
+  }
+
+  @Override
+  public Object valAt(Object key, Object notFound) {
+    if (key == KW_NAME) return name;
+    if (key == KW_VALUE) return value;
+    return notFound;
+  }
+
+  @Override
+  public String toString() {
+    return "#WalColumn{:name \"" + name + "\", :value " + value + "}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof WalColumn)) return false;
+    WalColumn that = (WalColumn) o;
+    return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
+  }
+}

--- a/server/src/java/instant/jdbc/WalColumnVectorDeserializer.java
+++ b/server/src/java/instant/jdbc/WalColumnVectorDeserializer.java
@@ -1,0 +1,34 @@
+package instant.jdbc;
+
+import clojure.lang.ITransientCollection;
+import clojure.lang.PersistentVector;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Deserializes a JSON array of {@link WalColumn} objects into a Clojure
+ * {@link PersistentVector}, which also implements {@link List}, so the
+ * declared field type can stay {@code List<WalColumn>}. Using a Clojure
+ * vector ensures Nippy serializes the collection natively — if we left
+ * Jackson's default {@code ArrayList}, Nippy would fall back to Java
+ * serialization and fail on the non-{@code Serializable} elements.
+ */
+public final class WalColumnVectorDeserializer extends JsonDeserializer<List<WalColumn>> {
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<WalColumn> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    if (!p.isExpectedStartArrayToken()) {
+      return (List<WalColumn>) ctxt.handleUnexpectedToken(List.class, p);
+    }
+    ITransientCollection v = PersistentVector.EMPTY.asTransient();
+    while (p.nextToken() != JsonToken.END_ARRAY) {
+      WalColumn col = p.readValueAs(WalColumn.class);
+      v = v.conj(col);
+    }
+    return (List<WalColumn>) v.persistent();
+  }
+}

--- a/server/src/java/instant/jdbc/WalEntry.java
+++ b/server/src/java/instant/jdbc/WalEntry.java
@@ -1,0 +1,177 @@
+package instant.jdbc;
+
+import clojure.lang.ILookup;
+import clojure.lang.Keyword;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.postgresql.replication.LogSequenceNumber;
+
+/**
+ * Jackson deserialization target for a single wal2json format-version 2
+ * entry. Fields that don't apply to the entry's action are left null.
+ *
+ * {@code action} is deserialized directly into a Clojure Keyword by
+ * {@link WalEntry.ActionDeserializer}. {@code txBytes} is not in JSON
+ * and is set by {@code instant.jdbc.wal-entry/parse-buffer}.
+ *
+ * {@code lsn} and {@code nextlsn} are deserialized via
+ * {@code LogSequenceNumber.valueOf(String)} — Jackson picks up the
+ * static factory method automatically.
+ *
+ * Implements ILookup so existing Clojure consumers can continue to use
+ * {@code (:action r)}, {@code (:columns r)}, etc. unchanged.
+ */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public final class WalEntry implements ILookup {
+  private static final Keyword KW_ACTION = Keyword.intern("action");
+  private static final Keyword KW_TX_BYTES = Keyword.intern("tx-bytes");
+  private static final Keyword KW_TABLE = Keyword.intern("table");
+  private static final Keyword KW_COLUMNS = Keyword.intern("columns");
+  private static final Keyword KW_IDENTITY = Keyword.intern("identity");
+  private static final Keyword KW_PREFIX = Keyword.intern("prefix");
+  private static final Keyword KW_CONTENT = Keyword.intern("content");
+  private static final Keyword KW_LSN = Keyword.intern("lsn");
+  private static final Keyword KW_NEXTLSN = Keyword.intern("nextlsn");
+
+  /** Normalized Keyword (:begin, :insert, ...). Unknown actions pass through as the raw String. */
+  @JsonDeserialize(using = ActionDeserializer.class)
+  public Object action;
+
+  /** Byte length of the original WAL record. Set by parse-buffer; not in JSON. */
+  public long txBytes;
+
+  /** Table name. Present for insert/update/delete entries. */
+  public String table;
+
+  /** New row values. Present for insert and update entries. */
+  @JsonDeserialize(using = WalColumnVectorDeserializer.class)
+  public List<WalColumn> columns;
+
+  /** Old row / replica-identity values. Present for update and delete entries. */
+  @JsonDeserialize(using = WalColumnVectorDeserializer.class)
+  public List<WalColumn> identity;
+
+  /** Prefix of a pg_logical_emit_message call. Present only for message entries. */
+  public String prefix;
+
+  /** Body of a pg_logical_emit_message call (text). Present only for message entries. */
+  public String content;
+
+  /** Commit LSN. Present only for commit (close) entries. */
+  public LogSequenceNumber lsn;
+
+  /** Next LSN after the commit. Present only for commit (close) entries. */
+  public LogSequenceNumber nextlsn;
+
+  public WalEntry() {}
+
+  public WalEntry(Object action,
+                  long txBytes,
+                  String table,
+                  List<WalColumn> columns,
+                  List<WalColumn> identity,
+                  String prefix,
+                  String content,
+                  LogSequenceNumber lsn,
+                  LogSequenceNumber nextlsn) {
+    this.action = action;
+    this.txBytes = txBytes;
+    this.table = table;
+    this.columns = columns;
+    this.identity = identity;
+    this.prefix = prefix;
+    this.content = content;
+    this.lsn = lsn;
+    this.nextlsn = nextlsn;
+  }
+
+  @Override
+  public Object valAt(Object key) {
+    return valAt(key, null);
+  }
+
+  @Override
+  public Object valAt(Object key, Object notFound) {
+    if (key == KW_ACTION) return action;
+    if (key == KW_TX_BYTES) return txBytes;
+    if (key == KW_TABLE) return table;
+    if (key == KW_COLUMNS) return columns;
+    if (key == KW_IDENTITY) return identity;
+    if (key == KW_PREFIX) return prefix;
+    if (key == KW_CONTENT) return content;
+    if (key == KW_LSN) return lsn;
+    if (key == KW_NEXTLSN) return nextlsn;
+    return notFound;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("#WalEntry{");
+    sb.append(":action ").append(action);
+    sb.append(", :tx-bytes ").append(txBytes);
+    if (table != null) sb.append(", :table \"").append(table).append('"');
+    if (columns != null) sb.append(", :columns ").append(columns);
+    if (identity != null) sb.append(", :identity ").append(identity);
+    if (prefix != null) sb.append(", :prefix \"").append(prefix).append('"');
+    if (content != null) sb.append(", :content \"").append(content).append('"');
+    if (lsn != null) sb.append(", :lsn ").append(lsn);
+    if (nextlsn != null) sb.append(", :nextlsn ").append(nextlsn);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof WalEntry)) return false;
+    WalEntry that = (WalEntry) o;
+    return txBytes == that.txBytes
+        && Objects.equals(action, that.action)
+        && Objects.equals(table, that.table)
+        && Objects.equals(columns, that.columns)
+        && Objects.equals(identity, that.identity)
+        && Objects.equals(prefix, that.prefix)
+        && Objects.equals(content, that.content)
+        && Objects.equals(lsn, that.lsn)
+        && Objects.equals(nextlsn, that.nextlsn);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(action, txBytes, table, columns, identity, prefix, content, lsn, nextlsn);
+  }
+
+  public static final class ActionDeserializer extends JsonDeserializer<Object> {
+    private static final Keyword KW_BEGIN = Keyword.intern("begin");
+    private static final Keyword KW_INSERT = Keyword.intern("insert");
+    private static final Keyword KW_UPDATE = Keyword.intern("update");
+    private static final Keyword KW_DELETE = Keyword.intern("delete");
+    private static final Keyword KW_TRUNCATE = Keyword.intern("truncate");
+    private static final Keyword KW_MESSAGE = Keyword.intern("message");
+    private static final Keyword KW_CLOSE = Keyword.intern("close");
+
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      String s = p.getText();
+      if (s.length() == 1) {
+        switch (s.charAt(0)) {
+          case 'B': return KW_BEGIN;
+          case 'I': return KW_INSERT;
+          case 'U': return KW_UPDATE;
+          case 'D': return KW_DELETE;
+          case 'T': return KW_TRUNCATE;
+          case 'M': return KW_MESSAGE;
+          case 'C': return KW_CLOSE;
+          default: break;
+        }
+      }
+      return s;
+    }
+  }
+}

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -455,7 +455,7 @@
         first-res (f)
         delta (- (System/nanoTime) start)
         deadline (+ start duration)
-        tight-iters (max (quot (quot duration delta) 10) 1)]
+        tight-iters (max (quot (quot duration (max 1 delta)) 10) 1)]
     (loop [i 1]
       (let [now (System/nanoTime)]
         (if (< now deadline)

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -98,7 +98,6 @@
            [:bar {:select :* :from :bar}]]
     :select :* :from :bar}))
 
-
 ;; Copied from sql.clj
 (defn ->pg-text-array
   "Formats as text[] in pg, i.e. {item-1, item-2, item3}"
@@ -447,3 +446,41 @@
    (require 'clj-memory-meter.core)
    (let [measure (resolve 'clj-memory-meter.core/measure)]
      (measure obj opts))))
+
+(defn time+* [^long duration-in-ms f]
+  (let [^com.sun.management.ThreadMXBean bean (java.lang.management.ManagementFactory/getThreadMXBean)
+        bytes-before (.getCurrentThreadAllocatedBytes bean)
+        duration (* duration-in-ms 1000000)
+        start (System/nanoTime)
+        first-res (f)
+        delta (- (System/nanoTime) start)
+        deadline (+ start duration)
+        tight-iters (max (quot (quot duration delta) 10) 1)]
+    (loop [i 1]
+      (let [now (System/nanoTime)]
+        (if (< now deadline)
+          (do (dotimes [_ tight-iters] (f))
+              (recur (+ i tight-iters)))
+          (let [i' (double i)
+                bytes-after (.getCurrentThreadAllocatedBytes bean)
+                t (/ (- now start) i')]
+            (println
+             (format "Time per call: %s   Alloc per call: %,.0fb   Iterations: %d"
+                     (cond (< t 1e3) (format "%.0f ns" t)
+                           (< t 1e6) (format "%.2f us" (/ t 1e3))
+                           (< t 1e9) (format "%.2f ms" (/ t 1e6))
+                           :else (format "%.2f s" (/ t 1e9)))
+                     (/ (- bytes-after bytes-before) i')
+                     i))
+            first-res))))))
+
+(defmacro time+
+  "Like `time`, but runs the supplied body for 2000 ms and prints the average
+   time for a single iteration. Custom total time in milliseconds can be provided
+   as the first argument. Returns the returned value of the FIRST iteration.
+   From https://clojure-goes-fast.com/kb/benchmarking/time-plus/"
+  [?duration-in-ms & body]
+  (let [[duration body] (if (integer? ?duration-in-ms)
+                          [?duration-in-ms body]
+                          [2000 (cons ?duration-in-ms body)])]
+    `(~time+* ~duration (fn [] ~@body))))

--- a/server/test/instant/nippy_test.clj
+++ b/server/test/instant/nippy_test.clj
@@ -7,12 +7,14 @@
    [taoensso.nippy :as nippy])
   (:import
    (instant.isn ISN)
+   (instant.jdbc WalColumn WalEntry)
+   (java.time Instant)
    (java.util Arrays)
    (org.postgresql.replication LogSequenceNumber)))
 
 (deftest all-of-the-custom-readers-are-tested
   ;; Only update this number if you also added a freeze/thaw test for the type
-  (is (= 9 (count nippy/*custom-readers*))))
+  (is (= 12 (count nippy/*custom-readers*))))
 
 (defn roundtrip [x]
   (nippy/fast-thaw (nippy/fast-freeze x)))
@@ -97,4 +99,124 @@
 
 (deftest stream-aborted
   (let [obj (grpc/->StreamAborted "whoops")]
+    (is (= obj (roundtrip obj)))))
+
+(deftest wal-column
+  (let [obj (WalColumn. "id" "abc-123")]
+    (is (= obj (roundtrip obj)))))
+
+(defn- rand-lsn []
+  (LogSequenceNumber/valueOf (long (rand-int Integer/MAX_VALUE))))
+
+(deftest wal-entry
+  (testing "begin"
+    (let [obj (WalEntry. :begin 48 nil nil nil nil nil nil nil)]
+      (is (= obj (roundtrip obj)))))
+
+  (testing "insert"
+    (let [obj (WalEntry. :insert
+                         256
+                         "triples"
+                         [(WalColumn. "id" 1)
+                          (WalColumn. "app_id" (str (random-uuid)))
+                          (WalColumn. "value" "{\"a\":1}")]
+                         nil
+                         nil
+                         nil
+                         nil
+                         nil)]
+      (is (= obj (roundtrip obj)))))
+
+  (testing "update"
+    (let [obj (WalEntry. :update
+                         320
+                         "attrs"
+                         [(WalColumn. "id" 2)
+                          (WalColumn. "value" "new")]
+                         [(WalColumn. "id" 1)
+                          (WalColumn. "value" "old")]
+                         nil
+                         nil
+                         nil
+                         nil)]
+      (is (= obj (roundtrip obj)))))
+
+  (testing "delete"
+    (let [obj (WalEntry. :delete
+                         96
+                         "rules"
+                         nil
+                         [(WalColumn. "id" (str (random-uuid)))]
+                         nil
+                         nil
+                         nil
+                         nil)]
+      (is (= obj (roundtrip obj)))))
+
+  (testing "truncate"
+    (let [obj (WalEntry. :truncate 40 nil nil nil nil nil nil nil)]
+      (is (= obj (roundtrip obj)))))
+
+  (testing "message"
+    (let [obj (WalEntry. :message
+                         72
+                         nil
+                         nil
+                         nil
+                         "update_ents"
+                         "{\"etype\":{\"aid\":{\"eid\":{}}}}"
+                         nil
+                         nil)]
+      (is (= obj (roundtrip obj)))))
+
+  (testing "close"
+    (let [obj (WalEntry. :close 64 nil nil nil nil nil (rand-lsn) (rand-lsn))]
+      (is (= obj (roundtrip obj))))))
+
+(deftest wal-record
+  (let [app-id (random-uuid)
+        attr-insert (WalEntry. :insert
+                               128
+                               "attrs"
+                               [(WalColumn. "id" (str (random-uuid)))
+                                (WalColumn. "app_id" (str app-id))]
+                               nil nil nil nil nil)
+        ident-insert (WalEntry. :insert
+                                96
+                                "idents"
+                                [(WalColumn. "id" (str (random-uuid)))
+                                 (WalColumn. "app_id" (str app-id))]
+                                nil nil nil nil nil)
+        triple-insert (WalEntry. :insert
+                                 160
+                                 "triples"
+                                 [(WalColumn. "app_id" (str app-id))
+                                  (WalColumn. "entity_id" (str (random-uuid)))
+                                  (WalColumn. "attr_id" (str (random-uuid)))
+                                  (WalColumn. "value" "\"hello\"")]
+                                 nil nil nil nil nil)
+        message (WalEntry. :message
+                           72
+                           nil nil nil
+                           "update_ents"
+                           "{\"etype\":{\"aid\":{\"eid\":{}}}}"
+                           nil nil)
+        wal-log-insert (WalEntry. :insert
+                                  80
+                                  "wal_logs"
+                                  [(WalColumn. "prefix" "update_ents")
+                                   (WalColumn. "content" "{}")]
+                                  nil nil nil nil nil)
+        obj (grpc/->WalRecord app-id
+                              (rand-int Integer/MAX_VALUE)
+                              (ISN. (rand-int 1000) (rand-lsn))
+                              (ISN. (rand-int 1000) (rand-lsn))
+                              (Instant/now)
+                              536
+                              (rand-lsn)
+                              [attr-insert]
+                              [ident-insert]
+                              [triple-insert]
+                              [message]
+                              [wal-log-insert])]
     (is (= obj (roundtrip obj)))))


### PR DESCRIPTION
A few changes here to make serializing wal records more efficient. We'll be passing these between machines as part of the singleton invalidator and storing them (most likely in s3) to support webhooks and sync-table, so we'd like to keep them as small and efficient as possible.

Two main changes:

1. We use a jackson objectmapper to convert the wal2json records into java objects instead of creating plain clojure objects. I implemented ILookup on the new objects so that we can still do `(:action record)` instead of doing `(.action record)` (but I'll remove that later once we've fully switched over).
2. We create a `WalRecord` record instead of a map when we construct the wal-record.

Compared to regular json parse, the objectmapper is about twice as fast and uses about half the memory.

I've tested this locally, but it would be pretty bad if it failed in production. Before rolling it out to prod, we'll do two things: 1. I'll manually flip the `try-wal-entry?` def on one machine to make sure it all parses correctly, and 2. I'll manually flip the `use-wal-entry?` def on one machine to ensure that everything runs smoothly.

### Other changes

1. We pass a `previous-isn`, which we'll use in the singleton invalidator to detect if a machine somehow missed an update