### PR TITLE
[Auth] Fix missing app title in magic code emails

### DIFF
--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -71,10 +71,10 @@
     (or (= code postmark-unconfirmed-sender-body-error-code)
         (= code postmark-not-found-sender-body-error-code))))
 
-(defn default-body [{:keys [title code expiration]}]
+(defn default-body [{:keys [app_title code expiration]}]
   (postmark/standard-body "<p><strong>Welcome,</strong></p>
         <p>
-          You asked to join " title ". To complete your registration, use this
+          You asked to join " app_title ". To complete your registration, use this
           verification code:
         </p>
         <h2 style=\"text-align: center\"><strong>" code "</strong></h2>

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -19,6 +19,7 @@
    [instant.postmark :as postmark]
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.store :as rs]
+   [instant.runtime.magic-code-auth :as magic-code-auth]
    [instant.runtime.routes :as route]
    [instant.system-catalog :as system-catalog]
    [instant.util.coll :as coll]
@@ -153,6 +154,16 @@
                (is (= (str app-id) (:app_id user)))
                (is (= "a@b.c" (:email user)))
                (is (some? (:refresh_token user)))))))))))
+
+(deftest default-magic-code-body-renders-app-title
+  (let [body (magic-code-auth/default-body
+              {:user_email "a@b.c"
+               :code       "123456"
+               :app_title  "MyApp"
+               :expiration "10 minutes"})]
+    (is (re-find #"MyApp" body))
+    (is (re-find #"123456" body))
+    (is (re-find #"10 minutes" body))))
 
 (defn update-created-at [app-id code created-at]
   (sql/execute!


### PR DESCRIPTION
Got a report that app title's were missing from magic code emails. Was able to verify too

<img width="2660" height="872" alt="CleanShot 2026-04-25 at 18 20 05@2x" src="https://github.com/user-attachments/assets/26ae5664-42ad-4261-8f2e-29d4cf2d76ff" />

**Cause**
This was introduced in #2406 when default-body switched from positional args to a destructured map without renaming the key to match template-params.

**Fix**
title -> app_title in default-body. Also added a test asserting the rendered body includes the title, code, and expiration




