### PR TITLE
Fix attr name change timeouts

### DIFF
--- a/server/src/instant/db/model/attr.clj
+++ b/server/src/instant/db/model/attr.clj
@@ -615,10 +615,21 @@
                        :eav [:case [:= :a.value-type [:inline "ref"]] true :else false]
                        :av :a.is-unique
                        :ave :a.is-indexed}
-                 :from [[:attr-updates :a]]
+                 :from [[:attr-updates :a] [:attrs :old]]
                  :where [:and
                          [:= :triples.app-id :a.app-id]
-                         [:= :triples.attr-id :a.id]]
+                         [:= :triples.attr-id :a.id]
+                         [:= :old.id :a.id]
+                         [:= :old.app-id :a.app-id]
+                         [:or
+                          [:is-distinct-from
+                           [:= :a.cardinality [:inline "one"]]
+                           [:= :old.cardinality [:inline "one"]]]
+                          [:is-distinct-from
+                           [:= :a.value-type [:inline "ref"]]
+                           [:= :old.value-type [:inline "ref"]]]
+                          [:is-distinct-from :a.is-unique :old.is-unique]
+                          [:is-distinct-from :a.is-indexed :old.is-indexed]]]
                  :returning :triples.entity_id}]]
               (if-some [ident-table-vals (seq (ident-table-values app-id updates))]
                 [[[:ident-values

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -677,6 +677,84 @@
                                           [[:= :attr-id name-attr-id]])
                       (map :index)))))))))
 
+(deftest rename-attr-does-not-touch-triples
+  (with-empty-app
+    (fn [{app-id :id}]
+      (let [attr-id (random-uuid)
+            fwd-ident (random-uuid)
+            rev-ident (random-uuid)
+            other-attr-id (random-uuid)
+            other-ident (random-uuid)
+            eid-a (random-uuid)
+            eid-b (random-uuid)
+            triple-xmins (fn [a-id]
+                           (->> (sql/select
+                                 (aurora/conn-pool :read)
+                                 ["select entity_id, xmin::text as xmin
+                                     from triples
+                                    where app_id = ?::uuid and attr_id = ?::uuid
+                                    order by entity_id"
+                                  app-id a-id])
+                                (map (juxt :entity_id :xmin))))]
+        (tx/transact!
+         (aurora/conn-pool :write)
+         (attr-model/get-by-app-id app-id)
+         app-id
+         [[:add-attr
+           {:id attr-id
+            :forward-identity [fwd-ident "users" "tags"]
+            :reverse-identity [rev-ident "tags" "taggers"]
+            :value-type :ref
+            :cardinality :many
+            :unique? false
+            :index? false}]
+          [:add-attr
+           {:id other-attr-id
+            :forward-identity [other-ident "users" "name"]
+            :value-type :blob
+            :cardinality :one
+            :unique? false
+            :index? false}]
+          [:add-triple eid-a attr-id eid-b]
+          [:add-triple eid-a other-attr-id "stopa"]])
+
+        (let [xmins-before (triple-xmins attr-id)
+              other-xmins-before (triple-xmins other-attr-id)]
+          (is (seq xmins-before))
+
+          (testing "renaming forward-identity leaves triples untouched"
+            (tx/transact!
+             (aurora/conn-pool :write)
+             (attr-model/get-by-app-id app-id)
+             app-id
+             [[:update-attr
+               {:id attr-id
+                :forward-identity [fwd-ident "users" "tagz"]}]])
+            (is (= xmins-before (triple-xmins attr-id)))
+            (is (= other-xmins-before (triple-xmins other-attr-id))))
+
+          (testing "renaming reverse-identity leaves triples untouched"
+            (tx/transact!
+             (aurora/conn-pool :write)
+             (attr-model/get-by-app-id app-id)
+             app-id
+             [[:update-attr
+               {:id attr-id
+                :reverse-identity [rev-ident "tags" "taggerz"]}]])
+            (is (= xmins-before (triple-xmins attr-id)))
+            (is (= other-xmins-before (triple-xmins other-attr-id))))
+
+          (testing "flipping an index-affecting field still rewrites triples"
+            (tx/transact!
+             (aurora/conn-pool :write)
+             (attr-model/get-by-app-id app-id)
+             app-id
+             [[:update-attr
+               {:id attr-id
+                :cardinality :one}]])
+            (is (not= xmins-before (triple-xmins attr-id)))
+            (is (= other-xmins-before (triple-xmins other-attr-id)))))))))
+
 ;; Test passing map to transact that gets expanded into [:add-triple ...] and resolves attr-ids
 (deftest transact-map-form
   (with-empty-app

--- a/server/test/instant/db/transaction_test.clj
+++ b/server/test/instant/db/transaction_test.clj
@@ -689,7 +689,7 @@
             eid-b (random-uuid)
             triple-xmins (fn [a-id]
                            (->> (sql/select
-                                 (aurora/conn-pool :read)
+                                 (aurora/conn-pool :write)
                                  ["select entity_id, xmin::text as xmin
                                      from triples
                                     where app_id = ?::uuid and attr_id = ?::uuid


### PR DESCRIPTION
Fixes a timeout where changing the attr name would cause a timeout on large namespaces.

When you update the attr, we update the index fields on the triples. But when you change the name, none of the index fields should be affected. This PR skips updating the triples if none of the relevant attr columns change.