### PR TITLE
Redirect /getadb with a unique n param to bust upstream caches

### DIFF
--- a/client/www/app/getadb/route.ts
+++ b/client/www/app/getadb/route.ts
@@ -1,17 +1,44 @@
 import { randomUUID } from 'crypto';
+import { customAlphabet } from 'nanoid';
 import { getServerConfig } from '@/lib/config';
 import generateMarkdown from './generateMarkdown';
+
+// Base58 alphabet (omits confusable 0/O, I/l). Shorter and prettier than a
+// UUID in the URL bar. See https://www.unkey.com/blog/uuid-ux
+const nanoid = customAlphabet(
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
+  16,
+);
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: Request) {
+  const url = new URL(request.url);
+
+  // Redirect to a URL with a unique `n` so upstream fetchers (e.g. v0's
+  // WebFetch) can't reuse a cached response across users.
+  if (!url.searchParams.has('n')) {
+    const redirectUrl = new URL(url);
+    redirectUrl.searchParams.set('n', nanoid());
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: redirectUrl.toString(),
+        'Cache-Control':
+          'private, no-store, no-cache, max-age=0, must-revalidate, proxy-revalidate',
+        Pragma: 'no-cache',
+        Expires: '0',
+        Vary: '*',
+      },
+    });
+  }
+
   const token = process.env.GET_A_DB_PERSONAL_ACCESS_TOKEN;
   if (!token) {
     throw new Error('GET_A_DB_PERSONAL_ACCESS_TOKEN is not set');
   }
-  const title =
-    new URL(request.url).searchParams.get('title')?.trim() || DEFAULT_APP_TITLE;
+  const title = url.searchParams.get('title')?.trim() || DEFAULT_APP_TITLE;
   const app = await createApp(token, title);
 
   const markdown = await generateMarkdown(request, app);

--- a/client/www/app/getadb/route.ts
+++ b/client/www/app/getadb/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: Request) {
     const redirectUrl = new URL(url);
     redirectUrl.searchParams.set('n', nanoid());
     return new Response(null, {
-      status: 302,
+      status: 307,
       headers: {
         Location: redirectUrl.toString(),
         'Cache-Control':


### PR DESCRIPTION
## Summary
- Follow-up to #2599. Even with hard no-cache headers, upstream fetchers (notably v0's WebFetch) were still serving a cached `/getadb` response to different users.
- The cache key is the URL, so we now 302 bare `/getadb` → `/getadb?n=<base58 nanoid>`. Each new visitor gets a unique URL and therefore a unique cache entry.
- The `n` uses Unkey's base58 alphabet via `nanoid` (16 chars, omits confusable `0/O`, `I/l`) so the URL stays readable. See https://www.unkey.com/blog/uuid-ux.
- The redirect response itself is marked no-store so the 302 can't be cached either.

## Test plan
- [ ] `curl -i https://instantdb.com/getadb` returns a 302 with `Location: /getadb?n=<16 chars>` and no-store headers.
- [ ] Following the redirect returns the AGENTS.md markdown.
- [ ] Visiting `/getadb` twice in a row produces two different `n` values in the `Location`.
- [ ] `?title=Foo` is preserved through the redirect.
- [ ] Asking v0 to fetch `/getadb` no longer returns a stale / shared app.