### PR TITLE
Add npm license metadata to client packages

### DIFF
--- a/client/packages/admin/package.json
+++ b/client/packages/admin/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/admin",
   "version": "0.0.0",
   "description": "Admin SDK for Instant DB",
+  "license": "Apache-2.0",
   "type": "module",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/admin",
   "repository": {

--- a/client/packages/cli/package.json
+++ b/client/packages/cli/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "description": "Instant's CLI",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/cli",
   "repository": {
     "type": "git",

--- a/client/packages/components/package.json
+++ b/client/packages/components/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "description": "Instant's UI components",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/components",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/client/packages/core/package.json
+++ b/client/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/core",
   "version": "0.0.0",
   "description": "Instant's core local abstraction",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/core",
   "repository": {
     "type": "git",

--- a/client/packages/mcp/package.json
+++ b/client/packages/mcp/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/mcp",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for managing Instant apps, schemas, and permissions!",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/mcp",
   "repository": {
     "type": "git",

--- a/client/packages/platform/package.json
+++ b/client/packages/platform/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/platform",
   "version": "0.0.0",
   "description": "Instant's platform package for managing Instant apps.",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/platform",
   "repository": {
     "type": "git",

--- a/client/packages/react-common/package.json
+++ b/client/packages/react-common/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/react-common",
   "version": "0.0.0",
   "description": "Instant DB shared components for React and React Native",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/react-common",
   "repository": {
     "type": "git",

--- a/client/packages/react-native-mmkv/package.json
+++ b/client/packages/react-native-mmkv/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/react-native-mmkv",
   "version": "0.0.0",
   "description": "React Native MMKV interface for Instant DB",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/react-native-mmkv",
   "repository": {
     "type": "git",

--- a/client/packages/react-native/package.json
+++ b/client/packages/react-native/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/react-native",
   "version": "0.0.0",
   "description": "Instant DB for React Native",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/react-native",
   "repository": {
     "type": "git",

--- a/client/packages/react/package.json
+++ b/client/packages/react/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/react",
   "version": "0.0.0",
   "description": "Instant DB for React",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/react",
   "repository": {
     "type": "git",

--- a/client/packages/resumable-stream/package.json
+++ b/client/packages/resumable-stream/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/resumable-stream",
   "version": "0.0.0",
   "description": "Instant's drop-in replacement for Vercel's resumable-stream package.",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/resumable-stream",
   "repository": {
     "type": "git",

--- a/client/packages/solidjs/package.json
+++ b/client/packages/solidjs/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "description": "SolidJS client for InstantDB",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/instantdb/instant.git",

--- a/client/packages/svelte/package.json
+++ b/client/packages/svelte/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "description": "Svelte client for InstantDB",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/svelte",
   "repository": {
     "type": "git",

--- a/client/packages/version/package.json
+++ b/client/packages/version/package.json
@@ -2,6 +2,7 @@
   "name": "@instantdb/version",
   "version": "0.0.0",
   "description": "Instant's shared version package",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/instantdb/instant/tree/main/client/packages/version",
   "repository": {
     "type": "git",

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.13';
+const version = 'v1.0.14';
 
 export { version };


### PR DESCRIPTION
Add license field to the package.json for all of the packages.

I used the same license, [Apache-2.0 license](https://github.com/instantdb/instant?tab=Apache-2.0-1-ov-file#), that we show on github.

Looks like this on npm: https://www.npmjs.com/package/@instantdb/react/v/1.0.13-branch-codex-add-license-to-all-packages.24801379929.1