### PR TITLE
[CLI] Make abort actions cancel isntead of confirm

### DIFF
--- a/client/packages/cli/__tests__/promptOk.test.ts
+++ b/client/packages/cli/__tests__/promptOk.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, describe, vi } from 'vitest';
+import { Effect, Layer } from 'effect';
+import { promptOk } from '../src/lib/ui.ts';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CancelledPromptError } from '../src/ui/lib.ts';
+
+const run = (effect: Effect.Effect<boolean, any, GlobalOpts>, yes: boolean) =>
+  Effect.runPromise(
+    effect.pipe(Effect.provide(Layer.succeed(GlobalOpts, { yes }))),
+  );
+
+let mockPromptReturn: boolean | Error = true;
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: () =>
+      mockPromptReturn instanceof Error
+        ? Promise.reject(mockPromptReturn)
+        : Promise.resolve(mockPromptReturn),
+  };
+});
+
+const baseProps = { promptText: 'Push these changes?' };
+
+describe('yes flag', () => {
+  test('yes=true → returns defaultValue (true)', async () => {
+    const result = await run(promptOk(baseProps, true), true);
+    expect(result).toBe(true);
+  });
+
+  test('yes=true → returns defaultValue (false)', async () => {
+    const result = await run(promptOk(baseProps, false), true);
+    expect(result).toBe(false);
+  });
+});
+
+describe('interactive', () => {
+  test('user confirms → true', async () => {
+    mockPromptReturn = true;
+    const result = await run(promptOk(baseProps, true), false);
+    expect(result).toBe(true);
+  });
+
+  test('user declines → false', async () => {
+    mockPromptReturn = false;
+    const result = await run(promptOk(baseProps, true), false);
+    expect(result).toBe(false);
+  });
+
+  test('user aborts (Esc) → false, even when defaultValue=true', async () => {
+    mockPromptReturn = new CancelledPromptError('Prompt was aborted');
+    const result = await run(promptOk(baseProps, true), false);
+    expect(result).toBe(false);
+  });
+});

--- a/client/packages/cli/src/lib/ui.ts
+++ b/client/packages/cli/src/lib/ui.ts
@@ -25,7 +25,7 @@ export const promptOk = Effect.fn('promptOk')(function* (
         defaultValue,
       }),
     ),
-  ).pipe(Effect.orElseSucceed(() => defaultValue));
+  ).pipe(Effect.orElseSucceed(() => false));
 
   return ok;
 });


### PR DESCRIPTION
We got a report that hitting `Esc` when pushing with `instant-cli` would confirm instead of abort. This is because we would use `defaultValue` in the abort/error case which is often set to true.

This updates behavior so aborts return `false`, making it so pressing escape works as expected