### PR TITLE
Print app ID and add --temp flag to CIA (#2608) [bump to v1.0.19]

### DIFF
--- a/client/packages/create-instant-app/src/cli.ts
+++ b/client/packages/create-instant-app/src/cli.ts
@@ -32,6 +32,7 @@ export type Project = {
   app: string | null;
   token: string | null;
   yes: boolean;
+  temporary: boolean;
 };
 
 export const unwrapSkippablePrompt = <T>(result: Promise<T | symbol>) => {
@@ -52,6 +53,7 @@ const defaultOptions: Project = {
   app: null,
   token: null,
   yes: false,
+  temporary: false,
 };
 
 const baseFromFlags = (flags: Record<string, any>): Project['base'] | null =>
@@ -168,6 +170,9 @@ export const runCli = async (): Promise<Project> => {
         'Use all defaults (requires project name as first argument)',
       ).default(false),
     )
+    .addOption(
+      new Option('--temp', 'Create a temporary app by default').default(false),
+    )
     .version(version)
     .parse(process.argv);
   const cliProvidedName = program.args[0] && coerceAppName(program.args[0]);
@@ -181,6 +186,10 @@ export const runCli = async (): Promise<Project> => {
   }
 
   const flags = program.opts();
+
+  if (flags.app && flags.temp) {
+    throw new Error('--app and --temp cannot be used together');
+  }
 
   if (flags.yes) {
     if (flags.ai) {
@@ -201,6 +210,7 @@ export const runCli = async (): Promise<Project> => {
       app: flags.app ?? null,
       token: flags.token ?? null,
       yes: true,
+      temporary: flags.temp ?? false,
     };
   }
 
@@ -352,6 +362,9 @@ export const runCli = async (): Promise<Project> => {
           return flags.git as boolean;
         }
         return true;
+      },
+      temporary: async () => {
+        return flags.temp ?? false;
       },
     } satisfies {
       [K in keyof Omit<Project, 'app' | 'token' | 'yes'>]: (args: {

--- a/client/packages/create-instant-app/src/index.ts
+++ b/client/packages/create-instant-app/src/index.ts
@@ -23,6 +23,7 @@ import { promptClaude } from './claude.js';
 import { parseNameAndPath } from './utils/validateAppName.js';
 import { execa } from 'execa';
 import { getRules, getSchema } from './utils/appConfig.js';
+import { printAppCreateResult } from './utils/printAppCreateResult.js';
 
 const main = async () => {
   if (
@@ -63,6 +64,7 @@ const main = async () => {
     project,
     scaffoldMetadata,
   );
+  printAppCreateResult(possibleAppTokenPair);
   if (possibleAppTokenPair) {
     applyEnvFile(
       project,

--- a/client/packages/create-instant-app/src/login.ts
+++ b/client/packages/create-instant-app/src/login.ts
@@ -180,7 +180,7 @@ const getAuthToken = async (): Promise<string | null> => {
   return authToken;
 };
 
-type AppTokenResponse = {
+export type AppTokenResponse = {
   appId: string;
   adminToken: string;
   approach: 'ephemeral' | 'import' | 'create';
@@ -232,14 +232,12 @@ export const tryConnectApp = async (
         undefined,
         metadata,
       );
-      UI.log(`Created new app with App ID: ${appId}`, UI.ciaModifier());
       return { appId, adminToken, approach: 'create' };
     } else {
       const { appId, adminToken } = await createPermissiveEphemeralApp(
         toTitleCase(scopedAppName),
         metadata,
       );
-      UI.log(`Created temporary app with App ID: ${appId}`, UI.ciaModifier());
       return { appId, adminToken, approach: 'ephemeral' };
     }
   }

--- a/client/packages/create-instant-app/src/login.ts
+++ b/client/packages/create-instant-app/src/login.ts
@@ -51,7 +51,7 @@ export const createApp = async (
     body: app,
     metadata,
   });
-  return { appID: id, adminToken: token, source: 'created' };
+  return { appId: id, adminToken: token, source: 'created' };
 };
 
 /**
@@ -225,21 +225,37 @@ export const tryConnectApp = async (
 
   if (project?.yes && !project?.app) {
     // Create a real app if logged in, ephemeral if not
-    if (authToken) {
-      const { appID, adminToken } = await createApp(
+    if (authToken && !project.temporary) {
+      const { appId, adminToken } = await createApp(
         toTitleCase(scopedAppName),
         authToken,
         undefined,
         metadata,
       );
-      return { appId: appID, adminToken, approach: 'create' };
+      UI.log(`Created new app with App ID: ${appId}`, UI.ciaModifier());
+      return { appId, adminToken, approach: 'create' };
     } else {
       const { appId, adminToken } = await createPermissiveEphemeralApp(
         toTitleCase(scopedAppName),
         metadata,
       );
+      UI.log(`Created temporary app with App ID: ${appId}`, UI.ciaModifier());
       return { appId, adminToken, approach: 'ephemeral' };
     }
+  }
+
+  // User wants to create a temporary app and is interactive
+  if (project?.temporary) {
+    const name = await renderUnwrap(
+      new UI.TextInput({
+        defaultValue: toTitleCase(scopedAppName),
+        prompt: 'Enter a name for your temporary app:',
+        placeholder: toTitleCase(scopedAppName),
+        modifyOutput: UI.ciaModifier(),
+      }),
+    );
+    const app = await createPermissiveEphemeralApp(name, metadata);
+    return { ...app, approach: 'ephemeral' };
   }
 
   // Handle --app flag: skip interactive selection
@@ -343,9 +359,9 @@ export const tryConnectApp = async (
     if (choice === 'ephemeral') {
       const name = await renderUnwrap(
         new UI.TextInput({
-          defaultValue: 'my-cool-app',
+          defaultValue: toTitleCase(scopedAppName),
           prompt: 'Enter a name for your temporary app:',
-          placeholder: `my-cool-app`,
+          placeholder: toTitleCase(scopedAppName),
           modifyOutput: UI.ciaModifier(),
         }),
       );
@@ -382,13 +398,13 @@ export const tryConnectApp = async (
         },
 
         createApp: async (title: string, orgId?: string) => {
-          const { appID, adminToken } = await createApp(
+          const { appId, adminToken } = await createApp(
             title,
             authToken,
             orgId,
             metadata,
           );
-          return { appId: appID, adminToken };
+          return { appId, adminToken };
         },
       },
       modifyOutput: UI.ciaModifier(),

--- a/client/packages/create-instant-app/src/utils/printAppCreateResult.ts
+++ b/client/packages/create-instant-app/src/utils/printAppCreateResult.ts
@@ -6,6 +6,11 @@ export const printAppCreateResult = (result: AppTokenResponse | null) => {
     return;
   }
 
+  if (result.approach === 'import') {
+    UI.log(`Imported app with App ID: ${result.appId}`, UI.ciaModifier());
+    return;
+  }
+
   if (result.approach === 'create') {
     UI.log(`Created new app with App ID: ${result.appId}`, UI.ciaModifier());
   }

--- a/client/packages/create-instant-app/src/utils/printAppCreateResult.ts
+++ b/client/packages/create-instant-app/src/utils/printAppCreateResult.ts
@@ -1,0 +1,19 @@
+import { UI } from 'instant-cli/ui';
+import type { AppTokenResponse } from '../login.js';
+
+export const printAppCreateResult = (result: AppTokenResponse | null) => {
+  if (!result) {
+    return;
+  }
+
+  if (result.approach === 'create') {
+    UI.log(`Created new app with App ID: ${result.appId}`, UI.ciaModifier());
+  }
+
+  if (result.approach === 'ephemeral') {
+    UI.log(
+      `Created temporary app with App ID: ${result.appId}`,
+      UI.ciaModifier(),
+    );
+  }
+};

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.18';
+const version = 'v1.0.19';
 
 export { version };


### PR DESCRIPTION
Adds a print statement after creating/importing an app in create instant app.

Also added a --temp flag so that temporary apps can be created if the user is logged in and using --yes. 
If --temp is used without --yes (interactive mode) the user will be prompted for a title without being given any other options for creating/connecting the app. 

<img width="839" height="603" alt="image" src="https://github.com/user-attachments/assets/40f7edd1-40b7-4eb2-b75e-285d88ccce29" />
<img width="729" height="259" alt="image" src="https://github.com/user-attachments/assets/d804583f-4792-44dd-b157-125f4282c3c5" />

How to test
`cd /tmp && create-instant-app --yes` and verify that an app id is printed
`cd /tmp && create-instant-app --yes --temp` and verify that a temporary app id is printed
`cd /tmp && create-instant-app --yes --app <app_id>` and verify that an imported app id is printed
`cd /tmp && create-instant-app` import/create an app and verify the id is printed. 
