### PR TITLE
Manage OAuth Redirects from the CLI (#2603) [bump to v1.0.20]

### DIFF
--- a/client/packages/cli/__tests__/authOriginManagement.test.ts
+++ b/client/packages/cli/__tests__/authOriginManagement.test.ts
@@ -1,0 +1,308 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import { InstantHttpAuthed } from '../src/lib/http.ts';
+
+// -- mocks --
+
+// Prevent src/index.ts side-effect (program.parse) from running.
+// The command files import types from index.ts, but vitest still evaluates it.
+vi.mock('../src/index.ts', () => ({}));
+
+let prompts: any[] = [];
+let mockPromptReturn: any = '';
+
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: (prompt: any) => {
+      prompts.push(prompt);
+      return Promise.resolve(mockPromptReturn);
+    },
+  };
+});
+
+let origins: any[] = [];
+let addedOrigins: any[] = [];
+let removedOriginIds: string[] = [];
+
+vi.mock('../src/lib/oauth.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    getAppsAuth: () =>
+      Effect.succeed({
+        authorized_redirect_origins: origins,
+        oauth_service_providers: [],
+        oauth_clients: [],
+      }),
+    addAuthorizedOrigin: (params: any) => {
+      addedOrigins.push(params);
+      return Effect.succeed({
+        origin: {
+          id: `origin-${addedOrigins.length}`,
+          service: params.service,
+          params: params.params,
+        },
+      });
+    },
+    removeAuthorizedOrigin: (originId: string) => {
+      removedOriginIds.push(originId);
+      return Effect.succeed({
+        origin: origins.find((origin) => origin.id === originId) ?? {
+          id: originId,
+          service: 'generic',
+          params: ['example.com'],
+        },
+      });
+    },
+  };
+});
+
+// Lazy import so mocks are in place.
+const { authOriginAddCmd } = await import('../src/commands/auth/origin/add.ts');
+const { authOriginDeleteCmd } = await import(
+  '../src/commands/auth/origin/delete.ts'
+);
+const { authOriginListCmd } = await import(
+  '../src/commands/auth/origin/list.ts'
+);
+
+// -- helpers --
+
+let logs: string[] = [];
+
+type TestContext = GlobalOpts | CurrentApp | InstantHttpAuthed;
+
+const run = (
+  cmd: Effect.Effect<void, any, TestContext>,
+  { yes }: { yes: boolean },
+) =>
+  Effect.runPromise(
+    cmd.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(GlobalOpts, { yes }),
+          Layer.succeed(CurrentApp, { appId: 'test-app', source: 'env' }),
+          Layer.succeed(InstantHttpAuthed, {} as any),
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => {
+              logs.push(String(message));
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+const add = (flags: Map<string, string>, opts = { yes: true }) =>
+  run(authOriginAddCmd(Object.fromEntries(flags) as any), opts);
+
+const list = (flags: Map<string, any>, opts = { yes: true }) =>
+  run(authOriginListCmd(Object.fromEntries(flags) as any), opts);
+
+const remove = (flags: Map<string, string>, opts = { yes: true }) =>
+  run(authOriginDeleteCmd(Object.fromEntries(flags) as any), opts);
+
+const without = (flags: Map<string, string>, key: string) => {
+  const copy = new Map(flags);
+  copy.delete(key);
+  return copy;
+};
+
+beforeEach(() => {
+  prompts = [];
+  origins = [];
+  addedOrigins = [];
+  removedOriginIds = [];
+  logs = [];
+  mockPromptReturn = '';
+});
+
+// -- flag sets --
+
+const websiteFlags = new Map([
+  ['type', 'website'],
+  ['url', 'https://example.com/login'],
+]);
+
+const vercelFlags = new Map([
+  ['type', 'vercel'],
+  ['project', 'instant-preview'],
+]);
+
+const netlifyFlags = new Map([
+  ['type', 'netlify'],
+  ['site', 'instant-netlify'],
+]);
+
+const customSchemeFlags = new Map([
+  ['type', 'custom-scheme'],
+  ['scheme', 'instant://'],
+]);
+
+// -- add: build-up with --yes --
+
+describe('add: --yes errors on missing required flags', () => {
+  test('missing --type', async () => {
+    await add(without(websiteFlags, 'type'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --type');
+    expect(addedOrigins).toHaveLength(0);
+  });
+
+  test('website missing --url', async () => {
+    await add(without(websiteFlags, 'url'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --url');
+    expect(addedOrigins).toHaveLength(0);
+  });
+
+  test('vercel missing --project', async () => {
+    await add(without(vercelFlags, 'project'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --project');
+    expect(addedOrigins).toHaveLength(0);
+  });
+
+  test('netlify missing --site', async () => {
+    await add(without(netlifyFlags, 'site'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --site');
+    expect(addedOrigins).toHaveLength(0);
+  });
+
+  test('custom scheme missing --scheme', async () => {
+    await add(without(customSchemeFlags, 'scheme'), { yes: true });
+    expect(logs.join('\n')).toContain('Missing required value for --scheme');
+    expect(addedOrigins).toHaveLength(0);
+  });
+});
+
+// -- add: interactive prompts --
+
+describe('add: interactive prompts for missing flags', () => {
+  test('missing --type -> prompts type selector', async () => {
+    mockPromptReturn = 'website';
+    await add(without(websiteFlags, 'type'), { yes: false });
+    expect((prompts[0] as any).params.promptText).toBe(
+      'Select an origin type:',
+    );
+  });
+
+  test('website missing --url -> prompts for URL', async () => {
+    mockPromptReturn = 'example.com';
+    await add(without(websiteFlags, 'url'), { yes: false });
+    expect((prompts[0] as any).props.prompt).toBe('Website URL:');
+  });
+
+  test('delete missing --id -> prompts origin selector', async () => {
+    origins = [{ id: 'origin-1', service: 'generic', params: ['example.com'] }];
+    mockPromptReturn = origins[0];
+    await remove(new Map(), { yes: false });
+    expect((prompts[0] as any).params.promptText).toBe(
+      'Select an origin to delete:',
+    );
+    expect(removedOriginIds).toEqual(['origin-1']);
+  });
+});
+
+// -- add: success --
+
+describe('add: success', () => {
+  test('website origin -> creates generic origin with host only', async () => {
+    await add(websiteFlags, { yes: true });
+    expect(addedOrigins).toEqual([
+      { service: 'generic', params: ['example.com'] },
+    ]);
+    const output = logs.join('\n');
+    expect(output).toContain('Origin added: example.com');
+    expect(output).toContain('Type: Website');
+    expect(output).toContain('ID: origin-1');
+  });
+
+  test('website origin without protocol -> accepts domain', async () => {
+    await add(
+      new Map([
+        ['type', 'website'],
+        ['url', 'example.org'],
+      ]),
+      { yes: true },
+    );
+    expect(addedOrigins).toEqual([
+      { service: 'generic', params: ['example.org'] },
+    ]);
+  });
+
+  test('vercel origin -> creates vercel origin params', async () => {
+    await add(vercelFlags, { yes: true });
+    expect(addedOrigins).toEqual([
+      { service: 'vercel', params: ['vercel.app', 'instant-preview'] },
+    ]);
+    expect(logs.join('\n')).toContain('Origin added: instant-preview');
+  });
+
+  test('netlify origin -> creates netlify origin params', async () => {
+    await add(netlifyFlags, { yes: true });
+    expect(addedOrigins).toEqual([
+      { service: 'netlify', params: ['instant-netlify'] },
+    ]);
+  });
+
+  test('custom scheme origin -> creates custom scheme origin params', async () => {
+    await add(customSchemeFlags, { yes: true });
+    expect(addedOrigins).toEqual([
+      { service: 'custom-scheme', params: ['instant'] },
+    ]);
+    expect(logs.join('\n')).toContain('Origin added: instant://');
+  });
+});
+
+// -- list and delete --
+
+describe('list', () => {
+  test('prints configured origins', async () => {
+    origins = [
+      { id: 'origin-1', service: 'generic', params: ['example.com'] },
+      { id: 'origin-2', service: 'vercel', params: ['vercel.app', 'preview'] },
+    ];
+    await list(new Map(), { yes: true });
+    const output = logs.join('\n');
+    expect(output).toContain('example.com');
+    expect(output).toContain('Type: Website');
+    expect(output).toContain('ID: origin-1');
+    expect(output).toContain('preview');
+    expect(output).toContain('Type: Vercel project');
+  });
+
+  test('--json prints raw origins', async () => {
+    origins = [{ id: 'origin-1', service: 'generic', params: ['example.com'] }];
+    await list(new Map([['json', true]]), { yes: true });
+    expect(JSON.parse(logs.join('\n'))).toEqual(origins);
+  });
+});
+
+describe('delete', () => {
+  test('--id removes origin', async () => {
+    origins = [{ id: 'origin-1', service: 'generic', params: ['example.com'] }];
+    await remove(new Map([['id', 'origin-1']]), { yes: true });
+    expect(removedOriginIds).toEqual(['origin-1']);
+    expect(logs.join('\n')).toContain('Origin deleted!');
+  });
+
+  test('missing --id with --yes errors', async () => {
+    origins = [{ id: 'origin-1', service: 'generic', params: ['example.com'] }];
+    await expect(remove(new Map(), { yes: true })).rejects.toThrow(
+      'Must specify --id',
+    );
+    expect(removedOriginIds).toHaveLength(0);
+  });
+
+  test('no origins exits without deleting', async () => {
+    await remove(new Map(), { yes: false });
+    expect(logs.join('\n')).toContain(
+      'No authorized redirect origins configured.',
+    );
+    expect(prompts).toHaveLength(0);
+    expect(removedOriginIds).toHaveLength(0);
+  });
+});

--- a/client/packages/cli/src/commands/auth/origin/add.ts
+++ b/client/packages/cli/src/commands/auth/origin/add.ts
@@ -9,13 +9,20 @@ import chalk from 'chalk';
 import boxen from 'boxen';
 import { originDisplay, originSource } from './list.ts';
 
-export const OriginTypeSchema = Schema.Literal('generic');
+export const OriginTypeSchema = Schema.Literal(
+  'website',
+  'vercel',
+  'netlify',
+  'custom-scheme',
+);
 
 type OriginParams = string[];
 
-const validateGenericUrl = (
-  input: string,
-): { type: 'success'; params: OriginParams } | { type: 'error'; message: string } => {
+type Validated =
+  | { type: 'success'; params: OriginParams }
+  | { type: 'error'; message: string };
+
+const validateGenericUrl = (input: string): Validated => {
   const trimmed = input.trim();
   try {
     const url = new URL(trimmed);
@@ -35,11 +42,58 @@ const validateGenericUrl = (
   }
 };
 
+const validateNetlifyUrl = (input: string): Validated => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { type: 'error', message: 'Netlify site name is required.' };
+  }
+  return { type: 'success', params: [trimmed] };
+};
+
+const validateVercelUrl = (input: string): Validated => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { type: 'error', message: 'Vercel project name is required.' };
+  }
+  return { type: 'success', params: ['vercel.app', trimmed] };
+};
+
+const validateCustomScheme = (input: string): Validated => {
+  const trimmed = input.trim();
+  try {
+    const url = new URL(trimmed);
+    const scheme = url.protocol.slice(0, -1);
+    return { type: 'success', params: [scheme] };
+  } catch {
+    return { type: 'error', message: 'Invalid scheme.' };
+  }
+};
+
+const addOriginHandler = Effect.fn(function* (
+  type: Schema.Schema.Type<typeof OriginTypeSchema>,
+  validated: { params: OriginParams },
+) {
+  const response = yield* addAuthorizedOrigin({
+    service: type === 'website' ? 'generic' : type,
+    params: validated.params,
+  });
+
+  yield* Effect.log(
+    '\n' +
+      boxen(
+        [
+          `Origin added: ${originDisplay(response.origin)}`,
+          `Type: ${originSource(response.origin)}`,
+          `ID: ${response.origin.id}`,
+        ].join('\n'),
+        { dimBorder: true, padding: { right: 1, left: 1 } },
+      ),
+  );
+});
+
 const handleGenericOrigin = Effect.fn(function* (
   opts: Record<string, unknown>,
 ) {
-  const { yes } = yield* GlobalOpts;
-
   const url = yield* optOrPrompt(opts.url, {
     simpleName: '--url',
     required: true,
@@ -63,21 +117,80 @@ const handleGenericOrigin = Effect.fn(function* (
     return yield* BadArgsError.make({ message: validated.message });
   }
 
-  const response = yield* addAuthorizedOrigin({
-    service: 'generic',
-    params: validated.params,
+  yield* addOriginHandler('website', validated);
+});
+
+const handleVercelOrigin = Effect.fn(function* (opts: Record<string, unknown>) {
+  const project = yield* optOrPrompt(opts.project, {
+    simpleName: '--project',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'Vercel project name:',
+      placeholder: 'vercel-project-name',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
   });
 
-  yield* Effect.log('\n' + 
-    boxen(
-      [
-        `Origin added: ${originDisplay(response.origin)}`,
-        `Type: ${originSource(response.origin)}`,
-        `ID: ${response.origin.id}`,
-      ].join('\n'),
-      { dimBorder: true, padding: { right: 1, left: 1 } },
-    ),
-  );
+  const validated = validateVercelUrl(project ?? '');
+  if (validated.type === 'error') {
+    return yield* BadArgsError.make({ message: validated.message });
+  }
+
+  yield* addOriginHandler('vercel', validated);
+});
+
+const handleNetlifyOrigin = Effect.fn(function* (
+  opts: Record<string, unknown>,
+) {
+  const site = yield* optOrPrompt(opts.site, {
+    simpleName: '--site',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'Netlify site name:',
+      placeholder: 'netlify-site-name',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  const validated = validateNetlifyUrl(site ?? '');
+  if (validated.type === 'error') {
+    return yield* BadArgsError.make({ message: validated.message });
+  }
+
+  yield* addOriginHandler('netlify', validated);
+});
+
+const handleCustomSchemeOrigin = Effect.fn(function* (
+  opts: Record<string, unknown>,
+) {
+  const scheme = yield* optOrPrompt(opts.scheme, {
+    simpleName: '--scheme',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'App scheme:',
+      placeholder: 'app-scheme://',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  const validated = validateCustomScheme(scheme ?? '');
+  if (validated.type === 'error') {
+    return yield* BadArgsError.make({ message: validated.message });
+  }
+
+  yield* addOriginHandler('custom-scheme', validated);
 });
 
 export const authOriginAddCmd = Effect.fn(
@@ -94,7 +207,12 @@ export const authOriginAddCmd = Effect.fn(
       Effect.catchTag('NoSuchElementException', () =>
         runUIEffect(
           new UI.Select({
-            options: [{ label: 'Website', value: 'generic' }],
+            options: [
+              { label: 'Website', value: 'website' },
+              { label: 'Vercel previews', value: 'vercel' },
+              { label: 'Netlify previews', value: 'netlify' },
+              { label: 'App scheme', value: 'custom-scheme' },
+            ],
             promptText: 'Select an origin type:',
             modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
           }),
@@ -110,7 +228,10 @@ export const authOriginAddCmd = Effect.fn(
 
     yield* Match.value(originType).pipe(
       Match.withReturnType<Effect.Effect<void, any, any>>(),
-      Match.when('generic', () => handleGenericOrigin(opts)),
+      Match.when('website', () => handleGenericOrigin(opts)),
+      Match.when('vercel', () => handleVercelOrigin(opts)),
+      Match.when('netlify', () => handleNetlifyOrigin(opts)),
+      Match.when('custom-scheme', () => handleCustomSchemeOrigin(opts)),
       Match.exhaustive,
     );
   },

--- a/client/packages/cli/src/commands/auth/origin/add.ts
+++ b/client/packages/cli/src/commands/auth/origin/add.ts
@@ -1,0 +1,127 @@
+import { Effect, Match, Option, Schema } from 'effect';
+import type { authOriginAddDef, OptsFromCommand } from '../../../index.ts';
+import { BadArgsError } from '../../../errors.ts';
+import { GlobalOpts } from '../../../context/globalOpts.ts';
+import { optOrPrompt, runUIEffect } from '../../../lib/ui.ts';
+import { addAuthorizedOrigin } from '../../../lib/oauth.ts';
+import { UI } from '../../../ui/index.ts';
+import chalk from 'chalk';
+import boxen from 'boxen';
+import { originDisplay, originSource } from './list.ts';
+
+export const OriginTypeSchema = Schema.Literal('generic');
+
+type OriginParams = string[];
+
+const validateGenericUrl = (
+  input: string,
+): { type: 'success'; params: OriginParams } | { type: 'error'; message: string } => {
+  const trimmed = input.trim();
+  try {
+    const url = new URL(trimmed);
+    const host = url.host;
+    if (!host) {
+      throw new Error('missing host');
+    }
+    if (host.split('.').length === 1 && !url.port) {
+      throw new Error('invalid url');
+    }
+    return { type: 'success', params: [host] };
+  } catch {
+    if (!trimmed.startsWith('http')) {
+      return validateGenericUrl(`http://${trimmed}`);
+    }
+    return { type: 'error', message: 'Invalid URL.' };
+  }
+};
+
+const handleGenericOrigin = Effect.fn(function* (
+  opts: Record<string, unknown>,
+) {
+  const { yes } = yield* GlobalOpts;
+
+  const url = yield* optOrPrompt(opts.url, {
+    simpleName: '--url',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: 'Website URL:',
+      placeholder: 'example.com',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+
+  if (!url) {
+    return yield* BadArgsError.make({ message: 'URL is required.' });
+  }
+
+  const validated = validateGenericUrl(url);
+  if (validated.type === 'error') {
+    return yield* BadArgsError.make({ message: validated.message });
+  }
+
+  const response = yield* addAuthorizedOrigin({
+    service: 'generic',
+    params: validated.params,
+  });
+
+  yield* Effect.log('\n' + 
+    boxen(
+      [
+        `Origin added: ${originDisplay(response.origin)}`,
+        `Type: ${originSource(response.origin)}`,
+        `ID: ${response.origin.id}`,
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
+});
+
+export const authOriginAddCmd = Effect.fn(
+  function* (
+    opts: OptsFromCommand<typeof authOriginAddDef> & Record<string, unknown>,
+  ) {
+    const { yes } = yield* GlobalOpts;
+    if (!opts.type && yes) {
+      return yield* BadArgsError.make({
+        message: `Missing required value for --type. Expected one of: ${OriginTypeSchema.literals.join(', ')}`,
+      });
+    }
+    const originType = yield* Option.fromNullable(opts.type).pipe(
+      Effect.catchTag('NoSuchElementException', () =>
+        runUIEffect(
+          new UI.Select({
+            options: [{ label: 'Website', value: 'generic' }],
+            promptText: 'Select an origin type:',
+            modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
+          }),
+        ),
+      ),
+      Effect.andThen((s) => Schema.decodeUnknown(OriginTypeSchema)(s)),
+      Effect.catchTag('ParseError', () =>
+        BadArgsError.make({
+          message: `Invalid origin type, must be one of: ${OriginTypeSchema.literals.join(', ')}`,
+        }),
+      ),
+    );
+
+    yield* Match.value(originType).pipe(
+      Match.withReturnType<Effect.Effect<void, any, any>>(),
+      Match.when('generic', () => handleGenericOrigin(opts)),
+      Match.exhaustive,
+    );
+  },
+  Effect.catchTag('BadArgsError', (e) =>
+    Effect.gen(function* () {
+      yield* Effect.logError(e.message);
+      yield* Effect.log(
+        chalk.dim(
+          'hint: run `instant-cli auth origin add --help` for available arguments',
+        ),
+      );
+    }),
+  ),
+);

--- a/client/packages/cli/src/commands/auth/origin/delete.ts
+++ b/client/packages/cli/src/commands/auth/origin/delete.ts
@@ -1,0 +1,50 @@
+import chalk from 'chalk';
+import { Effect } from 'effect';
+import type { authOriginDeleteDef, OptsFromCommand } from '../../../index.ts';
+import { BadArgsError } from '../../../errors.ts';
+import { getAppsAuth, removeAuthorizedOrigin } from '../../../lib/oauth.ts';
+import { GlobalOpts } from '../../../context/globalOpts.ts';
+import { runUIEffect } from '../../../lib/ui.ts';
+import { UI } from '../../../ui/index.ts';
+import { originDisplay, originSource } from './list.ts';
+
+export const authOriginDeleteCmd = Effect.fn(function* (
+  opts: OptsFromCommand<typeof authOriginDeleteDef>,
+) {
+  const info = yield* getAppsAuth();
+  const origins = info.authorized_redirect_origins ?? [];
+
+  if (origins.length === 0) {
+    yield* Effect.log('No authorized redirect origins configured.');
+    return;
+  }
+
+  if (!opts.id) {
+    const { yes } = yield* GlobalOpts;
+    if (yes) {
+      return yield* BadArgsError.make({
+        message: 'Must specify --id',
+      });
+    }
+
+    const picked = yield* runUIEffect(
+      new UI.Select({
+        options: origins.map((origin) => ({
+          label:
+            `${originSource(origin)} — ${originDisplay(origin)} ` +
+            chalk.dim(`(${origin.id})`),
+          value: origin,
+        })),
+        promptText: 'Select an origin to delete:',
+      }),
+    );
+
+    yield* removeAuthorizedOrigin(picked.id);
+  }
+
+  if (opts.id) {
+    yield* removeAuthorizedOrigin(opts.id);
+  }
+
+  yield* Effect.log('Origin deleted!');
+});

--- a/client/packages/cli/src/commands/auth/origin/list.ts
+++ b/client/packages/cli/src/commands/auth/origin/list.ts
@@ -1,0 +1,62 @@
+import chalk from 'chalk';
+import { Effect, Schema } from 'effect';
+import type { authOriginListDef, OptsFromCommand } from '../../../index.ts';
+import { AuthorizedOrigin, getAppsAuth } from '../../../lib/oauth.ts';
+
+export const originSource = (origin: Schema.Schema.Type<typeof AuthorizedOrigin>) => {
+  switch (origin.service) {
+    case 'generic':
+      return 'Website';
+    case 'netlify':
+      return 'Netlify site';
+    case 'vercel':
+      if (origin.params[0] !== 'vercel.app') {
+        return `Vercel project (${origin.params[0]})`;
+      }
+      return 'Vercel project';
+    case 'custom-scheme':
+      return 'Native app';
+    default:
+      return origin.service;
+  }
+};
+
+export const originDisplay = (origin: Schema.Schema.Type<typeof AuthorizedOrigin>) => {
+  switch (origin.service) {
+    case 'generic':
+      return origin.params[0];
+    case 'netlify':
+      return origin.params[0];
+    case 'vercel':
+      return origin.params[1];
+    case 'custom-scheme':
+      return `${origin.params[0]}://`;
+    default:
+      return origin.params[0];
+  }
+};
+
+export const authOriginListCmd = Effect.fn(function* (
+  _opts: OptsFromCommand<typeof authOriginListDef>,
+) {
+  const info = yield* getAppsAuth();
+  if (_opts.json) {
+    yield* Effect.log(
+      JSON.stringify(info.authorized_redirect_origins, null, 2),
+    );
+    return;
+  }
+
+  const origins = info.authorized_redirect_origins ?? [];
+
+  if (origins.length === 0) {
+    yield* Effect.log('No authorized redirect origins configured.');
+    return;
+  }
+
+  for (const origin of origins) {
+    yield* Effect.log(chalk.cyan(originDisplay(origin)));
+    yield* Effect.log(`  Type: ${originSource(origin)}`);
+    yield* Effect.log(`  ID: ${origin.id}`);
+  }
+});

--- a/client/packages/cli/src/commands/auth/origin/list.ts
+++ b/client/packages/cli/src/commands/auth/origin/list.ts
@@ -3,7 +3,9 @@ import { Effect, Schema } from 'effect';
 import type { authOriginListDef, OptsFromCommand } from '../../../index.ts';
 import { AuthorizedOrigin, getAppsAuth } from '../../../lib/oauth.ts';
 
-export const originSource = (origin: Schema.Schema.Type<typeof AuthorizedOrigin>) => {
+export const originSource = (
+  origin: Schema.Schema.Type<typeof AuthorizedOrigin>,
+) => {
   switch (origin.service) {
     case 'generic':
       return 'Website';
@@ -21,7 +23,9 @@ export const originSource = (origin: Schema.Schema.Type<typeof AuthorizedOrigin>
   }
 };
 
-export const originDisplay = (origin: Schema.Schema.Type<typeof AuthorizedOrigin>) => {
+export const originDisplay = (
+  origin: Schema.Schema.Type<typeof AuthorizedOrigin>,
+) => {
   switch (origin.service) {
     case 'generic':
       return origin.params[0];

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -29,6 +29,8 @@ import { PACKAGE_ALIAS_AND_FULL_NAMES } from './context/projectInfo.ts';
 import { authClientAddCmd } from './commands/auth/client/add.ts';
 import { authClientListCmd } from './commands/auth/client/list.ts';
 import { authClientDeleteCmd } from './commands/auth/client/delete.ts';
+import { authOriginListCmd } from './commands/auth/origin/list.ts';
+import { authOriginDeleteCmd } from './commands/auth/origin/delete.ts';
 import { link } from './logging.ts';
 
 export type OptsFromCommand<C> =
@@ -183,6 +185,50 @@ export const authClientDeleteDef = authClient
   .action((opts) => {
     return runCommandEffect(
       authClientDeleteCmd(opts).pipe(
+        Effect.provide(
+          WithAppLayer({
+            coerce: false,
+            appId: opts.app,
+            allowAdminToken: true,
+          }),
+        ),
+      ),
+    );
+  });
+
+const authOrigin = auth.command('origin');
+export const authOriginListDef = authOrigin
+  .command('list')
+  .option(
+    '-a --app <app-id>',
+    'App ID to list origins for. Defaults to *_INSTANT_APP_ID in .env',
+  )
+  .option('--json', 'Enable JSON output')
+  .action((opts) => {
+    return runCommandEffect(
+      authOriginListCmd(opts).pipe(
+        Effect.provide(
+          WithAppLayer({
+            coerce: false,
+            coerceAuth: false,
+            appId: opts.app,
+            allowAdminToken: true,
+          }).pipe(Layer.annotateLogs('silent', !!opts.json)),
+        ),
+      ),
+    );
+  });
+
+export const authOriginDeleteDef = authOrigin
+  .command('delete')
+  .option('--id <origin-id>', 'Origin ID to delete')
+  .option(
+    '-a --app <app-id>',
+    'App ID to delete an origin from. Defaults to *_INSTANT_APP_ID in .env',
+  )
+  .action((opts) => {
+    return runCommandEffect(
+      authOriginDeleteCmd(opts).pipe(
         Effect.provide(
           WithAppLayer({
             coerce: false,

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -223,10 +223,19 @@ export const authOriginListDef = authOrigin
 export const authOriginAddDef = authOrigin
   .command('add')
   .option(
-    '--type <generic>',
-    'Type of origin to add. Currently only "generic" (website) is supported.',
+    '--type <website|vercel|netlify|custom-scheme>',
+    'Type of origin to add.',
   )
-  .option('--url <url>', 'Website URL (e.g. example.com)')
+  .option('--url <url>', 'Website URL (for website type, e.g. example.com)')
+  .option(
+    '--project <name>',
+    'Vercel project name (for vercel type, e.g. my-project)',
+  )
+  .option('--site <name>', 'Netlify site name (for netlify type, e.g. my-site)')
+  .option(
+    '--scheme <scheme>',
+    'App scheme (for custom-scheme type, e.g. myapp://)',
+  )
   .option(
     '-a --app <app-id>',
     'App ID to add an origin to. Defaults to *_INSTANT_APP_ID in .env',
@@ -235,7 +244,10 @@ export const authOriginAddDef = authOrigin
     'after',
     `
 Origin Types:
-  generic    A standard website origin (e.g. example.com)
+  website         A standard website origin (e.g. example.com)
+  vercel          Vercel preview deployments (project name)
+  netlify         Netlify preview deployments (site name)
+  custom-scheme   Native app scheme (e.g. your-app-scheme://)
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -31,6 +31,7 @@ import { authClientListCmd } from './commands/auth/client/list.ts';
 import { authClientDeleteCmd } from './commands/auth/client/delete.ts';
 import { authOriginListCmd } from './commands/auth/origin/list.ts';
 import { authOriginDeleteCmd } from './commands/auth/origin/delete.ts';
+import { authOriginAddCmd } from './commands/auth/origin/add.ts';
 import { link } from './logging.ts';
 
 export type OptsFromCommand<C> =
@@ -214,6 +215,39 @@ export const authOriginListDef = authOrigin
             appId: opts.app,
             allowAdminToken: true,
           }).pipe(Layer.annotateLogs('silent', !!opts.json)),
+        ),
+      ),
+    );
+  });
+
+export const authOriginAddDef = authOrigin
+  .command('add')
+  .option(
+    '--type <generic>',
+    'Type of origin to add. Currently only "generic" (website) is supported.',
+  )
+  .option('--url <url>', 'Website URL (e.g. example.com)')
+  .option(
+    '-a --app <app-id>',
+    'App ID to add an origin to. Defaults to *_INSTANT_APP_ID in .env',
+  )
+  .addHelpText(
+    'after',
+    `
+Origin Types:
+  generic    A standard website origin (e.g. example.com)
+`,
+  )
+  .action((opts) => {
+    return runCommandEffect(
+      authOriginAddCmd(opts).pipe(
+        Effect.provide(
+          WithAppLayer({
+            coerce: false,
+            coerceAuth: false,
+            appId: opts.app,
+            allowAdminToken: true,
+          }),
         ),
       ),
     );

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -236,9 +236,7 @@ export const getClientNameAndProvider = Effect.fn(function* (
   return { provider, clientName };
 });
 
-export const removeAuthorizedOrigin = Effect.fn(function* (
-  originId: string,
-) {
+export const removeAuthorizedOrigin = Effect.fn(function* (originId: string) {
   const http = (yield* InstantHttpAuthed).pipe(
     withCommand('auth origin delete'),
   );
@@ -257,9 +255,7 @@ export const addAuthorizedOrigin = Effect.fn(function* (params: {
   service: Schema.Schema.Type<typeof AuthorizedOriginService>;
   params: string[];
 }) {
-  const http = (yield* InstantHttpAuthed).pipe(
-    withCommand('auth origin add'),
-  );
+  const http = (yield* InstantHttpAuthed).pipe(withCommand('auth origin add'));
   const { appId } = yield* CurrentApp;
 
   return yield* http

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -56,6 +56,10 @@ export const AddOAuthClientResponse = Schema.Struct({
   client: OAuthClient,
 });
 
+export const AuthorizedOriginResponse = Schema.Struct({
+  origin: AuthorizedOrigin,
+});
+
 const NullableArray = <A, I, R>(schema: Schema.Schema<A, I, R>) =>
   Schema.Union(Schema.Array(schema).pipe(Schema.mutable), Schema.Null).pipe(
     Schema.optional,
@@ -230,4 +234,21 @@ export const getClientNameAndProvider = Effect.fn(function* (
     });
   }
   return { provider, clientName };
+});
+
+export const removeAuthorizedOrigin = Effect.fn(function* (
+  originId: string,
+) {
+  const http = (yield* InstantHttpAuthed).pipe(
+    withCommand('auth origin delete'),
+  );
+  const { appId } = yield* CurrentApp;
+
+  return yield* http
+    .del(`/dash/apps/${appId}/authorized_redirect_origins/${originId}`)
+    .pipe(
+      Effect.flatMap(
+        HttpClientResponse.schemaBodyJson(AuthorizedOriginResponse),
+      ),
+    );
 });

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -252,3 +252,26 @@ export const removeAuthorizedOrigin = Effect.fn(function* (
       ),
     );
 });
+
+export const addAuthorizedOrigin = Effect.fn(function* (params: {
+  service: Schema.Schema.Type<typeof AuthorizedOriginService>;
+  params: string[];
+}) {
+  const http = (yield* InstantHttpAuthed).pipe(
+    withCommand('auth origin add'),
+  );
+  const { appId } = yield* CurrentApp;
+
+  return yield* http
+    .post(`/dash/apps/${appId}/authorized_redirect_origins`, {
+      body: HttpBody.unsafeJson({
+        service: params.service,
+        params: params.params,
+      }),
+    })
+    .pipe(
+      Effect.flatMap(
+        HttpClientResponse.schemaBodyJson(AuthorizedOriginResponse),
+      ),
+    );
+});

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.19';
+const version = 'v1.0.20';
 
 export { version };

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -572,7 +572,7 @@
     (response/ok data)))
 
 (defn authorized-redirect-origins-post [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)
+  (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :collaborator :apps/write req)
         service (ex/get-param! req [:body :service] string-util/coerce-non-blank-str)
         service-params (ex/get-param! req [:body :params] #(when (coll? %) %))
         origin-req {:app-id app-id


### PR DESCRIPTION
Adds commands for managing Oauth redirects in the CLI.
Uses the same "add" "list" "delete" structure as how to manage clients. 

Tests were written by AI to match the same pattern as the auth client tests

```zsh
instant-cli auth origin add --help
instant-cli auth origin add --yes --type website --url drewh.net
instant-cli auth origin add --yes --type vercel --project test-project
instant-cli auth origin add --yes --type custom-scheme --scheme myapp://
instant-cli auth origin add --yes --type netlify --site test-site
instant-cli auth origin list
instant-cli auth origin delete
instant-cli auth origin delete --yes --id <ORIGIN_ID>
```