### PR TITLE
fix components package build

### DIFF
--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -244,6 +244,7 @@ export function TextInput({
         // the value as discs visually.
         type={type === 'sensitive' ? 'text' : (type ?? 'text')}
         style={
+          // @ts-expect-error non-standard css property
           type === 'sensitive' ? { WebkitTextSecurity: 'disc' } : undefined
         }
         // Turn off the text-entry protections that `type="password"`


### PR DESCRIPTION
<img width="1655" height="221" alt="image" src="https://github.com/user-attachments/assets/cad1317f-678a-417b-9ba1-188163ab1a9d" />

Fixes an error when trying to build the components package. Interestingly enough, this error doesn't cause the build to fail which is why CI has been passing but it is annoying to see pop up. 