### PR TITLE
Stop password managers from claiming sensitive inputs; fix noreferer typo

### DIFF
--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -231,14 +231,29 @@ export function TextInput({
       <input
         disabled={disabled}
         title={title}
-        type={type === 'sensitive' ? 'password' : (type ?? 'text')}
-        // Try to prevent password managers from trying to save
-        // sensitive input, LastPass, 1password, BitWarden
+        // Try to prevent password managers (LastPass, 1Password,
+        // BitWarden) from attaching to or saving sensitive input.
         autoComplete={type === 'sensitive' ? 'off' : undefined}
         data-lpignore={type === 'sensitive' ? 'true' : undefined}
         data-1p-ignore={type === 'sensitive' ? 'true' : undefined}
         data-bwignore={type === 'sensitive' ? 'true' : undefined}
         data-form-type={type === 'sensitive' ? 'other' : undefined}
+        // LastPass attaches its UI to any <input type="password"> even
+        // when data-lpignore="true" is set. To opt out we render the
+        // field as type="text" and use -webkit-text-security to mask
+        // the value as discs visually.
+        type={type === 'sensitive' ? 'text' : (type ?? 'text')}
+        style={
+          type === 'sensitive' ? { WebkitTextSecurity: 'disc' } : undefined
+        }
+        // Turn off the text-entry protections that `type="password"`
+        // gives you for free but `type="text"` doesn't: browsers
+        // spellcheck on desktop and autocorrect / autocapitalize on
+        // mobile for text inputs, any of which can quietly mutate a
+        // secret or train the keyboard on its characters.
+        spellCheck={type === 'sensitive' ? false : undefined}
+        autoCapitalize={type === 'sensitive' ? 'none' : undefined}
+        autoCorrect={type === 'sensitive' ? 'off' : undefined}
         ref={inputRef}
         inputMode={inputMode}
         placeholder={placeholder}

--- a/client/www/components/dash/auth/Apple.tsx
+++ b/client/www/components/dash/auth/Apple.tsx
@@ -113,7 +113,7 @@ export function AppleClient({
               className="underline"
               href="/docs/auth/apple"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
             >
               Setup and Usage
             </a>
@@ -266,7 +266,7 @@ export function AddClientExpanded({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://developer.apple.com/account/resources/identifiers/list/serviceId"
             >
               Identifiers
@@ -302,7 +302,7 @@ export function AddClientExpanded({
                   <a
                     className="underline"
                     target="_blank"
-                    rel="noopener noreferer"
+                    rel="noopener noreferrer"
                     href="https://developer.apple.com/account#MembershipDetailsCard"
                   >
                     Membership details
@@ -321,7 +321,7 @@ export function AddClientExpanded({
                   <a
                     className="underline"
                     target="_blank"
-                    rel="noopener noreferer"
+                    rel="noopener noreferrer"
                     href="https://developer.apple.com/account/resources/authkeys/list"
                   >
                     Keys

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -357,7 +357,7 @@ export function ClerkClient({
                 className="underline dark:text-white"
                 href={`https://dashboard.clerk.com`}
                 target="_blank"
-                rel="noopener noreferer"
+                rel="noopener noreferrer"
               >
                 Clerk dashboard
               </a>
@@ -531,7 +531,7 @@ export function AddClerkClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://dashboard.clerk.com/last-active?path=api-keys"
             >
               Clerk dashboard
@@ -547,7 +547,7 @@ export function AddClerkClientForm({
             className="underline dark:text-white"
             href={'https://dashboard.clerk.com/last-active?path=sessions'}
             target="_blank"
-            rel="noopener noreferer"
+            rel="noopener noreferrer"
           >
             Clerk dashboard
           </a>

--- a/client/www/components/dash/auth/Firebase.tsx
+++ b/client/www/components/dash/auth/Firebase.tsx
@@ -334,7 +334,7 @@ export function AddFirebaseClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://console.firebase.google.com/"
             >
               Firebase dashboard

--- a/client/www/components/dash/auth/GitHub.tsx
+++ b/client/www/components/dash/auth/GitHub.tsx
@@ -195,7 +195,7 @@ export function AddGitHubClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://github.com/settings/developers"
             >
               GitHub OAuth Apps
@@ -216,7 +216,7 @@ export function AddGitHubClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://github.com/settings/developers"
             >
               GitHub OAuth Apps

--- a/client/www/components/dash/auth/Google.tsx
+++ b/client/www/components/dash/auth/Google.tsx
@@ -185,7 +185,7 @@ export function AddGoogleClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://console.developers.google.com/apis/credentials"
             >
               Google console
@@ -207,7 +207,7 @@ export function AddGoogleClientForm({
               <a
                 className="underline"
                 target="_blank"
-                rel="noopener noreferer"
+                rel="noopener noreferrer"
                 href="https://console.developers.google.com/apis/credentials"
               >
                 Google console
@@ -227,7 +227,7 @@ export function AddGoogleClientForm({
             <a
               className="underline dark:text-white"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href={
                 clientId
                   ? `https://console.cloud.google.com/apis/credentials/oauthclient/${clientId}`
@@ -513,7 +513,7 @@ function Login() {
                     className="underline dark:text-white"
                     href={`https://console.cloud.google.com/apis/credentials/oauthclient/${client.client_id}`}
                     target="_blank"
-                    rel="noopener noreferer"
+                    rel="noopener noreferrer"
                   >
                     Google OAuth client
                   </a>{' '}

--- a/client/www/components/dash/auth/LinkedIn.tsx
+++ b/client/www/components/dash/auth/LinkedIn.tsx
@@ -197,7 +197,7 @@ export function AddLinkedInClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://www.linkedin.com/developers/apps"
             >
               LinkedIn developer portal
@@ -218,7 +218,7 @@ export function AddLinkedInClientForm({
             <a
               className="underline"
               target="_blank"
-              rel="noopener noreferer"
+              rel="noopener noreferrer"
               href="https://www.linkedin.com/developers/apps"
             >
               LinkedIn developer portal

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -106,7 +106,7 @@ export function NavTabBar({
           <Link
             key={t.id}
             {...t.link}
-            rel="noopener noreferer"
+            rel="noopener noreferrer"
             className={clsx(
               'flex cursor-pointer rounded bg-none p-2 py-0.5 whitespace-nowrap disabled:text-gray-400',
               {


### PR DESCRIPTION
Two small fixes that were bundled into #2553 (shared-creds). 

Splitting them out so they can land on their own.

## 1) TextInput sensitive-type handling

Our Client ID and Client Secret inputs kept being picked up by Lastpass. 

One big reason for it: **If you set `type=password`, lastpass would often ignore signals like `datalp-ignore`, and attach anyways**


**To fix this:** We now render sensitive inputs as type=text, and add `-webkit-text-security: disc`. The field stops being a password input as far as password managers are concerned. The value still appears as discs visually (Safari, Chrome, Edge, Firefox 130+).

## 2) \`rel=\"noopener noreferer\"\` → \`rel=\"noopener noreferrer\"\`

Single-r misspelling in 16 places across the OAuth provider tabs and \`NavTabBar\`. Browsers silently ignore unknown \`rel\` tokens, so the typo meant we weren't actually suppressing the Referer header on those external links.

@dwwoelfel @nezaj @drew-harris 