### PR TITLE
Strengthen no-cache headers on /getadb

### DIFF
--- a/client/www/app/getadb/route.ts
+++ b/client/www/app/getadb/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { getServerConfig } from '@/lib/config';
 import generateMarkdown from './generateMarkdown';
 
@@ -22,6 +23,7 @@ export async function GET(request: Request) {
       Pragma: 'no-cache',
       Expires: '0',
       Vary: '*',
+      ETag: `"${randomUUID()}"`,
       'Content-Disposition': 'inline; filename="AGENTS.md"',
       'Content-Type': 'text/markdown; charset=utf-8',
     },

--- a/client/www/app/getadb/route.ts
+++ b/client/www/app/getadb/route.ts
@@ -17,7 +17,11 @@ export async function GET(request: Request) {
 
   return new Response(markdown, {
     headers: {
-      'Cache-Control': 'private, no-store, max-age=0',
+      'Cache-Control':
+        'private, no-store, no-cache, max-age=0, must-revalidate, proxy-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
+      Vary: '*',
       'Content-Disposition': 'inline; filename="AGENTS.md"',
       'Content-Type': 'text/markdown; charset=utf-8',
     },


### PR DESCRIPTION
- Some fetchers (e.g. v0's WebFetch) appear to cache `getadb.com` responses globally despite `Cache-Control: no-store`
- Belt-and-suspenders: added the legacy HTTP/1.0 fallbacks (`Pragma: no-cache`, `Expires: 0`), `must-revalidate`, `proxy-revalidate`, and `Vary: *`

@dwwoelfel @nezaj @drew-harris 