### PR TITLE
[cli] client add/list: shared-dev-credentials

### DIFF
--- a/client/packages/cli/__tests__/authClientAddGoogle.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGoogle.test.ts
@@ -249,6 +249,28 @@ const webDevFlags = new Map([
 ]);
 
 describe('web: dev credentials', () => {
+  test('--dev-credentials → creates dev credentials client', async () => {
+    await run(withEntry(webDevFlags, 'dev-credentials', 'true'), { yes: true });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({
+      clientName: 'google-web',
+      useSharedCredentials: true,
+      discoveryEndpoint:
+        'https://accounts.google.com/.well-known/openid-configuration',
+    });
+    expect(addedClients[0].clientId).toBeUndefined();
+    expect(addedClients[0].clientSecret).toBeUndefined();
+    expect(addedClients[0].redirectTo).toBeUndefined();
+    const output = logs.join('\n');
+    expect(output).toContain('Credentials: Instant dev credentials');
+    expect(output).toContain('No Google Console setup required');
+    expect(output).toContain(
+      'For production, use your own Google OAuth credentials.',
+    );
+    expect(output).not.toContain('instant-cli auth client update');
+    expect(output).not.toContain('Add this redirect URI in Google Console');
+  });
+
   test('--yes with no Google credentials → creates dev credentials client', async () => {
     await run(webDevFlags, { yes: true });
     expect(addedClients).toHaveLength(1);
@@ -273,11 +295,7 @@ describe('web: dev credentials', () => {
 
   test('--dev-credentials with custom credential flags → error', async () => {
     await run(
-      new Map([
-        ...webDevFlags,
-        ['dev-credentials', 'true'],
-        ['client-id', '123456.apps.googleusercontent.com'],
-      ]),
+      new Map([...webDevFlags, ['dev-credentials', 'true'], ['client-id', '']]),
       { yes: true },
     );
     expect(logs.join('\n')).toContain(

--- a/client/packages/cli/__tests__/authClientAddGoogle.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGoogle.test.ts
@@ -240,6 +240,80 @@ describe('web: success', () => {
   });
 });
 
+// -- web: dev credentials --
+
+const webDevFlags = new Map([
+  ['type', 'google'],
+  ['app-type', 'web'],
+  ['name', 'google-web'],
+]);
+
+describe('web: dev credentials', () => {
+  test('--yes with no Google credentials → creates dev credentials client', async () => {
+    await run(webDevFlags, { yes: true });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({
+      clientName: 'google-web',
+      useSharedCredentials: true,
+      discoveryEndpoint:
+        'https://accounts.google.com/.well-known/openid-configuration',
+    });
+    expect(addedClients[0].clientId).toBeUndefined();
+    expect(addedClients[0].clientSecret).toBeUndefined();
+    expect(addedClients[0].redirectTo).toBeUndefined();
+    const output = logs.join('\n');
+    expect(output).toContain('Credentials: Instant dev credentials');
+    expect(output).toContain('No Google Console setup required');
+    expect(output).toContain(
+      'For production, use your own Google OAuth credentials.',
+    );
+    expect(output).not.toContain('instant-cli auth client update');
+    expect(output).not.toContain('Add this redirect URI in Google Console');
+  });
+
+  test('--dev-credentials with custom credential flags → error', async () => {
+    await run(
+      new Map([
+        ...webDevFlags,
+        ['dev-credentials', 'true'],
+        ['client-id', '123456.apps.googleusercontent.com'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain(
+      '--dev-credentials cannot be combined with --client-id',
+    );
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('--dev-credentials with native app type → error', async () => {
+    await run(
+      new Map([
+        ['type', 'google'],
+        ['app-type', 'ios'],
+        ['name', 'google-ios'],
+        ['dev-credentials', 'true'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain(
+      '--dev-credentials is only supported for --app-type web',
+    );
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('interactive with no Google credentials → prompts for credential mode', async () => {
+    mockPromptReturn = 'dev';
+    await run(webDevFlags, { yes: false });
+    expect(prompts).toHaveLength(1);
+    expect((prompts[0] as any).params.promptText).toBe(
+      'Select Google credential mode:',
+    );
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0].useSharedCredentials).toBe(true);
+  });
+});
+
 // -- ios: forbidden flags and success --
 
 describe('ios', () => {

--- a/client/packages/cli/__tests__/authClientList.test.ts
+++ b/client/packages/cli/__tests__/authClientList.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import { InstantHttpAuthed } from '../src/lib/http.ts';
+
+vi.mock('../src/index.ts', () => ({}));
+
+const authResponse = {
+  oauth_service_providers: [
+    { id: 'prov-google', provider_name: 'google' },
+    { id: 'prov-github', provider_name: 'github' },
+  ],
+  oauth_clients: [
+    {
+      id: 'google-shared',
+      provider_id: 'prov-google',
+      client_name: 'google-shared',
+      client_id: null,
+      redirect_to: null,
+      meta: { appType: 'web' },
+      use_shared_credentials: true,
+    },
+    {
+      id: 'github',
+      provider_id: 'prov-github',
+      client_name: 'github',
+      client_id: 'gh-id',
+      redirect_to: 'https://api.instantdb.com/runtime/oauth/callback',
+      meta: {},
+      use_shared_credentials: false,
+    },
+  ],
+};
+
+vi.mock('../src/lib/oauth.ts', () => ({
+  getAppsAuth: () => Effect.succeed(authResponse),
+}));
+
+const { authClientListCmd } = await import(
+  '../src/commands/auth/client/list.ts'
+);
+
+let logs: string[] = [];
+
+const run = (opts: { json?: boolean }) =>
+  Effect.runPromise(
+    authClientListCmd(opts as any).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(CurrentApp, { appId: 'test-app', source: 'env' }),
+          Layer.succeed(InstantHttpAuthed, {} as any),
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => {
+              logs.push(String(message));
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+beforeEach(() => {
+  logs = [];
+});
+
+describe('auth client list', () => {
+  test('shows shared dev credentials clearly', async () => {
+    await run({});
+    const output = logs.join('\n');
+    expect(output).toContain('google-shared');
+    expect(output).toContain('App type: web');
+    expect(output).toContain('Credentials: Instant dev credentials');
+    expect(output).toContain('Client id: managed by Instant');
+    expect(output).toContain(
+      'Redirect URL: localhost and Expo allowed automatically',
+    );
+    expect(output).toContain('Credentials: custom');
+    expect(output).toContain('Client id: gh-id');
+  });
+
+  test('--json prints raw clients', async () => {
+    await run({ json: true });
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed[0]).toMatchObject({
+      client_name: 'google-shared',
+      use_shared_credentials: true,
+    });
+  });
+});

--- a/client/packages/cli/__tests__/oauthMock.ts
+++ b/client/packages/cli/__tests__/oauthMock.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Effect, Schema } from 'effect';
 import { optOrPrompt, validateRequired } from '../src/lib/ui.ts';
 import { UI } from '../src/ui/index.ts';
 import { BadArgsError } from '../src/errors.ts';
@@ -17,6 +17,13 @@ export const makeOAuthMock = (mocks: {
       if (!used.has(c)) return c;
     }
   };
+
+  const GoogleAppTypeSchema = Schema.Literal(
+    'web',
+    'ios',
+    'android',
+    'button-for-web',
+  );
 
   const getOrCreateProvider = Effect.fn(function* (type: string) {
     const auth: any = yield* mocks.getAppsAuth();
@@ -62,6 +69,7 @@ export const makeOAuthMock = (mocks: {
 
   return {
     ...mocks,
+    GoogleAppTypeSchema,
     findName,
     getOrCreateProvider,
     getClientNameAndProvider,

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -15,6 +15,7 @@ import {
   findName,
   getClientNameAndProvider,
   getOrCreateProvider,
+  type OAuthClient,
 } from '../../../lib/oauth.ts';
 import {
   DEFAULT_OAUTH_CALLBACK_URL,
@@ -48,6 +49,8 @@ const GoogleAppTypeSchema = Schema.Literal(
   'android',
   'button-for-web',
 );
+
+const isTrueFlag = (value: unknown) => value === true || value === 'true';
 
 const selectGoogleAppType = (value: unknown) =>
   Effect.gen(function* () {
@@ -96,10 +99,165 @@ const selectGoogleAppType = (value: unknown) =>
     );
   });
 
+const selectGoogleCredentialMode = Effect.fn(function* () {
+  return yield* runUIEffect(
+    new UI.Select({
+      options: [
+        {
+          label:
+            'Use dev credentials' +
+            chalk.dim(' (works on localhost and Expo, no Google setup)'),
+          value: 'dev' as const,
+        },
+        {
+          label:
+            'Use my own credentials' +
+            chalk.dim(' (client ID and secret from Google Console)'),
+          value: 'custom' as const,
+        },
+      ],
+      promptText: 'Select Google credential mode:',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+      defaultValue: 'dev' as const,
+    }),
+  ).pipe(
+    Effect.catchTag('UIError', (e) =>
+      BadArgsError.make({ message: `UI error: ${e.message}` }),
+    ),
+  );
+});
+
+const resolveGoogleCredentialMode = Effect.fn(function* ({
+  appType,
+  opts,
+  yes,
+}: {
+  appType: typeof GoogleAppTypeSchema.Type;
+  opts: Record<string, unknown>;
+  yes: boolean;
+}) {
+  const devCredentialsFlag = isTrueFlag(opts['dev-credentials']);
+  const hasProvidedSomeCustomCredentials = Boolean(
+    opts['client-id'] || opts['client-secret'] || opts['custom-redirect-uri'],
+  );
+
+  if (devCredentialsFlag && appType !== 'web') {
+    return yield* BadArgsError.make({
+      message:
+        '--dev-credentials is only supported for --app-type web. Native Google clients need credentials from Google.',
+    });
+  }
+
+  if (devCredentialsFlag && hasProvidedSomeCustomCredentials) {
+    return yield* BadArgsError.make({
+      message:
+        '--dev-credentials cannot be combined with --client-id, --client-secret, or --custom-redirect-uri.',
+    });
+  }
+
+  if (appType !== 'web') {
+    return 'custom';
+  }
+
+  if (hasProvidedSomeCustomCredentials) {
+    return 'custom';
+  }
+
+  if (devCredentialsFlag) {
+    return 'dev';
+  }
+
+  if (yes) {
+    return 'dev';
+  }
+
+  return yield* selectGoogleCredentialMode();
+});
+
+const printGoogleDevCredentialsClient = Effect.fn(function* ({
+  appType,
+  client,
+}: {
+  appType: typeof GoogleAppTypeSchema.Type;
+  client: OAuthClient;
+}) {
+  yield* Effect.log(
+    boxen(
+      [
+        `Google OAuth client created: ${client.client_name}`,
+        `App type: ${appType}`,
+        `Credentials: Instant dev credentials`,
+        `ID: ${client.id}`,
+        '',
+        'No Google Console setup required.',
+        'Works on localhost and Expo during development.',
+        '',
+        'For production, use your own Google OAuth credentials.',
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
+});
+
+const printGoogleCustomCredentialsClient = Effect.fn(function* ({
+  appType,
+  client,
+  clientId,
+  customRedirectUri,
+  redirectUri,
+}: {
+  appType: typeof GoogleAppTypeSchema.Type;
+  client: OAuthClient;
+  clientId: string | undefined;
+  customRedirectUri: string | undefined;
+  redirectUri: string | undefined;
+}) {
+  const redirectMessages: string[] = [];
+  if (appType === 'web' && redirectUri) {
+    redirectMessages.push(
+      chalk.bold(
+        `\nAdd this redirect URI in Google Console:\n${redirectUri}\n`,
+      ),
+    );
+    if (customRedirectUri) {
+      redirectMessages.push(
+        `Your custom redirect must forward to ${chalk.bold(DEFAULT_OAUTH_CALLBACK_URL)} with all query parameters preserved.`,
+      );
+      redirectMessages.push(
+        `You can test it by visiting: ${chalk.bold(redirectUri + '?test-redirect=true')}`,
+      );
+    }
+  }
+
+  yield* Effect.log(
+    boxen(
+      [
+        `Google OAuth client created: ${client.client_name}`,
+        `App type: ${appType}`,
+        `ID: ${client.id}`,
+        `Google Client ID: ${client.client_id ?? clientId}`,
+        ...redirectMessages,
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
+});
+
 const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
   // This one requires special logic for getting client name
   // because the suggested name includes the app type
   const appType = yield* selectGoogleAppType(opts['app-type']);
+  const { yes } = yield* GlobalOpts;
+  const credentialMode = yield* resolveGoogleCredentialMode({
+    appType,
+    opts,
+    yes,
+  });
+  const useSharedCredentials = credentialMode === 'dev';
+
   const { auth, provider } = yield* getOrCreateProvider('google');
   const usedClientNames = new Set(
     (auth.oauth_clients ?? []).map((client) => client.client_name),
@@ -115,7 +273,10 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
       defaultValue: suggestedClientName,
       placeholder: suggestedClientName,
       validate: validateRequired,
-      modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
     },
   });
 
@@ -127,8 +288,10 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
 
   const clientId = yield* optOrPrompt(opts['client-id'], {
     simpleName: '--client-id',
-    required: true,
-    skipIf: false,
+    required: !useSharedCredentials,
+    skipIf: useSharedCredentials,
+    skipMessage:
+      '--client-id is not compatible with --dev-credentials. Drop one or the other.',
     prompt: {
       prompt: `Client ID: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
       modifyOutput: UI.modifiers.piped([
@@ -139,10 +302,14 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     },
   });
 
+  const usesCustomWebCredentials = !useSharedCredentials && appType === 'web';
   const clientSecret = yield* optOrPrompt(opts['client-secret'], {
-    required: appType === 'web',
-    skipIf: appType !== 'web',
+    required: usesCustomWebCredentials,
+    skipIf: !usesCustomWebCredentials,
     simpleName: '--client-secret',
+    skipMessage: useSharedCredentials
+      ? '--client-secret is not compatible with --dev-credentials. Drop one or the other.'
+      : undefined,
     prompt: {
       prompt: `Client Secret: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
       validate: validateRequired,
@@ -175,20 +342,24 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
       ]),
     },
     simpleName: '--custom-redirect-uri',
-    skipIf: appType !== 'web',
-    skipMessage: 'Provided custom redirect URI when not using web app type.',
+    skipIf: !usesCustomWebCredentials,
+    skipMessage: useSharedCredentials
+      ? '--custom-redirect-uri is not compatible with --dev-credentials.'
+      : 'Provided custom redirect URI when not using web app type.',
   });
 
   if (!clientName) {
     return yield* BadArgsError.make({ message: 'Client name is required.' }); // Should never reach this
   }
-  const redirectUri = customRedirectUri || DEFAULT_OAUTH_CALLBACK_URL;
+  const redirectUri = useSharedCredentials
+    ? undefined
+    : customRedirectUri || DEFAULT_OAUTH_CALLBACK_URL;
 
   const response = yield* addOAuthClient({
     providerId: provider.id,
     clientName,
-    clientId,
-    clientSecret: clientSecret,
+    clientId: useSharedCredentials ? undefined : clientId,
+    clientSecret: useSharedCredentials ? undefined : clientSecret,
     authorizationEndpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
     tokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
     discoveryEndpoint: GOOGLE_DISCOVERY_ENDPOINT,
@@ -197,37 +368,24 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
       appType,
       skipNonceChecks: true,
     },
+    useSharedCredentials,
   });
 
-  const redirectMessages: string[] = [];
-  if (appType === 'web') {
-    redirectMessages.push(
-      chalk.bold(
-        `\nAdd this redirect URI in Google Console:\n${redirectUri}\n`,
-      ),
-    );
-    if (customRedirectUri) {
-      redirectMessages.push(
-        `Your custom redirect must forward to ${chalk.bold(DEFAULT_OAUTH_CALLBACK_URL)} with all query parameters preserved.`,
-      );
-      redirectMessages.push(
-        `You can test it by visiting: ${chalk.bold(redirectUri + '?test-redirect=true')}`,
-      );
-    }
+  if (useSharedCredentials) {
+    yield* printGoogleDevCredentialsClient({
+      appType,
+      client: response.client,
+    });
+    return;
   }
 
-  yield* Effect.log(
-    boxen(
-      [
-        `Google OAuth client created: ${response.client.client_name}`,
-        `App type: ${appType}`,
-        `ID: ${response.client.id}`,
-        `Google Client ID: ${response.client.client_id ?? clientId}`,
-        ...redirectMessages,
-      ].join('\n'),
-      { dimBorder: true, padding: { right: 1, left: 1 } },
-    ),
-  );
+  yield* printGoogleCustomCredentialsClient({
+    appType,
+    client: response.client,
+    clientId,
+    customRedirectUri,
+    redirectUri,
+  });
 });
 
 const handleGithubClient = Effect.fn(function* (opts: Record<string, unknown>) {

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -15,7 +15,8 @@ import {
   findName,
   getClientNameAndProvider,
   getOrCreateProvider,
-  type OAuthClient,
+  GoogleAppTypeSchema,
+  OAuthClient,
 } from '../../../lib/oauth.ts';
 import {
   DEFAULT_OAUTH_CALLBACK_URL,
@@ -43,14 +44,8 @@ export const ClientTypeSchema = Schema.Literal(
   'firebase',
 );
 
-const GoogleAppTypeSchema = Schema.Literal(
-  'web',
-  'ios',
-  'android',
-  'button-for-web',
-);
-
 const isTrueFlag = (value: unknown) => value === true || value === 'true';
+const hasFlag = (opts: Record<string, unknown>, flag: string) => flag in opts;
 
 const selectGoogleAppType = (value: unknown) =>
   Effect.gen(function* () {
@@ -133,16 +128,16 @@ const selectGoogleCredentialMode = Effect.fn(function* () {
 const resolveGoogleCredentialMode = Effect.fn(function* ({
   appType,
   opts,
-  yes,
 }: {
   appType: typeof GoogleAppTypeSchema.Type;
   opts: Record<string, unknown>;
-  yes: boolean;
-}) {
+}): Effect.fn.Return<'custom' | 'dev', BadArgsError, GlobalOpts> {
+  const { yes } = yield* GlobalOpts;
   const devCredentialsFlag = isTrueFlag(opts['dev-credentials']);
-  const hasProvidedSomeCustomCredentials = Boolean(
-    opts['client-id'] || opts['client-secret'] || opts['custom-redirect-uri'],
-  );
+  const hasProvidedSomeCustomCredentials =
+    hasFlag(opts, 'client-id') ||
+    hasFlag(opts, 'client-secret') ||
+    hasFlag(opts, 'custom-redirect-uri');
 
   if (devCredentialsFlag && appType !== 'web') {
     return yield* BadArgsError.make({
@@ -182,7 +177,7 @@ const printGoogleDevCredentialsClient = Effect.fn(function* ({
   client,
 }: {
   appType: typeof GoogleAppTypeSchema.Type;
-  client: OAuthClient;
+  client: typeof OAuthClient.Type;
 }) {
   yield* Effect.log(
     boxen(
@@ -195,7 +190,7 @@ const printGoogleDevCredentialsClient = Effect.fn(function* ({
         'No Google Console setup required.',
         'Works on localhost and Expo during development.',
         '',
-        'For production, use your own Google OAuth credentials.',
+        chalk.bold('For production, use your own Google OAuth credentials.'),
       ].join('\n'),
       { dimBorder: true, padding: { right: 1, left: 1 } },
     ),
@@ -210,7 +205,7 @@ const printGoogleCustomCredentialsClient = Effect.fn(function* ({
   redirectUri,
 }: {
   appType: typeof GoogleAppTypeSchema.Type;
-  client: OAuthClient;
+  client: typeof OAuthClient.Type;
   clientId: string | undefined;
   customRedirectUri: string | undefined;
   redirectUri: string | undefined;
@@ -218,12 +213,13 @@ const printGoogleCustomCredentialsClient = Effect.fn(function* ({
   const redirectMessages: string[] = [];
   if (appType === 'web' && redirectUri) {
     redirectMessages.push(
-      chalk.bold(
-        `\nAdd this redirect URI in Google Console:\n${redirectUri}\n`,
-      ),
+      '',
+      chalk.bold('Add this redirect URI in Google Console:'),
+      chalk.bold(redirectUri),
     );
     if (customRedirectUri) {
       redirectMessages.push(
+        '',
         `Your custom redirect must forward to ${chalk.bold(DEFAULT_OAUTH_CALLBACK_URL)} with all query parameters preserved.`,
       );
       redirectMessages.push(
@@ -250,11 +246,9 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
   // This one requires special logic for getting client name
   // because the suggested name includes the app type
   const appType = yield* selectGoogleAppType(opts['app-type']);
-  const { yes } = yield* GlobalOpts;
   const credentialMode = yield* resolveGoogleCredentialMode({
     appType,
     opts,
-    yes,
   });
   const useSharedCredentials = credentialMode === 'dev';
 

--- a/client/packages/cli/src/commands/auth/client/list.ts
+++ b/client/packages/cli/src/commands/auth/client/list.ts
@@ -4,11 +4,6 @@ import type { authClientListDef, OptsFromCommand } from '../../../index.ts';
 import { getAppsAuth } from '../../../lib/oauth.ts';
 
 const formatValue = (value: string | null | undefined) => value ?? 'n/a';
-const appType = (meta: unknown) => {
-  if (!meta || typeof meta !== 'object') return undefined;
-  const value = (meta as Record<string, unknown>).appType;
-  return typeof value === 'string' ? value : undefined;
-};
 
 export const authClientListCmd = Effect.fn(function* (
   _opts: OptsFromCommand<typeof authClientListDef>,
@@ -39,7 +34,7 @@ export const authClientListCmd = Effect.fn(function* (
     yield* Effect.log(
       `  Provider: ${provider?.provider_name ?? client.provider_id}`,
     );
-    const clientAppType = appType(client.meta);
+    const clientAppType = client.meta?.appType;
     if (clientAppType) {
       yield* Effect.log(`  App type: ${clientAppType}`);
     }

--- a/client/packages/cli/src/commands/auth/client/list.ts
+++ b/client/packages/cli/src/commands/auth/client/list.ts
@@ -4,6 +4,11 @@ import type { authClientListDef, OptsFromCommand } from '../../../index.ts';
 import { getAppsAuth } from '../../../lib/oauth.ts';
 
 const formatValue = (value: string | null | undefined) => value ?? 'n/a';
+const appType = (meta: unknown) => {
+  if (!meta || typeof meta !== 'object') return undefined;
+  const value = (meta as Record<string, unknown>).appType;
+  return typeof value === 'string' ? value : undefined;
+};
 
 export const authClientListCmd = Effect.fn(function* (
   _opts: OptsFromCommand<typeof authClientListDef>,
@@ -34,8 +39,27 @@ export const authClientListCmd = Effect.fn(function* (
     yield* Effect.log(
       `  Provider: ${provider?.provider_name ?? client.provider_id}`,
     );
+    const clientAppType = appType(client.meta);
+    if (clientAppType) {
+      yield* Effect.log(`  App type: ${clientAppType}`);
+    }
+    yield* Effect.log(
+      `  Credentials: ${client.use_shared_credentials ? 'Instant dev credentials' : 'custom'}`,
+    );
     yield* Effect.log(`  ID: ${client.id}`);
-    yield* Effect.log(`  Client id: ${formatValue(client.client_id)}`);
-    yield* Effect.log(`  Redirect URL: ${formatValue(client.redirect_to)}`);
+    yield* Effect.log(
+      `  Client id: ${
+        client.use_shared_credentials
+          ? 'managed by Instant'
+          : formatValue(client.client_id)
+      }`,
+    );
+    yield* Effect.log(
+      `  Redirect URL: ${
+        client.use_shared_credentials
+          ? 'localhost and Expo allowed automatically'
+          : formatValue(client.redirect_to)
+      }`,
+    );
   }
 });

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -109,28 +109,29 @@ export const authClientAddDef = authClient
     `
 Provider Specific Options:
   Google:
-   --app-type       web|ios|android|button-for-web
-   --client-id
-   --client-secret                      (web only)
-   --custom-redirect-uri      (optional, web only)
+   --app-type             web|ios|android|button-for-web
+   --dev-credentials      (optional, web only)
+   --client-id            (required unless using dev credentials)
+   --client-secret        (web only, unless using dev credentials)
+   --custom-redirect-uri  (optional, web only)
   GitHub:
    --client-id
    --client-secret
-   --custom-redirect-uri      (optional)
+   --custom-redirect-uri  (optional)
   Apple:
-   --services-id              (Services ID from ${link('https://developer.apple.com', 'developer.apple.com')})
-   --team-id                  (optional, required for web redirect flow)
-   --key-id                   (optional, required for web redirect flow)
-   --private-key-file         (optional, path to .p8 PEM; required for web redirect flow)
-   --custom-redirect-uri      (optional, web redirect flow only)
+   --services-id          (Services ID from ${link('https://developer.apple.com', 'developer.apple.com')})
+   --team-id              (optional, required for web redirect flow)
+   --key-id               (optional, required for web redirect flow)
+   --private-key-file     (optional, path to .p8 PEM; required for web redirect flow)
+   --custom-redirect-uri  (optional, web redirect flow only)
   LinkedIn:
    --client-id
    --client-secret
-   --custom-redirect-uri      (optional)
+   --custom-redirect-uri  (optional)
   Clerk:
-   --publishable-key    (Publishable Key from ${link('https://dashboard.clerk.com', 'dashboard.clerk.com')})
+   --publishable-key      (Publishable Key from ${link('https://dashboard.clerk.com', 'dashboard.clerk.com')})
   Firebase:
-   --project-id         (Project ID from ${link('https://console.firebase.google.com', 'console.firebase.google.com')})
+   --project-id           (Project ID from ${link('https://console.firebase.google.com', 'console.firebase.google.com')})
 `,
   )
   .action((opts) => {

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -32,12 +32,28 @@ export const OAuthServiceProvider = Schema.Struct({
   provider_name: Schema.String,
 });
 
+export const GoogleAppTypeSchema = Schema.Literal(
+  'web',
+  'ios',
+  'android',
+  'button-for-web',
+);
+
 const NullableString = Schema.Union(Schema.String, Schema.Null).pipe(
   Schema.optional,
 );
 
 const NullableBoolean = Schema.Union(Schema.Boolean, Schema.Null).pipe(
   Schema.optional,
+);
+
+const OAuthClientMeta = Schema.Struct({
+  // Currently the CLI only reads Google app type from meta. Other providers store
+  // different meta shapes, so keep the rest open until we have a clean
+  // top-level discriminator for a full provider-specific union.
+  appType: GoogleAppTypeSchema.pipe(Schema.optional),
+}).pipe(
+  Schema.extend(Schema.Record({ key: Schema.String, value: Schema.Any })),
 );
 
 export const OAuthClient = Schema.Struct({
@@ -49,11 +65,9 @@ export const OAuthClient = Schema.Struct({
   token_endpoint: NullableString,
   discovery_endpoint: NullableString,
   redirect_to: NullableString,
-  meta: Schema.Any.pipe(Schema.optional),
+  meta: Schema.Union(OAuthClientMeta, Schema.Null).pipe(Schema.optional),
   use_shared_credentials: NullableBoolean,
 });
-
-export type OAuthClient = Schema.Schema.Type<typeof OAuthClient>;
 
 export const AddOAuthProviderResponse = Schema.Struct({
   provider: OAuthServiceProvider,

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -36,6 +36,10 @@ const NullableString = Schema.Union(Schema.String, Schema.Null).pipe(
   Schema.optional,
 );
 
+const NullableBoolean = Schema.Union(Schema.Boolean, Schema.Null).pipe(
+  Schema.optional,
+);
+
 export const OAuthClient = Schema.Struct({
   id: Schema.String,
   client_name: Schema.String,
@@ -46,7 +50,10 @@ export const OAuthClient = Schema.Struct({
   discovery_endpoint: NullableString,
   redirect_to: NullableString,
   meta: Schema.Any.pipe(Schema.optional),
+  use_shared_credentials: NullableBoolean,
 });
+
+export type OAuthClient = Schema.Schema.Type<typeof OAuthClient>;
 
 export const AddOAuthProviderResponse = Schema.Struct({
   provider: OAuthServiceProvider,
@@ -111,6 +118,7 @@ export const addOAuthClient = Effect.fn(function* (params: {
   discoveryEndpoint?: string;
   redirectTo?: string;
   meta?: unknown;
+  useSharedCredentials?: boolean;
 }) {
   const http = (yield* InstantHttpAuthed).pipe(withCommand('auth'));
   const targetAppId = params.appId ?? (yield* CurrentApp).appId;
@@ -127,6 +135,7 @@ export const addOAuthClient = Effect.fn(function* (params: {
         discovery_endpoint: params.discoveryEndpoint,
         redirect_to: params.redirectTo,
         meta: params.meta,
+        use_shared_credentials: params.useSharedCredentials,
       }),
     })
     .pipe(


### PR DESCRIPTION
Our Google Clients now support shared dev credentials!

This PR updates `npx instant-cli auth client add` and `npx instant-cli auth client list` to support shared dev credentials.

**Note:** You may wonder: how do you upgrade a client from dev-credentials? A follow-on PR will implement the `update` command.

## add

**--dev-credentials** 

You can pass in a `--dev-credentials` flag to explicitly choose dev-credentials: 

```
npx instant-cli auth client add --type google --app-type web --name google-dev --dev-credentials
```

When you do, we will include a notice in the prompt output saying you have dev credentials

**--yes defaults to --dev-credentials** 

If you create with --yes and don't provide a `--client-id` or a `--client-token`, we will default to `--dev-credentials`

```
npx instant-cli auth client add --type google --app-type web --name google-dev --yes
```

**Interactive mode asks you for your choice**

For interactive runs, Google web asks whether to use dev credentials or your own Google credentials. If you pass `--client-id`, `--client-secret`, or `--custom-redirect-uri`, the CLI treats that as the custom credentials path.

**This is how the output boxes look:**

```txt
┌──────────────────────────────────────────────────┐
│ Google OAuth client created: google-custom       │
│ App type: web                                    │
│ ID: bc87b763-bccb-431d-87f0-e3daa22d474a         │
│ Google Client ID: test-google-client-id          │
│                                                  │
│ Add this redirect URI in Google Console:         │
│ https://api.instantdb.com/runtime/oauth/callback │
│                                                  │
└──────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────┐
│ Google OAuth client created: google-dev-yes2           │
│ App type: web                                          │
│ Credentials: Instant dev credentials                   │
│ ID: ae5ac75d-6840-42c9-a8d5-2881f630300e               │
│                                                        │
│ No Google Console setup required.                      │
│ Works on localhost and Expo during development.        │
│                                                        │
│ For production, use your own Google OAuth credentials. │
└────────────────────────────────────────────────────────┘
```

## list

`auth client list` now explicitly notes that you are using `dev-credentials`. 

**This is how the output looks:**

```
google-dev-yes2
  Provider: google
  App type: web
  Credentials: Instant dev credentials
  ID: ae5ac75d-6840-42c9-a8d5-2881f630300e
  Client id: managed by Instant
  Redirect URL: localhost and Expo allowed automatically
google-custom
  Provider: google
  App type: web
  Credentials: custom
  ID: bc87b763-bccb-431d-87f0-e3daa22d474a
  Client id: test-google-client-id
  Redirect URL: https://api.instantdb.com/runtime/oauth/callback
```

## Testing

```bash
# 1. Come on into cli-nodejs and build a throwaway app.

export INSTANT_CLI_DEV=true
cd client/sandbox/cli-nodejs
rm -f .env
pnpm exec instant-cli init --yes --title testing-app

# 2. Create a Google web client with --yes and no Google credentials.

pnpm exec instant-cli auth client add \
  --type google \
  --app-type web \
  --name google-dev-yes \
  --yes

## This should choose dev credentials automatically.

# 3. Create a second Google web client by explicitly passing --dev-credentials.

pnpm exec instant-cli auth client add \
  --type google \
  --app-type web \
  --name google-dev-explicit \
  --dev-credentials

## This should automatically get created too

# 4. List confirm both dev clients show the same dev-credentials fields.

pnpm exec instant-cli auth client list

# 5. Create a normal custom Google web client.

pnpm exec instant-cli auth client add \
  --type google \
  --app-type web \
  --name google-custom \
  --client-id test-google-client-id \
  --client-secret test-google-client-secret \
  --yes

## Notice the success output is different from the dev-credentials flow:

# 6. List again and confirm the custom client is custom, while the first two are still dev clients.

pnpm exec instant-cli auth client list

# 7. Check JSON output. This should still be the raw API shape.

pnpm exec instant-cli auth client list --json

# 8. Test the interactive path.

#    Run add without --yes. 

pnpm exec instant-cli auth client add \
  --type google \
  --name google-dev-interactive

## See you get asked what type you want. Go through both the dev credential and custom flow

pnpm exec instant-cli auth client list

# 9. Test that --dev-credentials is rejected for native Google clients.

pnpm exec instant-cli auth client add \
  --type google \
  --app-type ios \
  --name google-ios-dev \
  --dev-credentials

# Notice this fails with a message saying --dev-credentials is only supported for Google web clients.

# 10. Test that --dev-credentials cannot be combined with custom credential flags.

pnpm exec instant-cli auth client add \
  --type google \
  --app-type web \
  --name google-invalid \
  --dev-credentials \
  --client-id test-google-client-id
```