### PR TITLE
Add hyperlinks to CLI output

### DIFF
--- a/client/packages/cli/package.json
+++ b/client/packages/cli/package.json
@@ -51,7 +51,7 @@
     "sisteransi": "^1.0.5",
     "string-width": "^8.1.0",
     "strip-ansi": "^7.1.2",
-    "terminal-link": "^3.0.0",
+    "supports-hyperlinks": "^4.4.0",
     "unconfig": "^0.5.5"
   },
   "scripts": {

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -31,6 +31,7 @@ import {
 import { UI } from '../../../ui/index.ts';
 import chalk from 'chalk';
 import boxen from 'boxen';
+import { link } from '../../../logging.ts';
 
 export const ClientTypeSchema = Schema.Literal(
   'google',
@@ -129,7 +130,7 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     required: true,
     skipIf: false,
     prompt: {
-      prompt: `Client ID: ${chalk.dim('(from https://console.developers.google.com/apis/credentials)')}`,
+      prompt: `Client ID: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
         UI.modifiers.dimOnComplete,
@@ -143,7 +144,7 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     skipIf: appType !== 'web',
     simpleName: '--client-secret',
     prompt: {
-      prompt: `Client Secret: ${chalk.dim('(from https://console.developers.google.com/apis/credentials)')}`,
+      prompt: `Client Secret: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
       validate: validateRequired,
       sensitive: true,
       modifyOutput: UI.modifiers.piped([
@@ -240,7 +241,7 @@ const handleGithubClient = Effect.fn(function* (opts: Record<string, unknown>) {
     required: true,
     skipIf: false,
     prompt: {
-      prompt: `Client ID ${chalk.dim('(from https://github.com/settings/developers)')}`,
+      prompt: `Client ID ${chalk.dim(`(from ${link('https://github.com/settings/developers')})`)}`,
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
         UI.modifiers.dimOnComplete,
@@ -254,7 +255,7 @@ const handleGithubClient = Effect.fn(function* (opts: Record<string, unknown>) {
     skipIf: false,
     simpleName: '--client-secret',
     prompt: {
-      prompt: `Client Secret: ${chalk.dim('(from https://github.com/settings/developers)')}`,
+      prompt: `Client Secret: ${chalk.dim(`(from ${link('https://github.com/settings/developers')})`)}`,
       validate: validateRequired,
       sensitive: true,
       modifyOutput: UI.modifiers.piped([
@@ -345,7 +346,7 @@ const handleLinkedInClient = Effect.fn(function* (
     required: true,
     skipIf: false,
     prompt: {
-      prompt: `Client ID: ${chalk.dim('(from https://www.linkedin.com/developers/apps)')}`,
+      prompt: `Client ID: ${chalk.dim(`(from ${link('https://www.linkedin.com/developers/apps')})`)}`,
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
         UI.modifiers.dimOnComplete,
@@ -359,7 +360,7 @@ const handleLinkedInClient = Effect.fn(function* (
     skipIf: false,
     simpleName: '--client-secret',
     prompt: {
-      prompt: `Client Secret: ${chalk.dim('(from https://www.linkedin.com/developers/apps)')}`,
+      prompt: `Client Secret: ${chalk.dim(`(from ${link('https://www.linkedin.com/developers/apps')})`)}`,
       validate: validateRequired,
       sensitive: true,
       modifyOutput: UI.modifiers.piped([
@@ -475,7 +476,7 @@ const handleAppleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     required: true,
     skipIf: false,
     prompt: {
-      prompt: `Services ID ${chalk.dim('(from https://developer.apple.com/account/resources/identifiers/list/serviceId)')}`,
+      prompt: `Services ID ${chalk.dim(`(from ${link('https://developer.apple.com/account/resources/identifiers/list/serviceId')})`)}`,
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
         UI.modifiers.dimOnComplete,
@@ -518,7 +519,7 @@ const handleAppleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     skipIf: skipWeb,
     skipMessage: `--team-id ${webSkipMessage}`,
     prompt: {
-      prompt: `Team ID ${chalk.dim('(from https://developer.apple.com/account#MembershipDetailsCard)')}`,
+      prompt: `Team ID ${chalk.dim(`(from ${link('https://developer.apple.com/account#MembershipDetailsCard')})`)}`,
       validate: validateRequired,
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
@@ -533,7 +534,7 @@ const handleAppleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     skipIf: skipWeb,
     skipMessage: `--key-id ${webSkipMessage}`,
     prompt: {
-      prompt: `Key ID ${chalk.dim('(from https://developer.apple.com/account/resources/authkeys/list)')}`,
+      prompt: `Key ID ${chalk.dim(`(from ${link('https://developer.apple.com/account/resources/authkeys/list')})`)}`,
       validate: validateRequired,
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,
@@ -621,7 +622,7 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
     summaryLines.push(`Key ID: ${keyId}`);
     summaryLines.push(
       chalk.bold(
-        `\nAdd this return URL under your Services ID on developer.apple.com:\n${redirectUri}\n`,
+        `\nAdd this return URL under your Services ID on ${link('https://developer.apple.com', 'developer.apple.com')}:\n${redirectUri}\n`,
       ),
     );
     if (customRedirectUri) {
@@ -652,7 +653,7 @@ const handleClerkClient = Effect.fn(function* (opts: Record<string, unknown>) {
     required: true,
     skipIf: false,
     prompt: {
-      prompt: `Clerk publishable key ${chalk.dim('(from https://dashboard.clerk.com/last-active?path=api-keys)')}`,
+      prompt: `Clerk publishable key ${chalk.dim(`(from ${link('https://dashboard.clerk.com/last-active?path=api-keys')})`)}`,
       placeholder:
         'pk_********************************************************',
       modifyOutput: UI.modifiers.piped([
@@ -736,8 +737,7 @@ const handleFirebaseClient = Effect.fn(function* (
     required: true,
     skipIf: false,
     prompt: {
-      prompt:
-        'Firebase project ID: (From Project Settings page on https://console.firebase.google.com/)',
+      prompt: `Firebase project ID: (From Project Settings page on ${link('https://console.firebase.google.com/')})`,
       placeholder: '',
       modifyOutput: UI.modifiers.piped([
         UI.modifiers.topPadding,

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -1,5 +1,4 @@
 import { loadEnv } from './util/loadEnv.ts';
-import supportsHyperlinks from 'supports-hyperlinks';
 
 loadEnv();
 
@@ -126,9 +125,9 @@ Provider Specific Options:
    --client-secret
    --custom-redirect-uri      (optional)
   Clerk:
-   --publishable-key    (Publishable Key from dashboard.clerk.com)
+   --publishable-key    (Publishable Key from ${link('https://dashboard.clerk.com', 'dashboard.clerk.com')})
   Firebase:
-   --project-id         (Project ID from console.firebase.google.com)
+   --project-id         (Project ID from ${link('https://console.firebase.google.com', 'console.firebase.google.com')})
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -1,4 +1,6 @@
 import { loadEnv } from './util/loadEnv.ts';
+import supportsHyperlinks from 'supports-hyperlinks';
+
 loadEnv();
 
 import minimist from 'minimist';
@@ -28,6 +30,7 @@ import { PACKAGE_ALIAS_AND_FULL_NAMES } from './context/projectInfo.ts';
 import { authClientAddCmd } from './commands/auth/client/add.ts';
 import { authClientListCmd } from './commands/auth/client/list.ts';
 import { authClientDeleteCmd } from './commands/auth/client/delete.ts';
+import { link } from './logging.ts';
 
 export type OptsFromCommand<C> =
   C extends Command<any, infer R, any> ? R : never;
@@ -113,7 +116,7 @@ Provider Specific Options:
    --client-secret
    --custom-redirect-uri      (optional)
   Apple:
-   --services-id              (Services ID from developer.apple.com)
+   --services-id              (Services ID from ${link('https://developer.apple.com', 'developer.apple.com')})
    --team-id                  (optional, required for web redirect flow)
    --key-id                   (optional, required for web redirect flow)
    --private-key-file         (optional, path to .p8 PEM; required for web redirect flow)

--- a/client/packages/cli/src/lib/handleEnv.ts
+++ b/client/packages/cli/src/lib/handleEnv.ts
@@ -6,9 +6,9 @@ import { readPackage } from 'pkg-types';
 import { GlobalOpts } from '../context/globalOpts.ts';
 import { FileSystem, Path } from '@effect/platform';
 import chalk from 'chalk';
-import terminalLink from 'terminal-link';
 import { getDashUrl } from './http.ts';
 import { promptOk } from './ui.ts';
+import { link } from '../logging.ts';
 
 export const handleEnv = Effect.fn(function* (app: CurrentAppInfo) {
   const opts = yield* GlobalOpts;
@@ -107,7 +107,7 @@ function printDotEnvInfo(
   otherEnvs.sort();
   const otherEnvStr = otherEnvs.map((x) => '  ' + chalk.green(x)).join('\n');
   console.log(`Alternative names: \n${otherEnvStr} \n`);
-  console.log(terminalLink('Dashboard:', appDashUrl(appId, dashOrigin)) + '\n');
+  console.log(link(appDashUrl(appId, dashOrigin), 'Dashboard:') + '\n');
 }
 
 function appDashUrl(id: string, instantOrigin: string) {

--- a/client/packages/cli/src/lib/handleEnv.ts
+++ b/client/packages/cli/src/lib/handleEnv.ts
@@ -107,7 +107,9 @@ function printDotEnvInfo(
   otherEnvs.sort();
   const otherEnvStr = otherEnvs.map((x) => '  ' + chalk.green(x)).join('\n');
   console.log(`Alternative names: \n${otherEnvStr} \n`);
-  console.log(link(appDashUrl(appId, dashOrigin), 'Dashboard:') + '\n');
+  console.log(
+    `${link(appDashUrl(appId, dashOrigin))}: ${appDashUrl(appId, dashOrigin)}\n`,
+  );
 }
 
 function appDashUrl(id: string, instantOrigin: string) {

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -11,6 +11,7 @@ import {
 } from './ui.ts';
 import { UI } from '../ui/index.ts';
 import { BadArgsError } from '../errors.ts';
+import { link } from '../logging.ts';
 import type { ClientTypeSchema } from '../commands/auth/client/add.ts';
 
 export const AuthorizedOriginService = Schema.Literal(
@@ -146,7 +147,7 @@ export const promptForRedirectURI = Effect.fn(function* (
             return (
               `\nCustom redirect URL (optional):
 ${chalk.dim('With a custom redirect URL, users will see "Redirecting to yoursite.com..." for a more branded experience.')}
-${chalk.dim('Your URL must forward to https://api.instantdb.com/runtime/oauth/callback with all query parameters preserved.')}\n\n` +
+${chalk.dim(`Your URL must forward to ${link('https://api.instantdb.com/runtime/oauth/callback')} with all query parameters preserved.`)}\n\n` +
               stripFirstBlankLine(output)
             );
           }

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -4,7 +4,6 @@ import { CurrentApp } from '../context/currentApp.ts';
 import { InstantHttpAuthed, withCommand } from './http.ts';
 import chalk from 'chalk';
 import {
-  getOptionalStringFlag,
   optOrPrompt,
   runUIEffect,
   stripFirstBlankLine,

--- a/client/packages/cli/src/logging.ts
+++ b/client/packages/cli/src/logging.ts
@@ -34,8 +34,8 @@ export const SimpleLogLayer = Logger.replace(
 );
 
 export const link = (url: string, text?: string): string => {
-  if (supportsHyperlinks) {
+  if (supportsHyperlinks.stdout) {
     return ansiEscapes.link(text ?? url, url);
   }
-  return url;
+  return text ?? url;
 };

--- a/client/packages/cli/src/logging.ts
+++ b/client/packages/cli/src/logging.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
+import ansiEscapes from 'ansi-escapes';
 import { HashMap, Logger, Match, Option } from 'effect';
+import supportsHyperlinks from 'supports-hyperlinks';
 
 export function warn(firstArg: string, ...rest: any[]) {
   console.warn(chalk.yellow('[warning]') + ' ' + firstArg, ...rest);
@@ -30,3 +32,10 @@ export const SimpleLogLayer = Logger.replace(
   Logger.defaultLogger,
   simpleLogger,
 );
+
+export const link = (url: string, text?: string): string => {
+  if (supportsHyperlinks) {
+    return ansiEscapes.link(text ?? url, url);
+  }
+  return url;
+};

--- a/client/packages/cli/src/old.js
+++ b/client/packages/cli/src/old.js
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import { program } from '@commander-js/extra-typings';
 import { readFile } from 'fs/promises';
 import path from 'path';
-import terminalLink from 'terminal-link';
 import { UI } from './ui/index.ts';
 import { deferred, renderUnwrap } from './ui/lib.ts';
 import {
@@ -12,9 +11,9 @@ import {
 } from './util/findConfigCandidates.ts';
 import { getAuthPaths } from './util/getAuthPaths.ts';
 import { loadConfig } from './util/loadConfig.ts';
-import { loadEnv } from './util/loadEnv.ts';
 import { ResolveRenamePrompt } from './util/renamePrompt.ts';
 import version from './version.js';
+import { link } from './logging.ts';
 
 const dev = Boolean(process.env.INSTANT_CLI_DEV);
 const verbose = Boolean(process.env.INSTANT_CLI_VERBOSE);
@@ -119,9 +118,7 @@ function indexingJobCompletedMessage(job) {
           header: 'id',
           width: 37,
           getValue: (triple) =>
-            terminalLink(triple.entity_id, createUrl(triple, job).toString(), {
-              fallback: () => triple.entity_id,
-            }),
+            link(createUrl(triple, job).toString(), triple.entity_id),
         },
         {
           header: label,

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.17';
+const version = 'v1.0.18';
 
 export { version };

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -156,9 +156,9 @@ importers:
       strip-ansi:
         specifier: ^7.1.2
         version: 7.1.2
-      terminal-link:
-        specifier: ^3.0.0
-        version: 3.0.0
+      supports-hyperlinks:
+        specifier: ^4.4.0
+        version: 4.4.0
       unconfig:
         specifier: ^0.5.5
         version: 0.5.5
@@ -3999,7 +3999,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.20.3':
     resolution: {integrity: sha512-+nL2f6ZPV6e4yXS0P02jChstSJePihfFluapqnRM8+4pH4wsBOL1GoOc7hVFfwsP0vRE3HDqn5EEzrO+ZaCbpQ==}
@@ -11261,6 +11261,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -15624,6 +15628,10 @@ packages:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
     engines: {node: '>=18'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -15643,6 +15651,10 @@ packages:
   supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
+
+  supports-hyperlinks@4.4.0:
+    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
+    engines: {node: '>=20'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -29045,6 +29057,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-flag@5.0.1: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -34543,6 +34557,8 @@ snapshots:
 
   supports-color@10.0.0: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -34564,6 +34580,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
 
   supports-preserve-symlinks-flag@1.0.0: {}
 


### PR DESCRIPTION
Adds hyperlinks via ascii codes wherever applicable, especially in the Oauth client commands. 

I noticed that previously we were using the terminal-link package. But that package was not properly detecting the hyperlink support in both ghostty and zed (alacritty based) for me. Re-implementing the library from its 2 dependencies made it work consistently. 

How to test:
`git switch drewh/cli-links && cd client && pnpm i`
`cd sandbox/cli-nodejs`
`pnpm exec instant-cli auth client add -h`
Validate that hyperlink for apple developer site works. 