### PR TITLE
Redirect getadb new aliases in middleware

### DIFF
--- a/client/www/middleware.ts
+++ b/client/www/middleware.ts
@@ -8,9 +8,20 @@ const GETADB_HOSTS = new Set([
 
 export function middleware(request: NextRequest) {
   const host = (request.headers.get('host') ?? '').split(':')[0];
+  const url = request.nextUrl.clone();
+
+  if (url.pathname === '/getadb/new') {
+    url.pathname = '/getadb/provision/new';
+    return NextResponse.redirect(url, 307);
+  }
+
   if (!GETADB_HOSTS.has(host)) return NextResponse.next();
 
-  const url = request.nextUrl.clone();
+  if (url.pathname === '/new') {
+    url.pathname = '/provision/new';
+    return NextResponse.redirect(url, 307);
+  }
+
   url.pathname = url.pathname === '/' ? '/getadb' : `/getadb${url.pathname}`;
   return NextResponse.rewrite(url);
 }


### PR DESCRIPTION
**Problem**

Claude Design only allows URLs in the web_fetch tool if the user has explicitly listed them. 

This breaks our system where the agent itself generates the random uuid. 

**Solution** 

I added a new getadb.com/new redirect to getadb.com/provision/new

Claude Design doesn't cache like the others, so this is usable there

@dwwoelfel @nezaj @drew-harris 