### PR TITLE
[server] get-a-db apps

### DIFF
--- a/server/resources/migrations/105_seed_get_a_db_app_creator.down.sql
+++ b/server/resources/migrations/105_seed_get_a_db_app_creator.down.sql
@@ -1,0 +1,3 @@
+delete from
+  instant_users
+where id = '9bacaf3d-0c7d-46e6-bb1b-4b9fdb9c5b61'::uuid;

--- a/server/resources/migrations/105_seed_get_a_db_app_creator.up.sql
+++ b/server/resources/migrations/105_seed_get_a_db_app_creator.up.sql
@@ -6,10 +6,4 @@ values
     'hello+getadbapps@instantdb.com',
     '2026-04-21 00:00:00',
     null
-  ),
-  (
-    '9bacaf3d-0c7d-46e6-bb1b-4b9fdb9c5b61',
-    'hello+getadbapps@instantdb.com',
-    '2026-04-21 00:00:00',
-    null
   ) on conflict do nothing;

--- a/server/resources/migrations/105_seed_get_a_db_app_creator.up.sql
+++ b/server/resources/migrations/105_seed_get_a_db_app_creator.up.sql
@@ -1,0 +1,15 @@
+insert into
+  instant_users (id, email, created_at, google_sub)
+values
+  (
+    '9bacaf3d-0c7d-46e6-bb1b-4b9fdb9c5b61',
+    'hello+getadbapps@instantdb.com',
+    '2026-04-21 00:00:00',
+    null
+  ),
+  (
+    '9bacaf3d-0c7d-46e6-bb1b-4b9fdb9c5b61',
+    'hello+getadbapps@instantdb.com',
+    '2026-04-21 00:00:00',
+    null
+  ) on conflict do nothing;

--- a/server/src/instant/dash/get_a_db.clj
+++ b/server/src/instant/dash/get_a_db.clj
@@ -10,9 +10,7 @@
    [instant.util.string :as string-util]
    [instant.util.uuid :as uuid-util]
    [instant.superadmin.routes :refer [req->superadmin-user!]]
-   [ring.util.http-response :as response])
-  (:import
-   (java.util UUID)))
+   [ring.util.http-response :as response]))
 
 (def get-a-db-creator-email "hello+getadbapps@instantdb.com")
 

--- a/server/src/instant/dash/get_a_db.clj
+++ b/server/src/instant/dash/get_a_db.clj
@@ -1,0 +1,72 @@
+(ns instant.dash.get-a-db
+  (:require
+   [clojure.walk :as w]
+   [instant.model.app :as app-model]
+   [instant.model.instant-user :as instant-user-model]
+   [instant.model.rule :as rule-model]
+   [instant.model.schema :as schema-model]
+   [instant.util.exception :as ex]
+   [instant.util.posthog :as posthog]
+   [instant.util.string :as string-util]
+   [instant.util.uuid :as uuid-util]
+   [instant.superadmin.routes :refer [req->superadmin-user!]]
+   [ring.util.http-response :as response])
+  (:import
+   (java.util UUID)))
+
+(def get-a-db-creator-email "hello+getadbapps@instantdb.com")
+
+(def get-a-db-creator
+  (delay
+    (instant-user-model/get-by-email {:email get-a-db-creator-email})))
+
+(defn create!
+  [{:keys [title]}]
+  (app-model/create!
+   {:id (UUID/randomUUID)
+    :title title
+    :creator-id (:id @get-a-db-creator)
+    :admin-token (UUID/randomUUID)}))
+
+;; -----------
+;; HTTP Handler
+
+(defn http-post-handler [req]
+  (let [{user-id :id} (req->superadmin-user! :apps/write req)
+        _ (ex/assert-permitted!
+           :get-a-db-user?
+           user-id
+           (= user-id (:id @get-a-db-creator)))
+        title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
+        schema (get-in req [:body :schema])
+        rules-code (ex/get-optional-param! req [:body :rules :code] w/stringify-keys)
+        _ (when rules-code
+            (ex/assert-valid! :rule rules-code (rule-model/validation-errors
+                                                rules-code)))
+        app (create! {:title title})]
+    (when rules-code
+      (rule-model/put! {:app-id (:id app)
+                        :code rules-code}))
+    (when schema
+      (->> schema
+           (schema-model/plan! {:app-id (:id app)
+                                :check-types? true
+                                :background-updates? false})
+           (schema-model/apply-plan! (:id app))))
+    (posthog/track! req
+                    "app:create-get-a-db-app"
+                    {:app-id (str (:id app))})
+    (response/ok {:app app})))
+
+(defn http-get-handler [req]
+  (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
+        {app-creator-id :creator_id :as app} (app-model/get-by-id! {:id app-id})]
+    (ex/assert-permitted!
+     :claimable-app?
+     app-id
+     (= (:id @get-a-db-creator) app-creator-id))
+    (response/ok {:app app})))
+
+(comment
+  (def res (http-post-handler {:body {:title "my-app"}}))
+  (http-get-handler {:params {:app_id (-> res :body :app :id str)}}))

--- a/server/src/instant/dash/get_a_db.clj
+++ b/server/src/instant/dash/get_a_db.clj
@@ -26,7 +26,7 @@
    {:id (random-uuid)
     :title title
     :creator-id (:id @get-a-db-creator)
-    :admin-token (UUID/randomUUID)}))
+    :admin-token (random-uuid)}))
 
 ;; -----------
 ;; HTTP Handler

--- a/server/src/instant/dash/get_a_db.clj
+++ b/server/src/instant/dash/get_a_db.clj
@@ -23,7 +23,7 @@
 (defn create!
   [{:keys [title]}]
   (app-model/create!
-   {:id (UUID/randomUUID)
+   {:id (random-uuid)
     :title title
     :creator-id (:id @get-a-db-creator)
     :admin-token (UUID/randomUUID)}))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -9,6 +9,7 @@
             [instant.config :as config]
             [instant.dash.admin :as dash-admin]
             [instant.dash.ephemeral-app :as ephemeral-app]
+            [instant.dash.get-a-db :as get-a-db]
             [instant.db.indexing-jobs :as indexing-jobs]
             [instant.db.transaction :as tx]
             [instant.db.model.attr :as attr-model]
@@ -666,22 +667,31 @@
     (response/ok {:client (select-keys client [:id :provider_id :client_name
                                                :client_id :created_at])})))
 
-(defn ephemeral-claim-post [req]
+(defn claim-app-post
+  "Users can claim two kinds of apps: 
+  
+  1. Ephemeral Apps 
+  2. Apps made by getadb.com"
+  [req]
   (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
         token (ex/get-param! req [:body :token] uuid-util/coerce)
         {app-creator-id :creator_id} (app-model/get-by-id! {:id app-id})
-        {user-id :id user-email :email} (req->auth-user! req)]
+        {user-id :id user-email :email} (req->auth-user! req)
+
+        ephemeral-app? (= (:id @ephemeral-app/ephemeral-creator) app-creator-id)
+        get-a-db-app? (= (:id @get-a-db/get-a-db-creator) app-creator-id)]
     (ex/assert-permitted!
-     :ephemeral-app?
-     app-id
-     (= (:id @ephemeral-app/ephemeral-creator) app-creator-id))
+     :claimable-app?
+     app-id (or ephemeral-app? get-a-db-app?))
     ;; make sure the request comes with a valid admin token
     (app-admin-token-model/fetch! {:app-id app-id :token token})
     (app-model/change-creator! {:id app-id
                                 :new-creator-id user-id})
     (posthog/capture! user-email
                       "app:claim"
-                      {:app-id  (str app-id)
+                      {:ephemeral-app? ephemeral-app?
+                       :get-a-db-app? get-a-db-app?
+                       :app-id  (str app-id)
                        :user-id (str user-id)
                        :$email  user-email
                        :$ip     (posthog/extract-client-ip req)
@@ -1965,7 +1975,12 @@
 
   (GET "/dash/apps/ephemeral/:app_id" [] ephemeral-app/http-get-handler)
   (POST "/dash/apps/ephemeral" [] ephemeral-app/http-post-handler)
-  (POST "/dash/apps/ephemeral/:app_id/claim" [] ephemeral-claim-post)
+
+  (POST "/dash/apps/ephemeral/:app_id/claim" [] claim-app-post)
+  (POST "/dash/apps/:app_id/claim" [] claim-app-post)
+
+  (GET "/dash/apps/get_a_db/:app_id" [] get-a-db/http-get-handler)
+  (POST "/dash/apps/get_a_db" [] get-a-db/http-post-handler)
 
   (GET "/dash/apps/:app_id/auth" [] dash-apps-auth-get)
   (POST "/dash/apps/:app_id/authorized_redirect_origins" [] authorized-redirect-origins-post)

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1080,7 +1080,7 @@
                                        :Content-Type "application/json"}
                              :as :json
                              :body (->json {:title "test-get-a-db"})})
-            app-id (UUID/fromString (get-in resp [:body :app :id]))]
+            app-id (parse-uuid (get-in resp [:body :app :id]))]
         (try
           (is (= 200 (:status resp)))
           (is (= (:id @get-a-db/get-a-db-creator)

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -17,9 +17,7 @@
    [instant.stripe :as stripe]
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [->json <-json]]
-   [instant.util.tracer :as tracer])
-  (:import
-   (java.util UUID)))
+   [instant.util.tracer :as tracer]))
 
 (defn silence-routes-exceptions [f]
   (with-redefs [tracer/*silence-exceptions?* (atom true)]

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1083,7 +1083,7 @@
             app-id (UUID/fromString (get-in resp [:body :app :id]))]
         (try
           (is (= 200 (:status resp)))
-          (is (= (:id `@get-a-db/get-a-db-creator`)
+          (is (= (:id @get-a-db/get-a-db-creator)
                  (:creator_id (app-model/get-by-id! {:id app-id}))))
           (finally (app-model/delete-immediately-by-id! {:id app-id})))))))
 

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1080,11 +1080,10 @@
                                        :Content-Type "application/json"}
                              :as :json
                              :body (->json {:title "test-get-a-db"})})
-            _ (def resp resp)
             app-id (UUID/fromString (get-in resp [:body :app :id]))]
         (try
           (is (= 200 (:status resp)))
-          (is (= (:id @get-a-db/get-a-db-creator)
+          (is (= (:id `@get-a-db/get-a-db-creator`)
                  (:creator_id (app-model/get-by-id! {:id app-id}))))
           (finally (app-model/delete-immediately-by-id! {:id app-id})))))))
 

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -4,17 +4,22 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [instant.config :as config]
    [instant.fixtures :refer [random-email with-empty-app with-org with-pro-app with-startup-org with-free-org with-user]]
+   [instant.dash.ephemeral-app :as ephemeral-app]
+   [instant.dash.get-a-db :as get-a-db]
    [instant.dash.routes :as routes]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
+   [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
    [instant.model.instant-stripe-customer :as stripe-customer-model]
    [instant.model.org-members :as org-members]
    [instant.model.app-members :as app-members]
    [instant.stripe :as stripe]
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [->json <-json]]
-   [instant.util.tracer :as tracer]))
+   [instant.util.tracer :as tracer])
+  (:import
+   (java.util UUID)))
 
 (defn silence-routes-exceptions [f]
   (with-redefs [tracer/*silence-exceptions?* (atom true)]
@@ -650,7 +655,6 @@
                                                     :role :collaborator
                                                     :expected :ok}
 
-
                                                    {:type "outside-user"
                                                     :user outside-user
                                                     :role :owner
@@ -670,8 +674,6 @@
                 :ok (is (= (:id app)
                            (:id (:app (routes/req->app-and-user! role req)))))
                 :error (is (thrown? Exception (routes/req->app-and-user! role req)))))))))))
-
-
 
 (deftest you-are-an-app-member-of-the-org-if-you-are-a-member-of-an-app
   (with-startup-org
@@ -1057,3 +1059,95 @@
               (is (= 400 (:status resp)))
               (is (= "admin-token-mismatch"
                      (-> resp :body <-json (get "hint") (get "reason")))))))))))
+
+;; ---
+;; get-a-db
+
+(defn- with-pat
+  "Mints a PAT on the given user, runs f with the token string, always cleans up."
+  [user f]
+  (let [{:keys [id token]} (instant-personal-access-token-model/create!
+                            {:user-id (:id user) :name "test-pat"})]
+    (try (f token)
+         (finally (instant-personal-access-token-model/delete-by-id!
+                   {:id id :user-id (:id user)})))))
+
+(deftest get-a-db-create-allowed-with-creator-pat
+  (with-pat @get-a-db/get-a-db-creator
+    (fn [token]
+      (let [resp (http/post (str config/server-origin "/dash/apps/get_a_db")
+                            {:headers {:Authorization (str "Bearer " token)
+                                       :Content-Type "application/json"}
+                             :as :json
+                             :body (->json {:title "test-get-a-db"})})
+            _ (def resp resp)
+            app-id (UUID/fromString (get-in resp [:body :app :id]))]
+        (try
+          (is (= 200 (:status resp)))
+          (is (= (:id @get-a-db/get-a-db-creator)
+                 (:creator_id (app-model/get-by-id! {:id app-id}))))
+          (finally (app-model/delete-immediately-by-id! {:id app-id})))))))
+
+(deftest get-a-db-create-denied-with-other-pat
+  (with-user
+    (fn [u]
+      (with-pat u
+        (fn [token]
+          (let [resp (http/post (str config/server-origin "/dash/apps/get_a_db")
+                                {:throw-exceptions false
+                                 :headers {:Authorization (str "Bearer " token)
+                                           :Content-Type "application/json"}
+                                 :as :json
+                                 :body (->json {:title "test-get-a-db"})})]
+            (is (= 400 (:status resp)))
+            (is (= "permission-denied"
+                   (-> resp :body <-json (get "type"))))))))))
+
+(deftest claim-get-a-db-app
+  (with-user
+    (fn [u]
+      (let [{app-id :id admin-token :admin-token} (get-a-db/create! {:title "claim-me"})]
+        (try
+          (let [resp (http/post (str config/server-origin "/dash/apps/" app-id "/claim")
+                                {:headers {:Authorization (str "Bearer " (:refresh-token u))
+                                           :Content-Type "application/json"}
+                                 :as :json
+                                 :body (->json {:token (str admin-token)})})]
+            (is (= 200 (:status resp)))
+            (is (= (:id u)
+                   (:creator_id (app-model/get-by-id! {:id app-id})))))
+          (finally (app-model/delete-immediately-by-id! {:id app-id})))))))
+
+(deftest claim-ephemeral-app
+  (with-user
+    (fn [u]
+      (let [{app-id :id admin-token :admin-token} (ephemeral-app/create! {:title "claim-me"})]
+        (try
+          (let [resp (http/post (str config/server-origin "/dash/apps/ephemeral/" app-id "/claim")
+                                {:headers {:Authorization (str "Bearer " (:refresh-token u))
+                                           :Content-Type "application/json"}
+                                 :as :json
+                                 :body (->json {:token (str admin-token)})})]
+            (is (= 200 (:status resp)))
+            (is (= (:id u)
+                   (:creator_id (app-model/get-by-id! {:id app-id})))))
+          (finally (app-model/delete-immediately-by-id! {:id app-id})))))))
+
+(deftest claim-denied-on-normal-app
+  (with-user
+    (fn [owner]
+      (with-empty-app (:id owner)
+        (fn [app]
+          (with-user
+            (fn [claimer]
+              (let [resp (http/post (str config/server-origin "/dash/apps/" (:id app) "/claim")
+                                    {:throw-exceptions false
+                                     :headers {:Authorization (str "Bearer " (:refresh-token claimer))
+                                               :Content-Type "application/json"}
+                                     :as :json
+                                     :body (->json {:token (str (:admin-token app))})})]
+                (is (= 400 (:status resp)))
+                (is (= "permission-denied"
+                       (-> resp :body <-json (get "type"))))
+                (is (= (:id owner)
+                       (:creator_id (app-model/get-by-id! {:id (:id app)}))))))))))))


### PR DESCRIPTION
For getadb.com, we need a way to:

1. Spin up apps that never expire
2. Have these apps be claimable

We couldn't use ephemeral apps to satisfy 1., since they expire. 

To solve for this, 

(1) I added separate `get-a-db` endpoints for creating these apps. They are quite similar to the ephemeral-app endpoints, with one caveat: this _requires_ an access token to create apps. These apps never expire

(2) I updated our claim flow, so we accept _both_ ephemeral apps and get-a-db apps.

**Notes** 

The only way to claim ephemeral apps and get-a-db apps currently is through the cli. 

**You may wonder: why not support the dashboard, by passing in ?appId=...&adminToken=... ?** 

This would expose the admin token in url history, which could be a security vulnerability. We could create a special-purpose UI in the dashboard that does this, or create some kind of ticketing system, but for now I think just the CLI is fine. 

@dwwoelfel @nezaj @drew-harris 