### PR TITLE
[Rules] Add solid/svelte packages and rooms guidelines

### DIFF
--- a/client/packages/create-instant-app/template/rules/AGENTS.md
+++ b/client/packages/create-instant-app/template/rules/AGENTS.md
@@ -262,11 +262,11 @@ const { data } = db.useQuery({ posts: { image: {} } });
 
 CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
 
-Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+Rooms host two ephemeral primitives: presence (cursor positions, who's online) and topics (live reactions). Use them only for data that should NOT persist. Persisted data via `transact` already syncs in real-time to all subscribed clients, so reach for rooms only when the data is intentionally ephemeral.
 
-## Presence (synced state)
+## Presence
 
-Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+Each peer publishes a presence object readable by all other peers in the room. Retained for the connection and cleaned up automatically on disconnect.
 
 ```tsx
 const room = db.room('chat', 'main');
@@ -277,9 +277,9 @@ const { user, peers, publishPresence } = db.rooms.usePresence(room, {
 publishPresence({ x: 50, y: 50 });
 ```
 
-## Topics (fire-and-forget broadcasts)
+## Topics
 
-Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+Topic payloads aren't retained. Peers only see events fired while they're listening.
 
 ```tsx
 const room = db.room('chat', 'main');

--- a/client/packages/create-instant-app/template/rules/AGENTS.md
+++ b/client/packages/create-instant-app/template/rules/AGENTS.md
@@ -13,6 +13,8 @@ Instant provides client-side JS SDKs and an admin SDK:
 - `@instantdb/core` --- vanilla JS
 - `@instantdb/react` --- React
 - `@instantdb/react-native` --- React Native / Expo
+- `@instantdb/solidjs` --- SolidJS
+- `@instantdb/svelte` --- Svelte
 - `@instantdb/admin` --- backend scripts / servers
 
 When installing, always check what package manager the project uses (npm, pnpm,
@@ -254,6 +256,40 @@ db.transact(
 // Query through the relationship to get the URL
 const { data } = db.useQuery({ posts: { image: {} } });
 <img src={post.image.url} />
+```
+
+# CRITICAL Rooms Guidelines
+
+CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
+
+Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+
+## Presence (synced state)
+
+Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+
+```tsx
+const room = db.room('chat', 'main');
+const { user, peers, publishPresence } = db.rooms.usePresence(room, {
+  initialPresence: { x: 0, y: 0 },
+});
+// peers is keyed by peerId, not an array. Use Object.values(peers) to iterate
+publishPresence({ x: 50, y: 50 });
+```
+
+## Topics (fire-and-forget broadcasts)
+
+Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+
+```tsx
+const room = db.room('chat', 'main');
+
+const publishEmoji = db.rooms.usePublishTopic(room, 'emoji');
+publishEmoji({ name: 'fire' });
+
+db.rooms.useTopicEffect(room, 'emoji', (payload) => {
+  animateEmoji(payload.name);
+});
 ```
 
 # Best Practices

--- a/client/packages/create-instant-app/template/rules/cursor-rules.md
+++ b/client/packages/create-instant-app/template/rules/cursor-rules.md
@@ -268,11 +268,11 @@ const { data } = db.useQuery({ posts: { image: {} } });
 
 CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
 
-Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+Rooms host two ephemeral primitives: presence (cursor positions, who's online) and topics (live reactions). Use them only for data that should NOT persist. Persisted data via `transact` already syncs in real-time to all subscribed clients, so reach for rooms only when the data is intentionally ephemeral.
 
-## Presence (synced state)
+## Presence
 
-Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+Each peer publishes a presence object readable by all other peers in the room. Retained for the connection and cleaned up automatically on disconnect.
 
 ```tsx
 const room = db.room('chat', 'main');
@@ -283,9 +283,9 @@ const { user, peers, publishPresence } = db.rooms.usePresence(room, {
 publishPresence({ x: 50, y: 50 });
 ```
 
-## Topics (fire-and-forget broadcasts)
+## Topics
 
-Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+Topic payloads aren't retained. Peers only see events fired while they're listening.
 
 ```tsx
 const room = db.room('chat', 'main');

--- a/client/packages/create-instant-app/template/rules/cursor-rules.md
+++ b/client/packages/create-instant-app/template/rules/cursor-rules.md
@@ -19,6 +19,8 @@ Instant provides client-side JS SDKs and an admin SDK:
 - `@instantdb/core` --- vanilla JS
 - `@instantdb/react` --- React
 - `@instantdb/react-native` --- React Native / Expo
+- `@instantdb/solidjs` --- SolidJS
+- `@instantdb/svelte` --- Svelte
 - `@instantdb/admin` --- backend scripts / servers
 
 When installing, always check what package manager the project uses (npm, pnpm,
@@ -260,6 +262,40 @@ db.transact(
 // Query through the relationship to get the URL
 const { data } = db.useQuery({ posts: { image: {} } });
 <img src={post.image.url} />
+```
+
+# CRITICAL Rooms Guidelines
+
+CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
+
+Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+
+## Presence (synced state)
+
+Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+
+```tsx
+const room = db.room('chat', 'main');
+const { user, peers, publishPresence } = db.rooms.usePresence(room, {
+  initialPresence: { x: 0, y: 0 },
+});
+// peers is keyed by peerId, not an array. Use Object.values(peers) to iterate
+publishPresence({ x: 50, y: 50 });
+```
+
+## Topics (fire-and-forget broadcasts)
+
+Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+
+```tsx
+const room = db.room('chat', 'main');
+
+const publishEmoji = db.rooms.usePublishTopic(room, 'emoji');
+publishEmoji({ name: 'fire' });
+
+db.rooms.useTopicEffect(room, 'emoji', (payload) => {
+  animateEmoji(payload.name);
+});
 ```
 
 # Best Practices

--- a/client/packages/create-instant-app/template/rules/windsurf-rules.md
+++ b/client/packages/create-instant-app/template/rules/windsurf-rules.md
@@ -268,11 +268,11 @@ const { data } = db.useQuery({ posts: { image: {} } });
 
 CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
 
-Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+Rooms host two ephemeral primitives: presence (cursor positions, who's online) and topics (live reactions). Use them only for data that should NOT persist. Persisted data via `transact` already syncs in real-time to all subscribed clients, so reach for rooms only when the data is intentionally ephemeral.
 
-## Presence (synced state)
+## Presence
 
-Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+Each peer publishes a presence object readable by all other peers in the room. Retained for the connection and cleaned up automatically on disconnect.
 
 ```tsx
 const room = db.room('chat', 'main');
@@ -283,9 +283,9 @@ const { user, peers, publishPresence } = db.rooms.usePresence(room, {
 publishPresence({ x: 50, y: 50 });
 ```
 
-## Topics (fire-and-forget broadcasts)
+## Topics
 
-Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+Topic payloads aren't retained. Peers only see events fired while they're listening.
 
 ```tsx
 const room = db.room('chat', 'main');

--- a/client/packages/create-instant-app/template/rules/windsurf-rules.md
+++ b/client/packages/create-instant-app/template/rules/windsurf-rules.md
@@ -19,6 +19,8 @@ Instant provides client-side JS SDKs and an admin SDK:
 - `@instantdb/core` --- vanilla JS
 - `@instantdb/react` --- React
 - `@instantdb/react-native` --- React Native / Expo
+- `@instantdb/solidjs` --- SolidJS
+- `@instantdb/svelte` --- Svelte
 - `@instantdb/admin` --- backend scripts / servers
 
 When installing, always check what package manager the project uses (npm, pnpm,
@@ -260,6 +262,40 @@ db.transact(
 // Query through the relationship to get the URL
 const { data } = db.useQuery({ posts: { image: {} } });
 <img src={post.image.url} />
+```
+
+# CRITICAL Rooms Guidelines
+
+CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
+
+Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+
+## Presence (synced state)
+
+Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+
+```tsx
+const room = db.room('chat', 'main');
+const { user, peers, publishPresence } = db.rooms.usePresence(room, {
+  initialPresence: { x: 0, y: 0 },
+});
+// peers is keyed by peerId, not an array. Use Object.values(peers) to iterate
+publishPresence({ x: 50, y: 50 });
+```
+
+## Topics (fire-and-forget broadcasts)
+
+Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+
+```tsx
+const room = db.room('chat', 'main');
+
+const publishEmoji = db.rooms.usePublishTopic(room, 'emoji');
+publishEmoji({ name: 'fire' });
+
+db.rooms.useTopicEffect(room, 'emoji', (payload) => {
+  animateEmoji(payload.name);
+});
 ```
 
 # Best Practices

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.21';
+const version = 'v1.0.22';
 
 export { version };

--- a/client/www/lib/intern/instant-rules.md
+++ b/client/www/lib/intern/instant-rules.md
@@ -13,6 +13,8 @@ Instant provides client-side JS SDKs and an admin SDK:
 - `@instantdb/core` --- vanilla JS
 - `@instantdb/react` --- React
 - `@instantdb/react-native` --- React Native / Expo
+- `@instantdb/solidjs` --- SolidJS
+- `@instantdb/svelte` --- Svelte
 - `@instantdb/admin` --- backend scripts / servers
 
 When installing, always check what package manager the project uses (npm, pnpm,

--- a/client/www/lib/intern/instant-rules.md
+++ b/client/www/lib/intern/instant-rules.md
@@ -262,11 +262,11 @@ const { data } = db.useQuery({ posts: { image: {} } });
 
 CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
 
-Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+Rooms host two ephemeral primitives: presence (cursor positions, who's online) and topics (live reactions). Use them only for data that should NOT persist. Persisted data via `transact` already syncs in real-time to all subscribed clients, so reach for rooms only when the data is intentionally ephemeral.
 
-## Presence (synced state)
+## Presence
 
-Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+Each peer publishes a presence object readable by all other peers in the room. Retained for the connection and cleaned up automatically on disconnect.
 
 ```tsx
 const room = db.room('chat', 'main');
@@ -277,9 +277,9 @@ const { user, peers, publishPresence } = db.rooms.usePresence(room, {
 publishPresence({ x: 50, y: 50 });
 ```
 
-## Topics (fire-and-forget broadcasts)
+## Topics
 
-Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+Topic payloads aren't retained. Peers only see events fired while they're listening.
 
 ```tsx
 const room = db.room('chat', 'main');

--- a/client/www/lib/intern/instant-rules.md
+++ b/client/www/lib/intern/instant-rules.md
@@ -258,6 +258,40 @@ const { data } = db.useQuery({ posts: { image: {} } });
 <img src={post.image.url} />
 ```
 
+# CRITICAL Rooms Guidelines
+
+CRITICAL: Hooks for presence and topics live on `db.rooms` and take the room as the first arg. The room object itself has no `usePresence` or `publishPresence` methods.
+
+Rooms host two ephemeral primitives: presence (synced state) and topics (fire-and-forget broadcasts).
+
+## Presence (synced state)
+
+Use presence for state that should sync across peers in a room but doesn't need to persist (cursor position, who's online, current selection).
+
+```tsx
+const room = db.room('chat', 'main');
+const { user, peers, publishPresence } = db.rooms.usePresence(room, {
+  initialPresence: { x: 0, y: 0 },
+});
+// peers is keyed by peerId, not an array. Use Object.values(peers) to iterate
+publishPresence({ x: 50, y: 50 });
+```
+
+## Topics (fire-and-forget broadcasts)
+
+Use topics for ephemeral signals you don't need persisted, like live reactions. Unlike presence, topic payloads aren't retained. Peers only see events fired while they're listening.
+
+```tsx
+const room = db.room('chat', 'main');
+
+const publishEmoji = db.rooms.usePublishTopic(room, 'emoji');
+publishEmoji({ name: 'fire' });
+
+db.rooms.useTopicEffect(room, 'emoji', (payload) => {
+  animateEmoji(payload.name);
+});
+```
+
 # Best Practices
 
 ## Pass `schema` when initializing Instant


### PR DESCRIPTION
Saw a PR for adding the svelte sdk to our rules, figured we should do that and also include solidjs.

Also, we've seen agents hallucinate how presence works. Agents seem to think `publishPresence` lives on rooms instead of db.rooms

Adding a section to show the right way to use both rooms and topics