### PR TITLE
[in-progress] [cli] dev credentials for google

### DIFF
--- a/client/packages/cli/__tests__/authClientAddGoogle.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGoogle.test.ts
@@ -169,10 +169,14 @@ describe('web: interactive prompts for each missing flag', () => {
     expect((prompts[0] as any).props.prompt).toBe('Client Name:');
   });
 
-  test('missing --client-id → prompts for client id', async () => {
-    mockPromptReturn = '123456.apps.googleusercontent.com';
+  test('missing --client-id → prompts for credential mode then client id', async () => {
+    // With neither --client-id nor --dev-credentials the CLI first
+    // asks whether the user wants dev creds or their own. After
+    // picking 'custom' it falls through to the Client ID prompt.
+    mockPromptReturn = 'custom';
     await run(without(webFlags, 'client-id'), { yes: false });
-    expect((prompts[0] as any).props.prompt).toContain('Client ID');
+    expect((prompts[0] as any).params.promptText).toBe('Credential mode:');
+    expect((prompts[1] as any).props.prompt).toContain('Client ID');
   });
 
   test('missing --client-secret → prompts for client secret', async () => {
@@ -273,5 +277,82 @@ describe('ios', () => {
     expect(output).toContain(
       'Google Client ID: 123456.apps.googleusercontent.com',
     );
+  });
+});
+
+// -- web: dev credentials (shared) --
+
+const webDevFlags = new Map([
+  ['type', 'google'],
+  ['app-type', 'web'],
+  ['name', 'g-dev'],
+  ['dev-credentials', 'true'],
+]);
+
+describe('web: --dev-credentials', () => {
+  test('--yes + --dev-credentials → creates a shared-creds client', async () => {
+    await run(webDevFlags, { yes: true });
+    expect(addedClients).toHaveLength(1);
+    const added = addedClients[0];
+    expect(added.clientName).toBe('g-dev');
+    expect(added.clientId).toBeUndefined();
+    expect(added.clientSecret).toBeUndefined();
+    expect(added.redirectTo).toBeUndefined();
+    expect(added.meta).toMatchObject({
+      appType: 'web',
+      useSharedCredentials: true,
+    });
+    const output = logs.join('\n');
+    expect(output).toContain('App type: web (dev credentials)');
+    expect(output).toContain('No setup required');
+    expect(output).toContain('Ready for production?');
+    expect(output).not.toContain('Add this redirect URI in Google Console');
+  });
+
+  test('--dev-credentials + --client-id → error', async () => {
+    await run(
+      withEntry(webDevFlags, 'client-id', '123.apps.googleusercontent.com'),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain(
+      '--dev-credentials cannot be combined with --client-id',
+    );
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('--dev-credentials + --app-type ios → error', async () => {
+    await run(
+      new Map([
+        ['type', 'google'],
+        ['app-type', 'ios'],
+        ['name', 'g-dev'],
+        ['dev-credentials', 'true'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain(
+      '--dev-credentials is only supported for --app-type web',
+    );
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('interactive: picks dev credentials → skips id/secret prompts', async () => {
+    // Selector for credential mode returns 'dev'. mockPromptReturn is
+    // also consumed by the name prompt but we don't assert on that.
+    mockPromptReturn = 'dev';
+    await run(
+      new Map([
+        ['type', 'google'],
+        ['app-type', 'web'],
+        ['name', 'g-dev'],
+      ]),
+      { yes: false },
+    );
+    // Only one prompt: the credential-mode selector. Name was supplied,
+    // id/secret/redirect are skipped for dev-credentials mode.
+    expect(prompts).toHaveLength(1);
+    expect((prompts[0] as any).params.promptText).toBe('Credential mode:');
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0].meta).toMatchObject({ useSharedCredentials: true });
   });
 });

--- a/client/packages/cli/__tests__/authClientUpdate.test.ts
+++ b/client/packages/cli/__tests__/authClientUpdate.test.ts
@@ -1,0 +1,214 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { NodeContext } from '@effect/platform-node';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import { InstantHttpAuthed } from '../src/lib/http.ts';
+
+// -- mocks --
+
+// Prevent src/index.ts side-effect (program.parse) from running.
+vi.mock('../src/index.ts', () => ({}));
+
+let prompts: any[] = [];
+let mockPromptReturn: any = '';
+
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: (prompt: any) => {
+      prompts.push(prompt);
+      return Promise.resolve(mockPromptReturn);
+    },
+  };
+});
+
+let updatedClients: any[] = [];
+let mockClients: any[] = [];
+
+vi.mock('../src/lib/oauth.ts', () => ({
+  getAppsAuth: () =>
+    Effect.succeed({
+      oauth_service_providers: [{ id: 'prov-1', provider_name: 'google' }],
+      oauth_clients: mockClients,
+    }),
+  updateOAuthClient: (params: any) => {
+    updatedClients.push(params);
+    return Effect.succeed({
+      client: {
+        id: params.oauthClientId,
+        client_name:
+          mockClients.find((c) => c.id === params.oauthClientId)?.client_name ??
+          'unknown',
+      },
+    });
+  },
+}));
+
+// Lazy import so mocks are in place
+const { authClientUpdateCmd } = await import(
+  '../src/commands/auth/client/update.ts'
+);
+
+// -- helpers --
+
+let logs: string[] = [];
+
+const run = (flags: Record<string, any>, { yes }: { yes: boolean }) =>
+  Effect.runPromise(
+    authClientUpdateCmd(flags as any).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(GlobalOpts, { yes } as any),
+          Layer.succeed(CurrentApp, { appId: 'app-1' } as any),
+          Layer.succeed(InstantHttpAuthed, {} as any),
+          NodeContext.layer,
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => {
+              logs.push(String(message));
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+beforeEach(() => {
+  prompts = [];
+  updatedClients = [];
+  logs = [];
+  mockPromptReturn = '';
+  mockClients = [
+    {
+      id: 'c-web',
+      client_name: 'google-web',
+      meta: { appType: 'web' },
+    },
+    {
+      id: 'c-dev',
+      client_name: 'g-dev',
+      meta: { appType: 'web', useSharedCredentials: true },
+    },
+    {
+      id: 'c-ios',
+      client_name: 'google-ios',
+      meta: { appType: 'ios' },
+    },
+  ];
+});
+
+// ---- tests ----
+
+describe('--yes', () => {
+  test('update by --name with both fields', async () => {
+    await run(
+      {
+        name: 'google-web',
+        clientId: 'NEW-ID',
+        clientSecret: 'NEW-SECRET',
+      },
+      { yes: true },
+    );
+    expect(updatedClients).toHaveLength(1);
+    expect(updatedClients[0].oauthClientId).toBe('c-web');
+    expect(updatedClients[0].body).toMatchObject({
+      client_id: 'NEW-ID',
+      client_secret: 'NEW-SECRET',
+      meta: { useSharedCredentials: false },
+    });
+    expect(logs.join('\n')).toContain('Credentials updated for google-web');
+  });
+
+  test('update by --id with only --client-id', async () => {
+    await run({ id: 'c-dev', clientId: 'NEW-ID' }, { yes: true });
+    expect(updatedClients).toHaveLength(1);
+    expect(updatedClients[0].oauthClientId).toBe('c-dev');
+    expect(updatedClients[0].body).toMatchObject({
+      client_id: 'NEW-ID',
+      meta: { useSharedCredentials: false },
+    });
+    expect(updatedClients[0].body.client_secret).toBeUndefined();
+  });
+
+  test('--yes with no id or name → error', async () => {
+    await run({ clientId: 'X', clientSecret: 'Y' }, { yes: true });
+    expect(logs.join('\n')).toContain('Must specify --id or --name');
+    expect(updatedClients).toHaveLength(0);
+  });
+
+  test('--yes with no fields → error', async () => {
+    await run({ name: 'google-web' }, { yes: true });
+    expect(logs.join('\n')).toContain(
+      'Must specify at least one of --client-id or --client-secret',
+    );
+    expect(updatedClients).toHaveLength(0);
+  });
+
+  test('--id + --name together → error', async () => {
+    await run({ id: 'c-web', name: 'google-web' }, { yes: true });
+    expect(logs.join('\n')).toContain('Cannot specify both --id and --name');
+    expect(updatedClients).toHaveLength(0);
+  });
+
+  test('--name pointing at unknown client → error', async () => {
+    await run(
+      { name: 'not-real', clientId: 'X', clientSecret: 'Y' },
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('OAuth client not found: not-real');
+    expect(updatedClients).toHaveLength(0);
+  });
+});
+
+describe('interactive', () => {
+  test('no identifier → picker lists clients with (dev credentials) suffix', async () => {
+    mockPromptReturn = mockClients[1]; // pick 'g-dev'
+    await run(
+      { clientId: 'NEW-ID', clientSecret: 'NEW-SECRET' },
+      { yes: false },
+    );
+    expect(prompts).toHaveLength(1);
+    const select = prompts[0] as any;
+    expect(select.params.promptText).toBe('Select a client to update:');
+    const labels = select.params.options.map((o: any) => o.label);
+    // Only the shared-creds client carries the suffix.
+    expect(labels.find((l: string) => l.includes('g-dev'))).toContain(
+      'dev credentials',
+    );
+    expect(labels.find((l: string) => l.includes('google-web'))).not.toContain(
+      'dev credentials',
+    );
+    expect(updatedClients).toHaveLength(1);
+    expect(updatedClients[0].oauthClientId).toBe('c-dev');
+  });
+
+  test('--name given, fields missing → prompts for both (web client)', async () => {
+    mockPromptReturn = 'something';
+    await run({ name: 'google-web' }, { yes: false });
+    expect(prompts).toHaveLength(2);
+    expect((prompts[0] as any).props.prompt).toContain('Client ID');
+    expect((prompts[1] as any).props.prompt).toContain('Client Secret');
+    expect((prompts[1] as any).props.sensitive).toBe(true);
+  });
+
+  test('--name + --client-id given → does NOT prompt for secret', async () => {
+    await run(
+      { name: 'google-web', clientId: 'NEW-ID' },
+      { yes: false },
+    );
+    expect(prompts).toHaveLength(0);
+    expect(updatedClients[0].body.client_id).toBe('NEW-ID');
+    expect(updatedClients[0].body.client_secret).toBeUndefined();
+  });
+
+  test('native client (ios) → prompts for id only, no secret', async () => {
+    mockPromptReturn = 'NEW-ID';
+    await run({ name: 'google-ios' }, { yes: false });
+    expect(prompts).toHaveLength(1);
+    expect((prompts[0] as any).props.prompt).toContain('Client ID');
+    expect(updatedClients).toHaveLength(1);
+    expect(updatedClients[0].oauthClientId).toBe('c-ios');
+  });
+});

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -47,6 +47,48 @@ const GoogleAppTypeSchema = Schema.Literal(
   'button-for-web',
 );
 
+const selectCredentialMode = (value: unknown) =>
+  Effect.gen(function* () {
+    const { yes } = yield* GlobalOpts;
+    // Explicit --dev-credentials wins.
+    if (value === true || value === 'true') return 'dev' as const;
+    // Explicit --client-id (or equivalent) means the user already
+    // committed to supplying their own credentials — skip the prompt.
+    if (value === false) return 'custom' as const;
+    if (yes) return 'custom' as const;
+
+    return yield* runUIEffect(
+      new UI.Select({
+        options: [
+          {
+            label:
+              'Use dev credentials' +
+              chalk.dim(
+                '  — works on localhost / Expo with no Google setup',
+              ),
+            value: 'dev' as const,
+          },
+          {
+            label:
+              'Use my own' +
+              chalk.dim('           — provide your own client_id / client_secret'),
+            value: 'custom' as const,
+          },
+        ],
+        promptText: 'Credential mode:',
+        modifyOutput: UI.modifiers.piped([
+          UI.modifiers.topPadding,
+          UI.modifiers.dimOnComplete,
+        ]),
+        defaultValue: 'dev' as const,
+      }),
+    ).pipe(
+      Effect.catchTag('UIError', (e) =>
+        BadArgsError.make({ message: `UI error: ${e.message}` }),
+      ),
+    );
+  });
+
 const selectGoogleAppType = (value: unknown) =>
   Effect.gen(function* () {
     const { yes } = yield* GlobalOpts;
@@ -126,6 +168,40 @@ const getOrCreateProvider = Effect.fn(function* (
 
 const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
   const appType = yield* selectGoogleAppType(opts['app-type']);
+
+  // Dev-credentials preconditions: Google + web only, and must not be
+  // combined with any of the fields it replaces.
+  const devCredentialsFlag = Boolean(opts['dev-credentials']);
+  if (devCredentialsFlag && appType !== 'web') {
+    return yield* BadArgsError.make({
+      message:
+        '--dev-credentials is only supported for --app-type web. Native clients need a real client_id from Google.',
+    });
+  }
+  if (
+    devCredentialsFlag &&
+    (opts['client-id'] || opts['client-secret'] || opts['custom-redirect-uri'])
+  ) {
+    return yield* BadArgsError.make({
+      message:
+        '--dev-credentials cannot be combined with --client-id, --client-secret, or --custom-redirect-uri. Omit them (Instant supplies the credentials) or drop --dev-credentials.',
+    });
+  }
+
+  // For web, ask whether the user wants dev creds or their own. Skip
+  // the selector if they already supplied --client-id (implicit
+  // "custom") or --dev-credentials (implicit "dev").
+  const credentialModeHint = devCredentialsFlag
+    ? true
+    : opts['client-id']
+      ? false
+      : undefined;
+  const credentialMode =
+    appType === 'web'
+      ? yield* selectCredentialMode(credentialModeHint)
+      : ('custom' as const);
+  const useDevCredentials = credentialMode === 'dev';
+
   const { auth, provider } = yield* getOrCreateProvider('google');
   const usedClientNames = new Set(
     (auth.oauth_clients ?? []).map((client) => client.client_name),
@@ -153,8 +229,10 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
 
   const clientId = yield* optOrPrompt(opts['client-id'], {
     simpleName: '--client-id',
-    required: true,
-    skipIf: false,
+    required: !useDevCredentials,
+    skipIf: useDevCredentials,
+    skipMessage:
+      '--client-id is not compatible with --dev-credentials. Drop one or the other.',
     prompt: {
       prompt: `Client ID: ${chalk.dim('(from https://console.developers.google.com/apis/credentials)')}`,
       modifyOutput: UI.modifiers.piped([
@@ -166,9 +244,12 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
   });
 
   const clientSecret = yield* optOrPrompt(opts['client-secret'], {
-    required: appType === 'web',
-    skipIf: appType !== 'web',
+    required: !useDevCredentials && appType === 'web',
+    skipIf: useDevCredentials || appType !== 'web',
     simpleName: '--client-secret',
+    skipMessage: useDevCredentials
+      ? '--client-secret is not compatible with --dev-credentials. Drop one or the other.'
+      : undefined,
     prompt: {
       prompt: `Client Secret: ${chalk.dim('(from https://console.developers.google.com/apis/credentials)')}`,
       validate: validateRequired,
@@ -201,20 +282,24 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
       ]),
     },
     simpleName: '--custom-redirect-uri',
-    skipIf: appType !== 'web',
-    skipMessage: 'Provided custom redirect URI when not using web app type.',
+    skipIf: useDevCredentials || appType !== 'web',
+    skipMessage: useDevCredentials
+      ? '--custom-redirect-uri is not compatible with --dev-credentials.'
+      : 'Provided custom redirect URI when not using web app type.',
   });
 
   if (!clientName) {
     return yield* BadArgsError.make({ message: 'Client name is required.' }); // Should never reach this
   }
-  const redirectUri = customRedirectUri || DEFAULT_OAUTH_CALLBACK_URL;
+  const redirectUri = useDevCredentials
+    ? undefined
+    : customRedirectUri || DEFAULT_OAUTH_CALLBACK_URL;
 
   const response = yield* addOAuthClient({
     providerId: provider.id,
     clientName,
-    clientId,
-    clientSecret: clientSecret,
+    clientId: useDevCredentials ? undefined : clientId,
+    clientSecret: useDevCredentials ? undefined : clientSecret,
     authorizationEndpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
     tokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
     discoveryEndpoint: GOOGLE_DISCOVERY_ENDPOINT,
@@ -222,11 +307,32 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
     meta: {
       appType,
       skipNonceChecks: true,
+      ...(useDevCredentials ? { useSharedCredentials: true } : {}),
     },
   });
 
+  if (useDevCredentials) {
+    yield* Effect.log(
+      boxen(
+        [
+          `Google OAuth client created: ${response.client.client_name}`,
+          `App type: ${appType} (dev credentials)`,
+          `ID: ${response.client.id}`,
+          '',
+          'No setup required — works on localhost / Expo out of the box.',
+          '',
+          'Ready for production? Run:',
+          `  instant-cli auth client update --name ${response.client.client_name} \\`,
+          `    --client-id <id> --client-secret <secret>`,
+        ].join('\n'),
+        { dimBorder: true, padding: { right: 1, left: 1 } },
+      ),
+    );
+    return;
+  }
+
   const redirectMessages: string[] = [];
-  if (appType === 'web') {
+  if (appType === 'web' && redirectUri) {
     redirectMessages.push(
       chalk.bold(
         `\nAdd this redirect URI in Google Console:\n${redirectUri}\n`,
@@ -769,6 +875,13 @@ export const authClientAddCmd = Effect.fn(
         }),
       ),
     );
+
+    if (Boolean(opts['dev-credentials']) && clientType !== 'google') {
+      return yield* BadArgsError.make({
+        message:
+          '--dev-credentials is only supported for --type google at the moment.',
+      });
+    }
 
     yield* Match.value(clientType).pipe(
       Match.withReturnType<Effect.Effect<void, any, any>>(),

--- a/client/packages/cli/src/commands/auth/client/update.ts
+++ b/client/packages/cli/src/commands/auth/client/update.ts
@@ -1,0 +1,214 @@
+import { Effect } from 'effect';
+import chalk from 'chalk';
+import boxen from 'boxen';
+import type {
+  authClientUpdateDef,
+  OptsFromCommand,
+} from '../../../index.ts';
+import { BadArgsError } from '../../../errors.ts';
+import { getAppsAuth, updateOAuthClient } from '../../../lib/oauth.ts';
+import { GlobalOpts } from '../../../context/globalOpts.ts';
+import { runUIEffect, validateRequired } from '../../../lib/ui.ts';
+import { UI } from '../../../ui/index.ts';
+
+export const authClientUpdateCmd = Effect.fn(
+  function* (opts: OptsFromCommand<typeof authClientUpdateDef>) {
+    if (opts.id && opts.name) {
+      return yield* BadArgsError.make({
+        message: 'Cannot specify both --id and --name',
+      });
+    }
+
+    const { yes } = yield* GlobalOpts;
+    const auth = yield* getAppsAuth();
+
+    const client = yield* resolveClient({
+      id: opts.id,
+      name: opts.name,
+      yes,
+      clients: auth.oauth_clients ?? [],
+    });
+
+    const clientMeta = (client.meta ?? {}) as Record<string, unknown>;
+    const appType =
+      typeof clientMeta.appType === 'string' ? clientMeta.appType : undefined;
+    // Native Google clients (ios/android/button-for-web) don't have a
+    // client_secret. Everything else (web, custom providers without
+    // an appType) accepts a secret.
+    const supportsSecret = appType === 'web' || appType === undefined;
+
+    const suppliedClientId =
+      typeof opts.clientId === 'string' ? opts.clientId : undefined;
+    const suppliedClientSecret =
+      typeof opts.clientSecret === 'string'
+        ? opts.clientSecret
+        : undefined;
+
+    if (yes && !suppliedClientId && !suppliedClientSecret) {
+      return yield* BadArgsError.make({
+        message: 'Must specify at least one of --client-id or --client-secret.',
+      });
+    }
+
+    // Interactive path: when the user didn't pass either flag, prompt
+    // for the fields that make sense for this client. If they passed
+    // at least one explicitly, we treat the call as a targeted update
+    // and don't nag for the other — supplying just a new client_secret
+    // is a valid partial update.
+    const promptForMissing = !yes && !suppliedClientId && !suppliedClientSecret;
+
+    const clientId =
+      suppliedClientId ??
+      (promptForMissing ? yield* promptClientId() : undefined);
+
+    const clientSecret =
+      suppliedClientSecret ??
+      (promptForMissing && supportsSecret
+        ? yield* promptClientSecret()
+        : undefined);
+
+    const body: {
+      client_id?: string;
+      client_secret?: string;
+      meta: { useSharedCredentials: false };
+    } = {
+      meta: { useSharedCredentials: false },
+    };
+    if (clientId) body.client_id = clientId;
+    if (clientSecret) body.client_secret = clientSecret;
+
+    const response = yield* updateOAuthClient({
+      oauthClientId: client.id,
+      body,
+    });
+
+    yield* Effect.log(
+      boxen(
+        [
+          `Credentials updated for ${response.client.client_name}.`,
+          '',
+          'If this client was using dev credentials, it is now using',
+          'the client_id / client_secret you provided.',
+        ].join('\n'),
+        { dimBorder: true, padding: { right: 1, left: 1 } },
+      ),
+    );
+  },
+  Effect.catchTag('BadArgsError', (e) =>
+    Effect.gen(function* () {
+      yield* Effect.logError(e.message);
+      yield* Effect.log(
+        chalk.dim(
+          'hint: run `instant-cli auth client update --help` for the list of available arguments',
+        ),
+      );
+    }),
+  ),
+);
+
+// -- helpers --
+
+const promptClientId = Effect.fn(function* () {
+  return yield* runUIEffect(
+    new UI.TextInput({
+      prompt: 'Client ID:',
+      validate: validateRequired,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    }),
+  ).pipe(
+    Effect.catchTag('UIError', (e) =>
+      BadArgsError.make({ message: `UI error: ${e.message}` }),
+    ),
+  );
+});
+
+const promptClientSecret = Effect.fn(function* () {
+  return yield* runUIEffect(
+    new UI.TextInput({
+      prompt: 'Client Secret:',
+      validate: validateRequired,
+      sensitive: true,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    }),
+  ).pipe(
+    Effect.catchTag('UIError', (e) =>
+      BadArgsError.make({ message: `UI error: ${e.message}` }),
+    ),
+  );
+});
+
+
+type ClientRow = {
+  id: string;
+  client_name: string;
+  meta?: unknown;
+};
+
+const resolveClient = Effect.fn(function* (params: {
+  id: string | undefined;
+  name: string | undefined;
+  yes: boolean;
+  clients: readonly ClientRow[];
+}) {
+  if (params.id) {
+    const match = params.clients.find((c) => c.id === params.id);
+    if (!match) {
+      return yield* BadArgsError.make({
+        message: `OAuth client not found: ${params.id}`,
+      });
+    }
+    return match;
+  }
+
+  if (params.name) {
+    const match = params.clients.find((c) => c.client_name === params.name);
+    if (!match) {
+      return yield* BadArgsError.make({
+        message: `OAuth client not found: ${params.name}`,
+      });
+    }
+    return match;
+  }
+
+  if (params.yes) {
+    return yield* BadArgsError.make({
+      message: 'Must specify --id or --name.',
+    });
+  }
+
+  if (params.clients.length === 0) {
+    return yield* BadArgsError.make({
+      message: 'No OAuth clients found for this app.',
+    });
+  }
+
+  return yield* runUIEffect(
+    new UI.Select({
+      options: params.clients.map((c) => ({
+        label:
+          c.client_name +
+          (isSharedCred(c) ? chalk.dim('   (dev credentials)') : '') +
+          chalk.dim(`   |   ${c.id}`),
+        value: c,
+      })),
+      promptText: 'Select a client to update:',
+    }),
+  ).pipe(
+    Effect.catchTag('UIError', (e) =>
+      BadArgsError.make({ message: `UI error: ${e.message}` }),
+    ),
+  );
+});
+
+const isSharedCred = (c: ClientRow) =>
+  Boolean(
+    c.meta &&
+      typeof c.meta === 'object' &&
+      (c.meta as Record<string, unknown>).useSharedCredentials,
+  );

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import { PACKAGE_ALIAS_AND_FULL_NAMES } from './context/projectInfo.ts';
 import { authClientAddCmd } from './commands/auth/client/add.ts';
 import { authClientListCmd } from './commands/auth/client/list.ts';
 import { authClientDeleteCmd } from './commands/auth/client/delete.ts';
+import { authClientUpdateCmd } from './commands/auth/client/update.ts';
 
 export type OptsFromCommand<C> =
   C extends Command<any, infer R, any> ? R : never;
@@ -182,6 +183,33 @@ export const authClientDeleteDef = authClient
   .action((opts) => {
     return runCommandEffect(
       authClientDeleteCmd(opts).pipe(
+        Effect.provide(
+          WithAppLayer({
+            coerce: false,
+            appId: opts.app,
+            allowAdminToken: true,
+          }),
+        ),
+      ),
+    );
+  });
+
+export const authClientUpdateDef = authClient
+  .command('update')
+  .description(
+    'Rotate an OAuth client\'s credentials, or upgrade one created with --dev-credentials to use your own.',
+  )
+  .option('--id <client-id>', 'Client ID to update')
+  .option('--name <client-name>', 'Client name to update')
+  .option('--client-id <client-id>', 'New client_id to set')
+  .option('--client-secret <client-secret>', 'New client_secret to set')
+  .option(
+    '-a --app <app-id>',
+    'App ID to update a client in. Defaults to *_INSTANT_APP_ID in .env',
+  )
+  .action((opts) => {
+    return runCommandEffect(
+      authClientUpdateCmd(opts).pipe(
         Effect.provide(
           WithAppLayer({
             coerce: false,

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -99,14 +99,19 @@ export const authClientAddDef = authClient
     '-a --app <app-id>',
     'App ID to modify. Defaults to *_INSTANT_APP_ID in .env',
   )
+  .option(
+    '--dev-credentials',
+    'Use Instant-provided dev credentials (Google web only). Works on localhost / Expo with no Google Cloud Console setup.',
+  )
   .addHelpText(
     'after',
     `
 Provider Specific Options:
   Google:
    --app-type       web|ios|android|button-for-web
-   --client-id
-   --client-secret                      (web only)
+   --dev-credentials          (optional, web only — skip client-id/secret)
+   --client-id                (required unless --dev-credentials)
+   --client-secret                      (web only, unless --dev-credentials)
    --custom-redirect-uri      (optional, web only)
   GitHub:
    --client-id

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -93,6 +93,29 @@ export const addOAuthProvider = Effect.fn(function* (params: {
     );
 });
 
+export const updateOAuthClient = Effect.fn(function* (params: {
+  appId?: string;
+  oauthClientId: string;
+  body: {
+    client_id?: string;
+    client_secret?: string;
+    meta?: unknown;
+    redirect_to?: string | null;
+  };
+}) {
+  const http = (yield* InstantHttpAuthed).pipe(withCommand('auth'));
+  const targetAppId = params.appId ?? (yield* CurrentApp).appId;
+
+  return yield* http
+    .post(
+      `/dash/apps/${targetAppId}/oauth_clients/${params.oauthClientId}`,
+      { body: HttpBody.unsafeJson(params.body) },
+    )
+    .pipe(
+      Effect.flatMap(HttpClientResponse.schemaBodyJson(AddOAuthClientResponse)),
+    );
+});
+
 export const addOAuthClient = Effect.fn(function* (params: {
   appId?: string;
   providerId: string;

--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -1107,7 +1107,7 @@ export function Copytext({ value }: { value: string }) {
   const [showCopied, setShowCopied] = useState(false);
 
   return (
-    <span className="inline-flex items-center rounded-sm bg-gray-500 px-2 text-sm text-white">
+    <span className="inline-flex items-center rounded-sm bg-gray-100 px-2 text-sm text-gray-800 dark:bg-neutral-700 dark:text-neutral-200">
       <code
         className="truncate"
         onClick={(e) => {

--- a/client/www/components/dash/MainDashLayout.tsx
+++ b/client/www/components/dash/MainDashLayout.tsx
@@ -181,10 +181,7 @@ export const MainDashLayout: React.FC<{
         )}
       >
         <div
-          className={cn(
-            'flex h-[100dvh] w-full flex-col',
-            darkMode ? 'dark' : '',
-          )}
+          className={cn('fixed inset-0 flex flex-col', darkMode ? 'dark' : '')}
         >
           <TopBar />
           <div

--- a/client/www/components/dash/auth/GitHub.tsx
+++ b/client/www/components/dash/auth/GitHub.tsx
@@ -156,7 +156,6 @@ export function AddGitHubClientForm({
         clientId,
         clientSecret,
         redirectTo,
-        meta: { providerName: 'github' },
       });
       onAddClient(resp.client);
     } catch (e) {

--- a/client/www/components/dash/auth/Google.tsx
+++ b/client/www/components/dash/auth/Google.tsx
@@ -1,5 +1,5 @@
 import { FormEventHandler, useState, useContext } from 'react';
-import { errorToast } from '@/lib/toast';
+import { errorToast, successToast } from '@/lib/toast';
 import { TokenContext } from '@/lib/contexts';
 import {
   InstantApp,
@@ -15,6 +15,7 @@ import {
   RedirectUrlInput,
   EditableRedirectUrl,
   TestRedirectButton,
+  updateClient,
 } from './shared';
 import { messageFromInstantError } from '@/lib/errors';
 import {
@@ -42,16 +43,6 @@ import {
 } from '@heroicons/react/24/solid';
 import { useDarkMode } from '../DarkModeToggle';
 
-function NonceCheckNotice() {
-  return (
-    <p className="dark:test-neutral-400 text-sm text-gray-500">
-      This option skips nonce checks for ID tokens. This is useful in iOS
-      environments, because libraries like `react-native-google-signin` do not
-      let you pass a nonce over to google.
-    </p>
-  );
-}
-
 type AppType = 'web' | 'ios' | 'android' | 'button-for-web';
 function isNative(appType: AppType) {
   return appType === 'ios' || appType === 'android';
@@ -71,9 +62,11 @@ export function AddGoogleClientForm({
   usedClientNames: Set<string>;
 }) {
   const token = useContext(TokenContext);
+  const [credentialMode, setCredentialMode] = useState<'dev' | 'custom'>('dev');
   const [appType, setAppType] = useState<
     'web' | 'ios' | 'android' | 'button-for-web'
   >('web');
+  const useSharedCredentials = appType === 'web' && credentialMode === 'dev';
   const [clientName, setClientName] = useState<string>(() =>
     findName(`google-${appType}`, usedClientNames),
   );
@@ -81,14 +74,12 @@ export function AddGoogleClientForm({
   const [clientSecret, setClientSecret] = useState<string>('');
   const [redirectTo, setRedirectTo] = useState<string>('');
   const [updatedRedirectURL, setUpdatedRedirectURL] = useState(false);
-  const [skipNonceChecks, setSkipNonceChecks] = useState(isNative(appType));
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const onChangeAppType = (item: { id: string; label: string }) => {
     const newAppType = item.id as 'web' | 'ios' | 'android' | 'button-for-web';
     setAppType(newAppType);
     setClientName(findName(`google-${newAppType}`, usedClientNames));
-    setSkipNonceChecks(isNative(newAppType));
   };
 
   const validationError = () => {
@@ -98,11 +89,13 @@ export function AddGoogleClientForm({
     if (usedClientNames.has(clientName)) {
       return `The unique name '${clientName}' is already in use.`;
     }
-    if (!clientId) {
-      return 'Missing client id';
-    }
-    if (appType === 'web' && !clientSecret) {
-      return 'Missing client secret';
+    if (!useSharedCredentials) {
+      if (!clientId) {
+        return 'Missing client id';
+      }
+      if (appType === 'web' && !clientSecret) {
+        return 'Missing client secret';
+      }
     }
   };
 
@@ -120,16 +113,21 @@ export function AddGoogleClientForm({
         appId: app.id,
         providerId: provider.id,
         clientName,
-        clientId,
-        clientSecret: clientSecret ? clientSecret : undefined,
+        clientId: useSharedCredentials ? undefined : clientId,
+        clientSecret: useSharedCredentials
+          ? undefined
+          : clientSecret
+            ? clientSecret
+            : undefined,
         authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
         tokenEndpoint: 'https://oauth2.googleapis.com/token',
         discoveryEndpoint:
           'https://accounts.google.com/.well-known/openid-configuration',
-        redirectTo,
+        redirectTo: useSharedCredentials ? undefined : redirectTo,
         meta: {
-          skipNonceChecks: skipNonceChecks,
+          skipNonceChecks: isNative(appType),
           appType,
+          ...(useSharedCredentials ? { useSharedCredentials: true } : {}),
         },
       });
       onAddClient(resp.client);
@@ -149,6 +147,9 @@ export function AddGoogleClientForm({
       onSubmit={onSubmit}
       autoComplete="off"
       data-lpignore="true"
+      data-1p-ignore="true"
+      data-bwignore="true"
+      data-form-type="other"
     >
       <SubsectionHeading>Add a new Google client</SubsectionHeading>
       <div className="mb-4">
@@ -167,6 +168,19 @@ export function AddGoogleClientForm({
           ariaLabel="Application type"
         />
       </div>
+      {appType === 'web' && (
+        <div className="mb-2">
+          <ToggleGroup
+            items={[
+              { id: 'dev', label: 'Use dev credentials' },
+              { id: 'custom', label: 'Use my own' },
+            ]}
+            selectedId={credentialMode}
+            onChange={({ id }) => setCredentialMode(id as 'dev' | 'custom')}
+            ariaLabel="Credential mode"
+          />
+        </div>
+      )}
       <TextInput
         tabIndex={1}
         value={clientName}
@@ -175,96 +189,104 @@ export function AddGoogleClientForm({
         placeholder={`e.g. google-${appType}`}
       />
 
-      <TextInput
-        tabIndex={2}
-        value={clientId}
-        onChange={setClientId}
-        label={
-          <>
-            Client ID from{' '}
-            <a
-              className="underline"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://console.developers.google.com/apis/credentials"
-            >
-              Google console
-            </a>
-          </>
-        }
-        placeholder=""
-      />
-
-      {appType === 'web' && (
-        <TextInput
-          type="sensitive"
-          tabIndex={3}
-          value={clientSecret}
-          onChange={setClientSecret}
-          label={
-            <>
-              Client secret from{' '}
-              <a
-                className="underline"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://console.developers.google.com/apis/credentials"
-              >
-                Google console
-              </a>
-            </>
-          }
-        />
-      )}
-      {appType === 'web' && (
-        <RedirectUrlInput value={redirectTo} onChange={setRedirectTo} />
-      )}
-      {appType === 'web' && (
-        <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <p className="overflow-hidden">
-            Add <Copytext value={redirectTo || DEFAULT_OAUTH_CALLBACK_URL} /> to
-            the "Authorized redirect URIs" on your{' '}
-            <a
-              className="underline dark:text-white"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={
-                clientId
-                  ? `https://console.cloud.google.com/apis/credentials/oauthclient/${clientId}`
-                  : 'https://console.developers.google.com/apis/credentials'
-              }
-            >
-              Google OAuth client
-            </a>
-            .
+      {useSharedCredentials ? (
+        <div className="rounded-sm bg-gray-50 p-3 text-sm text-gray-600 dark:bg-neutral-800 dark:text-neutral-400">
+          <p>
+            Instant provides dev credentials so you can test Google sign-in in
+            development without any setup.
           </p>
-          {redirectTo && (
-            <>
-              <p className="text-sm text-gray-500 dark:text-neutral-400">
-                Your redirect URL should forward to{' '}
-                <Copytext value={DEFAULT_OAUTH_CALLBACK_URL} /> with all query
-                parameters.
-              </p>
-              <TestRedirectButton redirectTo={redirectTo} />
-            </>
+          <button
+            type="button"
+            className="mt-2 text-blue-600 hover:underline dark:text-blue-400"
+            onClick={() => setCredentialMode('custom')}
+          >
+            Ready for production? Add your own credentials
+          </button>
+        </div>
+      ) : (
+        <>
+          <TextInput
+            tabIndex={2}
+            value={clientId}
+            onChange={setClientId}
+            label={
+              <>
+                Client ID from{' '}
+                <a
+                  className="underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://console.developers.google.com/apis/credentials"
+                >
+                  Google console
+                </a>
+              </>
+            }
+            placeholder=""
+          />
+
+          {appType === 'web' && (
+            <TextInput
+              type="sensitive"
+              tabIndex={3}
+              value={clientSecret}
+              onChange={setClientSecret}
+              label={
+                <>
+                  Client secret from{' '}
+                  <a
+                    className="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://console.developers.google.com/apis/credentials"
+                  >
+                    Google console
+                  </a>
+                </>
+              }
+            />
           )}
-          <Checkbox
-            checked={updatedRedirectURL}
-            onChange={setUpdatedRedirectURL}
-            label="I added the redirect to Google"
-          />
-        </div>
-      )}
-      {isNative(appType) && (
-        <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
-          {' '}
-          <Checkbox
-            checked={skipNonceChecks}
-            onChange={setSkipNonceChecks}
-            label="Skip nonce checks"
-          />
-          <NonceCheckNotice />
-        </div>
+          {appType === 'web' && (
+            <RedirectUrlInput value={redirectTo} onChange={setRedirectTo} />
+          )}
+          {appType === 'web' && (
+            <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
+              <p className="overflow-hidden">
+                Add{' '}
+                <Copytext value={redirectTo || DEFAULT_OAUTH_CALLBACK_URL} /> to
+                the "Authorized redirect URIs" on your{' '}
+                <a
+                  className="underline dark:text-white"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={
+                    clientId
+                      ? `https://console.cloud.google.com/apis/credentials/oauthclient/${clientId}`
+                      : 'https://console.developers.google.com/apis/credentials'
+                  }
+                >
+                  Google OAuth client
+                </a>
+                .
+              </p>
+              {redirectTo && (
+                <>
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">
+                    Your redirect URL should forward to{' '}
+                    <Copytext value={DEFAULT_OAUTH_CALLBACK_URL} /> with all
+                    query parameters.
+                  </p>
+                  <TestRedirectButton redirectTo={redirectTo} />
+                </>
+              )}
+              <Checkbox
+                checked={updatedRedirectURL}
+                onChange={setUpdatedRedirectURL}
+                label="I added the redirect to Google"
+              />
+            </div>
+          )}
+        </>
       )}
       <Button loading={isLoading} type="submit">
         Add client
@@ -330,6 +352,164 @@ function appTypeLabel(appType: AppType): string {
   }
 }
 
+function CredentialsEditor({
+  app,
+  client,
+  appType,
+  onUpdateClient,
+}: {
+  app: InstantApp;
+  client: OAuthClient;
+  appType: AppType;
+  onUpdateClient: (client: OAuthClient) => void;
+}) {
+  const token = useContext(TokenContext);
+  const [showUpgrade, setShowUpgrade] = useState(false);
+  const [upgradeClientId, setUpgradeClientId] = useState('');
+  const [upgradeClientSecret, setUpgradeClientSecret] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const needsClientSecret = appType === 'web';
+
+  const cancelUpgrade = () => {
+    setShowUpgrade(false);
+    setUpgradeClientId('');
+    setUpgradeClientSecret('');
+  };
+
+  const handleUpgradeCredentials = async () => {
+    if (!upgradeClientId) {
+      errorToast('Missing client id', { autoClose: 5000 });
+      return;
+    }
+    if (needsClientSecret && !upgradeClientSecret) {
+      errorToast('Missing client secret', { autoClose: 5000 });
+      return;
+    }
+    try {
+      setIsLoading(true);
+      const resp = await updateClient({
+        token,
+        appId: app.id,
+        oauthClientID: client.id,
+        body: {
+          client_id: upgradeClientId,
+          ...(needsClientSecret && upgradeClientSecret
+            ? { client_secret: upgradeClientSecret }
+            : {}),
+          meta: { useSharedCredentials: false },
+        },
+      });
+      onUpdateClient(resp.client);
+      cancelUpgrade();
+      successToast('Credentials updated');
+    } catch (e) {
+      console.error(e);
+      const msg =
+        messageFromInstantError(e as InstantIssue) ||
+        'Error updating credentials.';
+      errorToast(msg, { autoClose: 5000 });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const googleConsoleLink = (
+    <a
+      className="underline"
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://console.developers.google.com/apis/credentials"
+    >
+      Google console
+    </a>
+  );
+
+  const editForm = (
+    <form
+      className="mt-3 flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleUpgradeCredentials();
+      }}
+      autoComplete="off"
+      data-lpignore="true"
+      data-1p-ignore="true"
+      data-bwignore="true"
+      data-form-type="other"
+    >
+      <p className="text-sm text-gray-500 dark:text-neutral-400">
+        Find your credentials in the {googleConsoleLink} under "OAuth 2.0 Client
+        IDs".
+      </p>
+      <TextInput
+        value={upgradeClientId}
+        onChange={setUpgradeClientId}
+        label={<>Client ID from {googleConsoleLink}</>}
+      />
+      {needsClientSecret ? (
+        <TextInput
+          type="sensitive"
+          value={upgradeClientSecret}
+          onChange={setUpgradeClientSecret}
+          label={<>Client secret from {googleConsoleLink}</>}
+        />
+      ) : null}
+      <div className="flex gap-2">
+        <Button loading={isLoading} type="submit">
+          Save
+        </Button>
+        <Button variant="secondary" onClick={cancelUpgrade}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+
+  if (client.meta?.useSharedCredentials) {
+    return (
+      <div className="rounded-sm bg-gray-50 p-3 text-sm text-gray-600 dark:bg-neutral-800 dark:text-neutral-400">
+        <p>
+          Using Instant's dev credentials. Works in development out of the box.
+        </p>
+        {!showUpgrade ? (
+          <div className="mt-2 flex items-center gap-2">
+            <span>Ready to go to production?</span>
+            <Button
+              variant="secondary"
+              size="mini"
+              onClick={() => setShowUpgrade(true)}
+            >
+              Set custom credentials
+            </Button>
+          </div>
+        ) : (
+          editForm
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Copyable label="Google client ID" value={client.client_id || ''} />
+      {!showUpgrade ? (
+        <div className="flex justify-end">
+          <Button
+            variant="secondary"
+            size="mini"
+            onClick={() => setShowUpgrade(true)}
+          >
+            Update credentials
+          </Button>
+        </div>
+      ) : (
+        editForm
+      )}
+    </>
+  );
+}
+
 export function GoogleClient({
   app,
   client,
@@ -356,8 +536,6 @@ export function GoogleClient({
   const deleteDialog = useDialog();
 
   const { darkMode } = useDarkMode();
-
-  const didSkipNonceChecks = client.meta?.skipNonceChecks;
 
   const handleDelete = async () => {
     try {
@@ -476,8 +654,13 @@ function Login() {
             <div className="">App Type: {appTypeLabel(appType)}</div>
 
             <Copyable label="Client name" value={client.client_name} />
-            <Copyable label="Google client ID" value={client.client_id || ''} />
-            {appType === 'web' && (
+            <CredentialsEditor
+              app={app}
+              client={client}
+              appType={appType}
+              onUpdateClient={onUpdateClient}
+            />
+            {appType === 'web' && !client.meta?.useSharedCredentials && (
               <EditableRedirectUrl
                 app={app}
                 client={client}
@@ -486,16 +669,6 @@ function Login() {
               />
             )}
 
-            {didSkipNonceChecks ? (
-              <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-4 dark:border-neutral-700 dark:bg-neutral-800">
-                <Checkbox
-                  checked={client.meta?.skipNonceChecks || false}
-                  onChange={() => {}}
-                  label="Skip nonce checks"
-                />
-                <NonceCheckNotice />
-              </div>
-            ) : null}
             {appType === 'web' && (
               <>
                 <SubsectionHeading>
@@ -507,35 +680,42 @@ function Login() {
                     Setup and usage
                   </a>
                 </SubsectionHeading>
-                <Content>
-                  <strong className="dark:text-white">1.</strong> Navigate to{' '}
-                  <a
-                    className="underline dark:text-white"
-                    href={`https://console.cloud.google.com/apis/credentials/oauthclient/${client.client_id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Google OAuth client
-                  </a>{' '}
-                  and add the redirect URL under "Authorized redirect URIs"
-                </Content>
-                <Copyable
-                  label="Redirect URI"
-                  value={client.redirect_to || DEFAULT_OAUTH_CALLBACK_URL}
-                />
-                {client.redirect_to && (
+                {!client.meta?.useSharedCredentials && (
                   <>
-                    <Content className="text-sm text-gray-500 dark:text-neutral-400">
-                      Your redirect URL should forward to{' '}
-                      <Copytext value={DEFAULT_OAUTH_CALLBACK_URL} /> with all
-                      query parameters.
+                    <Content>
+                      <strong className="dark:text-white">1.</strong> Navigate
+                      to{' '}
+                      <a
+                        className="underline dark:text-white"
+                        href={`https://console.cloud.google.com/apis/credentials/oauthclient/${client.client_id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Google OAuth client
+                      </a>{' '}
+                      and add the redirect URL under "Authorized redirect URIs"
                     </Content>
-                    <TestRedirectButton redirectTo={client.redirect_to} />
+                    <Copyable
+                      label="Redirect URI"
+                      value={client.redirect_to || DEFAULT_OAUTH_CALLBACK_URL}
+                    />
+                    {client.redirect_to && (
+                      <>
+                        <Content className="text-sm text-gray-500 dark:text-neutral-400">
+                          Your redirect URL should forward to{' '}
+                          <Copytext value={DEFAULT_OAUTH_CALLBACK_URL} /> with
+                          all query parameters.
+                        </Content>
+                        <TestRedirectButton redirectTo={client.redirect_to} />
+                      </>
+                    )}
                   </>
                 )}
                 <Content>
-                  <strong className="dark:text-white">2.</strong> Use the code
-                  below to generate a login link in your app.
+                  {!client.meta?.useSharedCredentials && (
+                    <strong className="dark:text-white">2. </strong>
+                  )}
+                  Use the code below to generate a login link in your app.
                 </Content>
                 <div className="overflow-auto rounded-sm border text-sm dark:border-none">
                   <Fence

--- a/client/www/components/dash/auth/shared.tsx
+++ b/client/www/components/dash/auth/shared.tsx
@@ -168,6 +168,35 @@ export function updateClientRedirectTo({
   );
 }
 
+export function updateClient({
+  token,
+  appId,
+  oauthClientID,
+  body,
+}: {
+  token: string;
+  appId: string;
+  oauthClientID: string;
+  body: {
+    client_id?: string;
+    client_secret?: string;
+    meta?: Record<string, any>;
+    redirect_to?: string | null;
+  };
+}): Promise<{ client: OAuthClient }> {
+  return jsonFetch(
+    `${config.apiURI}/dash/apps/${appId}/oauth_clients/${oauthClientID}`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
 function RedirectUrlLabel() {
   return (
     <span className="flex items-center gap-1">
@@ -317,7 +346,7 @@ export function EditableRedirectUrl({
 
   if (!hasValue && !isEditing) {
     return (
-      <div>
+      <div className="flex justify-end">
         <Button
           variant="secondary"
           size="mini"

--- a/server/flags-config/instant.schema.ts
+++ b/server/flags-config/instant.schema.ts
@@ -63,6 +63,22 @@ const _schema = i.schema({
     "rule-where-testing": i.entity({
       enabled: i.boolean(),
     }),
+    "shared-oauth-clients": i.entity({
+      providerName: i.string().unique().indexed(),
+      clientId: i.string(),
+      encryptedClientSecretHexString: i.string(),
+    }),
+    // Parallel to `shared-oauth-clients`, these oauth clients
+    // are registered to allow `http://localhost:8888`
+    //
+    // This lets Instant engineers run the shared-creds flow locally. 
+    // There's a handy script to import these credential to your local server:
+    // Check out `instant.model.shared-oauth-client/import-from-prod!`.
+    "shared-oauth-clients-instant-dev": i.entity({
+      providerName: i.string().unique().indexed(),
+      clientId: i.string(),
+      encryptedClientSecretHexString: i.string(),
+    }),
     "rule-wheres": i.entity({
       "app-ids": i.json(),
       "query-hash-blacklist": i.any(),

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -32,6 +32,8 @@
             [instant.model.org-members :as instant-org-members]
             [instant.model.app-oauth-client :as app-oauth-client-model]
             [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
+            [instant.model.shared-oauth-client :refer [assert-shared-credentials-allowed!
+                                                       get-shared-credential!]]
             [instant.model.instant-cli-login :as instant-cli-login-model]
             [instant.model.instant-oauth-code :as instant-oauth-code-model]
             [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
@@ -614,7 +616,8 @@
         client-name (ex/get-param! req [:body :client_name] string-util/coerce-non-blank-str)
         client-id (coerce-optional-param! [:body :client_id])
         client-secret (coerce-optional-param! [:body :client_secret])
-        meta (ex/get-optional-param! req [:body :meta] (fn [x] (when (map? x) x)))
+        meta (ex/get-optional-param! req [:body :meta]
+                                     (fn [x] (when (map? x) (w/stringify-keys x))))
         redirect-to (-> req :body :redirect_to string-util/coerce-non-blank-str)
         _ (when redirect-to
             (ex/assert-valid!
@@ -622,12 +625,18 @@
              redirect-to
              (url-util/redirect-url-validation-errors
               redirect-to :allow-localhost? true)))
-        provider-name (ex/get-optional-param! meta [:providerName] string-util/coerce-non-blank-str)
+        {provider-name :provider_name}
+        (app-oauth-service-provider-model/get-by-id!
+         {:app-id app-id :id provider-id})
 
         ;; GitHub doesn't need discovery endpoints
         ;; OIDC providers (Google, LinkedIn, Apple) need discovery endpoints
         discovery-endpoint (when-not (= "github" provider-name)
                              (ex/get-param! req [:body :discovery_endpoint] string-util/coerce-non-blank-str))
+
+        _ (when (app-oauth-client-model/use-shared-credentials? meta)
+            (get-shared-credential! provider-name)
+            (assert-shared-credentials-allowed! app-id))
 
         client (app-oauth-client-model/create! {:app-id app-id
                                                 :provider-id provider-id
@@ -643,19 +652,31 @@
 (defn update-oauth-client [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
         id (ex/get-param! req [:params :id] uuid-util/coerce)
-        meta (ex/get-optional-param! req [:body :meta] (fn [x] (when (map? x) x)))
+        meta (ex/get-optional-param! req [:body :meta]
+                                     (fn [x] (when (map? x) (w/stringify-keys x))))
         redirect-to (-> req :body :redirect_to string-util/coerce-non-blank-str)
+        client-id (ex/get-optional-param! req [:body :client_id] string-util/coerce-non-blank-str)
+        client-secret (ex/get-optional-param! req [:body :client_secret] string-util/coerce-non-blank-str)
         _ (when redirect-to
             (ex/assert-valid!
              :redirect_to
              redirect-to
              (url-util/redirect-url-validation-errors
               redirect-to :allow-localhost? true)))
+        _ (when (app-oauth-client-model/use-shared-credentials? meta)
+            (let [existing (app-oauth-client-model/get-by-id! {:app-id app-id :id id})
+                  {provider-name :provider_name}
+                  (app-oauth-service-provider-model/get-by-id!
+                   {:app-id app-id :id (:provider_id existing)})]
+              (get-shared-credential! provider-name)
+              (assert-shared-credentials-allowed! app-id)))
         params (cond-> {:app-id app-id
                         :id id}
                  ;; Distinguish between null and undefined
                  (contains? (:body req) :meta) (assoc :meta meta)
-                 (contains? (:body req) :redirect_to) (assoc :redirect-to redirect-to))
+                 (contains? (:body req) :redirect_to) (assoc :redirect-to redirect-to)
+                 client-id (assoc :client-id client-id)
+                 client-secret (assoc :client-secret client-secret))
         client (app-oauth-client-model/update! params)]
     (response/ok {:client (select-keys client [:id :provider_id :client_name
                                                :client_id :created_at :meta :discovery_endpoint])})))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -7,6 +7,7 @@
    [clojure.tools.logging :as log]
    [clojure.walk :as w]
    [instant.config :as config]
+   [instant.util.crypt :as crypt-util]
    [instant.util.json :as json]
    [instant.util.uuid :as uuid-util]))
 
@@ -33,7 +34,8 @@
             :toggles {}
             :flags {}
             :handle-receive-timeout {}
-            :query-modifiers {}})
+            :query-modifiers {}
+            :shared-oauth-clients {}})
 
 (def toggle-defaults {:pg-hints-by-default (= :test (config/get-env))})
 
@@ -147,6 +149,14 @@
                                first
                                (get "enabled")
                                (or false))
+        shared-oauth-clients (->> (get result "shared-oauth-clients")
+                                  (map (fn [c]
+                                         {:id (parse-uuid (get c "id"))
+                                          :providerName (get c "providerName")
+                                          :clientId (get c "clientId")
+                                          :encryptedClientSecret (crypt-util/hex-string->bytes
+                                                                  (get c "encryptedClientSecretHexString"))}))
+                                  (group-by :providerName))
         query-modifiers (reduce (fn [acc {:strs [app-id query-hash etype dollar-params]}]
                                   (update-in acc
                                              [(parse-uuid app-id) query-hash]
@@ -174,7 +184,8 @@
      :toggles toggles
      :flags flags
      :handle-receive-timeout handle-receive-timeout
-     :query-modifiers query-modifiers}))
+     :query-modifiers query-modifiers
+     :shared-oauth-clients shared-oauth-clients}))
 
 (def queries [{:query query :transform #'transform-query-result}])
 
@@ -355,6 +366,9 @@
 
 (defn statement-cancel-wait-ms []
   (flag :statement-cancel-wait-ms 500))
+
+(defn shared-oauth-clients []
+  (get (query-result) :shared-oauth-clients))
 
 (defn query-modifiers [app-id query-hash]
   (get-in (query-result) [:query-modifiers app-id query-hash]))

--- a/server/src/instant/model/app_authorized_redirect_origin.clj
+++ b/server/src/instant/model/app_authorized_redirect_origin.clj
@@ -68,6 +68,30 @@
   (and (not (contains? reserved-uri-schemes uri-scheme))
        (= scheme uri-scheme)))
 
+(def ^:private localhost-hosts
+  "Hostnames we treat as a developer's own machine for shared-credential
+   redirects: the literal name, IPv4 loopback, IPv6 loopback, and the
+   wildcard bind address that browsers route back to localhost."
+  #{"localhost" "127.0.0.1" "[::1]" "0.0.0.0"})
+
+(defn shared-credentials-default-match
+  "When users choose shared credentials, we automatically allow
+   localhost (http/https) and expo dev (exp://) as redirect targets,
+   without them having to set those explicitly in their allowed
+   origins. For custom domains or schemes, they can still add them to
+   allowed origins."
+  [url]
+  (let [parsed-url (uri/uri url)
+        host (:host parsed-url)
+        scheme (:scheme parsed-url)]
+    (cond
+      (and (contains? localhost-hosts host)
+           (contains? #{"http" "https"} scheme))
+      {:service "localhost"}
+
+      (= scheme "exp")
+      {:service "custom-scheme"})))
+
 (defn find-match [site-origins url]
   (let [parsed-url (uri/uri url)
         raw-host (:host parsed-url)
@@ -85,6 +109,11 @@
                        (tracer/with-span! {:name "origins/unknown-service"
                                            :attributes {:service service}})))
                    site-origins))))
+
+(defn authorized-origin? [authorized-origins url use-shared-credentials?]
+  (boolean (or (find-match authorized-origins url)
+               (when use-shared-credentials?
+                 (shared-credentials-default-match url)))))
 
 (defn validation-error [service params]
   (case service

--- a/server/src/instant/model/app_oauth_client.clj
+++ b/server/src/instant/model/app_oauth_client.clj
@@ -2,6 +2,8 @@
   (:require
    [instant.auth.oauth :as oauth]
    [instant.jdbc.aurora :as aurora]
+   [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
+   [instant.model.shared-oauth-client :refer [get-shared-credential!]]
    [instant.system-catalog-ops :refer [query-op update-op]]
    [instant.util.crypt :as crypt-util]
    [instant.util.exception :as ex]
@@ -11,6 +13,9 @@
    (java.util UUID)))
 
 (def etype "$oauthClients")
+
+(defn use-shared-credentials? [meta]
+  (boolean (get meta "useSharedCredentials")))
 
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
@@ -39,11 +44,9 @@
           discovery-endpoint
           [{:message "Could not validate discovery endpoint."}]))))
    (let [id (UUID/randomUUID)
-
-         enc-client-secret
+         enc-client-secret-hex
          (when client-secret
-           (crypt-util/aead-encrypt {:plaintext (String/.getBytes client-secret)
-                                     :associated-data (uuid-util/->bytes id)}))]
+           (crypt-util/aead-encrypt-hex client-secret (uuid-util/->bytes id)))]
      (update-op
       conn
       {:app-id app-id
@@ -53,11 +56,7 @@
                     [:add-triple id (resolve-id :$oauthProvider) provider-id]
                     [:add-triple id (resolve-id :name) client-name]
                     [:add-triple id (resolve-id :clientId) client-id]
-                    [:add-triple
-                     id
-                     (resolve-id :encryptedClientSecret)
-                     (when enc-client-secret
-                       (crypt-util/bytes->hex-string enc-client-secret))]
+                    [:add-triple id (resolve-id :encryptedClientSecret) enc-client-secret-hex]
                     [:add-triple id (resolve-id :discoveryEndpoint) discovery-endpoint]
                     [:add-triple id (resolve-id :meta) meta]
                     [:add-triple id (resolve-id :redirectTo) redirect-to]])
@@ -75,7 +74,13 @@
                          (when (contains? params :meta)
                            [[:deep-merge-triple id (resolve-id :meta) (:meta params)]])
                          (when (contains? params :redirect-to)
-                           [[:add-triple id (resolve-id :redirectTo) (:redirect-to params)]])))
+                           [[:add-triple id (resolve-id :redirectTo) (:redirect-to params)]])
+                         (when (contains? params :client-id)
+                           [[:add-triple id (resolve-id :clientId) (:client-id params)]])
+                         (when (contains? params :client-secret)
+                           [[:add-triple id (resolve-id :encryptedClientSecret)
+                             (crypt-util/aead-encrypt-hex (:client-secret params)
+                                                          (uuid-util/->bytes id))]])))
       (get-entity id)))))
 
 (defn get-by-id
@@ -86,6 +91,11 @@
               :etype etype}
              (fn [{:keys [get-entity]}]
                (get-entity id)))))
+
+(defn get-by-id! [{:keys [app-id id] :as params}]
+  (ex/assert-record! (get-by-id params)
+                     :app-oauth-client
+                     {:app-id app-id :id id}))
 
 (defn get-by-client-name
   ([params] (get-by-client-name (aurora/conn-pool :read) params))
@@ -120,25 +130,36 @@
       (Secret.)))
 
 (defn ->OAuthClient [oauth-client]
-  (cond
-    (:discovery_endpoint oauth-client)
-    (oauth/generic-oauth-client-from-discovery-url
-     {:app-id (:app_id oauth-client)
-      :provider-id (:provider_id oauth-client)
-      :client-id (:client_id oauth-client)
-      :client-secret (when (:client_secret oauth-client)
-                       (decrypted-client-secret oauth-client))
-      :discovery-endpoint (:discovery_endpoint oauth-client)
-      :meta (:meta oauth-client)})
+  (let [{provider-name :provider_name}
+        (app-oauth-service-provider-model/get-by-id!
+         {:app-id (:app_id oauth-client)
+          :id (:provider_id oauth-client)})
+        oauth-client (if-not (use-shared-credentials? (:meta oauth-client))
+                       oauth-client
+                       (let [shared-cred (get-shared-credential! provider-name)]
+                         (assoc oauth-client
+                                :id (:id shared-cred)
+                                :client_id (:clientId shared-cred)
+                                :client_secret (:encryptedClientSecret shared-cred))))]
+    (cond
+      (:discovery_endpoint oauth-client)
+      (oauth/generic-oauth-client-from-discovery-url
+       {:app-id (:app_id oauth-client)
+        :provider-id (:provider_id oauth-client)
+        :client-id (:client_id oauth-client)
+        :client-secret (when (:client_secret oauth-client)
+                         (decrypted-client-secret oauth-client))
+        :discovery-endpoint (:discovery_endpoint oauth-client)
+        :meta (:meta oauth-client)})
 
-    (= "github" (get (:meta oauth-client) "providerName"))
-    (oauth/map->GitHubOAuthClient
-     {:app-id (:app_id oauth-client)
-      :provider-id (:provider_id oauth-client)
-      :client-id (:client_id oauth-client)
-      :client-secret (when (:client_secret oauth-client)
-                       (decrypted-client-secret oauth-client))
-      :meta (:meta oauth-client)})
+      (= "github" provider-name)
+      (oauth/map->GitHubOAuthClient
+       {:app-id (:app_id oauth-client)
+        :provider-id (:provider_id oauth-client)
+        :client-id (:client_id oauth-client)
+        :client-secret (when (:client_secret oauth-client)
+                         (decrypted-client-secret oauth-client))
+        :meta (:meta oauth-client)})
 
-    :else
-    (throw (ex-info "Unsupported OAuth client" {:oauth-client oauth-client}))))
+      :else
+      (throw (ex-info "Unsupported OAuth client" {:oauth-client oauth-client})))))

--- a/server/src/instant/model/app_oauth_service_provider.clj
+++ b/server/src/instant/model/app_oauth_service_provider.clj
@@ -2,10 +2,10 @@
   "A provider is an issuer of unique issuer of subject ids (sub).
   An app might have a provider named google that has multiple OAuth
   clients, e.g. one for web and one for native."
-  (:require [instant.jdbc.aurora :as aurora]
-            [instant.system-catalog-ops :refer [query-op update-op]])
-  (:import
-   (java.util UUID)))
+  (:require [instant.comment :as c]
+            [instant.jdbc.aurora :as aurora]
+            [instant.system-catalog-ops :refer [query-op update-op]]
+            [instant.util.exception :as ex]))
 
 (def etype "$oauthProviders")
 
@@ -40,9 +40,14 @@
              (fn [{:keys [get-entity]}]
                (get-entity id)))))
 
-(comment
-  (create! {:app-id (UUID/fromString "3cc5c5c8-07df-42b2-afdc-6a04cbf0c40a")
-            :provider-name "google"})
+(defn get-by-id! [{:keys [app-id id]}]
+  (let [provider (get-by-id {:app-id app-id :id id})]
+    (ex/assert-record! provider :oauth-service-provider {:provider-id id})
+    provider))
 
-  (get-by-provider-name {:app-id (UUID/fromString "3cc5c5c8-07df-42b2-afdc-6a04cbf0c40a")
+(comment
+  (def app (c/empty-app!))
+  (create! {:app-id (:id app)
+            :provider-name "google"})
+  (get-by-provider-name {:app-id (:id app)
                          :provider-name "google"}))

--- a/server/src/instant/model/app_user.clj
+++ b/server/src/instant/model/app_user.clj
@@ -4,12 +4,15 @@
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
    [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.instant-user :as instant-user-model]
    [instant.model.app-user-refresh-token :refer [hash-token]]
    [instant.model.rule :as rule-model]
+   [instant.system-catalog :as system-catalog]
    [instant.system-catalog-ops :refer [update-op query-op]]
-   [instant.util.exception :as ex])
+   [instant.util.exception :as ex]
+   [instant.util.hsql :as uhsql])
   (:import
    (java.util UUID)))
 
@@ -110,6 +113,32 @@
               :etype etype}
              (fn [{:keys [get-entity]}]
                (get-entity id)))))
+
+(def ^:private users-at-least-q
+  (uhsql/preformat
+   {:select [[[:count :*] :count]]
+    :from [[{:select :*
+             :from :triples
+             :where [:and
+                     [:= :app_id :?app-id]
+                     [:= :attr_id :?attr-id]]
+             :limit :?n} :sub]]}))
+
+(defn users-at-least?
+  "Bounded existence check: returns true when the app has at least `n`
+   users. Uses the deterministic `$users.id` attr_id, and the inner
+   LIMIT caps the scan at n rows so we don't pay for a full COUNT on
+   large apps."
+  ([params] (users-at-least? (aurora/conn-pool :read) params))
+  ([conn {:keys [app-id n]}]
+   (let [attr-id (system-catalog/get-attr-id "$users" "id")
+         {:keys [count]} (sql/select-one
+                          conn
+                          (uhsql/formatp users-at-least-q
+                                         {:app-id app-id
+                                          :attr-id attr-id
+                                          :n n}))]
+     (>= count n))))
 
 (defn get-by-ids
   ([params] (get-by-ids (aurora/conn-pool :read) params))

--- a/server/src/instant/model/shared_oauth_client.clj
+++ b/server/src/instant/model/shared_oauth_client.clj
@@ -1,0 +1,144 @@
+(ns instant.model.shared-oauth-client
+  "Shared OAuth credentials that Instant provides to app developers so
+   they can test OAuth (Google, etc.) without setting up their own
+   client in the provider's console.
+
+   Rows live in the `shared-oauth-clients` entity on the instant-config
+   app, keyed by provider name (e.g. \"google\"). The runtime reads
+   those rows via `get-shared-credential!` when an app's
+   `app-oauth-client` has `meta.useSharedCredentials = true`.
+
+   Two parallel entities live on instant-config:
+
+   - `shared-oauth-clients` — used by apps in every env. Registered
+     with the provider against
+     `https://api.instantdb.com/runtime/oauth/callback`.
+
+   - `shared-oauth-clients-instant-dev` — parallel entity, registered
+     against `http://localhost:8888/runtime/oauth/callback`. Used by
+     Instant engineers running the server locally. Pulled into a dev's
+     local `shared-oauth-clients` via `import-from-prod!` so the
+     runtime code stays provider-agnostic (it just reads
+     `shared-oauth-clients`).
+
+   KMS key ARN is the same across envs, so ciphertext produced in any
+   JVM decrypts in any other. `instant-config-app-id` is also the same
+   across envs."
+  (:require
+   [instant.config :as config]
+   [instant.flags :as flags]
+   [instant.jdbc.aurora :as aurora]
+   [instant.model.app-user :as app-user-model]
+   [instant.system-catalog-ops :as sco]
+   [instant.util.crypt :as crypt-util]
+   [instant.util.exception :as ex]
+   [instant.util.uuid :as uuid-util]))
+
+;; --------------------------------------------------------------
+;; Runtime reads
+
+(defn get-shared-credential [provider-name]
+  (first (get (flags/shared-oauth-clients) provider-name)))
+
+(defn get-shared-credential! [provider-name]
+  (ex/assert-record! (get-shared-credential provider-name)
+                     :shared-oauth-client
+                     {:provider-name provider-name}))
+
+;; --------------------------------------------------------------
+;; Cap enforcement
+
+(def shared-credentials-user-limit 100)
+
+(defn assert-shared-credentials-allowed!
+  "Shared dev credentials are strictly meant for development. Once an
+   app has `shared-credentials-user-limit` users signed up, we refuse
+   new sign-ups and new shared-credential clients so apps don't quietly
+   ride on our shared OAuth client in production. At that point the
+   user is expected to add their own client_id and client_secret."
+  [app-id]
+  (when (app-user-model/users-at-least? {:app-id app-id
+                                         :n shared-credentials-user-limit})
+    (ex/throw-validation-err!
+     :shared-credentials
+     app-id
+     [{:message (str "Shared dev credentials are limited to "
+                     shared-credentials-user-limit
+                     " users. Please add your own client_id and client_secret in the dashboard.")}])))
+
+;; --------------------------------------------------------------
+;; Ops helpers
+
+(defn make-row
+  "Build a row map ready to paste into instant-config's
+   `shared-oauth-clients` (or `shared-oauth-clients-instant-dev`) 
+   via the dashboard Explorer."
+  [{:keys [provider-name client-id client-secret]}]
+  (assert (and provider-name client-id client-secret)
+          "make-row needs :provider-name, :client-id, :client-secret")
+  (let [id (random-uuid)]
+    {:id id
+     :providerName provider-name
+     :clientId client-id
+     :encryptedClientSecretHexString (crypt-util/aead-encrypt-hex
+                                      client-secret
+                                      (uuid-util/->bytes id))}))
+
+(defn import-from-prod!
+  "Copy the `shared-oauth-clients-instant-dev` row for `provider-name`
+   from prod into the caller's local instant-config app's
+   `shared-oauth-clients` entity.
+
+   Run this once when setting up a local server so the shared-creds
+   flow works end-to-end"
+  [{:keys [provider-name prod-conn-pool]}]
+  (assert (and provider-name prod-conn-pool)
+          "import-from-prod! needs :provider-name and :prod-conn-pool")
+  (let [prod-row (sco/query-op
+                  prod-conn-pool
+                  {:app-id (config/instant-config-app-id)
+                   :etype "shared-oauth-clients-instant-dev"}
+                  (fn [{:keys [get-entity-where]}]
+                    (get-entity-where {:providerName provider-name})))
+        _ (assert prod-row
+                  (str "No shared-oauth-clients-instant-dev row for "
+                       provider-name " in prod"))
+        local-pool (aurora/conn-pool :write)]
+    (sco/update-op
+     local-pool
+     {:app-id (config/instant-config-app-id)
+      :etype "shared-oauth-clients"}
+     (fn [{:keys [transact! resolve-id get-entity delete-entity!]}]
+       ;; Replace any existing local row so the import is idempotent.
+       (delete-entity! [(resolve-id :providerName) provider-name])
+       ;; Reads come back with snake_case `:client_id` (system-catalog-
+       ;; ops remaps `:clientId` on output). Writes still use the
+       ;; original label via `resolve-id :clientId`.
+       (let [id (:id prod-row)]
+         (transact!
+          [[:add-triple id (resolve-id :id) id]
+           [:add-triple id (resolve-id :providerName) provider-name]
+           [:add-triple id (resolve-id :clientId) (:client_id prod-row)]
+           [:add-triple id (resolve-id :encryptedClientSecretHexString)
+            (:encryptedClientSecretHexString prod-row)]])
+         (dissoc (get-entity id) :encryptedClientSecretHexString))))))
+
+(comment
+  ;; Evaluate these from inside this ns in the REPL.
+  
+  ;; ---- Adding a new shared credential ----
+  
+  (make-row {:provider-name "google"
+             :client-id     "1234567890-abc.apps.googleusercontent.com"
+             :client-secret "GOCSPX-example-secret"})
+  ;; You can now paste the result in instant-config
+  
+  ;; ---- Local dev setup ----
+  ;;
+  ;; Pull the Instant-dev variant out of prod so shared-creds work
+  ;; against your locally-running server. 
+  
+  (tool/with-prod-conn [prod-conn]
+    (import-from-prod! {:provider-name "google"
+                        :prod-conn-pool prod-conn})))
+  

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -14,6 +14,7 @@
    [instant.model.app :as app-model]
    [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
    [instant.model.app-oauth-client :as app-oauth-client-model]
+   [instant.model.shared-oauth-client :refer [assert-shared-credentials-allowed!]]
    [instant.model.app-oauth-code :as app-oauth-code-model]
    [instant.model.app-oauth-redirect :as app-oauth-redirect-model]
    [instant.model.app-user :as app-user-model]
@@ -184,6 +185,27 @@
   (when (string/starts-with? v cookie-value-prefix)
     (uuid-util/coerce (subs v (count cookie-value-prefix)))))
 
+(defn assert-authorized-redirect-uri! [client redirect-uri]
+  (let [authorized-origins (app-authorized-redirect-origin-model/get-all-for-app
+                            {:app-id (:app_id client)})]
+    (when-not (app-authorized-redirect-origin-model/authorized-origin?
+               authorized-origins
+               redirect-uri
+               (app-oauth-client-model/use-shared-credentials? (:meta client)))
+      (ex/throw-validation-err!
+       :redirect-uri
+       redirect-uri
+       [{:message "Invalid redirect_uri. If you're the developer, make sure to add your website to the list of approved domains."}]))))
+
+(defn assert-authorized-request-origin! [client origin]
+  (let [authorized-origins (app-authorized-redirect-origin-model/get-all-for-app
+                            {:app-id (:app_id client)})]
+    (when-not (app-authorized-redirect-origin-model/authorized-origin?
+               authorized-origins
+               origin
+               (app-oauth-client-model/use-shared-credentials? (:meta client)))
+      (ex/throw-validation-err! :origin origin [{:message "Unauthorized origin."}]))))
+
 (defn oauth-start [{{:keys [state code_challenge code_challenge_method]} :params :as req}]
   (let [app-id (ex/get-param! req [:params :app_id] uuid-util/coerce)
 
@@ -206,16 +228,8 @@
                                     :let [value (get-in req [:params param])]
                                     :when value]
                                 [param value]))
-        authorized-origins (app-authorized-redirect-origin-model/get-all-for-app
-                            {:app-id (:app_id client)})
-        matched-origin (app-authorized-redirect-origin-model/find-match
-                        authorized-origins
-                        redirect-uri)
-        _ (when-not matched-origin
-            (ex/throw-validation-err!
-             :redirect-uri
-             redirect-uri
-             [{:message "Invalid redirect_uri. If you're the developer, make sure to add your website to the list of approved domains from the Dashboard."}]))
+
+        _ (assert-authorized-redirect-uri! client redirect-uri)
 
         app-redirect-url
         (if state
@@ -255,7 +269,8 @@
                               ;; matches everything under the subdirectory
                               :path "/runtime/oauth"}))))
 
-(defn upsert-oauth-link! [{:keys [email sub imageURL app-id provider-id guest-user-id extra-fields]}]
+(defn upsert-oauth-link! [{:keys [email sub imageURL app-id provider-id guest-user-id extra-fields
+                                  use-shared-credentials?]}]
   (let [users (app-user-model/get-by-email-or-oauth-link-qualified
                {:email email
                 :app-id app-id
@@ -283,23 +298,26 @@
                                        :sub (:app_user_oauth_links/sub oauth-link)})})))]
 
     (if-not user
-      (let [_        (app-user-model/assert-signup!
+      (let [new-user-id (or guest-user-id (random-uuid))
+            _        (when use-shared-credentials?
+                       (assert-shared-credentials-allowed! app-id))
+            _        (app-user-model/assert-signup!
                       {:app-id app-id
                        :email email
-                       :id (or guest-user-id (random-uuid))
+                       :id new-user-id
                        :extra-fields extra-fields})
             new-user (app-user-model/create!
-                       {:id guest-user-id
-                        :app-id app-id
-                        :email email
-                        :imageURL imageURL
-                        :type "user"
-                        :extra-fields extra-fields})]
+                      {:id new-user-id
+                       :app-id app-id
+                       :email email
+                       :imageURL imageURL
+                       :type "user"
+                       :extra-fields extra-fields})]
         (assoc (app-user-oauth-link-model/create! {:id (random-uuid)
-                                                    :app-id app-id
-                                                    :provider-id provider-id
-                                                    :sub sub
-                                                    :user-id (:id new-user)})
+                                                   :app-id app-id
+                                                   :provider-id provider-id
+                                                   :sub sub
+                                                   :user-id (:id new-user)})
                :created true))
 
       (do
@@ -591,19 +609,16 @@
         oauth-code (app-oauth-code-model/consume! {:code code
                                                    :app-id app-id
                                                    :verifier code-verifier})
-        _ (when-let [origin (get-in req [:headers "origin"])]
-            (let [authorized-origins (app-authorized-redirect-origin-model/get-all-for-app
-                                      {:app-id app-id})]
-              (when-not (app-authorized-redirect-origin-model/find-match
-                         authorized-origins origin)
-                (ex/throw-validation-err! :origin origin [{:message "Unauthorized origin."}]))))
         {:keys [app_id client_id user_info]} oauth-code
-
-        _ (assert (= app-id app_id) (str "(= " app-id " " app_id ")"))
 
         client (or (app-oauth-client-model/get-by-id {:app-id app-id
                                                       :id client_id})
                    (ex/throw-oauth-err! "Missing OAuth client"))
+
+        _ (when-let [origin (get-in req [:headers "origin"])]
+            (assert-authorized-request-origin! client origin))
+
+        _ (assert (= app-id app_id) (str "(= " app-id " " app_id ")"))
 
         guest-user (when-some [refresh-token (ex/get-optional-param! req [:body :refresh_token] uuid-util/coerce)]
                      (let [user (app-user-model/get-by-refresh-token!
@@ -619,7 +634,10 @@
                                                 :app-id app-id
                                                 :provider-id (:provider_id client)
                                                 :guest-user-id (:id guest-user)
-                                                :extra-fields extra-fields})
+                                                :extra-fields extra-fields
+                                                :use-shared-credentials?
+                                                (app-oauth-client-model/use-shared-credentials?
+                                                 (:meta client))})
 
         refresh-token-id (random-uuid)
 
@@ -647,14 +665,8 @@
         client (app-oauth-client-model/get-by-client-name! {:app-id app-id
                                                             :client-name client-name})
         oauth-client (app-oauth-client-model/->OAuthClient client)
-        _ (when-let [origin (and (:client_secret client)
-                                 (get-in req [:headers "origin"]))]
-            (let [authorized-origins (app-authorized-redirect-origin-model/get-all-for-app
-                                      {:app-id app-id})
-                  match (app-authorized-redirect-origin-model/find-match
-                         authorized-origins origin)]
-              (when-not match
-                (ex/throw-validation-err! :origin origin [{:message "Unauthorized origin."}]))))
+        _ (when-let [origin (get-in req [:headers "origin"])]
+            (assert-authorized-request-origin! client origin))
 
         {:keys [email sub imageURL]} (oauth/get-user-info-from-id-token
                                       oauth-client
@@ -685,7 +697,10 @@
                                           :app-id (:app_id client)
                                           :provider-id (:provider_id client)
                                           :guest-user-id (:id guest-user)
-                                          :extra-fields extra-fields})
+                                          :extra-fields extra-fields
+                                          :use-shared-credentials?
+                                          (app-oauth-client-model/use-shared-credentials?
+                                           (:meta client))})
 
         {refresh-token-id :id} (if (and current-refresh-token
                                         (= (:user_id social-login)
@@ -713,7 +728,7 @@
         app-id (req->app-id-untrusted! req)
         user (when auth-token
                (app-user-model/get-by-refresh-token {:refresh-token auth-token
-                                                      :app-id app-id}))
+                                                     :app-id app-id}))
         attrs (attr-model/get-by-app-id app-id)
         ctx {:db {:conn-pool (aurora/conn-pool :read)}
              :app-id app-id

--- a/server/src/instant/util/crypt.clj
+++ b/server/src/instant/util/crypt.clj
@@ -109,6 +109,14 @@
   (^bytes [^AeadWrapper$WrappedAead aead {:keys [^bytes ciphertext ^bytes associated-data] :as _input}]
    (.decrypt aead ciphertext associated-data)))
 
+(defn aead-encrypt-hex
+  "Encrypts `plaintext` (a string) with `associated-data` (bytes) via
+   `aead-encrypt`, returning the ciphertext as a hex string."
+  ^String [^String plaintext ^bytes associated-data]
+  (bytes->hex-string
+   (aead-encrypt {:plaintext (str->utf-8-bytes plaintext)
+                  :associated-data associated-data})))
+
 (defn hybrid-encrypt
   "Encrypts plaintext with associated data:
    https://developers.google.com/tink/exchange-data#hybrid_encryption"

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -7,9 +7,13 @@
    [instant.dash.ephemeral-app :as ephemeral-app]
    [instant.dash.get-a-db :as get-a-db]
    [instant.dash.routes :as routes]
+   [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
+   [instant.model.app-oauth-client :as app-oauth-client-model]
+   [instant.model.app-user :as app-user-model]
+   [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
    [instant.model.instant-stripe-customer :as stripe-customer-model]
    [instant.model.org-members :as org-members]
@@ -1148,3 +1152,92 @@
                        (-> resp :body <-json (get "type"))))
                 (is (= (:id owner)
                        (:creator_id (app-model/get-by-id! {:id (:id app)}))))))))))))
+
+(defn- create-provider! [app user provider-name]
+  (let [resp (http/post (str config/server-origin "/dash/apps/" (:id app) "/oauth_service_providers")
+                        {:headers {:Authorization (str "Bearer " (:refresh-token user))
+                                   :Content-Type "application/json"}
+                         :as :json
+                         :body (->json {:provider_name provider-name})})]
+    (get-in resp [:body :provider])))
+
+(defn- post-oauth-client [app user body]
+  (http/post (str config/server-origin "/dash/apps/" (:id app) "/oauth_clients")
+             {:throw-exceptions false
+              :headers {:Authorization (str "Bearer " (:refresh-token user))
+                        :Content-Type "application/json"}
+              :as :json
+              :body (->json body)}))
+
+(defn- post-oauth-client-update [app user client-id body]
+  (http/post (str config/server-origin "/dash/apps/" (:id app) "/oauth_clients/" client-id)
+             {:throw-exceptions false
+              :headers {:Authorization (str "Bearer " (:refresh-token user))
+                        :Content-Type "application/json"}
+              :as :json
+              :body (->json body)}))
+
+(deftest oauth-clients-post-rejects-shared-credentials-for-unconfigured-provider
+  (with-user
+    (fn [u]
+      (with-empty-app (:id u)
+        (fn [app]
+          (with-redefs [flags/shared-oauth-clients (constantly {})]
+            (let [provider (create-provider! app u "github")
+                  resp (post-oauth-client app u {:provider_id (:id provider)
+                                                 :client_name "github-web"
+                                                 :client_id "id"
+                                                 :client_secret "secret"
+                                                 :meta {:useSharedCredentials true}})
+                  body (some-> resp :body <-json)]
+              (is (= 400 (:status resp)))
+              (is (= "record-not-found" (get body "type")))
+              (is (= "shared-oauth-client" (get-in body ["hint" "record-type"]))))))))))
+
+(deftest oauth-clients-post-rejects-shared-credentials-over-user-cap
+  (with-user
+    (fn [u]
+      (with-empty-app (:id u)
+        (fn [app]
+          (dotimes [i 5]
+            (app-user-model/create! {:app-id (:id app)
+                                     :id (random-uuid)
+                                     :email (str "cap-" i "@test.com")
+                                     :type "user"}))
+          (let [fake-shared {"github" [{:id (random-uuid)
+                                        :clientId "shared-github"
+                                        :encryptedClientSecret "deadbeef"}]}]
+            (with-redefs [flags/shared-oauth-clients (constantly fake-shared)
+                          shared-credentials-user-limit 5]
+              (let [provider (create-provider! app u "github")
+                    resp (post-oauth-client app u {:provider_id (:id provider)
+                                                   :client_name "github-web"
+                                                   :meta {:useSharedCredentials true}})
+                    body (some-> resp :body <-json)]
+                (is (= 400 (:status resp)))
+                (is (= "validation-failed" (get body "type")))
+                (is (re-find #"Shared dev credentials are limited"
+                             (str (get body "message"))))))))))))
+
+(deftest update-oauth-client-rotates-credentials
+  (with-user
+    (fn [u]
+      (with-empty-app (:id u)
+        (fn [app]
+          (let [provider (create-provider! app u "github")
+                create-resp (post-oauth-client app u {:provider_id (:id provider)
+                                                      :client_name "github-web"
+                                                      :client_id "old-id"
+                                                      :client_secret "old-secret"})
+                _ (is (= 200 (:status create-resp)))
+                client-id (-> create-resp :body :client :id)
+                update-resp (post-oauth-client-update app u client-id
+                                                      {:client_id "new-id"
+                                                       :client_secret "new-secret"})]
+            (is (= 200 (:status update-resp)))
+            (is (= "new-id" (-> update-resp :body :client :client_id)))
+            (let [row (app-oauth-client-model/get-by-id {:app-id (:id app)
+                                                         :id (java.util.UUID/fromString client-id)})
+                  decrypted (app-oauth-client-model/decrypted-client-secret row)]
+              (is (= "new-id" (:client_id row)))
+              (is (= "new-secret" (crypt-util/secret-value decrypted))))))))))

--- a/server/test/instant/model/app_authorized_redirect_origin_test.clj
+++ b/server/test/instant/model/app_authorized_redirect_origin_test.clj
@@ -1,6 +1,6 @@
 (ns instant.model.app-authorized-redirect-origin-test
   (:require [instant.model.app-authorized-redirect-origin :as sut]
-            [clojure.test :as test :refer [deftest are testing]]))
+            [clojure.test :as test :refer [deftest are is testing]]))
 
 (deftest find-match
   (testing "find-match"
@@ -14,3 +14,45 @@
         "https://deploy-preview-42--mysitename.netlify.app" netlify
         "https://some-project-name.vercel.app" vercel
         "https://some-project-name-git-some-branch-name.vercel.app" vercel))))
+
+(deftest shared-credentials-default-match
+  (testing "accepts http/https on loopback hosts and exp://"
+    (are [url service] (= service (:service (sut/shared-credentials-default-match url)))
+      "http://localhost"                "localhost"
+      "http://localhost:3000"           "localhost"
+      "https://localhost"               "localhost"
+      "https://localhost:8443/foo"      "localhost"
+      "http://127.0.0.1"                "localhost"
+      "http://127.0.0.1:3000"           "localhost"
+      "https://127.0.0.1:8443"          "localhost"
+      "http://[::1]"                    "localhost"
+      "http://[::1]:3000"               "localhost"
+      "http://0.0.0.0"                  "localhost"
+      "http://0.0.0.0:3000"             "localhost"
+      "exp://"                          "custom-scheme"
+      "exp://192.168.1.5:8081"          "custom-scheme"
+      "exp://exp.host/@user/slug"       "custom-scheme"))
+  (testing "rejects other schemes on loopback hosts, non-exp custom schemes, and arbitrary domains"
+    (are [url] (nil? (sut/shared-credentials-default-match url))
+      "file://localhost"
+      "custom://localhost"
+      "ftp://localhost"
+      "file://127.0.0.1"
+      "https://example.com"
+      "https://localhost.example.com"
+      "https://127.0.0.1.nip.io"
+      "myapp://"
+      "")))
+
+(deftest authorized-origin?
+  (testing "delegates to find-match first"
+    (let [generic {:id (random-uuid) :service "generic" :params ["example.com"]}]
+      (is (true?  (sut/authorized-origin? [generic] "https://example.com" false)))
+      (is (false? (sut/authorized-origin? [generic] "https://other.com"   false)))))
+  (testing "without shared credentials, localhost and exp:// are not auto-allowed"
+    (is (false? (sut/authorized-origin? [] "http://localhost:3000" false)))
+    (is (false? (sut/authorized-origin? [] "exp://"                false))))
+  (testing "with shared credentials, localhost and exp:// fall back to default-match"
+    (is (true?  (sut/authorized-origin? [] "http://localhost:3000" true)))
+    (is (true?  (sut/authorized-origin? [] "exp://"                true)))
+    (is (false? (sut/authorized-origin? [] "https://example.com"   true)))))

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -11,7 +11,10 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
+   [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
+   [instant.model.app-oauth-client :as app-oauth-client-model]
    [instant.model.app-oauth-service-provider :as provider-model]
+   [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.model.app-user :as app-user-model]
    [instant.model.rule :as rule-model]
    [instant.postmark :as postmark]
@@ -796,4 +799,94 @@
                (permissioned-tx/transact!
                 ctx
                 [[:add-triple user-id (:id id-attr) user-id]]))))))))
+
+(deftest upsert-oauth-link-enforces-shared-credentials-cap
+  (with-empty-app
+    (fn [app]
+      (let [provider (provider-model/create! {:app-id (:id app)
+                                              :provider-name "google"})]
+        (testing "no cap check for non-shared-credentials clients"
+          (with-redefs [shared-credentials-user-limit 1]
+            (let [link (route/upsert-oauth-link! {:email "non-shared@example.com"
+                                                  :sub "non-shared-sub"
+                                                  :app-id (:id app)
+                                                  :provider-id (:id provider)
+                                                  :use-shared-credentials? false})]
+              (is (uuid? (:user_id link))))))
+        (testing "first sign-up under the cap succeeds for shared-credentials clients"
+          (with-redefs [shared-credentials-user-limit 2]
+            (let [link (route/upsert-oauth-link! {:email "shared-1@example.com"
+                                                  :sub "shared-1-sub"
+                                                  :app-id (:id app)
+                                                  :provider-id (:id provider)
+                                                  :use-shared-credentials? true})]
+              (is (uuid? (:user_id link))))))
+        (testing "hitting the cap rejects the new-user sign-up"
+          (with-redefs [shared-credentials-user-limit 2]
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"Shared dev credentials are limited"
+                 (route/upsert-oauth-link! {:email "shared-over@example.com"
+                                            :sub "shared-over-sub"
+                                            :app-id (:id app)
+                                            :provider-id (:id provider)
+                                            :use-shared-credentials? true})))))
+        (testing "returning users (same sub) are not blocked by the cap"
+          (with-redefs [shared-credentials-user-limit 2]
+            (let [link (route/upsert-oauth-link! {:email "shared-1@example.com"
+                                                  :sub "shared-1-sub"
+                                                  :app-id (:id app)
+                                                  :provider-id (:id provider)
+                                                  :use-shared-credentials? true})]
+              (is (uuid? (:user_id link))))))))))
+
+(deftest assert-authorized-redirect-uri!
+  (with-empty-app
+    (fn [app]
+      (app-authorized-redirect-origin-model/add!
+       {:app-id (:id app)
+        :service "generic"
+        :params ["example.com"]})
+      (let [shared-client {:app_id (:id app) :meta {"useSharedCredentials" true}}
+            custom-client {:app_id (:id app) :meta {"useSharedCredentials" false}}]
+        (testing "authorized origin always works regardless of shared-credentials flag"
+          (is (nil? (route/assert-authorized-redirect-uri! shared-client "https://example.com/cb")))
+          (is (nil? (route/assert-authorized-redirect-uri! custom-client "https://example.com/cb"))))
+        (testing "shared-credentials clients get the localhost / exp default fallback"
+          (is (nil? (route/assert-authorized-redirect-uri! shared-client "http://localhost:3000")))
+          (is (nil? (route/assert-authorized-redirect-uri! shared-client "https://localhost:8443")))
+          (is (nil? (route/assert-authorized-redirect-uri! shared-client "exp://192.168.1.5:8081"))))
+        (testing "non-shared clients do not get the default fallback"
+          (is (thrown-with-msg?
+               ExceptionInfo #"Invalid redirect_uri"
+               (route/assert-authorized-redirect-uri! custom-client "http://localhost:3000")))
+          (is (thrown-with-msg?
+               ExceptionInfo #"Invalid redirect_uri"
+               (route/assert-authorized-redirect-uri! custom-client "exp://192.168.1.5:8081"))))
+        (testing "unauthorized domain rejected even with shared credentials"
+          (is (thrown-with-msg?
+               ExceptionInfo #"Invalid redirect_uri"
+               (route/assert-authorized-redirect-uri! shared-client "https://attacker.com/cb"))))))))
+
+(deftest assert-authorized-request-origin!
+  (with-empty-app
+    (fn [app]
+      (app-authorized-redirect-origin-model/add!
+       {:app-id (:id app)
+        :service "generic"
+        :params ["example.com"]})
+      (let [shared-client {:app_id (:id app) :meta {"useSharedCredentials" true}}
+            custom-client {:app_id (:id app) :meta {"useSharedCredentials" false}}]
+        (testing "authorized origin always works"
+          (is (nil? (route/assert-authorized-request-origin! custom-client "https://example.com"))))
+        (testing "shared-credentials fall back to default match"
+          (is (nil? (route/assert-authorized-request-origin! shared-client "http://localhost:3000"))))
+        (testing "non-shared clients do not fall back"
+          (is (thrown-with-msg?
+               ExceptionInfo #"Unauthorized origin"
+               (route/assert-authorized-request-origin! custom-client "http://localhost:3000"))))
+        (testing "unauthorized origin rejected"
+          (is (thrown-with-msg?
+               ExceptionInfo #"Unauthorized origin"
+               (route/assert-authorized-request-origin! shared-client "https://attacker.com"))))))))
 

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -12,7 +12,6 @@
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
-   [instant.model.app-oauth-client :as app-oauth-client-model]
    [instant.model.app-oauth-service-provider :as provider-model]
    [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.model.app-user :as app-user-model]


### PR DESCRIPTION
CLI counterpart to the dashboard changes in #2553. Stacked on top of `sharedcred` so the diff here is only the CLI.

## What's new at a glance

| Before | After |
| --- | --- |
| `add --type google` always requires a real `client_id` (+ secret for web). | `add --type google --app-type web --dev-credentials` creates a working client with zero setup. |
| No way to rotate or upgrade credentials — users `delete` + re-`add`, which churns the client's db id and breaks any in-flight refresh tokens. | New `update` subcommand swaps credentials in place. |
| Interactive `add` for Google + web dumps the user straight into "paste your `client_id`". | A credential-mode selector (same shape as the dashboard toggle) appears first, defaulted to dev. |

## Why now

The backend PR (#2588) and the dashboard PR (#2553) already landed these capabilities. Without the CLI, a developer who bootstraps their app with `instant-cli init` still has to open the dashboard just to create an OAuth client — defeating the "no setup" value prop of shared dev credentials. This PR closes that loop.

## 1. `auth client add --dev-credentials`

### Interactive (non-`--yes`) flow — what the user sees

```
$ instant-cli auth client add --type google

? Select a Google app type:
❯ Web  (Redirect Flows or Expo Auth Session)
  iOS
  Android
  Google Button for Web

? Credential mode:                       ← NEW
❯ Use dev credentials  — works on localhost / Expo with no Google setup
  Use my own           — provide your own client_id / client_secret

? Client Name:  google-web

⠋ Creating Google OAuth client...

┌──────────────────────────────────────────────────────────────┐
│ Google OAuth client created: google-web                      │
│ App type: web (dev credentials)                              │
│ ID: 5a7e8d9f-1234-4aaa-b000-c1d2e3f4a5b6                     │
│                                                              │
│ No setup required — works on localhost / Expo out of the box.│
│                                                              │
│ Ready for production? Run:                                   │
│   instant-cli auth client update --name google-web \         │
│     --client-id <id> --client-secret <secret>                │
└──────────────────────────────────────────────────────────────┘
```

The credential-mode selector is deliberately *not* a Yes/No. Mirroring the dashboard's two-option toggle (`Use dev credentials` / `Use my own`) makes the alternative discoverable — users who don't know shared creds exist still learn about them when they run `add` for the first time.

### When the selector is skipped

The selector exists to resolve ambiguity. When the user's flags already commit to a mode, we skip it:

| User's flags | Selector shows? | Mode |
| --- | --- | --- |
| `--dev-credentials` | no | dev |
| `--client-id <x>` (or `--client-secret`) | no | custom |
| none of the above, `--yes` | no | custom (fall through to existing required-flag errors) |
| none of the above, interactive | **yes** | user picks |
| `--app-type` ≠ `web` | no | custom (shared creds are web-only) |

### Validation

Three new error paths, each with a specific message:

```
$ instant-cli auth client add --yes --type google --app-type web \
    --dev-credentials --client-id X
[error] --dev-credentials cannot be combined with --client-id,
        --client-secret, or --custom-redirect-uri. Omit them
        (Instant supplies the credentials) or drop --dev-credentials.

$ instant-cli auth client add --yes --type google --app-type ios \
    --dev-credentials
[error] --dev-credentials is only supported for --app-type web.
        Native clients need a real client_id from Google.

$ instant-cli auth client add --yes --type github --dev-credentials
[error] --dev-credentials is only supported for --type google at the
        moment.
```

### Request payload (shared-creds path vs existing web path)

```diff
  POST /dash/apps/:app_id/oauth_clients
  {
    provider_id: "prov-...",
    client_name: "google-web",
-   client_id: "123-abc.apps.googleusercontent.com",
-   client_secret: "GOCSPX-...",
    authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth",
    token_endpoint:         "https://oauth2.googleapis.com/token",
    discovery_endpoint:     "https://accounts.google.com/.well-known/openid-configuration",
-   redirect_to: "https://api.instantdb.com/runtime/oauth/callback",
    meta: {
      appType: "web",
      skipNonceChecks: true,
+     useSharedCredentials: true,
    }
  }
```

Endpoints stay the same on purpose — the record shape should be uniform whether or not it uses shared creds. The server substitutes `client_id` / `client_secret` at request time, triggered by `meta.useSharedCredentials`.

## 2. `auth client update` (new subcommand)

### What it does

One subcommand covers **two flows**, mirroring the dashboard's unified `CredentialsEditor`:

- **Rotate** — existing custom-cred client → new credentials.
- **Upgrade** — shared-cred client (created with `--dev-credentials`) → its own credentials; `meta.useSharedCredentials` flips from `true` to `false`.

The implementation is just one POST — `update-oauth-client` on the server (shipped in #2588) accepts either or both of `client_id` / `client_secret` along with a `meta` merge. The CLI always sends `meta: { useSharedCredentials: false }`, which is idempotent on already-custom clients and performs the upgrade on shared-cred ones.

### Interactive flow

```
$ instant-cli auth client update

? Select a client to update:
  google-web     |   c-web-a1b2
❯ g-dev           (dev credentials)   |   c-dev-7f3a
  google-ios     |   c-ios-55ea

? Client ID:
❯ 123-abc.apps.googleusercontent.com

? Client Secret:
❯ ••••••••••••••••••

⠋ Updating credentials...

┌──────────────────────────────────────────────────────────────┐
│ Credentials updated for g-dev.                               │
│                                                              │
│ If this client was using dev credentials, it is now using    │
│ the client_id / client_secret you provided.                  │
└──────────────────────────────────────────────────────────────┘
```

The `(dev credentials)` suffix in the picker comes from `meta.useSharedCredentials` on each client — critical signal for telling which clients are currently on shared creds.

### Prompt decision tree

```
                 ┌────────────────────────────────────┐
                 │ Resolve client                     │
                 │ (--id | --name | picker)           │
                 └────────────────────────────────────┘
                                   │
                                   ▼
                 ┌────────────────────────────────────┐
                 │ Read client.meta.appType           │
                 └────────────────────────────────────┘
                                   │
             ┌─────────────────────┴─────────────────────┐
             ▼                                           ▼
   appType === 'web' or absent            appType ∈ {ios, android, button-for-web}
             │                                           │
             │                                           ▼
             │                                 secret isn't prompted
             │                                 (native clients don't have one)
             ▼
   Both client_id + client_secret
   are candidates to prompt for.
                                   │
                                   ▼
            ┌────────────────────────────────────────────┐
            │ Did the user pass --client-id or           │
            │ --client-secret on the command line?       │
            └────────────────────────────────────────────┘
                                   │
                ┌──────────────────┴───────────────────┐
                ▼                                      ▼
          yes, one or both                         no (interactive only)
                │                                      │
                │                                      ▼
                ▼                             Prompt for each field that
        Skip all prompts; send                applies to this appType.
        only the flags that were
        explicitly provided.
```

The partial-update shape ("supplying only one field is fine") matches how the API works — both fields are optional on the server — and matches what users actually want when rotating just the secret.

### `--yes` mode

Two errors guard `--yes`:

```
$ instant-cli auth client update --yes --client-id X --client-secret Y
[error] Must specify --id or --name.

$ instant-cli auth client update --yes --name g-dev
[error] Must specify at least one of --client-id or --client-secret.
```

## Changes at file level

- **`client/packages/cli/src/commands/auth/client/add.ts`**
  - New `selectCredentialMode` effect — UI.Select that resolves to `'dev' | 'custom'`.
  - `handleGoogleClient` branches on shared-creds mode: skips id/secret/redirect prompts, sends the shared-creds payload, prints the new success summary.
  - Validation guards for the three error paths listed above.
  - Non-Google validation lives in `authClientAddCmd` before dispatch.
- **`client/packages/cli/src/commands/auth/client/update.ts`** *(new)*
  - `authClientUpdateCmd` effect.
  - `resolveClient` helper that handles `--id` / `--name` / picker + the `(dev credentials)` suffix rendering.
  - `promptClientId` / `promptClientSecret` effects (had to inline rather than use `optOrPrompt` — its `skipIf` helper errors when a flag value is present, which is wrong for partial updates where supplying a flag *should* mean "don't prompt for this one but do still accept it").
- **`client/packages/cli/src/lib/oauth.ts`**
  - `updateOAuthClient({ appId?, oauthClientId, body })` — thin POST wrapper. `body` is pass-through so the helper doesn't get opinionated about the update shape.
- **`client/packages/cli/src/index.ts`**
  - `--dev-credentials` flag + help-text entry on `authClientAddDef`.
  - New `authClientUpdateDef` command def mirroring `authClientDeleteDef` for identification + adding credential flags.
- **`client/packages/cli/__tests__/authClientAddGoogle.test.ts`**
  - Updated the "missing `--client-id` → prompts for id" test: the new credential-mode selector lands before the id prompt, so the test now asserts on prompts[0] (selector) and prompts[1] (id) explicitly.
  - 4 new cases: `--yes` shared-creds success, `--dev-credentials + --client-id` error, `--dev-credentials + --app-type ios` error, interactive "pick dev creds" success.
- **`client/packages/cli/__tests__/authClientUpdate.test.ts`** *(new)*
  - 10 cases covering `--yes` happy/error paths, interactive picker, partial updates, and native-client secret-prompt skipping.

## Design decisions

- **Flag name `--dev-credentials`** rather than `--shared-credentials`. Matches the dashboard copy ("Use dev credentials") which itself was chosen because "dev" is immediately meaningful to the user — they know what they're opting into.
- **Default in the interactive selector is `dev`**, not `custom`. Mirrors the dashboard. The zero-setup path is the path most users probably want on first contact; anyone who knows they want their own creds will skip past the selector anyway (either via `--client-id` on the command line or by picking option 2).
- **`update` always sets `meta.useSharedCredentials: false`**, regardless of the client's current state. The operation is semantically "I'm providing my own credentials now." If we ever need the inverse (go back to dev creds after setting custom ones), that would be an explicit separate flag.
- **`update` v1 scope is just `--client-id` / `--client-secret`**, not `--custom-redirect-uri` / `--name` / other meta fields. Keeps the diff small and matches what the dashboard's "Update credentials" button does today. Can extend later without API changes.
- **Partial updates allowed interactively too.** If the user passes just `--client-id`, we don't nag for `--client-secret` — they told us what they wanted.

## Pre-existing bug worth a follow-up (not fixed here)

The CLI hardcodes `skipNonceChecks: true` for all Google clients it creates (`add.ts`). The dashboard uses `isNative(appType)` — `true` only for iOS/Android, `false` for Web / Button-for-Web. Web clients shouldn't be opting out of nonce checks. Worth a one-line fix in a follow-up.

## Test plan

- [x] `pnpm --filter instant-cli exec vitest run` — 102 unit tests pass across 8 files. 30 e2e failures are unrelated (same failure set on `main`; they require infrastructure not available locally).
- [x] `pnpm exec tsc -p packages/cli/tsconfig.build.json --noEmit` — clean (ignoring the pre-existing `minimist` type error on main).
- [ ] Manual against local dev server:
  - `instant-cli auth client add --type google --app-type web --dev-credentials --name g-dev` → shared-cred client created; sign in on `http://localhost:3000` succeeds.
  - `instant-cli auth client add --type google --app-type web` → interactive selector appears, dev is default.
  - `instant-cli auth client update --name g-dev --client-id X --client-secret Y` → credentials rotated, same db id, `meta.useSharedCredentials` clears to `false`.
  - `instant-cli auth client update` → picker lists clients; `g-dev` shows `(dev credentials)` suffix.
  - Re-run `update` on the now-custom client → rotates, no meta change (idempotent).
