### PR TITLE
Add firebase clients via cli (#2593) [bump to v1.0.17]

### DIFF
--- a/client/packages/cli/__tests__/authClientAddApple.test.ts
+++ b/client/packages/cli/__tests__/authClientAddApple.test.ts
@@ -28,27 +28,30 @@ vi.mock('../src/ui/lib.ts', async (importOriginal) => {
 
 let addedClients: any[] = [];
 
-vi.mock('../src/lib/oauth.ts', () => ({
-  getAppsAuth: () =>
-    Effect.succeed({
-      oauth_service_providers: [{ id: 'prov-1', provider_name: 'apple' }],
-      oauth_clients: [],
-    }),
-  addOAuthProvider: () =>
-    Effect.succeed({
-      provider: { id: 'prov-1', provider_name: 'apple' },
-    }),
-  addOAuthClient: (params: any) => {
-    addedClients.push(params);
-    return Effect.succeed({
-      client: {
-        id: 'client-1',
-        client_name: params.clientName,
-        client_id: params.clientId,
-      },
-    });
-  },
-}));
+vi.mock('../src/lib/oauth.ts', async () => {
+  const { makeOAuthMock } = await import('./oauthMock.ts');
+  return makeOAuthMock({
+    getAppsAuth: () =>
+      Effect.succeed({
+        oauth_service_providers: [{ id: 'prov-1', provider_name: 'apple' }],
+        oauth_clients: [],
+      }),
+    addOAuthProvider: () =>
+      Effect.succeed({
+        provider: { id: 'prov-1', provider_name: 'apple' },
+      }),
+    addOAuthClient: (params: any) => {
+      addedClients.push(params);
+      return Effect.succeed({
+        client: {
+          id: 'client-1',
+          client_name: params.clientName,
+          client_id: params.clientId,
+        },
+      });
+    },
+  });
+});
 
 // Lazy import so mocks are in place
 const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');

--- a/client/packages/cli/__tests__/authClientAddClerk.test.ts
+++ b/client/packages/cli/__tests__/authClientAddClerk.test.ts
@@ -30,32 +30,35 @@ let addedClients: any[] = [];
 let addedProviders: any[] = [];
 let mockHasExistingProvider = true;
 
-vi.mock('../src/lib/oauth.ts', () => ({
-  getAppsAuth: () =>
-    Effect.succeed({
-      oauth_service_providers: mockHasExistingProvider
-        ? [{ id: 'prov-1', provider_name: 'clerk' }]
-        : [],
-      oauth_clients: [],
-    }),
-  addOAuthProvider: (params: any) => {
-    addedProviders.push(params);
-    return Effect.succeed({
-      provider: { id: 'prov-new', provider_name: 'clerk' },
-    });
-  },
-  addOAuthClient: (params: any) => {
-    addedClients.push(params);
-    return Effect.succeed({
-      client: {
-        id: 'client-1',
-        client_name: params.clientName,
-        client_id: params.clientId,
-        discovery_endpoint: params.discoveryEndpoint,
-      },
-    });
-  },
-}));
+vi.mock('../src/lib/oauth.ts', async () => {
+  const { makeOAuthMock } = await import('./oauthMock.ts');
+  return makeOAuthMock({
+    getAppsAuth: () =>
+      Effect.succeed({
+        oauth_service_providers: mockHasExistingProvider
+          ? [{ id: 'prov-1', provider_name: 'clerk' }]
+          : [],
+        oauth_clients: [],
+      }),
+    addOAuthProvider: (params: any) => {
+      addedProviders.push(params);
+      return Effect.succeed({
+        provider: { id: 'prov-new', provider_name: 'clerk' },
+      });
+    },
+    addOAuthClient: (params: any) => {
+      addedClients.push(params);
+      return Effect.succeed({
+        client: {
+          id: 'client-1',
+          client_name: params.clientName,
+          client_id: params.clientId,
+          discovery_endpoint: params.discoveryEndpoint,
+        },
+      });
+    },
+  });
+});
 
 // Lazy import so mocks are in place
 const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');

--- a/client/packages/cli/__tests__/authClientAddGithub.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGithub.test.ts
@@ -27,27 +27,30 @@ vi.mock('../src/ui/lib.ts', async (importOriginal) => {
 
 let addedClients: any[] = [];
 
-vi.mock('../src/lib/oauth.ts', () => ({
-  getAppsAuth: () =>
-    Effect.succeed({
-      oauth_service_providers: [{ id: 'prov-1', provider_name: 'github' }],
-      oauth_clients: [],
-    }),
-  addOAuthProvider: () =>
-    Effect.succeed({
-      provider: { id: 'prov-1', provider_name: 'github' },
-    }),
-  addOAuthClient: (params: any) => {
-    addedClients.push(params);
-    return Effect.succeed({
-      client: {
-        id: 'client-1',
-        client_name: params.clientName,
-        client_id: params.clientId,
-      },
-    });
-  },
-}));
+vi.mock('../src/lib/oauth.ts', async () => {
+  const { makeOAuthMock } = await import('./oauthMock.ts');
+  return makeOAuthMock({
+    getAppsAuth: () =>
+      Effect.succeed({
+        oauth_service_providers: [{ id: 'prov-1', provider_name: 'github' }],
+        oauth_clients: [],
+      }),
+    addOAuthProvider: () =>
+      Effect.succeed({
+        provider: { id: 'prov-1', provider_name: 'github' },
+      }),
+    addOAuthClient: (params: any) => {
+      addedClients.push(params);
+      return Effect.succeed({
+        client: {
+          id: 'client-1',
+          client_name: params.clientName,
+          client_id: params.clientId,
+        },
+      });
+    },
+  });
+});
 
 // Lazy import so mocks are in place
 const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');

--- a/client/packages/cli/__tests__/authClientAddGoogle.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGoogle.test.ts
@@ -27,27 +27,30 @@ vi.mock('../src/ui/lib.ts', async (importOriginal) => {
 
 let addedClients: any[] = [];
 
-vi.mock('../src/lib/oauth.ts', () => ({
-  getAppsAuth: () =>
-    Effect.succeed({
-      oauth_service_providers: [{ id: 'prov-1', provider_name: 'google' }],
-      oauth_clients: [],
-    }),
-  addOAuthProvider: () =>
-    Effect.succeed({
-      provider: { id: 'prov-1', provider_name: 'google' },
-    }),
-  addOAuthClient: (params: any) => {
-    addedClients.push(params);
-    return Effect.succeed({
-      client: {
-        id: 'client-1',
-        client_name: params.clientName,
-        client_id: params.clientId,
-      },
-    });
-  },
-}));
+vi.mock('../src/lib/oauth.ts', async () => {
+  const { makeOAuthMock } = await import('./oauthMock.ts');
+  return makeOAuthMock({
+    getAppsAuth: () =>
+      Effect.succeed({
+        oauth_service_providers: [{ id: 'prov-1', provider_name: 'google' }],
+        oauth_clients: [],
+      }),
+    addOAuthProvider: () =>
+      Effect.succeed({
+        provider: { id: 'prov-1', provider_name: 'google' },
+      }),
+    addOAuthClient: (params: any) => {
+      addedClients.push(params);
+      return Effect.succeed({
+        client: {
+          id: 'client-1',
+          client_name: params.clientName,
+          client_id: params.clientId,
+        },
+      });
+    },
+  });
+});
 
 // Lazy import so mocks are in place
 const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');

--- a/client/packages/cli/__tests__/authClientAddLinkedin.test.ts
+++ b/client/packages/cli/__tests__/authClientAddLinkedin.test.ts
@@ -29,31 +29,34 @@ let addedClients: any[] = [];
 let addedProviders: any[] = [];
 let mockHasExistingProvider = true;
 
-vi.mock('../src/lib/oauth.ts', () => ({
-  getAppsAuth: () =>
-    Effect.succeed({
-      oauth_service_providers: mockHasExistingProvider
-        ? [{ id: 'prov-1', provider_name: 'linkedin' }]
-        : [],
-      oauth_clients: [],
-    }),
-  addOAuthProvider: (params: any) => {
-    addedProviders.push(params);
-    return Effect.succeed({
-      provider: { id: 'prov-new', provider_name: 'linkedin' },
-    });
-  },
-  addOAuthClient: (params: any) => {
-    addedClients.push(params);
-    return Effect.succeed({
-      client: {
-        id: 'client-1',
-        client_name: params.clientName,
-        client_id: params.clientId,
-      },
-    });
-  },
-}));
+vi.mock('../src/lib/oauth.ts', async () => {
+  const { makeOAuthMock } = await import('./oauthMock.ts');
+  return makeOAuthMock({
+    getAppsAuth: () =>
+      Effect.succeed({
+        oauth_service_providers: mockHasExistingProvider
+          ? [{ id: 'prov-1', provider_name: 'linkedin' }]
+          : [],
+        oauth_clients: [],
+      }),
+    addOAuthProvider: (params: any) => {
+      addedProviders.push(params);
+      return Effect.succeed({
+        provider: { id: 'prov-new', provider_name: 'linkedin' },
+      });
+    },
+    addOAuthClient: (params: any) => {
+      addedClients.push(params);
+      return Effect.succeed({
+        client: {
+          id: 'client-1',
+          client_name: params.clientName,
+          client_id: params.clientId,
+        },
+      });
+    },
+  });
+});
 
 // Lazy import so mocks are in place
 const { authClientAddCmd } = await import('../src/commands/auth/client/add.ts');

--- a/client/packages/cli/__tests__/oauthMock.ts
+++ b/client/packages/cli/__tests__/oauthMock.ts
@@ -1,0 +1,69 @@
+import { Effect } from 'effect';
+import { optOrPrompt, validateRequired } from '../src/lib/ui.ts';
+import { UI } from '../src/ui/index.ts';
+import { BadArgsError } from '../src/errors.ts';
+
+type AnyEffect = Effect.Effect<any, any, any>;
+
+export const makeOAuthMock = (mocks: {
+  getAppsAuth: () => AnyEffect;
+  addOAuthProvider: (params: any) => AnyEffect;
+  addOAuthClient: (params: any) => AnyEffect;
+}) => {
+  const findName = (prefix: string, used: Set<string>) => {
+    if (!used.has(prefix)) return prefix;
+    for (let i = 2; ; i++) {
+      const c = `${prefix}${i}`;
+      if (!used.has(c)) return c;
+    }
+  };
+
+  const getOrCreateProvider = Effect.fn(function* (type: string) {
+    const auth: any = yield* mocks.getAppsAuth();
+    const provider = auth.oauth_service_providers?.find(
+      (e: any) => e.provider_name === type,
+    );
+    if (provider) return { auth, provider };
+    const created: any = yield* mocks.addOAuthProvider({ providerName: type });
+    return { auth, provider: created.provider };
+  });
+
+  const getClientNameAndProvider = Effect.fn(function* (
+    providerType: string,
+    opts: Record<string, unknown>,
+  ) {
+    const { auth, provider } = yield* getOrCreateProvider(providerType);
+    const used: Set<string> = new Set(
+      (auth.oauth_clients ?? []).map((c: any) => c.client_name),
+    );
+    const suggested = findName(providerType, used);
+    const clientName = yield* optOrPrompt(opts.name, {
+      simpleName: '--name',
+      required: true,
+      skipIf: false,
+      prompt: {
+        prompt: 'Client Name:',
+        defaultValue: suggested,
+        placeholder: suggested,
+        validate: validateRequired,
+        modifyOutput: UI.modifiers.piped([
+          UI.modifiers.topPadding,
+          UI.modifiers.dimOnComplete,
+        ]),
+      },
+    });
+    if (used.has(clientName || '')) {
+      return yield* BadArgsError.make({
+        message: `The unique name '${clientName}' is already in use.`,
+      });
+    }
+    return { provider, clientName };
+  });
+
+  return {
+    ...mocks,
+    findName,
+    getOrCreateProvider,
+    getClientNameAndProvider,
+  };
+};

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -12,8 +12,9 @@ import {
 } from '../../../lib/ui.ts';
 import {
   addOAuthClient,
-  addOAuthProvider,
-  getAppsAuth,
+  findName,
+  getClientNameAndProvider,
+  getOrCreateProvider,
 } from '../../../lib/oauth.ts';
 import {
   DEFAULT_OAUTH_CALLBACK_URL,
@@ -31,7 +32,7 @@ import { UI } from '../../../ui/index.ts';
 import chalk from 'chalk';
 import boxen from 'boxen';
 
-const ClientTypeSchema = Schema.Literal(
+export const ClientTypeSchema = Schema.Literal(
   'google',
   'github',
   'apple',
@@ -94,37 +95,9 @@ const selectGoogleAppType = (value: unknown) =>
     );
   });
 
-// If user has clients google-web-1 and google-web-2, it will provide google-web-3
-const findName = (prefix: string, used: Set<string>) => {
-  if (!used.has(prefix)) {
-    return prefix;
-  }
-
-  for (let i = 2; ; i++) {
-    const candidate = `${prefix}${i}`;
-    if (!used.has(candidate)) {
-      return candidate;
-    }
-  }
-};
-
-const getOrCreateProvider = Effect.fn(function* (
-  type: typeof ClientTypeSchema.Type,
-) {
-  const auth = yield* getAppsAuth();
-  const provider = auth.oauth_service_providers?.find(
-    (entry) => entry.provider_name === type,
-  );
-
-  if (provider) {
-    return { auth, provider };
-  }
-
-  const created = yield* addOAuthProvider({ providerName: type });
-  return { auth, provider: created.provider };
-});
-
 const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
+  // This one requires special logic for getting client name
+  // because the suggested name includes the app type
   const appType = yield* selectGoogleAppType(opts['app-type']);
   const { auth, provider } = yield* getOrCreateProvider('google');
   const usedClientNames = new Set(
@@ -257,33 +230,10 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
 });
 
 const handleGithubClient = Effect.fn(function* (opts: Record<string, unknown>) {
-  const { auth, provider } = yield* getOrCreateProvider('github');
-  const usedClientNames = new Set(
-    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  const { clientName, provider } = yield* getClientNameAndProvider(
+    'github',
+    opts,
   );
-  const suggestedClientName = findName('github-web', usedClientNames);
-
-  const clientName = yield* optOrPrompt(opts.name, {
-    simpleName: '--name',
-    required: true,
-    skipIf: false,
-    prompt: {
-      prompt: 'Client Name:',
-      defaultValue: suggestedClientName,
-      placeholder: suggestedClientName,
-      validate: validateRequired,
-      modifyOutput: UI.modifiers.piped([
-        UI.modifiers.topPadding,
-        UI.modifiers.dimOnComplete,
-      ]),
-    },
-  });
-
-  if (usedClientNames.has(clientName || '')) {
-    return yield* BadArgsError.make({
-      message: `The unique name '${clientName}' is already in use.`,
-    });
-  }
 
   const clientId = yield* optOrPrompt(opts['client-id'], {
     simpleName: '--client-id',
@@ -385,33 +335,10 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
 const handleLinkedInClient = Effect.fn(function* (
   opts: Record<string, unknown>,
 ) {
-  const { auth, provider } = yield* getOrCreateProvider('linkedin');
-  const usedClientNames = new Set(
-    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  const { clientName, provider } = yield* getClientNameAndProvider(
+    'linkedin',
+    opts,
   );
-  const suggestedClientName = findName('linkedin-web', usedClientNames);
-
-  const clientName = yield* optOrPrompt(opts.name, {
-    simpleName: '--name',
-    required: true,
-    skipIf: false,
-    prompt: {
-      prompt: 'Client Name:',
-      defaultValue: suggestedClientName,
-      placeholder: suggestedClientName,
-      validate: validateRequired,
-      modifyOutput: UI.modifiers.piped([
-        UI.modifiers.topPadding,
-        UI.modifiers.dimOnComplete,
-      ]),
-    },
-  });
-
-  if (usedClientNames.has(clientName || '')) {
-    return yield* BadArgsError.make({
-      message: `The unique name '${clientName}' is already in use.`,
-    });
-  }
 
   const clientId = yield* optOrPrompt(opts['client-id'], {
     simpleName: '--client-id',
@@ -538,30 +465,10 @@ const readPrivateKeyFile = Effect.fn('readPrivateKeyFile')(function* (
 
 const handleAppleClient = Effect.fn(function* (opts: Record<string, unknown>) {
   const { yes } = yield* GlobalOpts;
-  const { auth, provider } = yield* getOrCreateProvider('apple');
-  const usedClientNames = new Set(
-    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  const { clientName, provider } = yield* getClientNameAndProvider(
+    'apple',
+    opts,
   );
-  const suggestedClientName = findName('apple', usedClientNames);
-
-  const clientName = yield* optOrPrompt(opts.name, {
-    simpleName: '--name',
-    required: true,
-    skipIf: false,
-    prompt: {
-      prompt: 'Client Name:',
-      defaultValue: suggestedClientName,
-      placeholder: suggestedClientName,
-      validate: validateRequired,
-      modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
-    },
-  });
-
-  if (usedClientNames.has(clientName || '')) {
-    return yield* BadArgsError.make({
-      message: `The unique name '${clientName}' is already in use.`,
-    });
-  }
 
   const servicesId = yield* optOrPrompt(opts['services-id'], {
     simpleName: '--services-id',
@@ -735,33 +642,10 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
 });
 
 const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
-  const { auth, provider } = yield* getOrCreateProvider('clerk');
-  const usedClientNames = new Set(
-    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  const { clientName, provider } = yield* getClientNameAndProvider(
+    'clerk',
+    opts,
   );
-  const suggestedClientName = findName('clerk-web', usedClientNames);
-
-  const clientName = yield* optOrPrompt(opts.name, {
-    simpleName: '--name',
-    required: true,
-    skipIf: false,
-    prompt: {
-      prompt: 'Client Name:',
-      defaultValue: suggestedClientName,
-      placeholder: suggestedClientName,
-      validate: validateRequired,
-      modifyOutput: UI.modifiers.piped([
-        UI.modifiers.topPadding,
-        UI.modifiers.dimOnComplete,
-      ]),
-    },
-  });
-
-  if (usedClientNames.has(clientName || '')) {
-    return yield* BadArgsError.make({
-      message: `The unique name '${clientName}' is already in use.`,
-    });
-  }
 
   const publishableKey = yield* optOrPrompt(opts['publishable-key'], {
     simpleName: '--publishable-key',
@@ -841,7 +725,10 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
 const handleFirebaseClient = Effect.fn(function* (
   opts: OptsFromCommand<typeof authClientAddDef> & Record<string, unknown>,
 ) {
-  yield* Effect.log('HERE');
+  const { clientName, provider } = yield* getClientNameAndProvider(
+    'firebase',
+    opts,
+  );
 });
 
 export const authClientAddCmd = Effect.fn(

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -729,6 +729,40 @@ const handleFirebaseClient = Effect.fn(function* (
     'firebase',
     opts,
   );
+
+  const projectId = yield* optOrPrompt(opts['project-id'], {
+    simpleName: 'project-id',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt:
+        'Firebase project ID: (From Project Settings page on https://console.firebase.google.com/)',
+      placeholder: '',
+      validate: validateRequired,
+    },
+  });
+  // typeguard
+  if (!clientName || !projectId) {
+    return yield* BadArgsError.make({
+      message: 'Missing required arguments',
+    });
+  }
+  const response = yield* addOAuthClient({
+    providerId: provider.id,
+    clientName,
+    discoveryEndpoint: `https://securetoken.google.com/${projectId}/.well-known/openid-configuration`,
+  });
+
+  yield* Effect.log(
+    boxen(
+      [
+        `Firebase OAuth client created: ${response.client.client_name}`,
+        `ID: ${response.client.id}`,
+        `Firebase Project ID: ${projectId}`,
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
 });
 
 export const authClientAddCmd = Effect.fn(

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -37,7 +37,7 @@ const ClientTypeSchema = Schema.Literal(
   'apple',
   'linkedin',
   'clerk',
-  // 'firebase',
+  'firebase',
 );
 
 const GoogleAppTypeSchema = Schema.Literal(
@@ -858,8 +858,7 @@ export const authClientAddCmd = Effect.fn(
               { label: 'Apple', value: 'apple' },
               { label: 'LinkedIn', value: 'linkedin' },
               { label: 'Clerk', value: 'clerk' },
-              // TODO: implement
-              // { label: 'Firebase', value: 'firebase' },
+              { label: 'Firebase', value: 'firebase' },
             ],
             promptText: 'Select a client type:',
             modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
@@ -881,7 +880,7 @@ export const authClientAddCmd = Effect.fn(
       Match.when('apple', () => handleAppleClient(opts)),
       Match.when('linkedin', () => handleLinkedInClient(opts)),
       Match.when('clerk', () => handleClerkClient(opts)),
-      // Match.when('firebase', () => Effect.logError('Not Implemented')),
+      Match.when('firebase', () => Effect.logError('Not Implemented')),
       Match.exhaustive,
     );
   },

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -738,6 +738,10 @@ const handleFirebaseClient = Effect.fn(function* (
       prompt:
         'Firebase project ID: (From Project Settings page on https://console.firebase.google.com/)',
       placeholder: '',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
       validate: validateRequired,
     },
   });

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -730,8 +730,9 @@ const handleFirebaseClient = Effect.fn(function* (
     opts,
   );
 
+  const firebaseProjectIdRegex = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
   const projectId = yield* optOrPrompt(opts['project-id'], {
-    simpleName: 'project-id',
+    simpleName: '--project-id',
     required: true,
     skipIf: false,
     prompt: {
@@ -742,7 +743,14 @@ const handleFirebaseClient = Effect.fn(function* (
         UI.modifiers.topPadding,
         UI.modifiers.dimOnComplete,
       ]),
-      validate: validateRequired,
+      validate: (val) => {
+        if (!val) {
+          return 'Project ID is required';
+        }
+        if (!firebaseProjectIdRegex.test(val)) {
+          return 'Invalid Firebase project ID. It must be 6-30 characters, start with a lowercase letter, contain only lowercase letters, digits, and hyphens, and not end with a hyphen.';
+        }
+      },
     },
   });
   // typeguard
@@ -751,10 +759,16 @@ const handleFirebaseClient = Effect.fn(function* (
       message: 'Missing required arguments',
     });
   }
+  if (!firebaseProjectIdRegex.test(projectId)) {
+    return yield* BadArgsError.make({
+      message:
+        'Invalid Firebase project ID. It must be 6-30 characters, start with a lowercase letter, contain only lowercase letters, digits, and hyphens, and not end with a hyphen.',
+    });
+  }
   const response = yield* addOAuthClient({
     providerId: provider.id,
     clientName,
-    discoveryEndpoint: `https://securetoken.google.com/${projectId}/.well-known/openid-configuration`,
+    discoveryEndpoint: `https://securetoken.google.com/${encodeURIComponent(projectId)}/.well-known/openid-configuration`,
   });
 
   yield* Effect.log(

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -838,6 +838,12 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
   );
 });
 
+const handleFirebaseClient = Effect.fn(function* (
+  opts: OptsFromCommand<typeof authClientAddDef> & Record<string, unknown>,
+) {
+  yield* Effect.log('HERE');
+});
+
 export const authClientAddCmd = Effect.fn(
   function* (
     opts: OptsFromCommand<typeof authClientAddDef> & Record<string, unknown>,
@@ -880,7 +886,7 @@ export const authClientAddCmd = Effect.fn(
       Match.when('apple', () => handleAppleClient(opts)),
       Match.when('linkedin', () => handleLinkedInClient(opts)),
       Match.when('clerk', () => handleClerkClient(opts)),
-      Match.when('firebase', () => Effect.logError('Not Implemented')),
+      Match.when('firebase', () => handleFirebaseClient(opts)),
       Match.exhaustive,
     );
   },

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -124,6 +124,8 @@ Provider Specific Options:
    --custom-redirect-uri      (optional)
   Clerk:
    --publishable-key    (Publishable Key from dashboard.clerk.com)
+  Firebase:
+   --project-id         (Project ID from console.firebase.google.com)
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -205,7 +205,7 @@ export const getClientNameAndProvider = Effect.fn(function* (
   const usedClientNames = new Set(
     (auth.oauth_clients ?? []).map((client) => client.client_name),
   );
-  const suggestedClientName = findName('github-web', usedClientNames);
+  const suggestedClientName = findName(providerType, usedClientNames);
 
   const clientName = yield* optOrPrompt(opts.name, {
     simpleName: '--name',

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -5,11 +5,14 @@ import { InstantHttpAuthed, withCommand } from './http.ts';
 import chalk from 'chalk';
 import {
   getOptionalStringFlag,
+  optOrPrompt,
   runUIEffect,
   stripFirstBlankLine,
+  validateRequired,
 } from './ui.ts';
 import { UI } from '../ui/index.ts';
 import { BadArgsError } from '../errors.ts';
+import type { ClientTypeSchema } from '../commands/auth/client/add.ts';
 
 export const AuthorizedOriginService = Schema.Literal(
   'generic',
@@ -162,4 +165,68 @@ ${chalk.dim('Your URL must forward to https://api.instantdb.com/runtime/oauth/ca
   );
 
   return result === '' ? undefined : result;
+});
+
+export const getOrCreateProvider = Effect.fn(function* (
+  type: typeof ClientTypeSchema.Type,
+) {
+  const auth = yield* getAppsAuth();
+  const provider = auth.oauth_service_providers?.find(
+    (entry) => entry.provider_name === type,
+  );
+
+  if (provider) {
+    return { auth, provider };
+  }
+
+  const created = yield* addOAuthProvider({ providerName: type });
+  return { auth, provider: created.provider };
+});
+
+// If user has clients google-web-1 and google-web-2, it will provide google-web-3
+export const findName = (prefix: string, used: Set<string>) => {
+  if (!used.has(prefix)) {
+    return prefix;
+  }
+
+  for (let i = 2; ; i++) {
+    const candidate = `${prefix}${i}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+};
+
+export const getClientNameAndProvider = Effect.fn(function* (
+  providerType: typeof ClientTypeSchema.Type,
+  opts: Record<string, unknown>,
+) {
+  const { auth, provider } = yield* getOrCreateProvider(providerType);
+  const usedClientNames = new Set(
+    (auth.oauth_clients ?? []).map((client) => client.client_name),
+  );
+  const suggestedClientName = findName('github-web', usedClientNames);
+
+  const clientName = yield* optOrPrompt(opts.name, {
+    simpleName: '--name',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'Client Name:',
+      defaultValue: suggestedClientName,
+      placeholder: suggestedClientName,
+      validate: validateRequired,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  if (usedClientNames.has(clientName || '')) {
+    return yield* BadArgsError.make({
+      message: `The unique name '${clientName}' is already in use.`,
+    });
+  }
+  return { provider, clientName };
 });

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -183,7 +183,8 @@ export const getOrCreateProvider = Effect.fn(function* (
   return { auth, provider: created.provider };
 });
 
-// If user has clients google-web-1 and google-web-2, it will provide google-web-3
+// Returns prefix if unused; otherwise appends integers starting at 2.
+// e.g. findName('google', new Set(['google', 'google2'])) returns 'google3'.
 export const findName = (prefix: string, used: Set<string>) => {
   if (!used.has(prefix)) {
     return prefix;

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.16';
+const version = 'v1.0.17';
 
 export { version };


### PR DESCRIPTION
Adds ability to add firebase oauth clients via cli. 
- Refactors repeated code for creating providers / selecting client names into lib/oauth.
  - had to update the tests for mock around this

```zsh
#!/usr/bin/env zsh
cd sandbox/cli-nodejs

export INSTANT_CLI_DEV=true

# should show firebase specific flags
pnpm exec instant-cli auth client add --help

# Should fail without proper info
pnpm exec instant-cli auth client add -y
pnpm exec instant-cli auth client add --type firebase -y
pnpm exec instant-cli auth client add --type firebase --name firebase-app-9 -y

# Should work
pnpm exec instant-cli auth client add --type firebase --name firebase-app-9 --project-id fi-freestyle

# Should work as expected
pnpm exec instant-cli auth client add
```