### PR TITLE
Add bin/nrepl-eval script + document it in dev-llm-rules

### DIFF
--- a/server/bin/nrepl-eval
+++ b/server/bin/nrepl-eval
@@ -1,0 +1,51 @@
+#!/usr/bin/env bb
+;; Inspired by
+;; https://github.com/babashka/nrepl-client/blob/main/src/impl/babashka/nrepl_client.clj
+(require '[bencode.core :as bc]
+         '[clojure.java.io :as io]
+         '[clojure.string :as str])
+
+(defn- ->str [v] (if (bytes? v) (String. ^bytes v) v))
+
+(defn- decode [m]
+  (let [m (reduce-kv (fn [acc k v] (assoc acc (keyword (->str k)) (->str v))) {} m)]
+    (cond-> m
+      (:status m) (update :status #(mapv ->str %)))))
+
+(defn- send-recv [out in msg match?]
+  (bc/write-bencode out msg)
+  (.flush ^java.io.OutputStream out)
+  (loop []
+    (let [m (decode (bc/read-bencode in))]
+      (if (match? m) m (recur)))))
+
+(defn- read-until-done [out in msg]
+  (bc/write-bencode out msg)
+  (.flush ^java.io.OutputStream out)
+  (loop [acc {:vals [] :out "" :err ""}]
+    (let [{:keys [status value] :as m} (decode (bc/read-bencode in))
+          acc (cond-> acc
+                value        (update :vals conj value)
+                (:out m)     (update :out str (:out m))
+                (:err m)     (update :err str (:err m)))]
+      (if (some #{"done"} status) acc (recur acc)))))
+
+(defn nrepl-eval [port code]
+  (with-open [s   (java.net.Socket. "127.0.0.1" (int port))
+              in  (java.io.PushbackInputStream. (io/input-stream s))
+              out (io/output-stream s)]
+    (let [clone-id (str (random-uuid))
+          {session :new-session} (send-recv out in
+                                            {"op" "clone" "id" clone-id}
+                                            #(= clone-id (:id %)))
+          eval-id  (str (random-uuid))]
+      (read-until-done out in
+                       {"op" "eval" "code" code "id" eval-id "session" session}))))
+
+(let [[arg] *command-line-args*
+      code  (if (or (nil? arg) (= "-" arg)) (slurp *in*) arg)
+      port  (Integer/parseInt (str/trim (slurp ".nrepl-port")))
+      {:keys [vals out err]} (nrepl-eval port code)]
+  (when (seq out) (print out))
+  (when (seq err) (binding [*out* *err*] (print err)))
+  (doseq [v vals] (println v)))

--- a/server/dev-llm-rules.md
+++ b/server/dev-llm-rules.md
@@ -163,9 +163,11 @@ Application starts at `instant.core/-main`. Server runs on Undertow at port 8888
 When you need to debug Clojure code, the running nREPL is often the fastest way to poke at live state.
 
 `scripts/nrepl-eval` is a babashka one-shot client. It reads the port from
-`.nrepl-port` and accepts code via argv, stdin, or `-`. Fully-qualified
-symbols resolve from `user`; prepend `(in-ns 'foo)` if you need to be inside
-a namespace.
+`.nrepl-port` (or `--port N`) and accepts code via argv, stdin, or `-`.
+Fully-qualified symbols resolve from `user`; prepend `(in-ns 'foo)` if you
+need to be inside a namespace. If you edited code on disk and want the
+server to pick it up, reload the namespace first:
+`(require 'instant.runtime.routes :reload)`.
 
 ```bash
 scripts/nrepl-eval "(var instant.runtime.routes/client)"   # one-liner
@@ -174,6 +176,7 @@ scripts/nrepl-eval <<'EOF'                                  # big form, no escap
     (keys @(var r/client)))
 EOF
 scripts/nrepl-eval < scratch/probe.clj                     # from a file
+scripts/nrepl-eval --port 6006 "(+ 1 1)"                   # explicit port
 ```
 
 ## Navigation Guide

--- a/server/dev-llm-rules.md
+++ b/server/dev-llm-rules.md
@@ -158,6 +158,24 @@ Use `DEV_SLOT` for running multiple servers: `DEV_SLOT=1 make dev` (shifts all p
 
 Application starts at `instant.core/-main`. Server runs on Undertow at port 8888 (configurable via `PORT` env var). nREPL available on port 6005.
 
+### Talking to the running nREPL
+
+When you need to debug Clojure code, the running nREPL is often the fastest way to poke at live state.
+
+`bin/nrepl-eval` is a babashka one-shot client. It reads the port from
+`.nrepl-port` and accepts code via argv, stdin, or `-`. Fully-qualified
+symbols resolve from `user`; prepend `(in-ns 'foo)` if you need to be inside
+a namespace.
+
+```bash
+bin/nrepl-eval "(var instant.runtime.routes/client)"   # one-liner
+bin/nrepl-eval <<'EOF'                                  # big form, no escaping
+(do (require '[instant.runtime.routes :as r])
+    (keys @(var r/client)))
+EOF
+bin/nrepl-eval < scratch/probe.clj                     # from a file
+```
+
 ## Navigation Guide
 
 - **Schema/permissions work**: Start at `model/schema.clj` and `model/rule.clj`, then `db/cel.clj` for CEL evaluation

--- a/server/dev-llm-rules.md
+++ b/server/dev-llm-rules.md
@@ -166,8 +166,7 @@ When you need to debug Clojure code, the running nREPL is often the fastest way 
 `.nrepl-port` (or `--port N`) and accepts code via argv, stdin, or `-`.
 Fully-qualified symbols resolve from `user`; prepend `(in-ns 'foo)` if you
 need to be inside a namespace. If you edited code on disk and want the
-server to pick it up, reload the namespace first:
-`(require 'instant.runtime.routes :reload)`.
+server to pick it up, reload the namespace first: `(require 'foo :reload)`.
 
 ```bash
 scripts/nrepl-eval "(var instant.runtime.routes/client)"   # one-liner

--- a/server/dev-llm-rules.md
+++ b/server/dev-llm-rules.md
@@ -162,18 +162,18 @@ Application starts at `instant.core/-main`. Server runs on Undertow at port 8888
 
 When you need to debug Clojure code, the running nREPL is often the fastest way to poke at live state.
 
-`bin/nrepl-eval` is a babashka one-shot client. It reads the port from
+`scripts/nrepl-eval` is a babashka one-shot client. It reads the port from
 `.nrepl-port` and accepts code via argv, stdin, or `-`. Fully-qualified
 symbols resolve from `user`; prepend `(in-ns 'foo)` if you need to be inside
 a namespace.
 
 ```bash
-bin/nrepl-eval "(var instant.runtime.routes/client)"   # one-liner
-bin/nrepl-eval <<'EOF'                                  # big form, no escaping
+scripts/nrepl-eval "(var instant.runtime.routes/client)"   # one-liner
+scripts/nrepl-eval <<'EOF'                                  # big form, no escaping
 (do (require '[instant.runtime.routes :as r])
     (keys @(var r/client)))
 EOF
-bin/nrepl-eval < scratch/probe.clj                     # from a file
+scripts/nrepl-eval < scratch/probe.clj                     # from a file
 ```
 
 ## Navigation Guide

--- a/server/scripts/nrepl-eval
+++ b/server/scripts/nrepl-eval
@@ -42,9 +42,19 @@
       (read-until-done out in
                        {"op" "eval" "code" code "id" eval-id "session" session}))))
 
+(defn- find-port-file [start]
+  (loop [dir (.getAbsoluteFile ^java.io.File start)]
+    (when dir
+      (let [f (io/file dir ".nrepl-port")]
+        (if (.exists f) f (recur (.getParentFile dir)))))))
+
 (let [[arg] *command-line-args*
       code  (if (or (nil? arg) (= "-" arg)) (slurp *in*) arg)
-      port  (Integer/parseInt (str/trim (slurp ".nrepl-port")))
+      pf    (or (find-port-file (.getParentFile (io/file *file*)))
+                (binding [*out* *err*]
+                  (println "Could not find .nrepl-port. Is `make dev` running?")
+                  (System/exit 1)))
+      port  (Integer/parseInt (str/trim (slurp pf)))
       {:keys [vals out err]} (nrepl-eval port code)]
   (when (seq out) (print out))
   (when (seq err) (binding [*out* *err*] (print err)))

--- a/server/scripts/nrepl-eval
+++ b/server/scripts/nrepl-eval
@@ -1,7 +1,8 @@
 #!/usr/bin/env bb
 ;; Inspired by
 ;; https://github.com/babashka/nrepl-client/blob/main/src/impl/babashka/nrepl_client.clj
-(require '[bencode.core :as bc]
+(require '[babashka.cli :as cli]
+         '[bencode.core :as bc]
          '[clojure.java.io :as io]
          '[clojure.string :as str])
 
@@ -48,17 +49,12 @@
       (let [f (io/file dir ".nrepl-port")]
         (if (.exists f) f (recur (.getParentFile dir)))))))
 
-(defn- extract-port [args]
-  (loop [args args, port nil, acc []]
-    (cond
-      (empty? args)            [port acc]
-      (#{"--port" "-p"} (first args)) (recur (drop 2 args) (Integer/parseInt (second args)) acc)
-      :else                    (recur (next args) port (conj acc (first args))))))
-
-(let [[port-arg rest-args] (extract-port *command-line-args*)
-      [arg] rest-args
+(let [{:keys [opts args]} (cli/parse-args *command-line-args*
+                                          {:coerce {:port :long}
+                                           :alias  {:p :port}})
+      [arg] args
       code  (if (or (nil? arg) (= "-" arg)) (slurp *in*) arg)
-      port  (or port-arg
+      port  (or (:port opts)
                 (let [pf (or (find-port-file (.getParentFile (io/file *file*)))
                              (binding [*out* *err*]
                                (println "Could not find .nrepl-port. Is `make dev` running? Or pass --port N.")

--- a/server/scripts/nrepl-eval
+++ b/server/scripts/nrepl-eval
@@ -43,23 +43,17 @@
       (read-until-done out in
                        {"op" "eval" "code" code "id" eval-id "session" session}))))
 
-(defn- find-port-file [start]
-  (loop [dir (.getAbsoluteFile ^java.io.File start)]
-    (when dir
-      (let [f (io/file dir ".nrepl-port")]
-        (if (.exists f) f (recur (.getParentFile dir)))))))
-
 (let [{:keys [opts args]} (cli/parse-args *command-line-args*
                                           {:coerce {:port :long}
                                            :alias  {:p :port}})
       [arg] args
       code  (if (or (nil? arg) (= "-" arg)) (slurp *in*) arg)
+      pf    (io/file (.getParentFile (io/file *file*)) ".." ".nrepl-port")
       port  (or (:port opts)
-                (let [pf (or (find-port-file (.getParentFile (io/file *file*)))
-                             (binding [*out* *err*]
-                               (println "Could not find .nrepl-port. Is `make dev` running? Or pass --port N.")
-                               (System/exit 1)))]
-                  (Integer/parseInt (str/trim (slurp pf)))))
+                (when (.exists pf) (Integer/parseInt (str/trim (slurp pf))))
+                (binding [*out* *err*]
+                  (println "Could not find .nrepl-port. Is `make dev` running? Or pass --port N.")
+                  (System/exit 1)))
       {:keys [vals out err]} (nrepl-eval port code)]
   (when (seq out) (print out))
   (when (seq err) (binding [*out* *err*] (print err)))

--- a/server/scripts/nrepl-eval
+++ b/server/scripts/nrepl-eval
@@ -48,13 +48,22 @@
       (let [f (io/file dir ".nrepl-port")]
         (if (.exists f) f (recur (.getParentFile dir)))))))
 
-(let [[arg] *command-line-args*
+(defn- extract-port [args]
+  (loop [args args, port nil, acc []]
+    (cond
+      (empty? args)            [port acc]
+      (#{"--port" "-p"} (first args)) (recur (drop 2 args) (Integer/parseInt (second args)) acc)
+      :else                    (recur (next args) port (conj acc (first args))))))
+
+(let [[port-arg rest-args] (extract-port *command-line-args*)
+      [arg] rest-args
       code  (if (or (nil? arg) (= "-" arg)) (slurp *in*) arg)
-      pf    (or (find-port-file (.getParentFile (io/file *file*)))
-                (binding [*out* *err*]
-                  (println "Could not find .nrepl-port. Is `make dev` running?")
-                  (System/exit 1)))
-      port  (Integer/parseInt (str/trim (slurp pf)))
+      port  (or port-arg
+                (let [pf (or (find-port-file (.getParentFile (io/file *file*)))
+                             (binding [*out* *err*]
+                               (println "Could not find .nrepl-port. Is `make dev` running? Or pass --port N.")
+                               (System/exit 1)))]
+                  (Integer/parseInt (str/trim (slurp pf)))))
       {:keys [vals out err]} (nrepl-eval port code)]
   (when (seq out) (print out))
   (when (seq err) (binding [*out* *err*] (print err)))

--- a/server/scripts/prod_tunnel.sh
+++ b/server/scripts/prod_tunnel.sh
@@ -24,14 +24,10 @@ fi
 
 echo "Setting up tunnel to $instance_id on port $port"
 
-echo "$port" > .nrepl-port
-
 aws ssm start-session \
     --document-name "AWS-StartPortForwardingSession" \
     --target "$instance_id" \
     --parameters "{\"portNumber\":[\"6005\"],\"localPortNumber\":[\"$port\"]}" \
     --region "us-east-1"
-
-rm .nrepl-port
 
 echo "Tunnel closed"


### PR DESCRIPTION
**Wouldn't it be nice if agents could eval forms in the REPL?** 

I found myself wanting this when debugging shared-dev-credentials.

I asked Claude to generate a little `nrepl-eval` script in babashka. 

It can connect to your running nrepl and eval any form. 

I added a note about usage in server/dev-lllm-rules, so your friendly LLM can pick this up right away

@dwwoelfel @nezaj @drew-harris