### PR TITLE
Use gprc for singleton invalidator, store history

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/color.tsx
+++ b/client/sandbox/react-nextjs/pages/play/color.tsx
@@ -1,5 +1,5 @@
 import { i, init, tx } from '@instantdb/react';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import config from '../../config';
 
 const schema = i.schema({
@@ -18,6 +18,15 @@ const selectId = '4d39508b-9ee2-48a3-b70d-8192d9c5a059';
 
 const colorOptions = ['green', 'blue', 'purple'];
 
+const btnClass =
+  'bg-gray-800/70 hover:bg-gray-800/85 active:bg-gray-900/85 text-white font-medium text-sm px-4 py-2 rounded-lg border border-white/10 shadow-md backdrop-blur-sm transition-colors active:translate-y-px focus:outline-none focus:ring-2 focus:ring-white/60 cursor-pointer';
+
+const panelClass =
+  'bg-gray-800/70 text-white text-sm font-medium px-4 py-3 rounded-lg border border-white/10 shadow-md backdrop-blur-sm inline-flex items-center gap-5';
+
+const inputClass =
+  'w-14 bg-gray-900/60 text-white tabular-nums px-2 py-0.5 rounded-md border border-white/10 focus:outline-none focus:ring-2 focus:ring-white/40';
+
 function nextColor(c: string): string {
   const i = colorOptions.indexOf(c);
   if (i === -1) {
@@ -33,17 +42,43 @@ function Main() {
       console.log('localId', id);
     })();
   }, []);
+  const [autoCycle, setAutoCycle] = useState(false);
+  const [rate, setRate] = useState(1);
+  const [txCount, setTxCount] = useState(0);
+  const colorRef = useRef('grey');
   const { isLoading, error, data } = db.useQuery({
     colors: {},
   });
+  const color = data?.colors?.[0]?.color ?? 'grey';
+  colorRef.current = color;
+
+  useEffect(() => {
+    if (!autoCycle) return;
+    const interval = Math.floor(1000 / rate);
+    let i = colorOptions.indexOf(colorRef.current);
+    if (i === -1) i = 0;
+    const id = setInterval(() => {
+      i = (i + 1) % colorOptions.length;
+      db.transact(tx.colors[selectId].update({ color: colorOptions[i] }));
+      setTxCount((n) => n + 1);
+    }, interval);
+    return () => clearInterval(id);
+  }, [autoCycle, rate]);
+
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;
-  const { colors } = data;
-  const { color } = colors[0] || { color: 'grey' };
   return (
-    <div style={{ background: color, height: '100vh' }}>
-      <div className="space-y-4">
-        <h1>Hi! pick your favorite color</h1>
+    <div
+      style={{
+        background: color,
+        height: '100vh',
+        transition: 'background 120ms ease',
+      }}
+    >
+      <div className="space-y-4 p-4 text-white">
+        <h1 className="text-2xl font-semibold tracking-tight drop-shadow-sm">
+          Hi! pick your favorite color
+        </h1>
         <div className="space-x-4">
           {colorOptions.map((c) => {
             return (
@@ -51,7 +86,7 @@ function Main() {
                 onClick={() => {
                   db.transact(tx.colors[selectId].update({ color: c }));
                 }}
-                className={`bg-white p-2`}
+                className={btnClass}
                 key={c}
               >
                 {c}
@@ -59,7 +94,7 @@ function Main() {
             );
           })}
           <button
-            className={`bg-white p-2`}
+            className={btnClass}
             onClick={() => {
               db.transact(
                 tx.colors[selectId].update({ color: nextColor(color) }),
@@ -68,6 +103,36 @@ function Main() {
           >
             Cycle
           </button>
+        </div>
+        <div className={panelClass}>
+          <label className="inline-flex cursor-pointer items-center gap-2">
+            <input
+              type="checkbox"
+              className="h-4 w-4 cursor-pointer accent-white"
+              checked={autoCycle}
+              onChange={(e) => {
+                setAutoCycle(e.target.checked);
+                if (e.target.checked) setTxCount(0);
+              }}
+            />
+            <span>Auto-cycle</span>
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <span className="text-white/80">Rate (tx/sec)</span>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={rate}
+              onChange={(e) =>
+                setRate(Math.max(1, Math.floor(Number(e.target.value) || 1)))
+              }
+              className={inputClass}
+            />
+          </label>
+          <span className="text-white/80">
+            Sent <span className="text-white tabular-nums">{txCount}</span>
+          </span>
         </div>
       </div>
     </div>

--- a/server/docker-compose-dev.yml
+++ b/server/docker-compose-dev.yml
@@ -38,6 +38,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://instant:pass@postgres:5432/instant"
       NREPL_BIND_ADDRESS: "0.0.0.0"
+      WAL_HISTORY_STORAGE: "pg"
     volumes:
       - './:/app'
     ports:

--- a/server/resources/migrations/106_add_history.down.sql
+++ b/server/resources/migrations/106_add_history.down.sql
@@ -1,0 +1,2 @@
+drop table history;
+drop type isn;

--- a/server/resources/migrations/106_add_history.down.sql
+++ b/server/resources/migrations/106_add_history.down.sql
@@ -1,2 +1,3 @@
 drop table history;
+drop type history_storage;
 drop type isn;

--- a/server/resources/migrations/106_add_history.up.sql
+++ b/server/resources/migrations/106_add_history.up.sql
@@ -1,0 +1,49 @@
+create type isn as (slot_num int, lsn pg_lsn);
+create type history_storage as enum ('s3', 'pg');
+
+create table history (
+  isn isn not null,
+  app_id uuid not null,
+  -- Acts as a bloom filter for the `e`, and `a` (and possibly `v`) topic fields
+  topics bigint not null,
+  storage history_storage not null,
+  -- Only present if storage = 'pg'
+  content bytea,
+  -- Each bucket spans 30 days. 13 buckets cycle every 390 days, giving ≥360
+  -- days of retention. Truncate the next-to-be-reused bucket before writes
+  -- wrap around.
+  partition_bucket int not null,
+  primary key (isn, partition_bucket)
+) partition by range (partition_bucket);
+
+-- Skip TOAST compression on content; we compress application-side before writing.
+alter table history alter column content set storage external;
+
+create table history_0 partition of history for values from (0) to (1);
+create table history_1 partition of history for values from (1) to (2);
+create table history_2 partition of history for values from (2) to (3);
+create table history_3 partition of history for values from (3) to (4);
+create table history_4 partition of history for values from (4) to (5);
+create table history_5 partition of history for values from (5) to (6);
+create table history_6 partition of history for values from (6) to (7);
+create table history_7 partition of history for values from (7) to (8);
+create table history_8 partition of history for values from (8) to (9);
+create table history_9 partition of history for values from (9) to (10);
+create table history_10 partition of history for values from (10) to (11);
+create table history_11 partition of history for values from (11) to (12);
+create table history_12 partition of history for values from (12) to (13);
+
+-- topic_idx allows us to do:
+--   `select isn from history where app_id = :id and isn > :last-isn and (topics & :topic-mask != 0)`
+-- That will return false positives, but should be very fast and requires very little data.
+
+-- If it returns too many false positives, we have a few options:
+-- 1. Create multiple topics hashes and check them all (more cpu)
+-- 2. Store the `e` and `a` in array fields and check them (more space)
+
+-- There's not really a great way to index arrays of `e` and `a` that would work for our expected usage
+-- pattern. There should be a long history that is below the `:last-isn` we're querying, with a much
+-- smaller set in front. We could use a gin index, but it would return a very large set for the past.
+
+-- For more complex topics, we'll probably need to move topics to another linked table
+create index topic_idx on history (app_id, isn) include (topics);

--- a/server/resources/migrations/106_add_history.up.sql
+++ b/server/resources/migrations/106_add_history.up.sql
@@ -4,7 +4,7 @@ create type history_storage as enum ('s3', 'pg');
 create table history (
   isn isn not null,
   app_id uuid not null,
-  -- Acts as a bloom filter for the `e`, and `a` (and possibly `v`) topic fields
+  -- Acts as a bloom filter for the `a`, `e` (and possibly `v`) topic fields
   topics bigint not null,
   storage history_storage not null,
   -- Only present if storage = 'pg'
@@ -33,7 +33,7 @@ create table history_10 partition of history for values from (10) to (11);
 create table history_11 partition of history for values from (11) to (12);
 create table history_12 partition of history for values from (12) to (13);
 
--- topic_idx allows us to do:
+-- topics allows us to do:
 --   `select isn from history where app_id = :id and isn > :last-isn and (topics & :topic-mask != 0)`
 -- That will return false positives, but should be very fast and requires very little data.
 

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -249,6 +249,18 @@
     :staging "instant-storage-staging"
     "instantdb-test-bucket"))
 
+(def s3-wal-history-bucket-name
+  (when-not (= "pg" (System/getenv "WAL_HISTORY_STORAGE"))
+    (or (System/getenv "WAL_HISTORY_BUCKET_NAME")
+        (case (get-env)
+          :prod "instant-wal-logs-prod--use1-az4--x-s3"
+          :staging "instant-wal-logs-staging--use1-az4--x-s3"
+          "instant-wal-logs-dev--use1-az4--x-s3"))))
+
+(def wal-history-prefix
+  (when (= :dev (get-env))
+    @hostname))
+
 (def cloudfront-s3-bucket-url
   (case [(get-env) s3-bucket-name]
     [:dev "instantdb-test-bucket"] "https://files-dev.instantdb.com"

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -255,7 +255,8 @@
         (case (get-env)
           :prod "instant-wal-logs-prod--use1-az4--x-s3"
           :staging "instant-wal-logs-staging--use1-az4--x-s3"
-          "instant-wal-logs-dev--use1-az4--x-s3"))))
+          :dev "instant-wal-logs-dev--use1-az4--x-s3"
+          nil))))
 
 (def wal-history-prefix
   (when (= :dev (get-env))

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -258,14 +258,13 @@
       (stop))
     @(ua/all-of
       (future
-        (tracer/with-span! {:name "stop-invalidator"}
-          (inv/stop-global)))
-      (future
         (tracer/with-span! {:name "stop-aggregator"}
           (agg/stop-global)))
       (future
         (tracer/with-span! {:name "stop-ephemeral"}
           (eph/stop))
+        (tracer/with-span! {:name "stop-invalidator"}
+          (inv/stop-global))
         (tracer/with-span! {:name "stop-grpc"}
           (grpc-server/stop-global)))
       (future

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -16,6 +16,7 @@
    [instant.db.indexing-jobs :as indexing-jobs]
    [instant.db.hint-testing :as hint-testing]
    [instant.db.model.wal-log :as wal-log-model]
+   [instant.model.history :as history-model]
    [instant.db.model.transaction :as tx-model]
    [instant.demo-routes :as demo-routes]
    [instant.storage.sweeper :as storage-sweeper]
@@ -280,7 +281,13 @@
             (posthog/shutdown!))))
       (future
         (tracer/with-span! {:name "stop-rate-limit-sweeper"}
-          (rate-limit/stop)))))
+          (rate-limit/stop)))
+      (future
+        (tracer/with-span! {:name "stop-wal-log-truncator"}
+          (wal-log-model/stop)))
+      (future
+        (tracer/with-span! {:name "stop-history-truncator"}
+          (history-model/stop)))))
   (tracer/shutdown))
 
 (defn add-shutdown-hook []
@@ -371,6 +378,8 @@
         (rate-limit/start))
       (with-log-init :wal-log-truncator
         (wal-log-model/start))
+      (with-log-init :history-truncator
+        (history-model/start))
       (when (= (config/get-env) :prod)
         (with-log-init :analytics
           (analytics/start)))

--- a/server/src/instant/grpc.clj
+++ b/server/src/instant/grpc.clj
@@ -10,6 +10,7 @@
    (java.io ByteArrayInputStream DataInputStream)
    (java.time Instant)
    (java.util UUID)
+   (java.util.concurrent Executors)
    (org.postgresql.replication LogSequenceNumber)))
 
 ;; These defrecords are used to transfer messages between machines.
@@ -33,7 +34,6 @@
 
 (defrecord-once StreamError [error])
 
-
 (defrecord-once WalRecord [^UUID app-id
                            ^long tx-id
                            ^ISN isn
@@ -46,6 +46,13 @@
                            triple-changes
                            messages
                            wal-logs])
+
+(defrecord-once PackedWalRecord [^bytes ba])
+
+(defrecord-once SlotDisconnect [])
+
+(defrecord-once InvalidatorSubscribe [^UUID machine-id])
+
 (def stream-error-map
   {:unknown -1
    :rate-limit 1
@@ -78,6 +85,14 @@
       (.setResponseMarshaller nippy-marshaller)
       (.build)))
 
+(def invalidator-method
+  (-> (MethodDescriptor/newBuilder)
+      (.setType MethodDescriptor$MethodType/SERVER_STREAMING)
+      (.setFullMethodName "Invalidator/Subscribe")
+      (.setRequestMarshaller nippy-marshaller)
+      (.setResponseMarshaller nippy-marshaller)
+      (.build)))
+
 (def test-method
   (-> (MethodDescriptor/newBuilder)
       (.setType MethodDescriptor$MethodType/SERVER_STREAMING)
@@ -85,3 +100,5 @@
       (.setRequestMarshaller nippy-marshaller)
       (.setResponseMarshaller nippy-marshaller)
       (.build)))
+
+(def invalidator-thread-pool (Executors/newFixedThreadPool 3))

--- a/server/src/instant/grpc.clj
+++ b/server/src/instant/grpc.clj
@@ -51,7 +51,7 @@
 
 (defrecord-once SlotDisconnect [])
 
-(defrecord-once InvalidatorSubscribe [^UUID machine-id])
+(defrecord-once InvalidatorSubscribe [^UUID machine-id ^Integer process-id])
 
 (def stream-error-map
   {:unknown -1

--- a/server/src/instant/grpc.clj
+++ b/server/src/instant/grpc.clj
@@ -101,4 +101,4 @@
       (.setResponseMarshaller nippy-marshaller)
       (.build)))
 
-(def invalidator-thread-pool (Executors/newFixedThreadPool 3))
+(defonce invalidator-thread-pool (Executors/newFixedThreadPool 3))

--- a/server/src/instant/grpc_client.clj
+++ b/server/src/instant/grpc_client.clj
@@ -77,6 +77,13 @@
      :cancel (fn [^String reason]
                (.cancel call reason nil))}))
 
+(defn subscribe-to-invalidator [^ManagedChannel channel ^StreamObserver observer]
+  (let [call (.newCall channel grpc/invalidator-method CallOptions/DEFAULT)
+        req (grpc/->InvalidatorSubscribe config/machine-id)]
+    (ClientCalls/asyncServerStreamingCall call req observer)
+    {:cancel (fn [^String reason]
+               (.cancel call reason nil))}))
+
 (defn subscribe-to-test [^ManagedChannel channel req ^StreamObserver observer]
   (let [call (.newCall channel grpc/test-method CallOptions/DEFAULT)]
     (ClientCalls/asyncServerStreamingCall call req observer)

--- a/server/src/instant/grpc_client.clj
+++ b/server/src/instant/grpc_client.clj
@@ -55,6 +55,16 @@
                                                     :ms-since-update (- now last-update)}}))
                (remove-client-on-shutdown client member machine-id now)))))))))
 
+(defn client-channel-counts
+  "Returns {:total N :ready M} for the cached ManagedChannels. Used by gauges."
+  []
+  (let [values (Map/.values grpc-client-map)]
+    {:total (Map/.size grpc-client-map)
+     :ready (count (filter (fn [^ManagedChannel c]
+                             (try (= ConnectivityState/READY (.getState c false))
+                                  (catch Throwable _ false)))
+                           values))}))
+
 (defn grpc-client-for-machine-id [machine-id]
   (when-let [member (get eph/hz-member-by-machine-id-cache machine-id)]
     (let [client (Map/.computeIfAbsent grpc-client-map
@@ -77,9 +87,9 @@
      :cancel (fn [^String reason]
                (.cancel call reason nil))}))
 
-(defn subscribe-to-invalidator [^ManagedChannel channel ^StreamObserver observer]
+(defn subscribe-to-invalidator [^ManagedChannel channel ^Integer process-id ^StreamObserver observer]
   (let [call (.newCall channel grpc/invalidator-method CallOptions/DEFAULT)
-        req (grpc/->InvalidatorSubscribe config/machine-id)]
+        req (grpc/->InvalidatorSubscribe config/machine-id process-id)]
     (ClientCalls/asyncServerStreamingCall call req observer)
     {:cancel (fn [^String reason]
                (.cancel call reason nil))}))

--- a/server/src/instant/grpc_server.clj
+++ b/server/src/instant/grpc_server.clj
@@ -42,7 +42,6 @@
 (def call-executor
   (reify ServerCallExecutorSupplier
     (getExecutor [_ server-call _metadata]
-      (tool/def-locals)
       (when (= (.getServiceName (.getMethodDescriptor server-call))
                "Invalidator")
         grpc/invalidator-thread-pool))))

--- a/server/src/instant/grpc_server.clj
+++ b/server/src/instant/grpc_server.clj
@@ -3,10 +3,11 @@
    [instant.config :as config]
    [instant.grpc :as grpc]
    [instant.model.app-stream :as app-stream-model]
+   [instant.reactive.invalidator :as invalidator]
    [instant.reactive.store :as rs]
    [instant.util.tracer :as tracer])
   (:import
-   (io.grpc Grpc InsecureServerCredentials Server ServerServiceDefinition)
+   (io.grpc Grpc InsecureServerCredentials Server ServerServiceDefinition ServerCallExecutorSupplier)
    (io.grpc.services AdminInterface)
    (io.grpc.stub ServerCalls ServerCalls$BidiStreamingMethod ServerCalls$ServerStreamingMethod StreamObserver)))
 
@@ -29,13 +30,32 @@
         (.addMethod grpc/subscribe-method subscribe-handler)
         (.build))))
 
+(defn instant-invalidator-service ^ServerServiceDefinition []
+  (let [subscribe-handler (ServerCalls/asyncServerStreamingCall
+                           (proxy [ServerCalls$ServerStreamingMethod] []
+                             (invoke [req ^StreamObserver observer]
+                               (invalidator/handle-grpc-subscribe req observer))))]
+    (-> (ServerServiceDefinition/builder "Invalidator")
+        (.addMethod grpc/invalidator-method subscribe-handler)
+        (.build))))
+
+(def call-executor
+  (reify ServerCallExecutorSupplier
+    (getExecutor [_ server-call _metadata]
+      (tool/def-locals)
+      (when (= (.getServiceName (.getMethodDescriptor server-call))
+               "Invalidator")
+        grpc/invalidator-thread-pool))))
+
 (defn grpc-server ^Server [store port]
   (tracer/with-span! {:name "grpc-server/start"
                       :attributes {:port port}}
     (-> (Grpc/newServerBuilderForPort port (InsecureServerCredentials/create))
         (.addService (instant-stream-service store))
         (.addService (instant-test-service))
+        (.addService (instant-invalidator-service))
         (.addServices (AdminInterface/getStandardServices))
+        (.callExecutor call-executor)
         (.build))))
 
 (declare global-server)

--- a/server/src/instant/grpc_server.clj
+++ b/server/src/instant/grpc_server.clj
@@ -1,15 +1,21 @@
 (ns instant.grpc-server
   (:require
+   [clojure.string :as str]
    [instant.config :as config]
+   [instant.gauges :as gauges]
    [instant.grpc :as grpc]
    [instant.model.app-stream :as app-stream-model]
    [instant.reactive.invalidator :as invalidator]
    [instant.reactive.store :as rs]
    [instant.util.tracer :as tracer])
   (:import
-   (io.grpc Grpc InsecureServerCredentials Server ServerServiceDefinition ServerCallExecutorSupplier)
+   (io.grpc ConnectivityState Grpc InsecureServerCredentials InternalChannelz
+            InternalChannelz$ChannelStats InternalChannelz$ServerStats
+            InternalInstrumented Server ServerCallExecutorSupplier
+            ServerServiceDefinition)
    (io.grpc.services AdminInterface)
-   (io.grpc.stub ServerCalls ServerCalls$BidiStreamingMethod ServerCalls$ServerStreamingMethod StreamObserver)))
+   (io.grpc.stub ServerCalls ServerCalls$BidiStreamingMethod ServerCalls$ServerStreamingMethod StreamObserver)
+   (java.util.concurrent TimeUnit)))
 
 (defn instant-test-service ^ServerServiceDefinition []
   (let [test-handler (ServerCalls/asyncServerStreamingCall
@@ -67,10 +73,91 @@
 (defn stop [^Server server]
   (.shutdownNow server))
 
+;; Gauges derived from io.grpc.InternalChannelz — the same registry that
+;; powers AdminInterface/Channelz. Every ManagedChannel we build and every
+;; Server we start registers with the singleton automatically, so we get
+;; server-side and client-side counters without any custom instrumentation.
+
+(def ^:private channelz-page-size 100)
+
+(defn- instrumented-stats [^InternalInstrumented x]
+  (try
+    (.. x getStats (get 100 TimeUnit/MILLISECONDS))
+    (catch Throwable _ nil)))
+
+(defn- all-servers [^InternalChannelz channelz]
+  (loop [acc []
+         start-id 0]
+    (let [page (.getServers channelz start-id channelz-page-size)
+          servers (.servers page)]
+      (if (or (.end page) (empty? servers))
+        (into acc servers)
+        (recur (into acc servers)
+               (inc (InternalChannelz/id (last servers))))))))
+
+(defn- all-root-channels [^InternalChannelz channelz]
+  (loop [acc []
+         start-id 0]
+    (let [page (.getRootChannels channelz start-id channelz-page-size)
+          channels (.channels page)]
+      (if (or (.end page) (empty? channels))
+        (into acc channels)
+        (recur (into acc channels)
+               (inc (InternalChannelz/id (last channels))))))))
+
+(defn- server-metrics [^InternalChannelz channelz]
+  (let [stats (keep instrumented-stats (all-servers channelz))
+        started (reduce + 0 (map #(.callsStarted ^InternalChannelz$ServerStats %) stats))
+        succeeded (reduce + 0 (map #(.callsSucceeded ^InternalChannelz$ServerStats %) stats))
+        failed (reduce + 0 (map #(.callsFailed ^InternalChannelz$ServerStats %) stats))]
+    [{:path "instant.grpc.server.count"
+      :value (count stats)}
+     {:path "instant.grpc.server.calls.started"
+      :value started}
+     {:path "instant.grpc.server.calls.succeeded"
+      :value succeeded}
+     {:path "instant.grpc.server.calls.failed"
+      :value failed}
+     {:path "instant.grpc.server.calls.active"
+      :value (- started succeeded failed)}]))
+
+(defn- client-metrics [^InternalChannelz channelz]
+  (let [stats (keep instrumented-stats (all-root-channels channelz))
+        by-state (frequencies (map #(.state ^InternalChannelz$ChannelStats %) stats))
+        started (reduce + 0 (map #(.callsStarted ^InternalChannelz$ChannelStats %) stats))
+        succeeded (reduce + 0 (map #(.callsSucceeded ^InternalChannelz$ChannelStats %) stats))
+        failed (reduce + 0 (map #(.callsFailed ^InternalChannelz$ChannelStats %) stats))]
+    (into [{:path "instant.grpc.client.channels.count"
+            :value (count stats)}
+           {:path "instant.grpc.client.calls.started"
+            :value started}
+           {:path "instant.grpc.client.calls.succeeded"
+            :value succeeded}
+           {:path "instant.grpc.client.calls.failed"
+            :value failed}
+           {:path "instant.grpc.client.calls.active"
+            :value (- started succeeded failed)}]
+          (for [^ConnectivityState state (ConnectivityState/values)]
+            {:path (str "instant.grpc.client.channels." (str/lower-case (.name state)) ".count")
+             :value (get by-state state 0)}))))
+
+(defn channelz-metrics-fn
+  "Gauge fn that reads gRPC server + client stats from InternalChannelz.
+   Every ManagedChannel and Server registers with the singleton automatically."
+  [_]
+  (let [channelz (InternalChannelz/instance)]
+    (concat (server-metrics channelz)
+            (client-metrics channelz))))
+
+(declare stop-metrics-gauge)
+
 (defn start-global []
-  (def global-server (start rs/store (config/get-grpc-server-port))))
+  (def global-server (start rs/store (config/get-grpc-server-port)))
+  (def stop-metrics-gauge (gauges/add-gauge-metrics-fn #'channelz-metrics-fn)))
 
 (defn stop-global []
+  (when (bound? #'stop-metrics-gauge)
+    (stop-metrics-gauge))
   (when (bound? #'global-server)
     (stop global-server)))
 

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -28,6 +28,16 @@
 
 (set! *warn-on-reflection* true)
 
+(defn parse-isn
+  "Parses the value that we get from postgres into an isn.
+   We get something that looks like (0,328/26EEF7F8)"
+  ^ISN [^String value]
+  (let [idx (.indexOf value (int \,))
+        slot-str (subs value 1 idx)
+        lsn-str (subs value (inc idx) (dec (count value)))]
+    (ISN. (Integer/parseInt slot-str)
+          (LogSequenceNumber/valueOf lsn-str))))
+
 (defn <-pgobject
   "Transform PGobject containing `json` or `jsonb` value to Clojure data"
   [^PGobject v]
@@ -38,12 +48,7 @@
         ("json" "jsonb") (<-json value)
         "bit" (Long/parseLong value 2)
         "pg_lsn" (LogSequenceNumber/valueOf value)
-        "isn" (let [inner (subs value 1 (dec (count value)))
-                    idx (.indexOf ^String inner (int \,))
-                    slot-str (subs inner 0 idx)
-                    lsn-str (subs inner (inc idx))]
-                (ISN. (Integer/parseInt slot-str)
-                      (LogSequenceNumber/valueOf ^String lsn-str)))
+        "isn" (parse-isn value)
         value))))
 
 (defn <-array [^Array a]
@@ -51,6 +56,7 @@
         vs (.getArray a)]
     (case type
       ("json" "jsonb") (mapv <-json vs)
+      "isn" (mapv <-pgobject vs)
       (vec vs))))
 
 (defn- create-pg-array [^PreparedStatement s pgtype clazz vs]
@@ -90,7 +96,6 @@
       (.setObject s i (doto (PGobject.)
                         (.setType pgtype)
                         (.setValue (->json v)))))))
-
 
 (extend-protocol rs/ReadableColumn
   Array

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -63,7 +63,7 @@
 
 (def byte-class (Class/forName "[B"))
 
-(defn ^String isn->composite-str [^ISN isn]
+(defn isn->composite-str ^String [^ISN isn]
   (str "(" (.slotNum isn) "," (.asString ^LogSequenceNumber (.-lsn isn)) ")"))
 
 (defn set-param

--- a/server/src/instant/jdbc/sql.clj
+++ b/server/src/instant/jdbc/sql.clj
@@ -5,6 +5,7 @@
    ;; load all pg-ops for hsql
    [honey.sql :as hsql]
    [honey.sql.pg-ops]
+   [instant.isn]
    [instant.jdbc.socket-track :as socket-track]
    [instant.util.exception :as ex]
    [instant.util.io :as io]
@@ -18,6 +19,7 @@
   (:import
    (clojure.lang IPersistentList IPersistentMap IPersistentSet IPersistentVector ISeq)
    (com.zaxxer.hikari HikariDataSource)
+   (instant.isn ISN)
    (java.sql Array Connection PreparedStatement ResultSet ResultSetMetaData)
    (java.time Instant LocalDate LocalDateTime)
    (javax.sql DataSource)
@@ -36,6 +38,12 @@
         ("json" "jsonb") (<-json value)
         "bit" (Long/parseLong value 2)
         "pg_lsn" (LogSequenceNumber/valueOf value)
+        "isn" (let [inner (subs value 1 (dec (count value)))
+                    idx (.indexOf ^String inner (int \,))
+                    slot-str (subs inner 0 idx)
+                    lsn-str (subs inner (inc idx))]
+                (ISN. (Integer/parseInt slot-str)
+                      (LogSequenceNumber/valueOf ^String lsn-str)))
         value))))
 
 (defn <-array [^Array a]
@@ -55,6 +63,9 @@
 
 (def byte-class (Class/forName "[B"))
 
+(defn ^String isn->composite-str [^ISN isn]
+  (str "(" (.slotNum isn) "," (.asString ^LogSequenceNumber (.-lsn isn)) ")"))
+
 (defn set-param
   "Transform PGobject containing `json` or `jsonb` value to Clojure data"
   [^PreparedStatement s i v]
@@ -69,11 +80,13 @@
       "timestamptz[]" (.setArray s i (create-pg-array s "timestamptz" Instant v))
       "float8[]" (.setArray s i (create-pg-array s "float8" Number v))
       "boolean[]" (.setArray s i (create-pg-array s "boolean" Boolean v))
-      "integer[]" (.setArray s i (create-pg-array s "integer" Integer v))
+      ("integer[]" "int[]") (.setArray s i (create-pg-array s "integer" Integer v))
       "bigint[]" (.setArray s i (create-pg-array s "bigint" Long v))
       "bigint[][]" (.setArray s i (create-2d-pg-array s "bigint" Long v))
       "bytea[]" (.setArray s i (create-pg-array s "bytea" byte-class v))
       "bytea[][]" (.setArray s i (create-2d-pg-array s "bytea" byte-class v))
+      "isn[]" (.setArray s i (create-pg-array s "isn" String (map isn->composite-str v)))
+      "history_storage[]" (.setArray s i (create-pg-array s "history_storage" String v))
       (.setObject s i (doto (PGobject.)
                         (.setType pgtype)
                         (.setValue (->json v)))))))
@@ -106,6 +119,12 @@
     (.setObject ps i (doto (PGobject.)
                        (.setType "pg_lsn")
                        (.setValue (.asString v)))))
+
+  ISN
+  (set-parameter [^ISN v ^PreparedStatement ps ^long i]
+    (.setObject ps i (doto (PGobject.)
+                       (.setType "isn")
+                       (.setValue (isn->composite-str v)))))
 
   IPersistentMap
   (set-parameter [m ^PreparedStatement s i]

--- a/server/src/instant/model/app_stream.clj
+++ b/server/src/instant/model/app_stream.clj
@@ -619,7 +619,7 @@
    the same machine instead of sending it through GRPC.
    We need to upgrade it to a ServerCallStreamObserver with support for setOnCancelHandler.
    Sets up an executor so that calling `onNext` for a local observer operates the same as
-   if we had sent that observer through the gprc server."
+   if we had sent that observer through the grpc server."
   ^ServerCallStreamObserver [^StreamObserver observer on-cancel-atom]
   (let [closed? (atom false)
         check-state (fn []

--- a/server/src/instant/model/history.clj
+++ b/server/src/instant/model/history.clj
@@ -1,0 +1,265 @@
+(ns instant.model.history
+  (:require
+   [chime.core :as chime-core]
+   [instant.config :as config]
+   [instant.flags :as flags]
+   [instant.grpc]
+   [instant.isn :as isn]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.storage.s3 :refer [s3-async-client]]
+   [instant.util.async :as ua]
+   [instant.util.date :as date-util]
+   [instant.util.hsql :as uhsql]
+   [instant.util.lang :as lang]
+   [instant.util.s3 :refer [upload-body-to-s3]]
+   [instant.util.tracer :as tracer]
+   [taoensso.nippy :as nippy]
+   [honey.sql :as hsql])
+  (:import
+   (software.amazon.awssdk.core.async AsyncRequestBody)
+   (com.github.luben.zstd Zstd)
+   (instant.grpc WalRecord)
+   (instant.isn ISN)
+   (java.time Instant Period ZonedDateTime)
+   (java.util UUID)
+   (net.openhft.hashing LongHashFunction)
+   (org.postgresql.replication LogSequenceNumber)))
+
+(defn store-to-s3? []
+  (and config/s3-wal-history-bucket-name
+       (not (flags/toggled? :store-history-in-db))))
+
+(defn s3-key [{:keys [^UUID app-id ^ISN isn]}]
+  (str (when config/wal-history-prefix
+         (str config/wal-history-prefix "/"))
+       (format "%s/%08x/%016x" app-id (.slotNum isn) (.asLong ^LogSequenceNumber (.lsn isn)))))
+
+(defn attr-id-of-triple-change [triple-change]
+  (reduce (fn [_acc col]
+            (when (= "attr_id" (:name col))
+              (reduced (parse-uuid (:value col)))))
+          nil
+          (concat (:identity triple-change)
+                  (:columns triple-change))))
+
+(defn bloom-bit [^UUID uuid]
+  (let [h (LongHashFunction/xx3 (.getMostSignificantBits uuid))
+        v (.hashLong h (.getLeastSignificantBits uuid))]
+    (bit-shift-left 1 (mod v 64))))
+
+(defn topic-filter-of-wal-record
+  "Right now we're just interested in invalidating create/update/delete webhooks,
+   so we only need to store the attr ids (really only the id attrs, but we don't
+   want to look those up, and we're also interested in our false-positive rate)."
+  [^WalRecord wal-record]
+  (reduce (fn [acc triple-change]
+            (bit-or acc (bloom-bit (attr-id-of-triple-change triple-change))))
+          0
+          (:triple-changes wal-record)))
+
+(defn partition-bucket-of-wal-record
+  "Extract the partition from the tx-created-at. Each bucket spans 30 days, with
+   13 total buckets. That allows us to store up to 1 year of history."
+  [^WalRecord wal-record]
+  (-> ^Instant (:tx-created-at wal-record)
+      (.getEpochSecond)
+      (quot 86400) ; 1 day
+      (quot 30)
+      (mod 13)
+      int))
+
+(def push-q (uhsql/preformat {:insert-into :history
+                              :values [{:isn :?isn
+                                        :app-id :?app-id
+                                        :topics :?topics
+                                        :storage [:cast :?storage :history_storage]
+                                        :content :?content
+                                        :partition-bucket :?partition-bucket}]
+                              :on-conflict [:isn :partition-bucket]
+                              :do-nothing true}))
+
+(defn pack-wal-record ^bytes [^WalRecord wal-record]
+  (tracer/with-span! {:name "pack-wal-record"
+                      :attributes {:packed? (boolean (:packed (meta wal-record)))}}
+    (if-let [packed (:packed (meta wal-record))]
+      packed
+      (Zstd/compress (nippy/fast-freeze wal-record)))))
+
+(defn unpack-wal-record ^WalRecord [^bytes ba]
+  (tracer/with-span! {:name "unpack-wal-record"}
+    (-> ba
+        (Zstd/decompress)
+        (nippy/fast-thaw))))
+
+(defn upload-to-s3
+  ([^WalRecord wal-record]
+   (upload-to-s3 0 3 wal-record))
+  ([attempt max-attempts ^WalRecord wal-record]
+   (let [ba (pack-wal-record wal-record)]
+     (try (upload-body-to-s3 (s3-async-client)
+                             config/s3-wal-history-bucket-name
+                             {:object-key (s3-key wal-record)
+                              :content-length (long (alength ba))
+                              :content-type "application/octet-stream"}
+                             (AsyncRequestBody/fromBytesUnsafe ba))
+          (catch Throwable t
+            (if (> attempt max-attempts)
+              (throw t)
+              (do
+                (tracer/record-exception-span! t {:name "history/upload-to-s3-failure"
+                                                  :attributes {:attempt attempt
+                                                               :max-attempts max-attempts}})
+                (upload-to-s3 (inc attempt) max-attempts wal-record))))))))
+
+(defn push!
+  ([wal-record] (push! (aurora/conn-pool :write) wal-record))
+  ([conn wal-record]
+   (let [topic-filter (topic-filter-of-wal-record wal-record)
+         storage (if (store-to-s3?) "s3" "pg")]
+     (when (= storage "s3")
+       (upload-to-s3 wal-record))
+     (sql/do-execute! ::push!
+                      conn
+                      (uhsql/formatp push-q
+                                     {:isn (:isn wal-record)
+                                      :app-id (:app-id wal-record)
+                                      :topics topic-filter
+                                      :storage storage
+                                      :content (when (= storage "pg")
+                                                 (pack-wal-record wal-record))
+                                      :partition-bucket (partition-bucket-of-wal-record wal-record)})))))
+
+(defn upload-batch-to-s3! [wal-records]
+  (->> wal-records
+       (mapv (fn [wal-record]
+               (ua/vfuture (try
+                             (upload-to-s3 wal-record)
+                             {:status :ok
+                              :wal-record wal-record}
+                             (catch Exception e
+                               (tracer/record-exception-span! e {:name "history/upload-batch-to-s3-failure"})
+                               {:status :error
+                                :wal-record wal-record})))))
+       (mapv deref)))
+
+(defn collect-push-batch-params [upload-results]
+  (loop [isns (transient [])
+         app-ids (transient [])
+         topics (transient [])
+         storage (transient [])
+         content (transient [])
+         partition-bucket (transient [])
+         upload-results upload-results]
+    (if-let [{:keys [status wal-record]} (first upload-results)]
+      (recur (conj! isns (:isn wal-record))
+             (conj! app-ids (:app-id wal-record))
+             (conj! topics (topic-filter-of-wal-record wal-record))
+             (conj! storage (case status
+                              :ok "s3"
+                              :error "pg"))
+             (conj! content (case status
+                              :ok nil
+                              :error (pack-wal-record wal-record)))
+             (conj! partition-bucket (partition-bucket-of-wal-record wal-record))
+             (rest upload-results))
+
+      {:isn (with-meta (persistent! isns) {:pgtype "isn[]"})
+       :app-id (with-meta (persistent! app-ids) {:pgtype "uuid[]"})
+       :topics (with-meta (persistent! topics) {:pgtype "bigint[]"})
+       :storage (with-meta (persistent! storage) {:pgtype "history_storage[]"})
+       :content (with-meta (persistent! content) {:pgtype "bytea[]"})
+       :partition-bucket (with-meta (persistent! partition-bucket) {:pgtype "int[]"})})))
+
+(def push-batch-q (uhsql/preformat {:insert-into [[:history [:isn :app_id :topics :storage :content]]
+                                                  {:select [:isn :app_id :topics :storage :content]
+                                                   :from [[[:unnest :?isn :?app-id :?topics :?storage :?content]
+                                                           [[:t :isn :app-id :topics :storage :content]]]]}]
+
+                                    :on-conflict [:isn :partition-bucket]
+                                    :do-nothing true}))
+
+(def push-batch-q
+  (uhsql/preformat
+   {:insert-into [[:history [:isn :app-id :topics :storage :content :partition-bucket]]
+                  {:select [[[:cast [:composite :slot-num :lsn] :isn]]
+                            :app-id :topics :storage :content :partition-bucket]
+                   :from [[[:unnest :?isn :?app-id :?topics :?storage :?content :?partition-bucket]
+                           [:t [:composite :slot-num :lsn :app-id :topics :storage :content :partition-bucket]]]]}]
+    :on-conflict [:isn :partition-bucket]
+    :do-nothing true}))
+
+(defn push-batch!
+  ([wal-records] (push-batch! (aurora/conn-pool :write) wal-records))
+  ([conn wal-records]
+   (let [upload-results (if (store-to-s3?)
+                          (upload-batch-to-s3! wal-records)
+                          ;; If we don't have a bucket to upload to, pretend
+                          ;; the upload failed and we'll store in the db.
+                          (mapv (fn [wal-record]
+                                  {:status :error
+                                   :wal-record wal-record})
+                                wal-records))
+         params (collect-push-batch-params upload-results)]
+     (tool/def-locals)
+     (sql/do-execute! ::push-batch!
+                      conn
+                      (uhsql/formatp push-batch-q params)))))
+
+(defn partitions-to-truncate
+  "Calculates which partitions to truncate. Each bucket spans 30 days, with 13 buckets cycling.
+   The bucket formula is (days-since-epoch / 30) % 13.
+   To save at least 90 days, we must keep the current bucket and at least 3 previous buckets.
+   Keeping 4 buckets (current + 3 previous) covers 90 to 120 days.
+   We truncate everything else, which means buckets (current + 4) through (current + 12) mod 13."
+  [^Instant now]
+  (let [current-bucket (-> now
+                           (.getEpochSecond)
+                           (quot 86400) ; 1 day
+                           (quot 30)
+                           (mod 13))]
+    (for [offset (range 4 13)]
+      (mod (+ current-bucket offset) 13))))
+
+(defn truncate-old-partitions!
+  "Truncates old history partitions."
+  ([] (truncate-old-partitions! (aurora/conn-pool :write)))
+  ([conn]
+   (tracer/with-span! {:name "history/truncate-old-partitions!"}
+     (let [to-truncate (partitions-to-truncate (Instant/now))]
+       (doseq [bucket-idx to-truncate]
+         (let [table-name (keyword (str "history_" bucket-idx))]
+           (sql/do-execute! ::truncate-old-partitions!
+                            conn
+                            (hsql/format {:truncate table-name}))))))))
+
+(defn period []
+  (let [now (date-util/pt-now)
+        run-time (-> now
+                     (.withHour 16) ; Run at 4 PM PT
+                     (.withMinute 0)
+                     (.withSecond 0)
+                     (.withNano 0))
+        periodic-seq (chime-core/periodic-seq
+                      run-time
+                      (Period/ofDays 1))]
+    (->> periodic-seq
+         (filter (fn [x] (ZonedDateTime/.isAfter x now))))))
+
+(declare schedule)
+
+(defn start []
+  (tracer/record-info! {:name "history-truncator/start"})
+  (def schedule
+    (chime-core/chime-at (period) (fn [_time]
+                                    (when-not (flags/failing-over?)
+                                      (truncate-old-partitions!))))))
+
+(defn stop []
+  (tracer/record-info! {:name "history-truncator/stop"})
+  (when (bound? #'schedule)
+    (lang/close schedule)))
+
+(defn restart []
+  (stop)
+  (start))

--- a/server/src/instant/model/history.clj
+++ b/server/src/instant/model/history.clj
@@ -171,14 +171,6 @@
        :content (with-meta (persistent! content) {:pgtype "bytea[]"})
        :partition-bucket (with-meta (persistent! partition-bucket) {:pgtype "int[]"})})))
 
-(def push-batch-q (uhsql/preformat {:insert-into [[:history [:isn :app_id :topics :storage :content]]
-                                                  {:select [:isn :app_id :topics :storage :content]
-                                                   :from [[[:unnest :?isn :?app-id :?topics :?storage :?content]
-                                                           [[:t :isn :app-id :topics :storage :content]]]]}]
-
-                                    :on-conflict [:isn :partition-bucket]
-                                    :do-nothing true}))
-
 (def push-batch-q
   (uhsql/preformat
    {:insert-into [[:history [:isn :app-id :topics :storage :content :partition-bucket]]
@@ -201,7 +193,6 @@
                                    :wal-record wal-record})
                                 wal-records))
          params (collect-push-batch-params upload-results)]
-     (tool/def-locals)
      (sql/do-execute! ::push-batch!
                       conn
                       (uhsql/formatp push-batch-q params)))))
@@ -209,16 +200,17 @@
 (defn partitions-to-truncate
   "Calculates which partitions to truncate. Each bucket spans 30 days, with 13 buckets cycling.
    The bucket formula is (days-since-epoch / 30) % 13.
-   To save at least 90 days, we must keep the current bucket and at least 3 previous buckets.
-   Keeping 4 buckets (current + 3 previous) covers 90 to 120 days.
-   We truncate everything else, which means buckets (current + 4) through (current + 12) mod 13."
+   To save at least 90 days, we keep the current bucket and the 3 previous buckets.
+   The kept buckets are at offsets 0, -1 (≡ +12), -2 (≡ +11), -3 (≡ +10) mod 13,
+   which covers 90 to 120 days.
+   We truncate the complement: buckets (current + 1) through (current + 9) mod 13."
   [^Instant now]
   (let [current-bucket (-> now
                            (.getEpochSecond)
                            (quot 86400) ; 1 day
                            (quot 30)
                            (mod 13))]
-    (for [offset (range 4 13)]
+    (for [offset (range 1 10)]
       (mod (+ current-bucket offset) 13))))
 
 (defn truncate-old-partitions!

--- a/server/src/instant/model/history.clj
+++ b/server/src/instant/model/history.clj
@@ -86,17 +86,14 @@
 (defn pack-wal-record
   "byte-encodes the wal record with nippy and compresses it with zstd."
   ^bytes [^WalRecord wal-record]
-  (tracer/with-span! {:name "pack-wal-record"
-                      :attributes {:packed? (boolean (:packed (meta wal-record)))}}
-    (if-let [packed (:packed (meta wal-record))]
-      packed
-      (Zstd/compress (nippy/fast-freeze wal-record)))))
+  (if-let [packed (:packed (meta wal-record))]
+    packed
+    (Zstd/compress (nippy/fast-freeze wal-record))))
 
 (defn unpack-wal-record ^WalRecord [^bytes ba]
-  (tracer/with-span! {:name "unpack-wal-record"}
-    (-> ba
-        (Zstd/decompress)
-        (nippy/fast-thaw))))
+  (-> ba
+      (Zstd/decompress)
+      (nippy/fast-thaw)))
 
 (defn upload-to-s3
   "Uploads the wal-record to s3, trying 3 times by default."

--- a/server/src/instant/model/history.clj
+++ b/server/src/instant/model/history.clj
@@ -30,7 +30,11 @@
   (and config/s3-wal-history-bucket-name
        (not (flags/toggled? :store-history-in-db))))
 
-(defn s3-key [{:keys [^UUID app-id ^ISN isn]}]
+(defn s3-key
+  "Creates an s3 key that is sortable by isn (for a given app id).
+   We convert the slot num and lsn to fixed-length hex strings that will
+   sort the same way as numbers."
+  [{:keys [^UUID app-id ^ISN isn]}]
   (str (when config/wal-history-prefix
          (str config/wal-history-prefix "/"))
        (format "%s/%08x/%016x" app-id (.slotNum isn) (.asLong ^LogSequenceNumber (.lsn isn)))))
@@ -79,7 +83,9 @@
                               :on-conflict [:isn :partition-bucket]
                               :do-nothing true}))
 
-(defn pack-wal-record ^bytes [^WalRecord wal-record]
+(defn pack-wal-record
+  "byte-encodes the wal record with nippy and compresses it with zstd."
+  ^bytes [^WalRecord wal-record]
   (tracer/with-span! {:name "pack-wal-record"
                       :attributes {:packed? (boolean (:packed (meta wal-record)))}}
     (if-let [packed (:packed (meta wal-record))]
@@ -93,8 +99,9 @@
         (nippy/fast-thaw))))
 
 (defn upload-to-s3
+  "Uploads the wal-record to s3, trying 3 times by default."
   ([^WalRecord wal-record]
-   (upload-to-s3 0 3 wal-record))
+   (upload-to-s3 1 3 wal-record))
   ([attempt max-attempts ^WalRecord wal-record]
    (let [ba (pack-wal-record wal-record)]
      (try (upload-body-to-s3 (s3-async-client)
@@ -104,7 +111,7 @@
                               :content-type "application/octet-stream"}
                              (AsyncRequestBody/fromBytesUnsafe ba))
           (catch Throwable t
-            (if (> attempt max-attempts)
+            (if (>= attempt max-attempts)
               (throw t)
               (do
                 (tracer/record-exception-span! t {:name "history/upload-to-s3-failure"
@@ -113,6 +120,8 @@
                 (upload-to-s3 (inc attempt) max-attempts wal-record))))))))
 
 (defn push!
+  "Saves a single wal record in the history table, pushing the content to s3 (or
+   the database if s3 is disabled)."
   ([wal-record] (push! (aurora/conn-pool :write) wal-record))
   ([conn wal-record]
    (let [topic-filter (topic-filter-of-wal-record wal-record)
@@ -130,7 +139,10 @@
                                                  (pack-wal-record wal-record))
                                       :partition-bucket (partition-bucket-of-wal-record wal-record)})))))
 
-(defn upload-batch-to-s3! [wal-records]
+(defn upload-batch-to-s3!
+  "Uploads a batch of wal records to s3 simultaneously, trying 3 times for each.
+   Returns {:status :ok|:error, :wal-record wal-record}[]"
+  [wal-records]
   (->> wal-records
        (mapv (fn [wal-record]
                (ua/vfuture (try
@@ -182,6 +194,8 @@
     :do-nothing true}))
 
 (defn push-batch!
+  "Saves a batch of wal records in the history table, pushing the content to s3 (or
+   the database if s3 is disabled)."
   ([wal-records] (push-batch! (aurora/conn-pool :write) wal-records))
   ([conn wal-records]
    (let [upload-results (if (store-to-s3?)

--- a/server/src/instant/nippy.clj
+++ b/server/src/instant/nippy.clj
@@ -4,7 +4,7 @@
    [instant.isn]
    [taoensso.nippy :as nippy])
   (:import
-   (instant.grpc StreamAborted StreamComplete StreamContent StreamError StreamFile StreamInit StreamRequest WalRecord)
+   (instant.grpc InvalidatorSubscribe PackedWalRecord SlotDisconnect StreamAborted StreamComplete StreamContent StreamError StreamFile StreamInit StreamRequest WalRecord)
    (instant.isn ISN)
    (instant.jdbc WalColumn WalEntry)
    (java.io DataInput DataOutput)
@@ -247,3 +247,26 @@
                               (nippy/thaw-from-in! data-input) ; triple-changes
                               (nippy/thaw-from-in! data-input) ; messages
                               (nippy/thaw-from-in! data-input)))) ; wal-logs
+
+;; 13 is our custom identifier for SlotDisconnect, no other type can use it and
+;; it must be the same across all machines.
+(nippy/extend-freeze SlotDisconnect 13 [^SlotDisconnect _ _data-output])
+
+(nippy/extend-thaw 13 [_data-input]
+  (instant.grpc/->SlotDisconnect))
+
+;; 14 is our custom identifier for SlotDisconnect, no other type can use it and
+;; it must be the same across all machines.
+(nippy/extend-freeze PackedWalRecord 14 [^PackedWalRecord r data-output]
+  (nippy/freeze-to-out! data-output (:ba r)))
+
+(nippy/extend-thaw 14 [data-input]
+  (instant.grpc/->PackedWalRecord (nippy/thaw-from-in! data-input)))
+
+;; 15 is our custom identifier for SlotDisconnect, no other type can use it and
+;; it must be the same across all machines.
+(nippy/extend-freeze InvalidatorSubscribe 15 [^InvalidatorSubscribe {:keys [machine-id]} data-output]
+  (write-uuid data-output machine-id))
+
+(nippy/extend-thaw 15 [data-input]
+  (instant.grpc/->InvalidatorSubscribe (read-uuid data-input)))

--- a/server/src/instant/nippy.clj
+++ b/server/src/instant/nippy.clj
@@ -255,7 +255,7 @@
 (nippy/extend-thaw 13 [_data-input]
   (instant.grpc/->SlotDisconnect))
 
-;; 14 is our custom identifier for SlotDisconnect, no other type can use it and
+;; 14 is our custom identifier for PackedWalRecord, no other type can use it and
 ;; it must be the same across all machines.
 (nippy/extend-freeze PackedWalRecord 14 [^PackedWalRecord r data-output]
   (nippy/freeze-to-out! data-output (:ba r)))
@@ -263,7 +263,7 @@
 (nippy/extend-thaw 14 [data-input]
   (instant.grpc/->PackedWalRecord (nippy/thaw-from-in! data-input)))
 
-;; 15 is our custom identifier for SlotDisconnect, no other type can use it and
+;; 15 is our custom identifier for InvalidatorSubscribe, no other type can use it and
 ;; it must be the same across all machines.
 (nippy/extend-freeze InvalidatorSubscribe 15 [^InvalidatorSubscribe {:keys [machine-id]} data-output]
   (write-uuid data-output machine-id))

--- a/server/src/instant/nippy.clj
+++ b/server/src/instant/nippy.clj
@@ -265,8 +265,12 @@
 
 ;; 15 is our custom identifier for InvalidatorSubscribe, no other type can use it and
 ;; it must be the same across all machines.
-(nippy/extend-freeze InvalidatorSubscribe 15 [^InvalidatorSubscribe {:keys [machine-id]} data-output]
-  (write-uuid data-output machine-id))
+(nippy/extend-freeze InvalidatorSubscribe 15 [^InvalidatorSubscribe {:keys [machine-id
+                                                                            process-id]}
+                                              data-output]
+  (write-uuid data-output machine-id)
+  (nippy/freeze-to-out! data-output process-id))
 
 (nippy/extend-thaw 15 [data-input]
-  (instant.grpc/->InvalidatorSubscribe (read-uuid data-input)))
+  (instant.grpc/->InvalidatorSubscribe (read-uuid data-input)
+                                       (nippy/thaw-from-in! data-input)))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -51,9 +51,14 @@
 
 (declare handle-broadcast-message)
 
+;; {machine-id Member}
 (defonce hz-member-by-machine-id-cache ^ConcurrentHashMap (ConcurrentHashMap.))
 
+;; {machine-id {callback-id (fn [:action])}}
 (defonce hz-member-callbacks ^ConcurrentHashMap (ConcurrentHashMap.))
+
+;; {callback-id (fn [machine-id :action])}
+(defonce hz-member-change-callbacks ^ConcurrentHashMap (ConcurrentHashMap.))
 
 (defn remove-hz-member-callback [machine-id cb-id]
   (Map/.compute hz-member-callbacks machine-id ^BiFunction (reify BiFunction
@@ -70,9 +75,20 @@
     (fn []
       (remove-hz-member-callback machine-id cb-id))))
 
+(defn remove-hz-member-change-callback [cb-id]
+  (Map/.remove hz-member-change-callbacks cb-id))
+
+(defn add-hz-member-change-callback [cb]
+  (let [cb-id (random-uuid)]
+    (Map/.put hz-member-change-callbacks cb-id cb)
+    (fn []
+      (remove-hz-member-change-callback cb-id))))
+
 (defn run-member-callbacks [machine-id action]
   (doseq [[_k cb] (Map/.get hz-member-callbacks machine-id)]
-    (cb action)))
+    (cb action))
+  (doseq [[_k cb] hz-member-change-callbacks]
+    (cb machine-id action)))
 
 (defn- add-member-listener [^HazelcastInstance hz]
   (.addMembershipListener (.getCluster hz)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -437,7 +437,7 @@
 
 (defn broadcast-wal-record [connections packed-wal-record]
   (let [msg (grpc/->PackedWalRecord packed-wal-record)]
-    (doseq [^StreamObserver observer @connections]
+    (doseq [^StreamObserver observer (vals @connections)]
       (try
         (.onNext observer msg)
         (catch Throwable t

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -370,15 +370,24 @@
       (grouped-queue/put! queue wal-record))))
 
 (defn broadcast-slot-disconnect [{:keys [connections]}]
-  (doseq [^StreamObserver observer (vals @connections)]
-    (.onNext observer (grpc/->SlotDisconnect))))
+  (let [msg (grpc/->SlotDisconnect)]
+    (doseq [^StreamObserver observer @connections]
+      (try
+        (.onNext observer msg)
+        (catch Throwable t
+          ;; Isolate failures: one flaky observer must not abort the loop.
+          ;; The cancel handler in handle-grpc-subscribe takes care of removing
+          ;; dead observers.
+          (tracer/record-exception-span! t {:name "invalidator/broadcast-slot-disconnect-observer-error"
+                                            :escaping? false}))))))
 
 (defn start-save-history-process
   "Saves wal records to history table in batches of up to 1000.
    Returns a map with `push` function that takes a wal-record
    and a `shutdown` function that will wait for the queue to clear
    before returning."
-  [{:keys [flush-lsn-chan]}]
+  [{:keys [flush-lsn-chan
+           on-error]}]
   (let [executor (Executors/newSingleThreadExecutor)
         q (LinkedBlockingQueue.)
         stop-gauge (gauges/add-gauge-metrics-fn (fn [_]
@@ -391,25 +400,30 @@
                                                                   (.toEpochMilli ^Instant (:tx-created-at item)))))}]))
         shutdown-sentinel (Object.)
         shutdown? (atom false)
-        ;; XXX: Need to bubble up if this throws
         process (reify Runnable
                   (run [_]
-                    (loop [batch (ArrayList.)
-                          ;; First item will block
-                           item (.take q)]
-                      (.add batch item)
-                      ;; Grab up to 1000 items from the queue
-                      (.drainTo q batch 999)
-                      (let [quit? (identical? shutdown-sentinel (.get batch (dec (.size batch))))]
-                        (when quit?
-                          (.remove batch (dec (.size batch))))
-                        (when-not (.isEmpty batch)
-                          (history-model/push-batch! batch)
-                          (a/put! flush-lsn-chan (:nextlsn (.get batch (dec (.size batch))))))
+                    (try
+                      (loop [batch (ArrayList.)
+                             ;; First item will block
+                             item (.take q)]
+                        (.add batch item)
+                        ;; Grab up to 1000 items from the queue
+                        (.drainTo q batch 999)
+                        (let [quit? (identical? shutdown-sentinel (.get batch (dec (.size batch))))]
+                          (when quit?
+                            (.remove batch (dec (.size batch))))
+                          (when-not (.isEmpty batch)
+                            (history-model/push-batch! batch)
+                            (a/put! flush-lsn-chan (:nextlsn (.get batch (dec (.size batch))))))
 
-                        (when-not quit?
-                          (recur (ArrayList.)
-                                 (.take q)))))))]
+                          (when-not quit?
+                            (recur (ArrayList.)
+                                   (.take q)))))
+                      (catch Throwable t
+                        (on-error t))
+                      (finally
+                        (when-not @shutdown?
+                          (on-error (Exception. "Save history process exited before shut down.")))))))]
     (.submit executor process)
     {:push (fn [wal-record]
              (when @shutdown?
@@ -442,7 +456,8 @@
                                       queue
                                       previous-isn-atom]}]
   (tracer/record-info! {:name "invalidator/singleton-worker-start"})
-  (let [save-history-process (start-save-history-process {:flush-lsn-chan flush-lsn-chan})
+  (let [save-history-process (start-save-history-process {:flush-lsn-chan flush-lsn-chan
+                                                          :on-error on-error})
         process (a/go
                   (loop []
                     (if (check-disabled)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -1,6 +1,7 @@
 (ns instant.reactive.invalidator
   (:require
    [clojure.core.async :as a]
+   [clojure.set :as set]
    [datascript.core :as ds]
    [instant.config :as config]
    [instant.db.pg-introspect :as pg-introspect]
@@ -8,27 +9,28 @@
    [instant.gauges :as gauges]
    [instant.grouped-queue :as grouped-queue]
    [instant.grpc :as grpc]
+   [instant.grpc-client :as grpc-client]
+   [instant.isn]
+   [instant.jdbc.sql :as sql]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
+   [instant.model.history :as history-model]
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.store :as rs]
    [instant.reactive.topics :as topics]
    [instant.util.async :as ua]
    [instant.util.e2e-tracer :as e2e-tracer]
-   [instant.util.tracer :as tracer]
-   [clojure.set :as set])
+   [instant.util.tracer :as tracer])
   (:import
-   (com.hazelcast.core HazelcastInstance)
-   (com.hazelcast.ringbuffer Ringbuffer)
-   (com.hazelcast.ringbuffer.impl RingbufferService)
-   (com.hazelcast.topic Message ITopic ReliableMessageListener TopicOverloadPolicy)
+   (instant.grpc InvalidatorSubscribe PackedWalRecord SlotDisconnect WalRecord)
+   (io.grpc Status Status$Code)
+   (io.grpc.stub ServerCallStreamObserver StreamObserver)
    (java.sql Timestamp)
    (java.time Instant)
    (java.time.temporal ChronoUnit)
-   (java.util Map Queue)
-   (java.util.concurrent ConcurrentHashMap Executors)
-   (java.util.concurrent.atomic AtomicLong)
+   (java.util ArrayList Map Queue)
+   (java.util.concurrent ConcurrentHashMap Executors LinkedBlockingQueue)
    (org.postgresql.replication LogSequenceNumber)))
 
 (declare wal-opts)
@@ -36,18 +38,18 @@
 (declare invalidator-q)
 
 (defn- schema-changes-require-refreshing-sessions?
-  "All sessions may need to know about some schema changes. 
+  "All sessions may need to know about some schema changes.
 
-   For example, if we create an attr, then all sessions should know about this, 
-   so they don't accidentally try create the same attr again. 
+   For example, if we create an attr, then all sessions should know about this,
+   so they don't accidentally try create the same attr again.
 
-   Right now we detect: 
+   Right now we detect:
     - Attr creates or deletes
-    - Ident changes 
+    - Ident changes
 
-   Technically, sessions may need to know about other things: like if an attr 
-   becomes unique. But I am worried we may end up causing too much thrash 
-   for larger apps. 
+   Technically, sessions may need to know about other things: like if an attr
+   becomes unique. But I am worried we may end up causing too much thrash
+   for larger apps.
 
    For now, I'm only notifying on these changes."
   [{:keys [attr-changes ident-changes]}]
@@ -284,31 +286,9 @@
       (tracer/record-info! {:name "invalidation-worker/shutdown"}))
     queue))
 
-(defn start-singleton-worker [{:keys [wal-chan
-                                      close-signal-chan
-                                      flush-lsn-chan
-                                      ^ITopic _hz-topic
-                                      on-error
-                                      stop-lsn
-                                      check-disabled]}]
-  (tracer/record-info! {:name "invalidator/singleton-worker-start"})
-  (let [process (a/go
-                  (loop []
-                    (if (check-disabled)
-                      (on-error (ex-info "Invalidator singleton disabled" {}))
-                      (when-let [wal-record (a/<! wal-chan)]
-                        (when-not (and stop-lsn
-                                       (= -1 (compare stop-lsn (:nextlsn wal-record))))
-                          (try
-                            ;; Remove while we prepare to switch from hazelcast to grpc
-                            ;;(.publish hz-topic (->WalRecord wal-record))
-                            (ua/>!-close-safe close-signal-chan flush-lsn-chan (:nextlsn wal-record))
-                            (catch Exception e
-                              (on-error e)))
-                          (recur)))))
-
-                  (tracer/record-info! {:name "invalidator/singleton-worker-stop"}))]
-    {:completed-chan process}))
+;; ----
+;; BYOP
+;; ----
 
 (defn handle-byop-record [table-info app-id store wal-record]
   (when-let [record (transform-byop-wal-record wal-record)]
@@ -344,6 +324,143 @@
                 (def -store-value store)
                 (tracer/add-exception! t {:escaping? false})))
             (recur)))))))
+
+;; ---------------------
+;; Singleton Invalidator
+;; ---------------------
+
+(defn handle-singleton-wal-record
+  "This can be called either by the wal listener or by the stream observer,
+   so it's either from our machine processing the wal, or by a stream of another
+   machine processing the wal.
+
+   You might worry that things will get out of sync, since this function tracks
+   the previous isn and it could be called by two different streams simultaneously
+   when the wal slot changes machines. It shouldn't be a problem because the calls
+   from each individual stream will always be in order.
+
+   The worst case should be that we handle the same record twice."
+  [{:keys [queue previous-isn-atom]} ^WalRecord wal-record]
+  (let [{:keys [isn previous-isn]} wal-record
+        [old-previous next-previous] (swap-vals! previous-isn-atom
+                                                 (fn [v]
+                                                   (cond (nil? v)
+                                                         isn ;; This is our first record
+
+                                                         ;; Don't let previous-isn go backwards
+                                                         (= -1 (compare isn v))
+                                                         v
+
+                                                         :else isn)))]
+    (when (and old-previous
+               (not= old-previous previous-isn))
+      ;; TODO: We should fetch the missing wal-records from the history table
+      ;; XXX: This will probably fire when the slot switches machines
+      (tracer/record-info! {:name "singleton-missing-wal-records"
+                            :attributes {:isn isn
+                                         :previous-isn previous-isn
+                                         :old-previous old-previous
+                                         :next-previous next-previous
+                                         :compare (compare previous-isn old-previous)}}))
+    (tracer/with-span! {:name "handle-singleton-wal-record"
+                        :attributes {:isn isn
+                                     :previous-isn previous-isn
+                                     :previous-handled-isn old-previous
+                                     :skip? (= -1 (compare isn old-previous))}}
+      (grouped-queue/put! queue wal-record))))
+
+(defn broadcast-slot-disconnect [{:keys [connections]}]
+  (doseq [^StreamObserver observer (vals @connections)]
+    (.onNext observer (grpc/->SlotDisconnect))))
+
+(defn start-save-history-process
+  "Saves wal records to history table in batches of up to 1000.
+   Returns a map with `push` function that takes a wal-record
+   and a `shutdown` function that will wait for the queue to clear
+   before returning."
+  [{:keys [flush-lsn-chan]}]
+  (let [executor (Executors/newSingleThreadExecutor)
+        q (LinkedBlockingQueue.)
+        stop-gauge (gauges/add-gauge-metrics-fn (fn [_]
+                                                  [{:path "instant.reactive.invalidator.save-history-queue.size"
+                                                    :value (.size q)}
+                                                   {:path "instant.reactive.invalidator.save-history-queue.oldest-waiting-ms"
+                                                    :value (when-let [item (.peek q)]
+                                                             (when (instance? WalRecord item)
+                                                               (- (System/currentTimeMillis)
+                                                                  (.toEpochMilli ^Instant (:tx-created-at item)))))}]))
+        shutdown-sentinel (Object.)
+        shutdown? (atom false)
+        ;; XXX: Need to bubble up if this throws
+        process (reify Runnable
+                  (run [_]
+                    (loop [batch (ArrayList.)
+                          ;; First item will block
+                           item (.take q)]
+                      (.add batch item)
+                      ;; Grab up to 1000 items from the queue
+                      (.drainTo q batch 999)
+                      (let [quit? (identical? shutdown-sentinel (.get batch (dec (.size batch))))]
+                        (when quit?
+                          (.remove batch (dec (.size batch))))
+                        (when-not (.isEmpty batch)
+                          (history-model/push-batch! batch)
+                          (a/put! flush-lsn-chan (:nextlsn (.get batch (dec (.size batch))))))
+
+                        (when-not quit?
+                          (recur (ArrayList.)
+                                 (.take q)))))))]
+    (.submit executor process)
+    {:push (fn [wal-record]
+             (when @shutdown?
+               (throw (Exception. "Put after shutdown to save-history queue")))
+             (.put q wal-record))
+     :shutdown (fn []
+                 (reset! shutdown? true)
+                 (.put q shutdown-sentinel)
+                 (.shutdown executor)
+                 (stop-gauge))}))
+
+(defn broadcast-wal-record [connections packed-wal-record]
+  (let [msg (grpc/->PackedWalRecord packed-wal-record)]
+    ;; XXX: Log if it's ready
+    (doseq [^StreamObserver observer (vals @connections)]
+      (.onNext observer msg))))
+
+(defn start-singleton-worker [{:keys [wal-chan
+                                      connections
+                                      flush-lsn-chan
+                                      on-error
+                                      stop-lsn
+                                      check-disabled
+                                      queue
+                                      previous-isn-atom]}]
+  (tracer/record-info! {:name "invalidator/singleton-worker-start"})
+  (let [save-history-process (start-save-history-process {:flush-lsn-chan flush-lsn-chan})
+        process (a/go
+                  (loop []
+                    (if (check-disabled)
+                      (on-error (ex-info "Invalidator singleton disabled" {}))
+                      (when-let [wal-record (a/<! wal-chan)]
+                        ;; Compress and encode it here once so that don't have to encode it for every
+                        ;; grpc send and saving history
+                        (let [packed-wal-record (history-model/pack-wal-record wal-record)
+                              wal-record (with-meta wal-record {:packed packed-wal-record})]
+                          (when-not (and stop-lsn
+                                         (= -1 (compare stop-lsn (:nextlsn wal-record))))
+                            (try
+                              (broadcast-wal-record connections packed-wal-record)
+                              (handle-singleton-wal-record {:queue queue
+                                                            :previous-isn-atom previous-isn-atom}
+                                                           wal-record)
+                              ((:push save-history-process) wal-record)
+                              (catch Exception e
+                                (on-error e)))
+                            (recur))))))
+
+                  ((:shutdown save-history-process))
+                  (tracer/record-info! {:name "invalidator/singleton-worker-stop"}))]
+    {:completed-chan process}))
 
 ;; ------
 ;; orchestration
@@ -387,14 +504,28 @@
   (a/close! (:close-signal-chan wal-opts))
   (a/close! (:worker-chan wal-opts)))
 
+(defn fast-active-slot-check
+  "Just checks the db to see if the slot is active. It only
+   works when we're in the middle of switching db instances, but we check for that."
+  [{:keys [get-conn-config
+           slot-type
+           slot-suffix]}]
+  (when (:same-as-read-conn (meta get-conn-config))
+    (let [slot-name (wal/full-slot-name slot-type slot-suffix)]
+      (:active (sql/select-one ::fast-active-slot-check
+                               (aurora/conn-pool :read)
+                               ["select active from pg_replication_slots where slot_name = ?" slot-name])))))
+
 (defn start-singleton-listener [{:keys [acquire-slot-interval-ms
                                         process-id
                                         check-disabled
                                         stop-lsn
                                         acquire-slot-interrupt-chan
                                         get-conn-config
-                                        ^ITopic hz-topic
-                                        slot-num]}]
+                                        slot-num
+                                        connections
+                                        previous-isn-atom
+                                        queue]}]
   (let [shutdown-chan (a/chan)
 
         process (a/go
@@ -405,6 +536,11 @@
                       (cond
                         (= matched-chan shutdown-chan) nil
                         (check-disabled) (recur (a/timeout acquire-slot-interval-ms))
+
+                        (fast-active-slot-check {:get-conn-config get-conn-config
+                                                 :slot-type :invalidator})
+                        (recur (a/timeout acquire-slot-interval-ms))
+
                         :else
                         (let [{:keys [wal-chan worker-chan flush-lsn-chan close-signal-chan]}
                               (create-wal-chans)
@@ -449,7 +585,9 @@
                                                            :close-signal-chan close-signal-chan
                                                            :flush-lsn-chan flush-lsn-chan
                                                            :process-id process-id
-                                                           :hz-topic hz-topic
+                                                           :connections connections
+                                                           :previous-isn-atom previous-isn-atom
+                                                           :queue queue
                                                            :on-error (fn [e]
                                                                        (tracer/record-exception-span! e {:name "invalidator/singleton-worker-error"})
                                                                        (a/close! close-signal-chan))
@@ -462,7 +600,7 @@
                                 (stop wal-opts))
                               ;; serves as a signal to the other instances that they should
                               ;; grab the topic
-                              (.publish hz-topic process-id)
+                              (broadcast-slot-disconnect {:connections connections})
                               (when (= exit-ch close-signal-chan)
                                 (tracer/record-info! {:name "invalidator-singleton/retry"
                                                       :attributes {:wait-ms acquire-slot-interval-ms
@@ -477,90 +615,152 @@
                    @wal-worker-finished))
      :completed-chan process}))
 
-(defn hz-gauges [^ITopic topic]
-  (let [stats (.getLocalTopicStats topic)]
-    [{:path "hz.invalidator-topic.publishOperationCount"
-      :value (.getPublishOperationCount stats)}
-     {:path "hz.invalidator-topic.receiveOperationCount"
-      :value (.getReceiveOperationCount stats)}]))
+(defonce remote-observers (atom {}))
 
-(defn hz-topic-listener [^Ringbuffer ring-buffer on-msg]
-  (let [seq-id (AtomicLong. -1)]
-    (reify ReliableMessageListener
-      (onMessage [_ m]
-        (on-msg m))
-      (isLossTolerant [_]
-        true)
-      (isTerminal [_ t]
-        (tracer/record-exception-span! t {:name "invalidator/singleton-listener-error"})
-        false)
-      (retrieveInitialSequence [_]
-        (inc (.tailSequence ring-buffer)))
-      (onCancel [_]
-        nil)
-      (storeSequence [_ s]
-        (let [prev-seq-id (AtomicLong/.getAndSet seq-id s)]
-          (when (and (not= prev-seq-id -1)
-                     (not= s (inc prev-seq-id)))
-            (tracer/record-exception-span! (ex-info "Skipped a message in the reliable topic"
-                                                    {:s s
-                                                     :prev-seq-id prev-seq-id
-                                                     :lost-message-count (inc (- s prev-seq-id))})
-                                           {:name "invalidator/singleton-listener-skipped-tx"})))))))
+;; Used to indicate to grpc that we meant to cancel
+(def shutdown-reason "s")
 
-(defn topic-ring-buffer [^HazelcastInstance hz topic-name]
-  (.getRingbuffer hz (str RingbufferService/TOPIC_RB_PREFIX topic-name)))
+(defn make-subscription-observer
+  "This observer receives the wal records from the remote machine."
+  [{:keys [queue
+           previous-isn-atom
+           acquire-slot-interrupt-chan]}
+   remote-machine-id
+   on-cancel]
+  (let [cleanup (fn []
+                  (on-cancel)
+                  (tracer/record-info! {:name "invalidator/subscription-ended"
+                                        :attributes {:remote-machine-id remote-machine-id}}))]
+    (reify StreamObserver
+      (onNext [_ msg]
+        (condp instance? msg
+          WalRecord (handle-singleton-wal-record {:queue queue
+                                                  :previous-isn-atom previous-isn-atom}
+                                                 msg)
+          PackedWalRecord (handle-singleton-wal-record {:queue queue
+                                                        :previous-isn-atom previous-isn-atom}
+                                                       (history-model/unpack-wal-record (:ba msg)))
+          SlotDisconnect (a/put! acquire-slot-interrupt-chan true)
+          (tracer/record-info! {:name "invalidator/unknown-message"
+                                :attributes {:msg msg}})))
+      (onError [_ t]
+        (cleanup)
+        (let [status (Status/fromThrowable t)]
+          (when (or (not= (.getCode status) Status$Code/CANCELLED)
+                    (not= (.getDescription status) shutdown-reason))
+            (tracer/record-exception-span! t {:name "invalidator/singleton-gprc-subscription-stream-error"}))))
+      (onCompleted [_]
+        (cleanup)))))
 
-(defn start-singleton-hz-topic [{:keys [acquire-slot-interrupt-chan]}]
-  (let [queue
-        (grouped-queue/start
-         {:group-key-fn :app-id
-          :combine-fn combine-wal-records
-          :process-fn (fn [_key wal-record]
-                        ;; Just testing what kind of latency we'll see with the hazelcast topic
-                        (tracer/with-span! {:name "singleton-hz-topic-latency"
-                                            :attributes {:tx-id (:tx-id wal-record)
-                                                         :latency-ms (wal-latency-ms wal-record)}}))
-          :metrics-path "instant.reactive.invalidator.singleton-q"
-          :max-workers 8})
+(defn handle-grpc-subscribe
+  "This is called when a remote machine subscribes to our invalidator stream.
+   The remote machine will create the connection when it starts up the
+   singleton invalidator, indicating that it wants to subscribe to wal records."
+  [^InvalidatorSubscribe {:keys [machine-id]} ^ServerCallStreamObserver observer]
+  (tracer/with-span! {:name "handle-grpc-subscribe"
+                      :attributes {:machine-id machine-id}}
+    (let [[old-observers new-observers] (swap-vals! remote-observers assoc machine-id observer)]
+      (when-let [^ServerCallStreamObserver old-observer (get old-observers machine-id)]
+        (when (not= old-observer observer)
+          (.onError old-observer (Exception. "New subscription for same machine-id, closing old subscription."))))
+      (if (not= (get new-observers machine-id) observer)
+        (.onError observer (Exception. "Clashing subscribe requests."))
+        (let [cleanup (reify Runnable
+                        (run [_]
+                          (swap! remote-observers
+                                 (fn [observers]
+                                   (if (= observer (get observers machine-id))
+                                     (dissoc observers machine-id)
+                                     observers)))))]
+          (.setOnCloseHandler observer cleanup)
+          (.setOnCancelHandler observer cleanup))))))
 
-        topic-name "invalidator-wal-logs"
-        hz (eph/get-hz)
-        topic (.getReliableTopic hz topic-name)
-        topic-config (.getReliableTopicConfig (.getConfig hz) topic-name)
-        _ (.setTopicOverloadPolicy topic-config TopicOverloadPolicy/DISCARD_OLDEST)
-        _ (.setExecutor topic-config (Executors/newSingleThreadExecutor))
-        _ (.setStatisticsEnabled topic-config true)
-        ring-buffer (topic-ring-buffer hz topic-name)
-        stop-gauge (gauges/add-gauge-metrics-fn (fn [_]
-                                                  (hz-gauges topic)))
-        on-msg (fn [^Message m]
-                 (let [msg (.getMessageObject m)]
-                   (if true ;; remove while we switch to grpc (instance? WalRecord msg)
-                     (grouped-queue/put! queue (:record msg))
-                     ;; We should try to reconnect, but only if we weren't
-                     ;; the ones that sent the message to reconnect (if there
-                     ;; is only one machine it will try again within 10 seconds)
-                     (when (not (.localMember (.getPublishingMember m)))
-                       (a/put! acquire-slot-interrupt-chan true)))))
-        listener (hz-topic-listener ring-buffer on-msg)
-        listener-id (.addMessageListener topic listener)]
-    {:topic topic
-     :shutdown (fn []
-                 (.removeMessageListener topic listener-id)
-                 (grouped-queue/stop queue)
-                 (stop-gauge))}))
+;; How the singleton subscriber works
+;; # Connecting
+;; 1. On startup, we connect via grpc to all of the existing instances to register
+;;    our interest in receiving wal records
+;; 2. When new machines are added to hazelcast, we automatically connect via grpc
+;; 3. Remote instances connect to us when we join hazelcast
+;;
+;; # If someone else holds the invalidator slot
+;; 1. The machine that holds the slot will send us wal records through the grpc connection
+;;    and we will apply them, sending an ack after each one
+;; 2. When the remote machine gives up the slot, they'll broadcast a message through the
+;;    grpc connection and we'll race to pick it up.
+;;    a. We'll also periodically try to grab the slot in case the disconnect message is lost
+;;
+;; # If we hold the invalidator slot
+;; 1. We distribute each wal record to all subscribers over the grpc connection
+;; 2. We push the wal record into an s3 directory bucket (or directly into the db if there
+;;    is no bucket defined for self-hosted) and write an entry into the history table.
+;; 3. We mark the lsn as flushed once we've finished writing to the history table.
+;;    a. If any of the subscribers miss a transaction, they can read it from the history table
+;;    b. By waiting until we write to the history table, we can ensure that we never miss a
+;;       transaction
+
+;; TODO:
+;;  1. We need to have something that retries if we're unable to connect to a machine
+;;  2. We need to have something that turns off the thing globally
 
 (defn start-singleton []
-  (let [get-conn-config (fn []
-                          (config/get-aurora-config))
+  (let [conn-config (config/get-aurora-config)
+        get-conn-config (with-meta (fn []
+                                     conn-config)
+                          ;; When we're not transitioning to a new cluster,
+                          ;; this lets us check if the slot is active without
+                          ;; creating a new connection
+                          {:same-as-read-conn true})
         _ (wal/ensure-slot (get-conn-config) "invalidator")
         acquire-slot-interrupt-chan (a/chan (a/sliding-buffer 1))
 
-        {hz-topic :topic
-         shutdown-topic :shutdown}
-        (start-singleton-hz-topic
-         {:acquire-slot-interrupt-chan acquire-slot-interrupt-chan})
+        queue (grouped-queue/start
+               {:group-key-fn :app-id
+                :combine-fn combine-wal-records
+                :process-fn (fn [_key wal-record]
+                              ;; Just testing what kind of latency we'll see with this setup
+                              (tracer/with-span! {:name "singleton-topic-latency"
+                                                  :attributes {:tx-id (:tx-id wal-record)
+                                                               :latency-ms (wal-latency-ms wal-record)}}))
+                :metrics-path "instant.reactive.invalidator.singleton-q"
+                :max-workers 8})
+
+        previous-isn-atom (atom nil)
+
+        grpc-cancels (atom {})
+
+        ;; Add listener so that we can subscribe to machines as they arrive
+        remove-cb (eph/add-hz-member-change-callback
+                   (fn [member-id action]
+                     (when (and (= action :added)
+                                (not= member-id config/machine-id))
+                       (let [client (grpc-client/grpc-client-for-machine-id member-id)
+                             cancel-id (random-uuid)
+                             on-cancel (fn []
+                                         (swap! grpc-cancels dissoc cancel-id))
+                             observer (make-subscription-observer {:queue queue
+                                                                   :previous-isn-atom previous-isn-atom
+                                                                   :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
+                                                                  member-id
+                                                                  on-cancel)
+                             {:keys [cancel]} (grpc-client/subscribe-to-invalidator client observer)]
+                         (swap! grpc-cancels assoc cancel-id cancel)))))
+
+        ;; Start the grpc subscribers to remote machines that arrive before we added the listener
+        ;; If we race and connect to the same machine twice, the remote machine will error on one
+        ;; of the connections
+        _ (doseq [member-id (keys eph/hz-member-by-machine-id-cache)]
+            (when (not= member-id config/machine-id)
+              (let [client (grpc-client/grpc-client-for-machine-id member-id)
+                    cancel-id (random-uuid)
+                    on-cancel (fn []
+                                (swap! grpc-cancels dissoc cancel-id))
+                    observer (make-subscription-observer {:queue queue
+                                                          :previous-isn-atom previous-isn-atom
+                                                          :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
+                                                         member-id
+                                                         on-cancel)
+                    {:keys [cancel]} (grpc-client/subscribe-to-invalidator client observer)]
+                (swap! grpc-cancels assoc cancel-id cancel))))
 
         {shutdown-listener :shutdown}
         (start-singleton-listener
@@ -569,13 +769,16 @@
           :check-disabled (fn []
                             (flags/toggled? :disable-singleton-invalidator))
           :acquire-slot-interrupt-chan acquire-slot-interrupt-chan
-          :get-conn-config (fn []
-                             (config/get-aurora-config))
-          :hz-topic hz-topic
-          :slot-num config/invalidator-slot-num})]
+          :get-conn-config get-conn-config
+          :slot-num config/invalidator-slot-num
+          :previous-isn-atom previous-isn-atom
+          :connections remote-observers
+          :queue queue})]
     {:shutdown (fn []
-                 (shutdown-listener)
-                 (shutdown-topic))}))
+                 (remove-cb)
+                 (doseq [cancel (vals @grpc-cancels)]
+                   (cancel shutdown-reason))
+                 (shutdown-listener))}))
 
 (defn start
   "Entry point for invalidator. Starts a WAL listener and pipes WAL records to
@@ -596,7 +799,7 @@
                                       :slot-type :invalidator
                                       :slot-num config/invalidator-slot-num})]
      (ua/fut-bg
-       (wal/start-worker wal-opts))
+      (wal/start-worker wal-opts))
 
      @(:started-promise wal-opts)
 
@@ -605,20 +808,21 @@
 
      (when byop-chan
        (ua/fut-bg
-         (start-byop-worker rs/store byop-chan)))
+        (start-byop-worker rs/store byop-chan)))
 
      wal-opts)))
 
 (defn start-global []
   (def wal-opts (start))
-  (when false ;; disable while we figure out why hazelcast is unhappy
-    (def shutdown-singleton (:shutdown (start-singleton)))))
+  (when true
+    (def singleton-process (start-singleton))))
 
 (defn stop-global []
   (when (bound? #'wal-opts)
     (stop wal-opts))
-  (when (bound? #'shutdown-singleton)
-    (shutdown-singleton)))
+  (when (and (bound? #'singleton-process)
+             singleton-process)
+    ((:shutdown singleton-process))))
 
 (defn restart []
   (stop-global)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -371,7 +371,7 @@
 
 (defn broadcast-slot-disconnect [{:keys [connections]}]
   (let [msg (grpc/->SlotDisconnect)]
-    (doseq [^StreamObserver observer @connections]
+    (doseq [^StreamObserver observer (vals @connections)]
       (try
         (.onNext observer msg)
         (catch Throwable t

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -31,7 +31,7 @@
    (java.time Instant)
    (java.time.temporal ChronoUnit)
    (java.util ArrayList Map Queue)
-   (java.util.concurrent ConcurrentHashMap Executors LinkedBlockingQueue)
+   (java.util.concurrent ConcurrentHashMap Executors LinkedBlockingQueue TimeUnit)
    (org.postgresql.replication LogSequenceNumber)))
 
 (declare wal-opts)
@@ -433,6 +433,7 @@
                  (reset! shutdown? true)
                  (.put q shutdown-sentinel)
                  (.shutdown executor)
+                 (.awaitTermination executor 20 TimeUnit/SECONDS)
                  (stop-gauge))}))
 
 (defn broadcast-wal-record [get-remote-observers packed-wal-record]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -527,8 +527,8 @@
   (a/close! (:worker-chan wal-opts)))
 
 (defn fast-active-slot-check
-  "Just checks the db to see if the slot is active. It only
-   works when we're in the middle of switching db instances, but we check for that."
+  "Just checks the db to see if the slot is active. It only works when we're not
+   in the middle of switching db instances, but we check for that."
   [{:keys [get-conn-config
            slot-type
            slot-suffix]}]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -20,6 +20,7 @@
    [instant.reactive.store :as rs]
    [instant.reactive.topics :as topics]
    [instant.util.async :as ua]
+   [instant.util.coll :as ucoll]
    [instant.util.e2e-tracer :as e2e-tracer]
    [instant.util.tracer :as tracer])
   (:import
@@ -369,9 +370,9 @@
                                      :skip? (neg? (compare isn old-previous))}}
       (grouped-queue/put! queue wal-record))))
 
-(defn broadcast-slot-disconnect [{:keys [connections]}]
+(defn broadcast-slot-disconnect [{:keys [get-remote-observers]}]
   (let [msg (grpc/->SlotDisconnect)]
-    (doseq [^StreamObserver observer (vals @connections)]
+    (doseq [^StreamObserver observer (get-remote-observers)]
       (try
         (.onNext observer msg)
         (catch Throwable t
@@ -435,9 +436,9 @@
                  (.shutdown executor)
                  (stop-gauge))}))
 
-(defn broadcast-wal-record [connections packed-wal-record]
+(defn broadcast-wal-record [get-remote-observers packed-wal-record]
   (let [msg (grpc/->PackedWalRecord packed-wal-record)]
-    (doseq [^StreamObserver observer (vals @connections)]
+    (doseq [^StreamObserver observer (get-remote-observers)]
       (try
         (.onNext observer msg)
         (catch Throwable t
@@ -448,7 +449,7 @@
                                             :escaping? false}))))))
 
 (defn start-singleton-worker [{:keys [wal-chan
-                                      connections
+                                      get-remote-observers
                                       flush-lsn-chan
                                       on-error
                                       stop-lsn
@@ -470,7 +471,7 @@
                           (when-not (and stop-lsn
                                          (neg? (compare stop-lsn (:nextlsn wal-record))))
                             (try
-                              (broadcast-wal-record connections packed-wal-record)
+                              (broadcast-wal-record get-remote-observers packed-wal-record)
                               (handle-singleton-wal-record {:queue queue
                                                             :previous-isn-atom previous-isn-atom}
                                                            wal-record)
@@ -544,7 +545,7 @@
                                         acquire-slot-interrupt-chan
                                         get-conn-config
                                         slot-num
-                                        connections
+                                        get-remote-observers
                                         previous-isn-atom
                                         queue]}]
   (let [shutdown-chan (a/chan)
@@ -606,7 +607,7 @@
                                                            :close-signal-chan close-signal-chan
                                                            :flush-lsn-chan flush-lsn-chan
                                                            :process-id process-id
-                                                           :connections connections
+                                                           :get-remote-observers get-remote-observers
                                                            :previous-isn-atom previous-isn-atom
                                                            :queue queue
                                                            :on-error (fn [e]
@@ -621,7 +622,7 @@
                                 (stop wal-opts))
                               ;; serves as a signal to the other instances that they should
                               ;; grab the topic
-                              (broadcast-slot-disconnect {:connections connections})
+                              (broadcast-slot-disconnect {:get-remote-observers get-remote-observers})
                               (when (= exit-ch close-signal-chan)
                                 (tracer/record-info! {:name "invalidator-singleton/retry"
                                                       :attributes {:wait-ms acquire-slot-interval-ms
@@ -636,7 +637,44 @@
                    @wal-worker-finished))
      :completed-chan process}))
 
-(defonce remote-observers (atom {}))
+(defonce next-process-id (atom (int 0)))
+(defn gen-process-id []
+  (swap! next-process-id unchecked-inc-int))
+
+(defonce remote-observers {})
+
+(defonce grpc-registry (atom {:local-processes {}
+                              :remote-observers {}}))
+
+(defn handle-grpc-subscribe
+  "This is called when a remote machine subscribes to our invalidator stream.
+   The remote machine will create the connection when it starts up the
+   singleton invalidator, indicating that it wants to subscribe to wal records
+   on this machine."
+  [^InvalidatorSubscribe req ^ServerCallStreamObserver observer]
+  (tracer/with-span! {:name "handle-grpc-subscribe"
+                      :attributes {:remote-machine-id (:machine-id req)
+                                   :remote-process-id (:process-id req)}}
+    (let [new-state (swap! grpc-registry
+                           (fn [state]
+                             (if (empty? (:local-processes state))
+                               state
+                               (assoc-in state [:remote-observers req] observer))))
+          new-observer (get-in new-state [:remote-observers req])]
+      (if (or (not new-observer) ; We don't have any processes running, so tell them to go away
+              (not= new-observer observer)) ; Someone else won the race, close this one
+        (.onCompleted observer)
+        (let [cleanup (reify Runnable
+                        (run [_]
+                          (swap! grpc-registry
+                                 (fn [state]
+                                   (if (= observer (get-in state [:remote-observers req]))
+                                     (ucoll/dissoc-in state [:remote-observers req])
+                                     state)))))]
+          (.setOnCloseHandler observer cleanup)
+          (.setOnCancelHandler observer cleanup)
+          (doseq [{:keys [subscribe]} (vals (:local-processes new-state))]
+            (subscribe (:machine-id req))))))))
 
 ;; Used to indicate to grpc that we meant to cancel
 (def shutdown-reason "s")
@@ -667,34 +705,13 @@
       (onError [_ t]
         (cleanup)
         (let [status (Status/fromThrowable t)]
-          (when (or (not= (.getCode status) Status$Code/CANCELLED)
-                    (not= (.getDescription status) shutdown-reason))
+          (if (= (.getCode status) Status$Code/CANCELLED)
+            (tracer/record-info! {:name "invalidator/singleton-gprc-subscription-cancelled"
+                                  :attributes {:description (.getDescription status)
+                                               :remote-machine-id remote-machine-id}})
             (tracer/record-exception-span! t {:name "invalidator/singleton-gprc-subscription-stream-error"}))))
       (onCompleted [_]
         (cleanup)))))
-
-(defn handle-grpc-subscribe
-  "This is called when a remote machine subscribes to our invalidator stream.
-   The remote machine will create the connection when it starts up the
-   singleton invalidator, indicating that it wants to subscribe to wal records."
-  [^InvalidatorSubscribe {:keys [machine-id]} ^ServerCallStreamObserver observer]
-  (tracer/with-span! {:name "handle-grpc-subscribe"
-                      :attributes {:machine-id machine-id}}
-    (let [[old-observers new-observers] (swap-vals! remote-observers assoc machine-id observer)]
-      (when-let [^ServerCallStreamObserver old-observer (get old-observers machine-id)]
-        (when (not= old-observer observer)
-          (.onError old-observer (Exception. "New subscription for same machine-id, closing old subscription."))))
-      (if (not= (get new-observers machine-id) observer)
-        (.onError observer (Exception. "Clashing subscribe requests."))
-        (let [cleanup (reify Runnable
-                        (run [_]
-                          (swap! remote-observers
-                                 (fn [observers]
-                                   (if (= observer (get observers machine-id))
-                                     (dissoc observers machine-id)
-                                     observers)))))]
-          (.setOnCloseHandler observer cleanup)
-          (.setOnCancelHandler observer cleanup))))))
 
 ;; How the singleton subscriber works
 ;; # Connecting
@@ -723,8 +740,60 @@
 ;;  1. We need to have something that retries if we're unable to connect to a machine
 ;;  2. We need to have something that turns off the thing globally
 
+(defn subscribe-to-machine [{:keys [grpc-cancels
+                                    previous-isn-atom
+                                    acquire-slot-interrupt-chan
+                                    process-id
+                                    queue
+                                    outbound-subscriptions]}
+                            machine-id]
+  (tracer/with-span! {:name "invalidator/subscribe-to-machine"
+                      :attributes {:remote-machine-id machine-id
+                                   :process-id process-id}}
+    (let [sentinel (Object.)
+          after (swap! outbound-subscriptions (fn [subs]
+                                                (if (get subs machine-id)
+                                                  subs
+                                                  (assoc subs machine-id sentinel))))]
+      (if-not (= sentinel (get after machine-id))
+        (tracer/add-data! {:attributes {:already-subscribed? true}})
+        (let [client (grpc-client/grpc-client-for-machine-id machine-id)
+              cancel-id (random-uuid)
+              on-close (fn []
+                         (swap! outbound-subscriptions (fn [state]
+                                                         (if (= sentinel (get state machine-id))
+                                                           (dissoc state machine-id)
+                                                           state)))
+                         (swap! grpc-cancels dissoc cancel-id))
+              observer (make-subscription-observer {:queue queue
+                                                    :previous-isn-atom previous-isn-atom
+                                                    :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
+                                                   machine-id
+                                                   on-close)
+              {:keys [cancel]} (grpc-client/subscribe-to-invalidator client process-id observer)]
+          (swap! grpc-cancels assoc cancel-id cancel))))))
+
+(defn cleanup-local-process
+  "Removes the process from the grpc-registry and closes any
+   remote-observers if we're the last process."
+  [process-id]
+  (let [[old new] (swap-vals! grpc-registry (fn [state]
+                                              (let [processes-after (dissoc (:local-processes state) process-id)]
+                                                (cond-> state
+                                                  true (assoc :local-processes processes-after)
+
+                                                  (empty? processes-after)
+                                                  (assoc :remote-observers {})))))]
+    (when (empty? (:remote-observers new))
+      ;; XXX: What happens if you call onCompleted twice?
+      (doseq [^StreamObserver observer (vals (:remote-observers old))]
+        (try
+          (.onCompleted observer)
+          (catch Throwable _ nil))))))
+
 (defn start-singleton []
-  (let [conn-config (config/get-aurora-config)
+  (let [process-id (gen-process-id)
+        conn-config (config/get-aurora-config)
         get-conn-config (with-meta (fn []
                                      conn-config)
                           ;; When we're not transitioning to a new cluster,
@@ -747,41 +816,35 @@
 
         previous-isn-atom (atom nil)
 
+        ;; Holds a map of unique-id to cancel function
+        ;; used to close the outbound grpc connections
         grpc-cancels (atom {})
 
+        outbound-subscriptions (atom {})
+
+        subscribe (partial subscribe-to-machine {:grpc-cancels grpc-cancels
+                                                 :previous-isn-atom previous-isn-atom
+                                                 :acquire-slot-interrupt-chan acquire-slot-interrupt-chan
+                                                 :process-id process-id
+                                                 :queue queue
+                                                 :outbound-subscriptions outbound-subscriptions})
+
+        _ (swap! grpc-registry (fn [state]
+                                 (assoc-in state [:local-processes process-id] {:subscribe subscribe})))
+
         ;; Add listener so that we can subscribe to machines as they arrive
-        remove-cb (eph/add-hz-member-change-callback
-                   (fn [member-id action]
-                     (when (and (= action :added)
-                                (not= member-id config/machine-id))
-                       (let [client (grpc-client/grpc-client-for-machine-id member-id)
-                             cancel-id (random-uuid)
-                             on-cancel (fn []
-                                         (swap! grpc-cancels dissoc cancel-id))
-                             observer (make-subscription-observer {:queue queue
-                                                                   :previous-isn-atom previous-isn-atom
-                                                                   :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
-                                                                  member-id
-                                                                  on-cancel)
-                             {:keys [cancel]} (grpc-client/subscribe-to-invalidator client observer)]
-                         (swap! grpc-cancels assoc cancel-id cancel)))))
+        remove-hz-cb (eph/add-hz-member-change-callback
+                      (fn [member-id action]
+                        (when (and (= action :added)
+                                   (not= member-id config/machine-id))
+                          (subscribe member-id))))
 
         ;; Start the grpc subscribers to remote machines that arrive before we added the listener
         ;; If we race and connect to the same machine twice, the remote machine will error on one
         ;; of the connections
         _ (doseq [member-id (keys eph/hz-member-by-machine-id-cache)]
             (when (not= member-id config/machine-id)
-              (let [client (grpc-client/grpc-client-for-machine-id member-id)
-                    cancel-id (random-uuid)
-                    on-cancel (fn []
-                                (swap! grpc-cancels dissoc cancel-id))
-                    observer (make-subscription-observer {:queue queue
-                                                          :previous-isn-atom previous-isn-atom
-                                                          :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
-                                                         member-id
-                                                         on-cancel)
-                    {:keys [cancel]} (grpc-client/subscribe-to-invalidator client observer)]
-                (swap! grpc-cancels assoc cancel-id cancel))))
+              (subscribe member-id)))
 
         {shutdown-listener :shutdown}
         (start-singleton-listener
@@ -793,13 +856,22 @@
           :get-conn-config get-conn-config
           :slot-num config/invalidator-slot-num
           :previous-isn-atom previous-isn-atom
-          :connections remote-observers
+          :get-remote-observers (fn []
+                                  (-> @grpc-registry
+                                      :remote-observers
+                                      vals))
           :queue queue})]
     {:shutdown (fn []
-                 (remove-cb)
+                 (remove-hz-cb)
+                 (shutdown-listener)
+                 ;; Shutdown outbound subscribers
                  (doseq [cancel (vals @grpc-cancels)]
-                   (cancel shutdown-reason))
-                 (shutdown-listener))}))
+                   (try
+                     (tracer/with-span! {:name "invalidator/cancel-outbound-sub"}
+                       (cancel shutdown-reason))
+                     (catch Throwable _ nil)))
+                 ;; Shutdown inbound subscribers if we're the last
+                 (cleanup-local-process process-id))}))
 
 (defn start
   "Entry point for invalidator. Starts a WAL listener and pipes WAL records to

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -348,7 +348,7 @@
                                                          isn ;; This is our first record
 
                                                          ;; Don't let previous-isn go backwards
-                                                         (= -1 (compare isn v))
+                                                         (neg? (compare isn v))
                                                          v
 
                                                          :else isn)))]
@@ -366,7 +366,7 @@
                         :attributes {:isn isn
                                      :previous-isn previous-isn
                                      :previous-handled-isn old-previous
-                                     :skip? (= -1 (compare isn old-previous))}}
+                                     :skip? (neg? (compare isn old-previous))}}
       (grouped-queue/put! queue wal-record))))
 
 (defn broadcast-slot-disconnect [{:keys [connections]}]
@@ -423,9 +423,15 @@
 
 (defn broadcast-wal-record [connections packed-wal-record]
   (let [msg (grpc/->PackedWalRecord packed-wal-record)]
-    ;; XXX: Log if it's ready
-    (doseq [^StreamObserver observer (vals @connections)]
-      (.onNext observer msg))))
+    (doseq [^StreamObserver observer @connections]
+      (try
+        (.onNext observer msg)
+        (catch Throwable t
+          ;; Isolate failures: one flaky observer must not abort the loop or
+          ;; trigger the outer singleton-worker restart. The cancel handler
+          ;; in handle-grpc-subscribe takes care of removing dead observers.
+          (tracer/record-exception-span! t {:name "invalidator/broadcast-wal-record-observer-error"
+                                            :escaping? false}))))))
 
 (defn start-singleton-worker [{:keys [wal-chan
                                       connections
@@ -447,7 +453,7 @@
                         (let [packed-wal-record (history-model/pack-wal-record wal-record)
                               wal-record (with-meta wal-record {:packed packed-wal-record})]
                           (when-not (and stop-lsn
-                                         (= -1 (compare stop-lsn (:nextlsn wal-record))))
+                                         (neg? (compare stop-lsn (:nextlsn wal-record))))
                             (try
                               (broadcast-wal-record connections packed-wal-record)
                               (handle-singleton-wal-record {:queue queue

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -640,8 +640,6 @@
 (defn gen-process-id []
   (swap! next-process-id unchecked-inc-int))
 
-(defonce remote-observers {})
-
 (defonce grpc-registry (atom {:local-processes {}
                               :remote-observers {}}))
 

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -704,7 +704,7 @@
         (cleanup)
         (let [status (Status/fromThrowable t)]
           (if (= (.getCode status) Status$Code/CANCELLED)
-            (tracer/record-info! {:name "invalidator/singleton-gprc-subscription-cancelled"
+            (tracer/record-info! {:name "invalidator/singleton-grpc-subscription-cancelled"
                                   :attributes {:description (.getDescription status)
                                                :remote-machine-id remote-machine-id}})
             (tracer/record-exception-span! t {:name "invalidator/singleton-grpc-subscription-stream-error"}))))

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -356,7 +356,6 @@
     (when (and old-previous
                (not= old-previous previous-isn))
       ;; TODO: We should fetch the missing wal-records from the history table
-      ;; XXX: This will probably fire when the slot switches machines
       (tracer/record-info! {:name "singleton-missing-wal-records"
                             :attributes {:isn isn
                                          :previous-isn previous-isn
@@ -722,7 +721,7 @@
 ;;
 ;; # If someone else holds the invalidator slot
 ;; 1. The machine that holds the slot will send us wal records through the grpc connection
-;;    and we will apply them, sending an ack after each one
+;;    and we will apply them
 ;; 2. When the remote machine gives up the slot, they'll broadcast a message through the
 ;;    grpc connection and we'll race to pick it up.
 ;;    a. We'll also periodically try to grab the slot in case the disconnect message is lost
@@ -735,10 +734,6 @@
 ;;    a. If any of the subscribers miss a transaction, they can read it from the history table
 ;;    b. By waiting until we write to the history table, we can ensure that we never miss a
 ;;       transaction
-
-;; TODO:
-;;  1. We need to have something that retries if we're unable to connect to a machine
-;;  2. We need to have something that turns off the thing globally
 
 (defn subscribe-to-machine [{:keys [grpc-cancels
                                     previous-isn-atom
@@ -785,7 +780,6 @@
                                                   (empty? processes-after)
                                                   (assoc :remote-observers {})))))]
     (when (empty? (:remote-observers new))
-      ;; XXX: What happens if you call onCompleted twice?
       (doseq [^StreamObserver observer (vals (:remote-observers old))]
         (try
           (.onCompleted observer)
@@ -905,10 +899,26 @@
 
      wal-opts)))
 
+(defn singleton-startup-disabled?
+  "Reads the `prevent-singleton-invalidator-startup` row from the config table.
+   The flags subscription isn't initialised until after the invalidator starts,
+   so we can't use `flags/toggled?` here."
+  []
+  (-> (sql/select-one
+       ::singleton-startup-disabled?
+       (aurora/conn-pool :read)
+       ["select v from config where k = 'prevent-singleton-invalidator-startup'"])
+      :v
+      boolean))
+
 (defn start-global []
   (def wal-opts (start))
-  (when true
-    (def singleton-process (start-singleton))))
+  (def singleton-process
+    (if (singleton-startup-disabled?)
+      (do
+        (tracer/record-info! {:name "invalidator/singleton-startup-prevented-by-config"})
+        nil)
+      (start-singleton))))
 
 (defn stop-global []
   (when (bound? #'wal-opts)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -708,7 +708,7 @@
             (tracer/record-info! {:name "invalidator/singleton-gprc-subscription-cancelled"
                                   :attributes {:description (.getDescription status)
                                                :remote-machine-id remote-machine-id}})
-            (tracer/record-exception-span! t {:name "invalidator/singleton-gprc-subscription-stream-error"}))))
+            (tracer/record-exception-span! t {:name "invalidator/singleton-grpc-subscription-stream-error"}))))
       (onCompleted [_]
         (cleanup)))))
 
@@ -752,21 +752,32 @@
                                                   (assoc subs machine-id sentinel))))]
       (if-not (= sentinel (get after machine-id))
         (tracer/add-data! {:attributes {:already-subscribed? true}})
-        (let [client (grpc-client/grpc-client-for-machine-id machine-id)
-              cancel-id (random-uuid)
+        (let [cancel-id (random-uuid)
               on-close (fn []
                          (swap! outbound-subscriptions (fn [state]
                                                          (if (= sentinel (get state machine-id))
                                                            (dissoc state machine-id)
                                                            state)))
-                         (swap! grpc-cancels dissoc cancel-id))
-              observer (make-subscription-observer {:queue queue
-                                                    :previous-isn-atom previous-isn-atom
-                                                    :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
-                                                   machine-id
-                                                   on-close)
-              {:keys [cancel]} (grpc-client/subscribe-to-invalidator client process-id observer)]
-          (swap! grpc-cancels assoc cancel-id cancel))))))
+                         (swap! grpc-cancels dissoc cancel-id))]
+          (try
+            (let [client (grpc-client/grpc-client-for-machine-id machine-id)
+                  observer (make-subscription-observer {:queue queue
+                                                        :previous-isn-atom previous-isn-atom
+                                                        :acquire-slot-interrupt-chan acquire-slot-interrupt-chan}
+                                                       machine-id
+                                                       on-close)
+                  {:keys [cancel]} (grpc-client/subscribe-to-invalidator client process-id observer)]
+              (swap! grpc-cancels assoc cancel-id cancel))
+            (catch Throwable t
+              ;; Setup failed before the observer could drive its own cleanup,
+              ;; so release the sentinel to unblock future reconnect attempts.
+              (swap! outbound-subscriptions (fn [state]
+                                              (if (= sentinel (get state machine-id))
+                                                (dissoc state machine-id)
+                                                state)))
+              (tracer/record-exception-span! t {:name "invalidator/subscribe-to-machine-failed"
+                                                :escaping? false
+                                                :attributes {:remote-machine-id machine-id}}))))))))
 
 (defn cleanup-local-process
   "Removes the process from the grpc-registry and closes any

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -215,20 +215,21 @@
     (throw (ex-info "Unsupported method for presigned url" {:method method}))))
 
 (defn- make-s3-put-opts
-  [bucket-name {:keys [object-key content-type content-disposition content-length]} file-opts]
+  [bucket-name {:keys [object-key content-type content-disposition content-length content-encoding]} file-opts]
   (merge
    {:bucket-name bucket-name
     :key object-key
     :metadata {:content-type (or content-type default-content-type)
                :content-disposition (or content-disposition default-content-disposition)
-               :content-length content-length}}
+               :content-length content-length
+               :content-encoding content-encoding}}
    file-opts))
 
-(defn upload-stream-to-s3
-  [^S3AsyncClient async-client bucket-name ctx stream]
+(defn upload-body-to-s3
+  [^S3AsyncClient async-client bucket-name ctx ^AsyncRequestBody body]
   (let [{:keys [key metadata] :as _opts} (make-s3-put-opts bucket-name ctx {})
-        {:keys [content-disposition content-type content-length]} metadata]
-    (tracer/with-span! {:name "s3/upload-stream-to-s3"
+        {:keys [content-disposition content-type content-length content-encoding]} metadata]
+    (tracer/with-span! {:name "s3/upload-body-to-s3"
                         :attributes {:bucket-name bucket-name
                                      :key key
                                      :content-type content-type
@@ -240,10 +241,16 @@
                                     true (.contentType content-type)
                                     true (.contentDisposition content-disposition)
                                     content-length (.contentLength content-length)
-                                    true (.build))
-            body (AsyncRequestBody/fromInputStream stream
-                                                   (when content-length
-                                                     (long content-length))
-                                                   default-virtual-thread-executor)]
+                                    content-encoding (.contentEncoding content-encoding)
+                                    true (.build))]
         (-> (.putObject async-client req body)
             deref)))))
+
+(defn upload-stream-to-s3
+  [^S3AsyncClient async-client bucket-name ctx stream]
+  (let [content-length (:content-length ctx)
+        body (AsyncRequestBody/fromInputStream stream
+                                               (when content-length (long content-length))
+                                               default-virtual-thread-executor)]
+    (upload-body-to-s3 async-client bucket-name ctx body)))
+

--- a/server/src/tool.clj
+++ b/server/src/tool.clj
@@ -148,6 +148,38 @@
     (.append s "}")
     (.toString s)))
 
+;; ISN is a Clojure deftype in instant.isn; we can't :import it here because
+;; tool.clj loads before instant.isn. Check by class name instead.
+(defn isn?
+  [v]
+  (and (some? v)
+       (= "instant.isn.ISN" (.getName ^Class (class v)))))
+
+;; Delegate to the reflection-free version in instant.jdbc.sql. tool.clj can't
+;; :import ISN (loaded before instant.isn) and can't :require instant.jdbc.sql
+;; eagerly for the same reason, so resolve at first call.
+(def ^:private sql-isn->composite-str
+  (delay (requiring-resolve 'instant.jdbc.sql/isn->composite-str)))
+
+(defn isn->composite-str
+  "Serializes an ISN as the Postgres composite literal (slot_num,lsn)."
+  ^String [v]
+  (@sql-isn->composite-str v))
+
+(defn ->pg-isn-array
+  "Array-literal form: {\"(s,l)\",\"(s,l)\"}. Composites must be double-quoted
+   inside an array literal because they contain commas."
+  [isns]
+  (let [s (StringBuilder. "{")]
+    (doseq [isn isns]
+      (when (not= 1 (.length s))
+        (.append s \,))
+      (.append s \")
+      (.append s (isn->composite-str isn))
+      (.append s \"))
+    (.append s "}")
+    (.toString s)))
+
 (defn ->pg-json-array [items]
   (let [s (StringBuilder. "ARRAY[")]
     (doseq [item items]
@@ -199,7 +231,9 @@
                                                      (= "float8[]" (-> v meta :pgtype))
                                                      (= "timestamptz[]" (-> v meta :pgtype))
                                                      (= "integer[]" (-> v meta :pgtype))
+                                                     (= "int[]" (-> v meta :pgtype))
                                                      (= "bigint[]" (-> v meta :pgtype))
+                                                     (= "history_storage[]" (-> v meta :pgtype))
                                                      (and (set? v)
                                                           (or (every? uuid? v)
                                                               (every? boolean? v)
@@ -244,6 +278,12 @@
 
                                                  (instance? LogSequenceNumber v)
                                                  (format "'%s'::pg_lsn" (LogSequenceNumber/.asString v))
+
+                                                 (isn? v)
+                                                 (format "'%s'::isn" (isn->composite-str v))
+
+                                                 (= "isn[]" (-> v meta :pgtype))
+                                                 (format "'%s'::isn[]" (->pg-isn-array v))
 
                                                  ;; Fallback to JSON
                                                  (set? v)

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -6,10 +6,12 @@
    [instant.util.test :refer [wait-for]]
    [clojure.test :refer [deftest testing is]])
   (:import
+   (clojure.lang ExceptionInfo)
+   (instant.isn ISN)
    (java.time Instant)
    (java.time.temporal ChronoUnit)
    (java.sql Timestamp)
-   (clojure.lang ExceptionInfo)))
+   (org.postgresql.replication LogSequenceNumber)))
 
 (deftest in-progress-stmts
   (let [in-progress (sql/make-statement-tracker)]
@@ -96,7 +98,21 @@
     (let [vs [true false true]]
       (is (= {:v vs}
              (sql/select-one (aurora/conn-pool :read)
-                             ["select ? as v" (with-meta vs {:pgtype "boolean[]"})]))))))
+                             ["select ? as v" (with-meta vs {:pgtype "boolean[]"})])))))
+
+  (testing "isn"
+    (let [isn (ISN. 7 (LogSequenceNumber/valueOf "16/B374D848"))]
+      (is (= {:v isn}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" isn])))))
+
+  (testing "isn[]"
+    (let [vs [(ISN. 0 (LogSequenceNumber/valueOf 0))
+              (ISN. 7 (LogSequenceNumber/valueOf "16/B374D848"))
+              (ISN. 42 (LogSequenceNumber/valueOf "1A2B/3C4D5E6F"))]]
+      (is (= {:v vs}
+             (sql/select-one (aurora/conn-pool :read)
+                             ["select ? as v" (with-meta vs {:pgtype "isn[]"})]))))))
 
 (deftest elementset-test
   (let [xs [1 2 3]
@@ -154,6 +170,23 @@
             (aurora/conn-pool :read)
             (hsql/format
              (sql/recordset [] columns)))))))
+
+(deftest parse-isn-test
+  (testing "basic composite from postgres"
+    (let [isn (sql/parse-isn "(0,328/26EEF7F8)")]
+      (is (= (ISN. 0 (LogSequenceNumber/valueOf "328/26EEF7F8")) isn))))
+
+  (testing "zero slot and zero lsn"
+    (is (= (ISN. 0 (LogSequenceNumber/valueOf 0))
+           (sql/parse-isn "(0,0/0)"))))
+
+  (testing "multi-digit slot number"
+    (is (= (ISN. 42 (LogSequenceNumber/valueOf "16/B374D848"))
+           (sql/parse-isn "(42,16/B374D848)"))))
+
+  (testing "roundtrip with isn->composite-str"
+    (let [isn (ISN. 7 (LogSequenceNumber/valueOf "1A2B/3C4D5E6F"))]
+      (is (= isn (sql/parse-isn (sql/isn->composite-str isn)))))))
 
 (deftest format-test
   (testing "static"

--- a/server/test/instant/model/history_test.clj
+++ b/server/test/instant/model/history_test.clj
@@ -1,0 +1,97 @@
+(ns instant.model.history-test
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is]]
+   [instant.grpc :as grpc]
+   [instant.model.history :as history])
+  (:import
+   (instant.isn ISN)
+   (instant.jdbc WalColumn WalEntry)
+   (java.time Instant)
+   (org.postgresql.replication LogSequenceNumber)))
+
+(defn- rand-lsn []
+  (LogSequenceNumber/valueOf (long (rand-int Integer/MAX_VALUE))))
+
+(defn- sample-wal-record []
+  (let [app-id (random-uuid)
+        attr-insert (WalEntry. :insert
+                               128
+                               "attrs"
+                               [(WalColumn. "id" (str (random-uuid)))
+                                (WalColumn. "app_id" (str app-id))]
+                               nil nil nil nil nil)
+        ident-insert (WalEntry. :insert
+                                96
+                                "idents"
+                                [(WalColumn. "id" (str (random-uuid)))
+                                 (WalColumn. "app_id" (str app-id))]
+                                nil nil nil nil nil)
+        triple-insert (WalEntry. :insert
+                                 160
+                                 "triples"
+                                 [(WalColumn. "app_id" (str app-id))
+                                  (WalColumn. "entity_id" (str (random-uuid)))
+                                  (WalColumn. "attr_id" (str (random-uuid)))
+                                  (WalColumn. "value" "\"hello\"")]
+                                 nil nil nil nil nil)]
+    (grpc/->WalRecord app-id
+                      (rand-int Integer/MAX_VALUE)
+                      (ISN. (rand-int 1000) (rand-lsn))
+                      (ISN. (rand-int 1000) (rand-lsn))
+                      (Instant/now)
+                      536
+                      (rand-lsn)
+                      [attr-insert]
+                      [ident-insert]
+                      [triple-insert]
+                      []
+                      [])))
+
+(deftest pack-unpack-wal-record
+  (let [wal-record (sample-wal-record)
+        packed (history/pack-wal-record wal-record)
+        unpacked (history/unpack-wal-record packed)]
+    (is (bytes? packed))
+    (is (= wal-record unpacked))))
+
+(deftest pack-wal-record-reuses-packed-meta
+  ;; When a wal-record already carries its packed form in metadata, pack-wal-record
+  ;; should return that bytes instance directly rather than re-freezing.
+  (let [wal-record (sample-wal-record)
+        pre-packed (history/pack-wal-record wal-record)
+        tagged (with-meta wal-record {:packed pre-packed})]
+    (is (identical? pre-packed (history/pack-wal-record tagged)))
+    (is (= wal-record (history/unpack-wal-record (history/pack-wal-record tagged))))))
+
+(defn- instant-for-bucket
+  "Returns an Instant whose bucket (days-since-epoch / 30 mod 13) equals b."
+  ^Instant [b]
+  (Instant/ofEpochSecond (* b 30 86400)))
+
+(deftest partitions-to-truncate-specific-buckets
+  ;; current=0: keep {0,12,11,10}, truncate {1..9}
+  (is (= #{1 2 3 4 5 6 7 8 9}
+         (set (history/partitions-to-truncate (instant-for-bucket 0)))))
+
+  ;; current=5: keep {5,4,3,2}, truncate the rest modulo 13
+  (is (= #{6 7 8 9 10 11 12 0 1}
+         (set (history/partitions-to-truncate (instant-for-bucket 5)))))
+
+  ;; current=12: keep {12,11,10,9}, truncate {0..8}
+  (is (= #{0 1 2 3 4 5 6 7 8}
+         (set (history/partitions-to-truncate (instant-for-bucket 12))))))
+
+(deftest partitions-to-truncate-keeps-90-days-for-all-buckets
+  ;; For every possible current bucket, we always truncate 9 partitions and
+  ;; never touch the current bucket or the 3 previous (90-day retention floor).
+  (doseq [current (range 13)]
+    (let [truncate (set (history/partitions-to-truncate (instant-for-bucket current)))
+          keep (into #{} (map #(mod (+ current %) 13)) [0 -1 -2 -3])]
+      (is (= 9 (count truncate))
+          (str "truncate count must be 9 for current=" current))
+      (is (empty? (set/intersection keep truncate))
+          (str "keep and truncate must be disjoint for current=" current
+               " (keep=" keep " truncate=" truncate ")"))
+      (is (= (set (range 13)) (set/union keep truncate))
+          (str "keep ∪ truncate must cover all 13 buckets for current=" current)))))

--- a/server/test/instant/nippy_test.clj
+++ b/server/test/instant/nippy_test.clj
@@ -14,7 +14,7 @@
 
 (deftest all-of-the-custom-readers-are-tested
   ;; Only update this number if you also added a freeze/thaw test for the type
-  (is (= 12 (count nippy/*custom-readers*))))
+  (is (= 15 (count nippy/*custom-readers*))))
 
 (defn roundtrip [x]
   (nippy/fast-thaw (nippy/fast-freeze x)))
@@ -219,4 +219,20 @@
                               [triple-insert]
                               [message]
                               [wal-log-insert])]
+    (is (= obj (roundtrip obj)))))
+
+(deftest slot-disconnect
+  (let [obj (grpc/->SlotDisconnect)]
+    (is (= obj (roundtrip obj)))))
+
+(deftest packed-wal-record
+  (let [ba (.getBytes "packed-wal-record-payload" "UTF-8")
+        obj (grpc/->PackedWalRecord ba)
+        round (roundtrip obj)]
+    ;; byte arrays don't compare with =, so roundtrip is checked by value
+    (is (Arrays/equals ^bytes (:ba obj) ^bytes (:ba round)))
+    (is (= (dissoc obj :ba) (dissoc round :ba)))))
+
+(deftest invalidator-subscribe
+  (let [obj (grpc/->InvalidatorSubscribe (random-uuid))]
     (is (= obj (roundtrip obj)))))

--- a/server/test/instant/nippy_test.clj
+++ b/server/test/instant/nippy_test.clj
@@ -234,5 +234,5 @@
     (is (= (dissoc obj :ba) (dissoc round :ba)))))
 
 (deftest invalidator-subscribe
-  (let [obj (grpc/->InvalidatorSubscribe (random-uuid))]
+  (let [obj (grpc/->InvalidatorSubscribe (random-uuid) (rand-int 1000))]
     (is (= obj (roundtrip obj)))))

--- a/server/test/instant/reactive/invalidator_singleton_test.clj
+++ b/server/test/instant/reactive/invalidator_singleton_test.clj
@@ -1,0 +1,322 @@
+(ns instant.reactive.invalidator-singleton-test
+  (:require
+   [clojure.core.async :as a]
+   [clojure.test :as test :refer [deftest is testing]]
+   [instant.grouped-queue :as grouped-queue]
+   [instant.grpc :as grpc]
+   [instant.isn :as isn]
+   [instant.model.history :as history-model]
+   [instant.reactive.invalidator :as inv]
+   [instant.util.test :refer [wait-for]])
+  (:import
+   (io.grpc.stub ServerCallStreamObserver StreamObserver)))
+
+;; ------
+;; helpers
+
+(defn make-wal-record
+  [{:keys [app-id tx-id isn previous-isn nextlsn]
+    :or {app-id (random-uuid)
+         tx-id 0
+         nextlsn nil}}]
+  (grpc/->WalRecord app-id
+                    tx-id
+                    isn
+                    previous-isn
+                    nil
+                    0
+                    nextlsn
+                    []
+                    []
+                    []
+                    []
+                    []))
+
+(defn capture-queue
+  "Start a grouped-queue whose process-fn just collects records into an atom.
+   Strips the :instant.grouped-queue/put-at timestamp that put! adds so
+   tests can compare against the originals."
+  []
+  (let [records (atom [])
+        queue (grouped-queue/start
+               {:group-key-fn :app-id
+                :process-fn (fn [_k r]
+                              (swap! records conj
+                                     (dissoc r :instant.grouped-queue/put-at)))
+                :max-workers 1})]
+    {:queue queue
+     :records records
+     :stop (fn [] (grouped-queue/stop queue {}))}))
+
+(defn fake-observer
+  "StreamObserver that collects onNext payloads; optionally throws from onNext."
+  [{:keys [on-next throw?]}]
+  (let [received (atom [])
+        completed? (atom false)]
+    {:observer (reify StreamObserver
+                 (onNext [_ v]
+                   (swap! received conj v)
+                   (when on-next (on-next v))
+                   (when throw?
+                     (throw (ex-info "observer boom" {}))))
+                 (onError [_ _])
+                 (onCompleted [_]
+                   (reset! completed? true)))
+     :received received
+     :completed? completed?}))
+
+(defn fake-server-observer
+  "Minimal ServerCallStreamObserver that captures the close/cancel handlers
+   the singleton invalidator installs on it."
+  []
+  (let [state (atom {:completed? false
+                     :received []
+                     :on-close nil
+                     :on-cancel nil})
+        observer (proxy [ServerCallStreamObserver] []
+                   (onNext [v]
+                     (swap! state update :received conj v))
+                   (onError [_t]
+                     (swap! state assoc :errored? true))
+                   (onCompleted []
+                     (swap! state assoc :completed? true))
+                   (setOnCloseHandler [^Runnable r]
+                     (swap! state assoc :on-close r))
+                   (setOnCancelHandler [^Runnable r]
+                     (swap! state assoc :on-cancel r))
+                   (isReady []
+                     true))]
+    {:observer observer
+     :state state}))
+
+(defmacro with-fresh-registry
+  "Runs body with a freshly-initialised inv/grpc-registry, restored afterward."
+  [& body]
+  `(with-redefs [inv/grpc-registry (atom {:local-processes {}
+                                          :remote-observers {}})]
+     ~@body))
+
+;; ------
+;; handle-singleton-wal-record
+
+(deftest handle-singleton-wal-record-sets-previous-isn-on-first-record
+  (let [{:keys [queue records stop]} (capture-queue)
+        previous-isn-atom (atom nil)
+        rec (make-wal-record {:isn (isn/test-isn 10)
+                              :previous-isn (isn/test-isn 9)
+                              :tx-id 1})]
+    (try
+      (inv/handle-singleton-wal-record {:queue queue
+                                        :previous-isn-atom previous-isn-atom}
+                                       rec)
+      (wait-for #(seq @records) 1000)
+      (is (= (isn/test-isn 10) @previous-isn-atom))
+      (is (= [rec] @records))
+      (finally (stop)))))
+
+(deftest handle-singleton-wal-record-advances-on-newer-isn
+  (let [{:keys [queue records stop]} (capture-queue)
+        previous-isn-atom (atom (isn/test-isn 10))
+        rec (make-wal-record {:isn (isn/test-isn 20)
+                              :previous-isn (isn/test-isn 10)
+                              :tx-id 2})]
+    (try
+      (inv/handle-singleton-wal-record {:queue queue
+                                        :previous-isn-atom previous-isn-atom}
+                                       rec)
+      (wait-for #(seq @records) 1000)
+      (is (= (isn/test-isn 20) @previous-isn-atom))
+      (is (= [rec] @records))
+      (finally (stop)))))
+
+(deftest handle-singleton-wal-record-does-not-go-backwards
+  (testing "an older isn leaves the previous-isn-atom unchanged but still enqueues"
+    (let [{:keys [queue records stop]} (capture-queue)
+          previous-isn-atom (atom (isn/test-isn 20))
+          rec (make-wal-record {:isn (isn/test-isn 10)
+                                :previous-isn (isn/test-isn 9)
+                                :tx-id 1})]
+      (try
+        (inv/handle-singleton-wal-record {:queue queue
+                                          :previous-isn-atom previous-isn-atom}
+                                         rec)
+        (wait-for #(seq @records) 1000)
+        (is (= (isn/test-isn 20) @previous-isn-atom))
+        (is (= [rec] @records))
+        (finally (stop))))))
+
+;; ------
+;; broadcast-wal-record / broadcast-slot-disconnect
+
+(deftest broadcast-wal-record-sends-to-every-observer
+  (let [o1 (fake-observer {})
+        o2 (fake-observer {})
+        packed (byte-array [1 2 3])]
+    (inv/broadcast-wal-record (fn [] [(:observer o1) (:observer o2)])
+                              packed)
+    (is (= 1 (count @(:received o1))))
+    (is (= 1 (count @(:received o2))))
+    (let [msg (first @(:received o1))]
+      (is (instance? instant.grpc.PackedWalRecord msg))
+      (is (= (seq packed) (seq (:ba msg)))))))
+
+(deftest broadcast-wal-record-isolates-a-failing-observer
+  (let [good (fake-observer {})
+        bad (fake-observer {:throw? true})]
+    (inv/broadcast-wal-record (fn [] [(:observer bad) (:observer good)])
+                              (byte-array [1]))
+    (is (= 1 (count @(:received good)))
+        "good observer still receives the record even though bad one threw")))
+
+(deftest broadcast-slot-disconnect-sends-to-every-observer-and-isolates-failures
+  (let [good (fake-observer {})
+        bad (fake-observer {:throw? true})]
+    (inv/broadcast-slot-disconnect {:get-remote-observers
+                                    (fn [] [(:observer bad) (:observer good)])})
+    (is (= 1 (count @(:received good))))
+    (is (instance? instant.grpc.SlotDisconnect (first @(:received good))))))
+
+;; ------
+;; handle-grpc-subscribe
+
+(deftest handle-grpc-subscribe-with-no-local-processes-rejects
+  (with-fresh-registry
+    (let [{:keys [observer state]} (fake-server-observer)
+          req (grpc/->InvalidatorSubscribe (random-uuid) (int 1))]
+      (inv/handle-grpc-subscribe req observer)
+      (is (:completed? @state)
+          "observer completes immediately when no local processes are registered")
+      (is (empty? (:remote-observers @inv/grpc-registry))))))
+
+(deftest handle-grpc-subscribe-registers-and-triggers-subscribe
+  (with-fresh-registry
+    (let [{:keys [observer state]} (fake-server-observer)
+          machine-id (random-uuid)
+          req (grpc/->InvalidatorSubscribe machine-id (int 1))
+          subscribed (atom [])]
+      (swap! inv/grpc-registry assoc-in
+             [:local-processes 99]
+             {:subscribe (fn [mid] (swap! subscribed conj mid))})
+      (inv/handle-grpc-subscribe req observer)
+      (is (not (:completed? @state)))
+      (is (instance? Runnable (:on-close @state)) "close handler installed")
+      (is (instance? Runnable (:on-cancel @state)) "cancel handler installed")
+      (is (= [machine-id] @subscribed))
+      (is (= observer
+             (get-in @inv/grpc-registry [:remote-observers req]))))))
+
+(deftest handle-grpc-subscribe-cancel-handler-removes-observer
+  (with-fresh-registry
+    (let [{:keys [observer state]} (fake-server-observer)
+          req (grpc/->InvalidatorSubscribe (random-uuid) (int 1))]
+      (swap! inv/grpc-registry assoc-in
+             [:local-processes 1] {:subscribe (fn [_])})
+      (inv/handle-grpc-subscribe req observer)
+      (is (some? (get-in @inv/grpc-registry [:remote-observers req])))
+      (.run ^Runnable (:on-cancel @state))
+      (is (nil? (get-in @inv/grpc-registry [:remote-observers req]))))))
+
+;; ------
+;; cleanup-local-process
+
+(deftest cleanup-local-process-closes-observers-when-last-process-leaves
+  (with-fresh-registry
+    (let [{obs-1 :observer state-1 :state} (fake-server-observer)
+          {obs-2 :observer state-2 :state} (fake-server-observer)
+          req-1 (grpc/->InvalidatorSubscribe (random-uuid) (int 1))
+          req-2 (grpc/->InvalidatorSubscribe (random-uuid) (int 2))]
+      (reset! inv/grpc-registry
+              {:local-processes {42 {:subscribe (fn [_])}}
+               :remote-observers {req-1 obs-1
+                                  req-2 obs-2}})
+      (inv/cleanup-local-process 42)
+      (is (empty? (:local-processes @inv/grpc-registry)))
+      (is (empty? (:remote-observers @inv/grpc-registry)))
+      (is (:completed? @state-1))
+      (is (:completed? @state-2)))))
+
+(deftest cleanup-local-process-keeps-observers-when-other-processes-remain
+  (with-fresh-registry
+    (let [{obs-1 :observer state-1 :state} (fake-server-observer)
+          req-1 (grpc/->InvalidatorSubscribe (random-uuid) (int 1))]
+      (reset! inv/grpc-registry
+              {:local-processes {1 {:subscribe (fn [_])}
+                                 2 {:subscribe (fn [_])}}
+               :remote-observers {req-1 obs-1}})
+      (inv/cleanup-local-process 1)
+      (is (= #{2} (set (keys (:local-processes @inv/grpc-registry)))))
+      (is (some? (get-in @inv/grpc-registry [:remote-observers req-1])))
+      (is (not (:completed? @state-1))))))
+
+;; ------
+;; make-subscription-observer
+
+(defn build-subscription-observer [{:keys [queue on-cancel]}]
+  (let [prev (atom nil)
+        chan (a/chan 4)]
+    {:observer (inv/make-subscription-observer
+                {:queue queue
+                 :previous-isn-atom prev
+                 :acquire-slot-interrupt-chan chan}
+                (random-uuid)
+                (or on-cancel (fn [])))
+     :previous-isn-atom prev
+     :acquire-slot-interrupt-chan chan}))
+
+(deftest make-subscription-observer-routes-wal-records-to-queue
+  (let [{:keys [queue records stop]} (capture-queue)
+        {:keys [observer previous-isn-atom]} (build-subscription-observer {:queue queue})
+        rec (make-wal-record {:isn (isn/test-isn 10) :tx-id 1})]
+    (try
+      (.onNext ^StreamObserver observer rec)
+      (wait-for #(seq @records) 1000)
+      (is (= [rec] @records))
+      (is (= (isn/test-isn 10) @previous-isn-atom))
+      (finally (stop)))))
+
+(deftest make-subscription-observer-unpacks-packed-wal-records
+  (let [{:keys [queue records stop]} (capture-queue)
+        {:keys [observer]} (build-subscription-observer {:queue queue})
+        rec (make-wal-record {:isn (isn/test-isn 7) :tx-id 3})
+        packed (history-model/pack-wal-record rec)]
+    (try
+      (.onNext ^StreamObserver observer (grpc/->PackedWalRecord packed))
+      (wait-for #(seq @records) 1000)
+      (is (= 1 (count @records)))
+      (is (= (:tx-id rec) (:tx-id (first @records))))
+      (finally (stop)))))
+
+(deftest make-subscription-observer-forwards-slot-disconnect
+  (let [{:keys [queue stop]} (capture-queue)
+        {:keys [observer acquire-slot-interrupt-chan]}
+        (build-subscription-observer {:queue queue})]
+    (try
+      (.onNext ^StreamObserver observer (grpc/->SlotDisconnect))
+      (is (true? (first (a/alts!! [acquire-slot-interrupt-chan
+                                   (a/timeout 1000)]))))
+      (finally (stop)))))
+
+(deftest make-subscription-observer-runs-on-cancel-on-completed
+  (let [{:keys [queue stop]} (capture-queue)
+        cancelled? (atom false)
+        {:keys [observer]} (build-subscription-observer
+                            {:queue queue
+                             :on-cancel #(reset! cancelled? true)})]
+    (try
+      (.onCompleted ^StreamObserver observer)
+      (is @cancelled?)
+      (finally (stop)))))
+
+(deftest make-subscription-observer-runs-on-cancel-on-error
+  (let [{:keys [queue stop]} (capture-queue)
+        cancelled? (atom false)
+        {:keys [observer]} (build-subscription-observer
+                            {:queue queue
+                             :on-cancel #(reset! cancelled? true)})]
+    (try
+      (.onError ^StreamObserver observer (ex-info "boom" {}))
+      (is @cancelled?)
+      (finally (stop)))))
+
+(comment
+  (test/run-tests *ns*))

--- a/server/test/instant/reactive/invalidator_test.clj
+++ b/server/test/instant/reactive/invalidator_test.clj
@@ -7,14 +7,11 @@
    [instant.db.transaction :as tx]
    [instant.fixtures :refer [with-zeneca-app]]
    [instant.jdbc.aurora :as aurora]
-   [instant.reactive.ephemeral :as eph]
    [instant.reactive.topics :as topics]
    [instant.reactive.invalidator :as inv]
    [instant.util.crypt :as crypt-util]
    [instant.util.json :refer [->json]]
-   [instant.util.test :refer [wait-for]])
-  (:import
-   (com.hazelcast.topic Message)))
+   [instant.util.test :refer [wait-for]]))
 
 (defn transform-change [{:keys [columnnames columntypes columnvalues] :as v1}]
   (merge (select-keys v1 [:schema :table])
@@ -533,35 +530,6 @@
 
               (finally
                 (inv/stop process)))))))))
-
-(deftest topic-listener-ignores-old-messages
-  (let [hz (eph/get-hz)
-        topic-name (str "test-topic-" (crypt-util/random-hex 8))
-        topic (.getReliableTopic (eph/get-hz) topic-name)]
-    (try
-      (let [ring-buffer (inv/topic-ring-buffer hz topic-name)
-            ;; Publish some messages to load up the queue
-            _ (dotimes [x 5] (.publish topic {:type :before-listener-added
-                                              :i x}))
-            msgs (atom [])
-            ;; Add listener after the messages were adde
-            listener (inv/hz-topic-listener ring-buffer (fn [^Message m]
-                                                          (swap! msgs conj (.getMessageObject m))))]
-        (.addMessageListener topic listener)
-
-        (dotimes [x 5] (.publish topic {:type :after-listener-added
-                                        :i x}))
-
-        (wait-for (fn []
-                    (<= 5 (count @msgs)))
-                  1000)
-
-        (is (every? (fn [m]
-                      (= :after-listener-added (:type m)))
-                    @msgs)
-            "Listener shouldn't get any of the messages that were added before, but should get all of the messages added after."))
-      (finally
-        (.destroy topic)))))
 
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
We had a singleton invalidator that distributed wal records to all machines with Hazelcast (see https://github.com/instantdb/instant/pull/2179), but we ran into issues with the hazelcast Topic stalling out in production.

This PR uses our grpc connection to distribute the wal records between machines. It also stores a little data about them in a new `history` table, and the full wal record in s3 (with a fallback to the history table).

### How it works

On startup, we'll create the permanent `invalidator` replication slot if it doesn't exist. 

We'll use the hazelcast member watcher to initiate grpc subscriptions to each machine and they will also initiate connections with us. It creates n^2 connections, but we can switch to a better system once that becomes a bottleneck (even with 1000 nodes, I think we would probably be fine with the current system, since each node would still only make 999 connections and only one node distributes writes).

If we happen to get the slot, then we'll distribute the wal records to all of the subscribers as we process them. Right now, we'll just log the latency (we even create a grouped queue to try to replicate what the normal invalidator does). This will help us ensure that we're not adding a bunch of latency compared to our current invalidator.

The owner of the slot will also push the wal records into the history table. The history table is partitioned into 30-day buckets, so that we can easily truncate older transactions (it's set to retain the last 90 days right now). I tried to make writing to the history table very efficient--the rows are compact at just 96 bytes each (if we don't store the wal records in them).

The history table exists so that we can distribute webhook payloads on entity create/update/delete (that's coming up next!). I'll be testing two methods of storing the wal-record content. Our two options right now are 1. an s3 directory bucket, and 2. the content column of the history table. We can toggle between them with a flag. I'll be checking the latency and cost for each approach.


If there are issues, we can turn it off with the `disable-singleton-invalidator` flag, and we can even prevent it from starting up by setting `prevent-singleton-invalidator-startup` to true in the `config` table (can't use a flag for that b/c flags start up after the invalidator).


Other changes:

- Adds an "auto-cycle" to the colors playground to make it easy to test lots of transactions
- Added some grpc metrics to gauges
