### PR TITLE
Update from jdk 22 to jdk 26

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -123,7 +123,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '22'
+        java-version: '26'
 
     - name: Prepare database
       env:
@@ -233,7 +233,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '22'
+        java-version: '26'
 
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@13.1
@@ -271,7 +271,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'corretto'
-        java-version: '22'
+        java-version: '26'
 
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@13.1

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:22 AS builder
+FROM amazoncorretto:26 AS builder
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN clojure -X:deps tree
 
 RUN clojure -T:build uber
 
-FROM amazoncorretto:22
+FROM amazoncorretto:26
 
 WORKDIR /app
 

--- a/server/Dockerfile-dev
+++ b/server/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM amazoncorretto:22
+FROM amazoncorretto:26
 
 WORKDIR /app
 

--- a/server/README.md
+++ b/server/README.md
@@ -17,7 +17,7 @@ The easiest way to get started is to run `make docker-compose`. That command wil
 
 If you want to run Instant locally, first install dependencies:
 
-1. Install Java 22 for [mac](https://docs.aws.amazon.com/corretto/latest/corretto-22-ug/macos-install.html), [linux](https://docs.aws.amazon.com/corretto/latest/corretto-22-ug/generic-linux-install.html), or [windows](https://docs.aws.amazon.com/corretto/latest/corretto-22-ug/windows-install.html).
+1. Install Java 26 for [mac](https://docs.aws.amazon.com/corretto/latest/corretto-26-ug/macos-install.html), [linux](https://docs.aws.amazon.com/corretto/latest/corretto-26-ug/generic-linux-install.html), or [windows](https://docs.aws.amazon.com/corretto/latest/corretto-26-ug/windows-install.html).
 
 2. Install Clojure [https://clojure.org/guides/install_clojure](https://clojure.org/guides/install_clojure).
 

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -120,6 +120,7 @@
                               virgil/virgil {:mvn/version "0.5.0"}}
                  :jvm-opts ["-XX:+UseZGC"
                             "-enableassertions"
+                            "-Djdk.tracePinnedThreads=full"
 
                             ;; force locale
                             "-Duser.language=en"


### PR DESCRIPTION
This should prevent `locking` from causing pinning on virtual threads.

I didn't see any changes between 22 and 26 that would cause issues for us.

Also adds `-Djdk.tracePinnedThreads=full` to dev mode so that it will be easier for us to catch pinned threads.

We should look into using compact object headers, which is supposed to help with the size of the heap in clojure since it creates lots of small objects and this saves 4 bytes per object (enabled with the `-XX:+UseCompactObjectHeaders` flag, which we can add later).

Tested locally and in staging.