### PR TITLE
[claude] shared dev credentials in instant-cli + auth client update

### DIFF
--- a/client/packages/cli/__tests__/authClientAddGoogle.test.ts
+++ b/client/packages/cli/__tests__/authClientAddGoogle.test.ts
@@ -242,6 +242,92 @@ describe('web: success', () => {
 
 // -- ios: forbidden flags and success --
 
+describe('shared dev credentials', () => {
+  const sharedFlags = new Map([
+    ['type', 'google'],
+    ['app-type', 'web'],
+    ['name', 'google-web'],
+  ]);
+
+  test('--yes with no creds and web app-type → auto-defaults to shared', async () => {
+    await run(sharedFlags, { yes: true });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({
+      clientName: 'google-web',
+      useSharedCredentials: true,
+    });
+    expect(addedClients[0].clientId).toBeUndefined();
+    expect(addedClients[0].clientSecret).toBeUndefined();
+    expect(addedClients[0].redirectTo).toBeUndefined();
+    const output = logs.join('\n');
+    expect(output).toContain("Using Instant's shared dev credentials");
+    expect(output).toContain('Mode: shared dev credentials');
+    expect(output).toContain('http://localhost');
+    expect(output).toContain('Capped at 100 sign-ups');
+    expect(output).not.toContain('Add this redirect URI in Google Console');
+  });
+
+  test('--use-shared-credentials → creates shared client', async () => {
+    await run(withEntry(sharedFlags, 'use-shared-credentials', 'true'), {
+      yes: true,
+    });
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({
+      useSharedCredentials: true,
+    });
+  });
+
+  test('--use-shared-credentials + --client-id → mutually-exclusive error', async () => {
+    await run(
+      withEntry(
+        withEntry(sharedFlags, 'use-shared-credentials', 'true'),
+        'client-id',
+        'foo',
+      ),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('mutually exclusive');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('--use-shared-credentials with ios app-type → error', async () => {
+    await run(
+      withEntry(
+        new Map([
+          ['type', 'google'],
+          ['app-type', 'ios'],
+          ['name', 'google-ios'],
+        ]),
+        'use-shared-credentials',
+        'true',
+      ),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('only supported for Google web flows');
+    expect(addedClients).toHaveLength(0);
+  });
+
+  test('--client-id keeps custom mode (no auto-default)', async () => {
+    await run(webFlags, { yes: true });
+    expect(addedClients[0]).toMatchObject({
+      clientId: '123456.apps.googleusercontent.com',
+    });
+    expect(addedClients[0].useSharedCredentials).toBeUndefined();
+  });
+
+  test('interactive without creds → prompts credential-mode selector', async () => {
+    mockPromptReturn = 'shared';
+    await run(sharedFlags, { yes: false });
+    const modePrompt = prompts.find(
+      (p: any) =>
+        p?.params?.promptText === 'How do you want to set up credentials?',
+    );
+    expect(modePrompt).toBeDefined();
+    expect(addedClients).toHaveLength(1);
+    expect(addedClients[0]).toMatchObject({ useSharedCredentials: true });
+  });
+});
+
 describe('ios', () => {
   test('--client-secret → error (not supported)', async () => {
     await run(withEntry(iosFlags, 'client-secret', 'secret'), { yes: true });

--- a/client/packages/cli/__tests__/authClientUpdate.test.ts
+++ b/client/packages/cli/__tests__/authClientUpdate.test.ts
@@ -1,0 +1,404 @@
+import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { NodeContext } from '@effect/platform-node';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import { InstantHttpAuthed } from '../src/lib/http.ts';
+import { BadArgsError } from '../src/errors.ts';
+
+vi.mock('../src/index.ts', () => ({}));
+
+let prompts: any[] = [];
+let mockPromptReturn: any = '';
+
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: (prompt: any) => {
+      prompts.push(prompt);
+      return Promise.resolve(mockPromptReturn);
+    },
+  };
+});
+
+let updateCalls: any[] = [];
+let mockClient: any;
+let mockProvider: any;
+
+vi.mock('../src/lib/oauth.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    getAppsAuth: () =>
+      Effect.succeed({
+        oauth_service_providers: [mockProvider],
+        oauth_clients: [mockClient],
+      }),
+    findClientByIdOrName: ({ id, name }: { id?: string; name?: string }) =>
+      Effect.gen(function* () {
+        if (id && name) {
+          return yield* BadArgsError.make({
+            message: 'Cannot specify both --id and --name',
+          });
+        }
+        if (!id && !name) {
+          return yield* BadArgsError.make({
+            message: 'Must specify --id or --name',
+          });
+        }
+        if (
+          (id && id !== mockClient.id) ||
+          (name && name !== mockClient.client_name)
+        ) {
+          return yield* BadArgsError.make({
+            message: `OAuth client not found`,
+          });
+        }
+        return {
+          client: mockClient,
+          auth: {
+            oauth_service_providers: [mockProvider],
+            oauth_clients: [mockClient],
+          },
+        };
+      }),
+    updateOAuthClient: (params: any) => {
+      updateCalls.push(params);
+      return Effect.succeed({
+        client: { ...mockClient, ...params.body },
+      });
+    },
+  };
+});
+
+const { authClientUpdateCmd } = await import(
+  '../src/commands/auth/client/update.ts'
+);
+
+let logs: string[] = [];
+
+const run = (flags: Map<string, string>, { yes }: { yes: boolean }) =>
+  Effect.runPromise(
+    authClientUpdateCmd(Object.fromEntries(flags) as any).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(GlobalOpts, { yes }),
+          Layer.succeed(CurrentApp, { appId: 'test-app', source: 'env' }),
+          Layer.succeed(InstantHttpAuthed, {} as any),
+          NodeContext.layer,
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => {
+              logs.push(String(message));
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+beforeEach(() => {
+  prompts = [];
+  updateCalls = [];
+  logs = [];
+  mockPromptReturn = '';
+});
+
+// ---------- Google ----------
+
+describe('google update', () => {
+  beforeEach(() => {
+    mockProvider = { id: 'prov-1', provider_name: 'google' };
+    mockClient = {
+      id: 'client-1',
+      client_name: 'google-web',
+      provider_id: 'prov-1',
+      use_shared_credentials: true,
+    };
+  });
+
+  test('--yes with no flags → errors', async () => {
+    await run(new Map([['name', 'google-web']]), { yes: true });
+    expect(logs.join('\n')).toContain('Nothing to update');
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test('upgrade shared → custom (--client-id + --client-secret)', async () => {
+    await run(
+      new Map([
+        ['name', 'google-web'],
+        ['client-id', 'new-id'],
+        ['client-secret', 'new-secret'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      client_id: 'new-id',
+      client_secret: 'new-secret',
+      use_shared_credentials: false,
+    });
+    const out = logs.join('\n');
+    expect(out).toContain('Mode: custom credentials');
+    expect(out).toContain('Add this redirect URI in Google Console');
+  });
+
+  test('rotate custom credentials', async () => {
+    mockClient.use_shared_credentials = false;
+    mockClient.client_id = 'old-id';
+    await run(
+      new Map([
+        ['name', 'google-web'],
+        ['client-id', 'rotated-id'],
+        ['client-secret', 'rotated-secret'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      client_id: 'rotated-id',
+      client_secret: 'rotated-secret',
+    });
+    expect(updateCalls[0].body.use_shared_credentials).toBeUndefined();
+  });
+
+  test('downgrade custom → shared (--use-shared-credentials)', async () => {
+    mockClient.use_shared_credentials = false;
+    mockClient.client_id = 'old-id';
+    await run(
+      new Map([
+        ['name', 'google-web'],
+        ['use-shared-credentials', 'true'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      use_shared_credentials: true,
+    });
+    expect(logs.join('\n')).toContain('shared dev credentials');
+  });
+
+  test('--use-shared-credentials + --client-id → mutually-exclusive error', async () => {
+    await run(
+      new Map([
+        ['name', 'google-web'],
+        ['use-shared-credentials', 'true'],
+        ['client-id', 'foo'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('mutually exclusive');
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test('update redirect only', async () => {
+    mockClient.use_shared_credentials = false;
+    await run(
+      new Map([
+        ['name', 'google-web'],
+        ['custom-redirect-uri', 'https://myapp.com/cb'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      redirect_to: 'https://myapp.com/cb',
+    });
+  });
+});
+
+// ---------- GitHub ----------
+
+describe('github update', () => {
+  beforeEach(() => {
+    mockProvider = { id: 'prov-2', provider_name: 'github' };
+    mockClient = {
+      id: 'gh-client',
+      client_name: 'github',
+      provider_id: 'prov-2',
+    };
+  });
+
+  test('rotate credentials', async () => {
+    await run(
+      new Map([
+        ['name', 'github'],
+        ['client-id', 'gh-id'],
+        ['client-secret', 'gh-secret'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      client_id: 'gh-id',
+      client_secret: 'gh-secret',
+    });
+  });
+
+  test('--yes with no flags → errors', async () => {
+    await run(new Map([['name', 'github']]), { yes: true });
+    expect(logs.join('\n')).toContain('Nothing to update');
+    expect(updateCalls).toHaveLength(0);
+  });
+});
+
+// ---------- Apple ----------
+
+describe('apple update', () => {
+  beforeEach(() => {
+    mockProvider = { id: 'prov-3', provider_name: 'apple' };
+    mockClient = {
+      id: 'apple-client',
+      client_name: 'apple',
+      provider_id: 'prov-3',
+    };
+  });
+
+  test('rotate services-id only', async () => {
+    await run(
+      new Map([
+        ['name', 'apple'],
+        ['services-id', 'new.services.id'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      client_id: 'new.services.id',
+    });
+  });
+
+  test('update team-id and key-id (meta)', async () => {
+    await run(
+      new Map([
+        ['name', 'apple'],
+        ['team-id', 'TEAM123'],
+        ['key-id', 'KEY456'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body.meta).toMatchObject({
+      teamId: 'TEAM123',
+      keyId: 'KEY456',
+    });
+  });
+});
+
+// ---------- Clerk ----------
+
+describe('clerk update', () => {
+  beforeEach(() => {
+    mockProvider = { id: 'prov-4', provider_name: 'clerk' };
+    mockClient = {
+      id: 'clerk-client',
+      client_name: 'clerk',
+      provider_id: 'prov-4',
+    };
+  });
+
+  test('rotate publishable key derives discovery endpoint', async () => {
+    // pk_live_<base64-encoded "clerk.example.com$">
+    const domain = 'clerk.example.com';
+    const encoded = Buffer.from(domain + '$').toString('base64');
+    const key = `pk_live_${encoded}`;
+    await run(
+      new Map([
+        ['name', 'clerk'],
+        ['publishable-key', key],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body).toMatchObject({
+      meta: { clerkPublishableKey: key },
+      discovery_endpoint: `https://${domain}/.well-known/openid-configuration`,
+    });
+  });
+});
+
+// ---------- Firebase ----------
+
+describe('firebase update', () => {
+  beforeEach(() => {
+    mockProvider = { id: 'prov-5', provider_name: 'firebase' };
+    mockClient = {
+      id: 'fb-client',
+      client_name: 'firebase',
+      provider_id: 'prov-5',
+    };
+  });
+
+  test('rotate project-id derives discovery endpoint', async () => {
+    await run(
+      new Map([
+        ['name', 'firebase'],
+        ['project-id', 'my-new-project-123'],
+      ]),
+      { yes: true },
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].body.discovery_endpoint).toBe(
+      'https://securetoken.google.com/my-new-project-123/.well-known/openid-configuration',
+    );
+  });
+
+  test('rotate project-id with invalid id → error', async () => {
+    await run(
+      new Map([
+        ['name', 'firebase'],
+        ['project-id', 'BAD'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('Invalid Firebase project ID');
+    expect(updateCalls).toHaveLength(0);
+  });
+});
+
+// ---------- Identification ----------
+
+describe('client identification', () => {
+  beforeEach(() => {
+    mockProvider = { id: 'prov-1', provider_name: 'google' };
+    mockClient = {
+      id: 'client-1',
+      client_name: 'google-web',
+      provider_id: 'prov-1',
+      use_shared_credentials: false,
+    };
+  });
+
+  test('both --id and --name → error', async () => {
+    await run(
+      new Map([
+        ['id', 'client-1'],
+        ['name', 'google-web'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('Cannot specify both --id and --name');
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test('--yes without --id or --name → error', async () => {
+    await run(new Map(), { yes: true });
+    expect(logs.join('\n')).toContain('Must specify --id or --name');
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test('unknown name → error', async () => {
+    await run(
+      new Map([
+        ['name', 'unknown'],
+        ['client-id', 'x'],
+        ['client-secret', 'y'],
+      ]),
+      { yes: true },
+    );
+    expect(logs.join('\n')).toContain('not found');
+    expect(updateCalls).toHaveLength(0);
+  });
+});

--- a/client/packages/cli/src/commands/auth/client/add.ts
+++ b/client/packages/cli/src/commands/auth/client/add.ts
@@ -96,10 +96,90 @@ const selectGoogleAppType = (value: unknown) =>
     );
   });
 
+type GoogleAppType = typeof GoogleAppTypeSchema.Type;
+
+const isFlagSet = (opts: Record<string, unknown>, ...keys: string[]) =>
+  keys.some((k) => opts[k] !== undefined && opts[k] !== null && opts[k] !== '');
+
+const selectGoogleCredentialMode = Effect.fn(function* (
+  opts: Record<string, unknown>,
+  appType: GoogleAppType,
+) {
+  // Shared credentials are only supported for Google web flows.
+  if (appType !== 'web') {
+    if (isFlagSet(opts, 'use-shared-credentials', 'useSharedCredentials')) {
+      return yield* BadArgsError.make({
+        message:
+          '--use-shared-credentials is only supported for Google web flows.',
+      });
+    }
+    return 'custom' as const;
+  }
+
+  const sharedFlag = isFlagSet(
+    opts,
+    'use-shared-credentials',
+    'useSharedCredentials',
+  );
+  const customFlags = isFlagSet(
+    opts,
+    'client-id',
+    'clientId',
+    'client-secret',
+    'clientSecret',
+    'custom-redirect-uri',
+    'customRedirectUri',
+  );
+
+  if (sharedFlag && customFlags) {
+    return yield* BadArgsError.make({
+      message:
+        '--use-shared-credentials is mutually exclusive with --client-id, --client-secret, and --custom-redirect-uri.',
+    });
+  }
+
+  if (sharedFlag) return 'shared' as const;
+  if (customFlags) return 'custom' as const;
+
+  const { yes } = yield* GlobalOpts;
+  if (yes) {
+    yield* Effect.log(chalk.bold("Using Instant's shared dev credentials."));
+    return 'shared' as const;
+  }
+
+  const picked = yield* runUIEffect(
+    new UI.Select({
+      options: [
+        {
+          label:
+            "Use Instant's shared dev credentials" +
+            chalk.dim(' (recommended for development)'),
+          value: 'shared',
+        },
+        { label: 'Use my own', value: 'custom' },
+      ],
+      promptText: 'How do you want to set up credentials?',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+      defaultValue: 'shared',
+    }),
+  ).pipe(
+    Effect.catchTag('UIError', (e) =>
+      BadArgsError.make({ message: `UI error: ${e.message}` }),
+    ),
+  );
+
+  return picked === 'shared' ? ('shared' as const) : ('custom' as const);
+});
+
 const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
   // This one requires special logic for getting client name
   // because the suggested name includes the app type
   const appType = yield* selectGoogleAppType(opts['app-type']);
+  const credentialMode = yield* selectGoogleCredentialMode(opts, appType);
+
   const { auth, provider } = yield* getOrCreateProvider('google');
   const usedClientNames = new Set(
     (auth.oauth_clients ?? []).map((client) => client.client_name),
@@ -123,6 +203,42 @@ const handleGoogleClient = Effect.fn(function* (opts: Record<string, unknown>) {
     return yield* BadArgsError.make({
       message: `The unique name '${clientName}' is already in use.`,
     });
+  }
+
+  if (!clientName) {
+    return yield* BadArgsError.make({ message: 'Client name is required.' }); // Should never reach this
+  }
+
+  if (credentialMode === 'shared') {
+    const response = yield* addOAuthClient({
+      providerId: provider.id,
+      clientName,
+      authorizationEndpoint: GOOGLE_AUTHORIZATION_ENDPOINT,
+      tokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
+      discoveryEndpoint: GOOGLE_DISCOVERY_ENDPOINT,
+      useSharedCredentials: true,
+      meta: {
+        appType,
+        skipNonceChecks: true,
+      },
+    });
+
+    yield* Effect.log(
+      boxen(
+        [
+          `Google OAuth client created: ${response.client.client_name}`,
+          `App type: ${appType}   Mode: shared dev credentials`,
+          `ID: ${response.client.id}`,
+          '',
+          'Redirect origins enabled: http://localhost, https://localhost, exp://',
+          chalk.dim(
+            'Capped at 100 sign-ups. Run `instant-cli auth client update` with --client-id and --client-secret before going to production.',
+          ),
+        ].join('\n'),
+        { dimBorder: true, padding: { right: 1, left: 1 } },
+      ),
+    );
+    return;
   }
 
   const clientId = yield* optOrPrompt(opts['client-id'], {
@@ -179,9 +295,6 @@ ${chalk.dim(`Your URI must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all que
     skipMessage: 'Provided custom redirect URI when not using web app type.',
   });
 
-  if (!clientName) {
-    return yield* BadArgsError.make({ message: 'Client name is required.' }); // Should never reach this
-  }
   const redirectUri = customRedirectUri || DEFAULT_OAUTH_CALLBACK_URL;
 
   const response = yield* addOAuthClient({

--- a/client/packages/cli/src/commands/auth/client/list.ts
+++ b/client/packages/cli/src/commands/auth/client/list.ts
@@ -36,6 +36,9 @@ export const authClientListCmd = Effect.fn(function* (
     );
     yield* Effect.log(`  ID: ${client.id}`);
     yield* Effect.log(`  Client id: ${formatValue(client.client_id)}`);
+    if (client.use_shared_credentials) {
+      yield* Effect.log(`  Mode: shared dev credentials`);
+    }
     yield* Effect.log(`  Redirect URL: ${formatValue(client.redirect_to)}`);
   }
 });

--- a/client/packages/cli/src/commands/auth/client/update.ts
+++ b/client/packages/cli/src/commands/auth/client/update.ts
@@ -1,0 +1,817 @@
+import { Effect, Match } from 'effect';
+import boxen from 'boxen';
+import chalk from 'chalk';
+import { FileSystem } from '@effect/platform';
+import type { authClientUpdateDef, OptsFromCommand } from '../../../index.ts';
+import { BadArgsError } from '../../../errors.ts';
+import { GlobalOpts } from '../../../context/globalOpts.ts';
+import {
+  findClientByIdOrName,
+  getAppsAuth,
+  updateOAuthClient,
+  type OAuthClientType,
+} from '../../../lib/oauth.ts';
+import {
+  optOrPrompt,
+  runUIEffect,
+  stripFirstBlankLine,
+  validateRequired,
+} from '../../../lib/ui.ts';
+import { UI } from '../../../ui/index.ts';
+import { DEFAULT_OAUTH_CALLBACK_URL } from '@instantdb/platform';
+import { link } from '../../../logging.ts';
+
+const isFlagSet = (opts: Record<string, unknown>, ...keys: string[]) =>
+  keys.some((k) => opts[k] !== undefined && opts[k] !== null && opts[k] !== '');
+
+const readPrivateKeyFile = Effect.fn('readPrivateKeyFile')(function* (
+  path: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const normalizedPath =
+    process.platform === 'win32' ? path : path.replace(/\\(.)/g, '$1');
+  const contents = yield* fs.readFileString(normalizedPath, 'utf8').pipe(
+    Effect.mapError(
+      (e) =>
+        new BadArgsError({
+          message: `Could not read private key file at ${normalizedPath}: ${e.message}`,
+        }),
+    ),
+  );
+  const trimmed = contents.trim();
+  if (!trimmed) {
+    return yield* BadArgsError.make({
+      message: `Private key file at ${normalizedPath} is empty.`,
+    });
+  }
+  return trimmed;
+});
+
+const promptCustomRedirectUri = Effect.fn(function* (
+  opts: Record<string, unknown>,
+) {
+  return yield* optOrPrompt(opts['custom-redirect-uri'], {
+    required: false,
+    simpleName: '--custom-redirect-uri',
+    skipIf: false,
+    prompt: {
+      prompt: '',
+      placeholder: 'https://yoursite.com/oauth/callback',
+      modifyOutput: UI.modifiers.piped([
+        (output, status) => {
+          if (status === 'idle') {
+            return (
+              `\nNew redirect URI:\n${chalk.dim(`Must forward to ${DEFAULT_OAUTH_CALLBACK_URL} with all query parameters preserved.`)}\n\n` +
+              stripFirstBlankLine(output)
+            );
+          }
+          return `\nNew redirect URI:\n${stripFirstBlankLine(output)}`;
+        },
+        UI.modifiers.dimOnComplete,
+      ]),
+    },
+  });
+});
+
+const logSummary = Effect.fn(function* (
+  client: OAuthClientType,
+  providerName: string,
+  extraLines: string[] = [],
+) {
+  yield* Effect.log(
+    boxen(
+      [
+        `${providerName} OAuth client updated: ${client.client_name}`,
+        `ID: ${client.id}`,
+        ...extraLines,
+      ].join('\n'),
+      { dimBorder: true, padding: { right: 1, left: 1 } },
+    ),
+  );
+});
+
+// ---------- Google ----------
+
+const handleGoogleUpdate = Effect.fn(function* (
+  client: OAuthClientType,
+  opts: Record<string, unknown>,
+) {
+  const { yes } = yield* GlobalOpts;
+  const isShared = !!client.use_shared_credentials;
+
+  const sharedFlag = isFlagSet(
+    opts,
+    'use-shared-credentials',
+    'useSharedCredentials',
+  );
+  const credFlags = isFlagSet(
+    opts,
+    'client-id',
+    'clientId',
+    'client-secret',
+    'clientSecret',
+  );
+  const redirectFlag = isFlagSet(
+    opts,
+    'custom-redirect-uri',
+    'customRedirectUri',
+  );
+
+  if (sharedFlag && (credFlags || redirectFlag)) {
+    return yield* BadArgsError.make({
+      message:
+        '--use-shared-credentials is mutually exclusive with --client-id, --client-secret, and --custom-redirect-uri.',
+    });
+  }
+
+  // Determine intent
+  type Intent =
+    | {
+        kind: 'set-custom';
+        clientId: string;
+        clientSecret: string;
+        redirect?: string;
+      }
+    | { kind: 'switch-to-shared' }
+    | { kind: 'rotate'; clientId: string; clientSecret: string }
+    | { kind: 'update-redirect'; redirect: string };
+
+  let intent: Intent | undefined;
+
+  if (sharedFlag) {
+    intent = { kind: 'switch-to-shared' };
+  } else if (credFlags) {
+    const clientId = yield* optOrPrompt(opts['client-id'], {
+      simpleName: '--client-id',
+      required: true,
+      skipIf: false,
+      prompt: {
+        prompt: `Client ID: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
+        validate: validateRequired,
+        modifyOutput: UI.modifiers.piped([
+          UI.modifiers.topPadding,
+          UI.modifiers.dimOnComplete,
+        ]),
+      },
+    });
+    const clientSecret = yield* optOrPrompt(opts['client-secret'], {
+      simpleName: '--client-secret',
+      required: true,
+      skipIf: false,
+      prompt: {
+        prompt: `Client Secret: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
+        validate: validateRequired,
+        sensitive: true,
+        modifyOutput: UI.modifiers.piped([
+          UI.modifiers.topPadding,
+          UI.modifiers.dimOnComplete,
+        ]),
+      },
+    });
+    if (!clientId || !clientSecret) {
+      return yield* BadArgsError.make({
+        message: 'Missing client credentials.',
+      });
+    }
+    const redirect = redirectFlag
+      ? (((yield* promptCustomRedirectUri(opts)) || undefined) as
+          | string
+          | undefined)
+      : undefined;
+    intent = isShared
+      ? { kind: 'set-custom', clientId, clientSecret, redirect }
+      : { kind: 'rotate', clientId, clientSecret };
+  } else if (redirectFlag) {
+    const redirect = yield* promptCustomRedirectUri(opts);
+    if (!redirect) {
+      return yield* BadArgsError.make({
+        message: '--custom-redirect-uri must be a non-empty URL.',
+      });
+    }
+    intent = { kind: 'update-redirect', redirect };
+  } else {
+    if (yes) {
+      return yield* BadArgsError.make({
+        message:
+          'Nothing to update. Pass at least one of --client-id, --client-secret, --use-shared-credentials, or --custom-redirect-uri.',
+      });
+    }
+    yield* Effect.log(
+      `\nCurrent mode: ${isShared ? chalk.bold('shared dev credentials') : 'custom'}`,
+    );
+    if (isShared) {
+      const clientId = yield* optOrPrompt(undefined, {
+        simpleName: '--client-id',
+        required: true,
+        skipIf: false,
+        prompt: {
+          prompt: `Client ID: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
+          validate: validateRequired,
+          modifyOutput: UI.modifiers.piped([
+            UI.modifiers.topPadding,
+            UI.modifiers.dimOnComplete,
+          ]),
+        },
+      });
+      const clientSecret = yield* optOrPrompt(undefined, {
+        simpleName: '--client-secret',
+        required: true,
+        skipIf: false,
+        prompt: {
+          prompt: `Client Secret: ${chalk.dim(`(from ${link('https://console.developers.google.com/apis/credentials')})`)}`,
+          validate: validateRequired,
+          sensitive: true,
+          modifyOutput: UI.modifiers.piped([
+            UI.modifiers.topPadding,
+            UI.modifiers.dimOnComplete,
+          ]),
+        },
+      });
+      if (!clientId || !clientSecret) {
+        return yield* BadArgsError.make({
+          message: 'Missing client credentials.',
+        });
+      }
+      intent = { kind: 'set-custom', clientId, clientSecret };
+    } else {
+      const action = yield* runUIEffect(
+        new UI.Select({
+          options: [
+            { label: 'Rotate credentials', value: 'rotate' },
+            {
+              label: "Switch to Instant's shared dev credentials",
+              value: 'switch-to-shared',
+            },
+            { label: 'Update redirect URI', value: 'update-redirect' },
+          ],
+          promptText: 'What do you want to update?',
+          modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
+        }),
+      ).pipe(
+        Effect.catchTag('UIError', (e) =>
+          BadArgsError.make({ message: `UI error: ${e.message}` }),
+        ),
+      );
+      if (action === 'rotate') {
+        const clientId = yield* optOrPrompt(undefined, {
+          simpleName: '--client-id',
+          required: true,
+          skipIf: false,
+          prompt: {
+            prompt: 'Client ID:',
+            validate: validateRequired,
+            modifyOutput: UI.modifiers.piped([
+              UI.modifiers.topPadding,
+              UI.modifiers.dimOnComplete,
+            ]),
+          },
+        });
+        const clientSecret = yield* optOrPrompt(undefined, {
+          simpleName: '--client-secret',
+          required: true,
+          skipIf: false,
+          prompt: {
+            prompt: 'Client Secret:',
+            validate: validateRequired,
+            sensitive: true,
+            modifyOutput: UI.modifiers.piped([
+              UI.modifiers.topPadding,
+              UI.modifiers.dimOnComplete,
+            ]),
+          },
+        });
+        if (!clientId || !clientSecret) {
+          return yield* BadArgsError.make({
+            message: 'Missing client credentials.',
+          });
+        }
+        intent = { kind: 'rotate', clientId, clientSecret };
+      } else if (action === 'switch-to-shared') {
+        intent = { kind: 'switch-to-shared' };
+      } else {
+        const redirect = yield* promptCustomRedirectUri(opts);
+        if (!redirect) {
+          return yield* BadArgsError.make({
+            message: 'Redirect URI cannot be empty.',
+          });
+        }
+        intent = { kind: 'update-redirect', redirect };
+      }
+    }
+  }
+
+  if (!intent) {
+    return yield* BadArgsError.make({ message: 'Nothing to update.' });
+  }
+
+  const body: Parameters<typeof updateOAuthClient>[0]['body'] = {};
+  const summaryLines: string[] = [];
+
+  switch (intent.kind) {
+    case 'set-custom':
+      body.client_id = intent.clientId;
+      body.client_secret = intent.clientSecret;
+      body.use_shared_credentials = false;
+      if (intent.redirect) body.redirect_to = intent.redirect;
+      summaryLines.push('Mode: custom credentials');
+      summaryLines.push(`Google Client ID: ${intent.clientId}`);
+      summaryLines.push(
+        chalk.bold(
+          `\nAdd this redirect URI in Google Console:\n${intent.redirect ?? DEFAULT_OAUTH_CALLBACK_URL}`,
+        ),
+      );
+      break;
+    case 'rotate':
+      body.client_id = intent.clientId;
+      body.client_secret = intent.clientSecret;
+      summaryLines.push(`Google Client ID: ${intent.clientId}`);
+      break;
+    case 'switch-to-shared':
+      body.use_shared_credentials = true;
+      summaryLines.push('Mode: shared dev credentials');
+      summaryLines.push(
+        'Redirect origins enabled: http://localhost, https://localhost, exp://',
+      );
+      break;
+    case 'update-redirect':
+      body.redirect_to = intent.redirect;
+      summaryLines.push(`Redirect URI: ${intent.redirect}`);
+      break;
+  }
+
+  const response = yield* updateOAuthClient({
+    oauthClientId: client.id,
+    body,
+  });
+  yield* logSummary(response.client, 'Google', summaryLines);
+});
+
+// ---------- GitHub ----------
+
+const handleGenericCredentialUpdate = Effect.fn(function* (
+  client: OAuthClientType,
+  opts: Record<string, unknown>,
+  providerLabel: string,
+  consoleLink: string,
+) {
+  const { yes } = yield* GlobalOpts;
+
+  const credFlags = isFlagSet(
+    opts,
+    'client-id',
+    'clientId',
+    'client-secret',
+    'clientSecret',
+  );
+  const redirectFlag = isFlagSet(
+    opts,
+    'custom-redirect-uri',
+    'customRedirectUri',
+  );
+
+  if (!credFlags && !redirectFlag && yes) {
+    return yield* BadArgsError.make({
+      message:
+        'Nothing to update. Pass --client-id, --client-secret, or --custom-redirect-uri.',
+    });
+  }
+
+  const body: Parameters<typeof updateOAuthClient>[0]['body'] = {};
+  const summaryLines: string[] = [];
+
+  if (credFlags) {
+    const clientId = yield* optOrPrompt(opts['client-id'], {
+      simpleName: '--client-id',
+      required: true,
+      skipIf: false,
+      prompt: {
+        prompt: `Client ID: ${chalk.dim(`(from ${link(consoleLink)})`)}`,
+        validate: validateRequired,
+        modifyOutput: UI.modifiers.piped([
+          UI.modifiers.topPadding,
+          UI.modifiers.dimOnComplete,
+        ]),
+      },
+    });
+    const clientSecret = yield* optOrPrompt(opts['client-secret'], {
+      simpleName: '--client-secret',
+      required: true,
+      skipIf: false,
+      prompt: {
+        prompt: `Client Secret: ${chalk.dim(`(from ${link(consoleLink)})`)}`,
+        validate: validateRequired,
+        sensitive: true,
+        modifyOutput: UI.modifiers.piped([
+          UI.modifiers.topPadding,
+          UI.modifiers.dimOnComplete,
+        ]),
+      },
+    });
+    if (!clientId || !clientSecret) {
+      return yield* BadArgsError.make({
+        message: 'Missing client credentials.',
+      });
+    }
+    body.client_id = clientId;
+    body.client_secret = clientSecret;
+    summaryLines.push(`${providerLabel} Client ID: ${clientId}`);
+  }
+
+  if (redirectFlag) {
+    const redirect = yield* promptCustomRedirectUri(opts);
+    if (redirect) {
+      body.redirect_to = redirect;
+      summaryLines.push(`Redirect URI: ${redirect}`);
+    }
+  }
+
+  if (!credFlags && !redirectFlag) {
+    // Interactive without flags
+    const action = yield* runUIEffect(
+      new UI.Select({
+        options: [
+          { label: 'Rotate credentials', value: 'rotate' },
+          { label: 'Update redirect URI', value: 'redirect' },
+        ],
+        promptText: 'What do you want to update?',
+        modifyOutput: UI.modifiers.piped([UI.modifiers.dimOnComplete]),
+      }),
+    ).pipe(
+      Effect.catchTag('UIError', (e) =>
+        BadArgsError.make({ message: `UI error: ${e.message}` }),
+      ),
+    );
+    if (action === 'rotate') {
+      const clientId = yield* optOrPrompt(undefined, {
+        simpleName: '--client-id',
+        required: true,
+        skipIf: false,
+        prompt: {
+          prompt: `Client ID: ${chalk.dim(`(from ${link(consoleLink)})`)}`,
+          validate: validateRequired,
+          modifyOutput: UI.modifiers.piped([
+            UI.modifiers.topPadding,
+            UI.modifiers.dimOnComplete,
+          ]),
+        },
+      });
+      const clientSecret = yield* optOrPrompt(undefined, {
+        simpleName: '--client-secret',
+        required: true,
+        skipIf: false,
+        prompt: {
+          prompt: `Client Secret: ${chalk.dim(`(from ${link(consoleLink)})`)}`,
+          validate: validateRequired,
+          sensitive: true,
+          modifyOutput: UI.modifiers.piped([
+            UI.modifiers.topPadding,
+            UI.modifiers.dimOnComplete,
+          ]),
+        },
+      });
+      if (!clientId || !clientSecret) {
+        return yield* BadArgsError.make({
+          message: 'Missing client credentials.',
+        });
+      }
+      body.client_id = clientId;
+      body.client_secret = clientSecret;
+      summaryLines.push(`${providerLabel} Client ID: ${clientId}`);
+    } else {
+      const redirect = yield* promptCustomRedirectUri(opts);
+      if (!redirect) {
+        return yield* BadArgsError.make({
+          message: 'Redirect URI cannot be empty.',
+        });
+      }
+      body.redirect_to = redirect;
+      summaryLines.push(`Redirect URI: ${redirect}`);
+    }
+  }
+
+  const response = yield* updateOAuthClient({
+    oauthClientId: client.id,
+    body,
+  });
+  yield* logSummary(response.client, providerLabel, summaryLines);
+});
+
+// ---------- Apple ----------
+
+const handleAppleUpdate = Effect.fn(function* (
+  client: OAuthClientType,
+  opts: Record<string, unknown>,
+) {
+  const { yes } = yield* GlobalOpts;
+
+  const servicesIdFlag = isFlagSet(opts, 'services-id', 'servicesId');
+  const privateKeyFlag = isFlagSet(opts, 'private-key-file', 'privateKeyFile');
+  const teamIdFlag = isFlagSet(opts, 'team-id', 'teamId');
+  const keyIdFlag = isFlagSet(opts, 'key-id', 'keyId');
+  const redirectFlag = isFlagSet(
+    opts,
+    'custom-redirect-uri',
+    'customRedirectUri',
+  );
+
+  const anyFlag =
+    servicesIdFlag || privateKeyFlag || teamIdFlag || keyIdFlag || redirectFlag;
+
+  if (!anyFlag && yes) {
+    return yield* BadArgsError.make({
+      message:
+        'Nothing to update. Pass at least one of --services-id, --private-key-file, --team-id, --key-id, or --custom-redirect-uri.',
+    });
+  }
+
+  if (!anyFlag) {
+    yield* Effect.log(
+      'Tip: pass flags directly. Available: --services-id, --private-key-file, --team-id, --key-id, --custom-redirect-uri.',
+    );
+    return yield* BadArgsError.make({
+      message: 'Specify at least one update flag.',
+    });
+  }
+
+  const body: Parameters<typeof updateOAuthClient>[0]['body'] = {};
+  const meta: { teamId?: string; keyId?: string } = {};
+  const summaryLines: string[] = [];
+
+  if (servicesIdFlag) {
+    const v = String(opts['services-id'] ?? opts['servicesId'] ?? '').trim();
+    if (!v) {
+      return yield* BadArgsError.make({
+        message: '--services-id must be non-empty.',
+      });
+    }
+    body.client_id = v;
+    summaryLines.push(`Services ID: ${v}`);
+  }
+  if (privateKeyFlag) {
+    const path = String(
+      opts['private-key-file'] ?? opts['privateKeyFile'] ?? '',
+    ).trim();
+    if (!path) {
+      return yield* BadArgsError.make({
+        message: '--private-key-file must be non-empty.',
+      });
+    }
+    body.client_secret = yield* readPrivateKeyFile(path);
+  }
+  if (teamIdFlag) {
+    meta.teamId = String(opts['team-id'] ?? opts['teamId']);
+    summaryLines.push(`Team ID: ${meta.teamId}`);
+  }
+  if (keyIdFlag) {
+    meta.keyId = String(opts['key-id'] ?? opts['keyId']);
+    summaryLines.push(`Key ID: ${meta.keyId}`);
+  }
+  if (Object.keys(meta).length > 0) {
+    body.meta = meta;
+  }
+  if (redirectFlag) {
+    const redirect = yield* promptCustomRedirectUri(opts);
+    if (redirect) {
+      body.redirect_to = redirect;
+      summaryLines.push(`Redirect URI: ${redirect}`);
+    }
+  }
+
+  const response = yield* updateOAuthClient({
+    oauthClientId: client.id,
+    body,
+  });
+  yield* logSummary(response.client, 'Apple', summaryLines);
+});
+
+// ---------- Clerk ----------
+
+const handleClerkUpdate = Effect.fn(function* (
+  client: OAuthClientType,
+  opts: Record<string, unknown>,
+) {
+  const publishableKey = yield* optOrPrompt(opts['publishable-key'], {
+    simpleName: '--publishable-key',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: `New Clerk publishable key ${chalk.dim(`(from ${link('https://dashboard.clerk.com/last-active?path=api-keys')})`)}`,
+      placeholder:
+        'pk_********************************************************',
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+      validate: (val) => {
+        if (!val) return 'Publishable key is required';
+        if (!val.startsWith('pk_')) {
+          return 'Invalid publishable key. It should start with "pk_".';
+        }
+      },
+    },
+  });
+  if (!publishableKey) {
+    return yield* BadArgsError.make({
+      message: 'Publishable key is required.',
+    });
+  }
+  const domain = domainFromClerkKey(publishableKey);
+  if (!domain) {
+    return yield* BadArgsError.make({
+      message: 'Invalid publishable key. Could not extract domain.',
+    });
+  }
+  const discoveryEndpoint = `https://${domain}/.well-known/openid-configuration`;
+  const response = yield* updateOAuthClient({
+    oauthClientId: client.id,
+    body: {
+      meta: { clerkPublishableKey: publishableKey },
+      discovery_endpoint: discoveryEndpoint,
+    },
+  });
+  yield* logSummary(response.client, 'Clerk', [
+    `Clerk Publishable Key: ${publishableKey}`,
+    `Clerk Domain: ${domain}`,
+  ]);
+});
+
+// ---------- Firebase ----------
+
+const handleFirebaseUpdate = Effect.fn(function* (
+  client: OAuthClientType,
+  opts: Record<string, unknown>,
+) {
+  const firebaseProjectIdRegex = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
+  const projectId = yield* optOrPrompt(opts['project-id'], {
+    simpleName: '--project-id',
+    required: true,
+    skipIf: false,
+    prompt: {
+      prompt: `New Firebase project ID: (From Project Settings page on ${link('https://console.firebase.google.com/')})`,
+      modifyOutput: UI.modifiers.piped([
+        UI.modifiers.topPadding,
+        UI.modifiers.dimOnComplete,
+      ]),
+      validate: (val) => {
+        if (!val) return 'Project ID is required';
+        if (!firebaseProjectIdRegex.test(val)) {
+          return 'Invalid Firebase project ID.';
+        }
+      },
+    },
+  });
+  if (!projectId || !firebaseProjectIdRegex.test(projectId)) {
+    return yield* BadArgsError.make({
+      message: 'Invalid Firebase project ID.',
+    });
+  }
+  const discoveryEndpoint = `https://securetoken.google.com/${encodeURIComponent(projectId)}/.well-known/openid-configuration`;
+  const response = yield* updateOAuthClient({
+    oauthClientId: client.id,
+    body: { discovery_endpoint: discoveryEndpoint },
+  });
+  yield* logSummary(response.client, 'Firebase', [
+    `Firebase Project ID: ${projectId}`,
+  ]);
+});
+
+// ---------- Entry ----------
+
+export const authClientUpdateCmd = Effect.fn(
+  function* (
+    opts: OptsFromCommand<typeof authClientUpdateDef> & Record<string, unknown>,
+  ) {
+    if (opts.id && opts.name) {
+      return yield* BadArgsError.make({
+        message: 'Cannot specify both --id and --name',
+      });
+    }
+
+    if (!opts.id && !opts.name) {
+      const { yes } = yield* GlobalOpts;
+      if (yes) {
+        return yield* BadArgsError.make({
+          message: 'Must specify --id or --name',
+        });
+      }
+      // Interactive picker
+      const { client, providerName } = yield* pickClientInteractively();
+      yield* dispatchByProvider(client, providerName, opts);
+      return;
+    }
+
+    const { client, auth } = yield* findClientByIdOrName({
+      id: opts.id,
+      name: opts.name,
+    });
+    const provider = (auth.oauth_service_providers ?? []).find(
+      (p) => p.id === client.provider_id,
+    );
+    if (!provider) {
+      return yield* BadArgsError.make({
+        message: `Provider not found for client ${client.client_name}`,
+      });
+    }
+    yield* dispatchByProvider(client, provider.provider_name, opts);
+  },
+  Effect.catchTag('BadArgsError', (e) =>
+    Effect.gen(function* () {
+      yield* Effect.logError(e.message);
+      yield* Effect.log(
+        chalk.dim(
+          'hint: run `instant-cli auth client update --help` for the list of available arguments',
+        ),
+      );
+    }),
+  ),
+);
+
+const pickClientInteractively = Effect.fn(function* () {
+  const auth = yield* getAppsAuth();
+  const clients = auth.oauth_clients ?? [];
+  if (clients.length === 0) {
+    return yield* BadArgsError.make({ message: 'No OAuth clients found.' });
+  }
+  const providersById = new Map(
+    (auth.oauth_service_providers ?? []).map((p) => [p.id, p]),
+  );
+  const picked = yield* runUIEffect(
+    new UI.Select({
+      options: clients.map((c) => ({
+        label:
+          c.client_name +
+          chalk.dim(
+            ` (${providersById.get(c.provider_id)?.provider_name ?? c.provider_id})`,
+          ),
+        value: c,
+      })),
+      promptText: 'Select a client to update:',
+    }),
+  ).pipe(
+    Effect.catchTag('UIError', (e) =>
+      BadArgsError.make({ message: `UI error: ${e.message}` }),
+    ),
+  );
+  const provider = providersById.get(picked.provider_id);
+  if (!provider) {
+    return yield* BadArgsError.make({
+      message: `Provider not found for client ${picked.client_name}`,
+    });
+  }
+  return { client: picked, providerName: provider.provider_name };
+});
+
+const dispatchByProvider = Effect.fn(function* (
+  client: OAuthClientType,
+  providerName: string,
+  opts: Record<string, unknown>,
+) {
+  yield* Match.value(providerName).pipe(
+    Match.withReturnType<Effect.Effect<void, any, any>>(),
+    Match.when('google', () => handleGoogleUpdate(client, opts)),
+    Match.when('github', () =>
+      handleGenericCredentialUpdate(
+        client,
+        opts,
+        'GitHub',
+        'https://github.com/settings/developers',
+      ),
+    ),
+    Match.when('linkedin', () =>
+      handleGenericCredentialUpdate(
+        client,
+        opts,
+        'LinkedIn',
+        'https://www.linkedin.com/developers/apps',
+      ),
+    ),
+    Match.when('apple', () => handleAppleUpdate(client, opts)),
+    Match.when('clerk', () => handleClerkUpdate(client, opts)),
+    Match.when('firebase', () => handleFirebaseUpdate(client, opts)),
+    Match.orElse(() =>
+      BadArgsError.make({
+        message: `Unsupported provider: ${providerName}`,
+      }),
+    ),
+  );
+});
+
+function domainFromClerkKey(key: string): string | null {
+  try {
+    const parts = key.split('_');
+    const domainPartB64 = parts[parts.length - 1];
+    const domainPart = base64Decode(domainPartB64);
+    return domainPart.replace('$', '');
+  } catch (e) {
+    console.error('Error getting domain from clerk key', e);
+    return null;
+  }
+}
+
+function base64Decode(s: string) {
+  try {
+    return Buffer.from(s, 'base64').toString('utf-8');
+  } catch (e) {
+    return Buffer.from(s, 'base64url').toString('utf-8');
+  }
+}

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ import { PACKAGE_ALIAS_AND_FULL_NAMES } from './context/projectInfo.ts';
 import { authClientAddCmd } from './commands/auth/client/add.ts';
 import { authClientListCmd } from './commands/auth/client/list.ts';
 import { authClientDeleteCmd } from './commands/auth/client/delete.ts';
+import { authClientUpdateCmd } from './commands/auth/client/update.ts';
 import { authOriginListCmd } from './commands/auth/origin/list.ts';
 import { authOriginDeleteCmd } from './commands/auth/origin/delete.ts';
 import { authOriginAddCmd } from './commands/auth/origin/add.ts';
@@ -104,14 +105,19 @@ export const authClientAddDef = authClient
     '-a --app <app-id>',
     'App ID to modify. Defaults to *_INSTANT_APP_ID in .env',
   )
+  .option(
+    '--use-shared-credentials',
+    "Use Instant's shared dev credentials (Google web only)",
+  )
   .addHelpText(
     'after',
     `
 Provider Specific Options:
   Google:
-   --app-type       web|ios|android|button-for-web
-   --client-id
-   --client-secret                      (web only)
+   --app-type                 web|ios|android|button-for-web
+   --use-shared-credentials   (web only, skips client-id/secret/redirect)
+   --client-id                (omit when using shared credentials)
+   --client-secret            (web only, omit when using shared credentials)
    --custom-redirect-uri      (optional, web only)
   GitHub:
    --client-id
@@ -170,6 +176,60 @@ export const authClientListDef = authClient
             allowAdminToken: true,
             // Silence "searching for instant sdk.. logs for json output"
           }).pipe(Layer.annotateLogs('silent', !!opts.json)),
+        ),
+      ),
+    );
+  });
+
+export const authClientUpdateDef = authClient
+  .command('update')
+  .allowExcessArguments(true)
+  .allowUnknownOption(true)
+  .option('--id <client-id>', 'Client ID to update')
+  .option('--name <client-name>', 'Client name to update')
+  .option(
+    '-a --app <app-id>',
+    'App ID to modify. Defaults to *_INSTANT_APP_ID in .env',
+  )
+  .addHelpText(
+    'after',
+    `
+Provider Specific Options:
+  Google:
+   --client-id
+   --client-secret
+   --use-shared-credentials   (switch to Instant's shared dev credentials)
+   --custom-redirect-uri
+  GitHub / LinkedIn:
+   --client-id
+   --client-secret
+   --custom-redirect-uri
+  Apple:
+   --services-id
+   --private-key-file
+   --team-id
+   --key-id
+   --custom-redirect-uri
+  Clerk:
+   --publishable-key
+  Firebase:
+   --project-id
+`,
+  )
+  .action((opts) => {
+    opts = {
+      ...opts,
+      ...minimist(process.argv),
+    };
+    return runCommandEffect(
+      authClientUpdateCmd(opts).pipe(
+        Effect.provide(
+          WithAppLayer({
+            coerce: false,
+            coerceAuth: false,
+            appId: opts.app,
+            allowAdminToken: true,
+          }),
         ),
       ),
     );

--- a/client/packages/cli/src/lib/oauth.ts
+++ b/client/packages/cli/src/lib/oauth.ts
@@ -46,7 +46,12 @@ export const OAuthClient = Schema.Struct({
   discovery_endpoint: NullableString,
   redirect_to: NullableString,
   meta: Schema.Any.pipe(Schema.optional),
+  use_shared_credentials: Schema.Union(Schema.Boolean, Schema.Null).pipe(
+    Schema.optional,
+  ),
 });
+
+export type OAuthClientType = Schema.Schema.Type<typeof OAuthClient>;
 
 export const AddOAuthProviderResponse = Schema.Struct({
   provider: OAuthServiceProvider,
@@ -111,6 +116,7 @@ export const addOAuthClient = Effect.fn(function* (params: {
   discoveryEndpoint?: string;
   redirectTo?: string;
   meta?: unknown;
+  useSharedCredentials?: boolean;
 }) {
   const http = (yield* InstantHttpAuthed).pipe(withCommand('auth'));
   const targetAppId = params.appId ?? (yield* CurrentApp).appId;
@@ -127,7 +133,32 @@ export const addOAuthClient = Effect.fn(function* (params: {
         discovery_endpoint: params.discoveryEndpoint,
         redirect_to: params.redirectTo,
         meta: params.meta,
+        use_shared_credentials: params.useSharedCredentials,
       }),
+    })
+    .pipe(
+      Effect.flatMap(HttpClientResponse.schemaBodyJson(AddOAuthClientResponse)),
+    );
+});
+
+export const updateOAuthClient = Effect.fn(function* (params: {
+  appId?: string;
+  oauthClientId: string;
+  body: {
+    client_id?: string;
+    client_secret?: string;
+    redirect_to?: string;
+    discovery_endpoint?: string;
+    meta?: unknown;
+    use_shared_credentials?: boolean;
+  };
+}) {
+  const http = (yield* InstantHttpAuthed).pipe(withCommand('auth'));
+  const targetAppId = params.appId ?? (yield* CurrentApp).appId;
+
+  return yield* http
+    .post(`/dash/apps/${targetAppId}/oauth_clients/${params.oauthClientId}`, {
+      body: HttpBody.unsafeJson(params.body),
     })
     .pipe(
       Effect.flatMap(HttpClientResponse.schemaBodyJson(AddOAuthClientResponse)),
@@ -234,6 +265,38 @@ export const getClientNameAndProvider = Effect.fn(function* (
     });
   }
   return { provider, clientName };
+});
+
+export const findClientByIdOrName = Effect.fn(function* (params: {
+  id?: string;
+  name?: string;
+}) {
+  if (params.id && params.name) {
+    return yield* BadArgsError.make({
+      message: 'Cannot specify both --id and --name',
+    });
+  }
+  if (!params.id && !params.name) {
+    return yield* BadArgsError.make({
+      message: 'Must specify --id or --name',
+    });
+  }
+
+  const auth = yield* getAppsAuth();
+  const clients = auth.oauth_clients ?? [];
+
+  const client = params.id
+    ? clients.find((c) => c.id === params.id)
+    : clients.find((c) => c.client_name === params.name);
+
+  if (!client) {
+    const lookup = params.id ? `id ${params.id}` : `name ${params.name}`;
+    return yield* BadArgsError.make({
+      message: `OAuth client not found: ${lookup}`,
+    });
+  }
+
+  return { client, auth };
 });
 
 export const removeAuthorizedOrigin = Effect.fn(function* (originId: string) {

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -660,6 +660,7 @@
         redirect-to (-> req :body :redirect_to string-util/coerce-non-blank-str)
         client-id (ex/get-optional-param! req [:body :client_id] string-util/coerce-non-blank-str)
         client-secret (ex/get-optional-param! req [:body :client_secret] string-util/coerce-non-blank-str)
+        discovery-endpoint (ex/get-optional-param! req [:body :discovery_endpoint] string-util/coerce-non-blank-str)
         _ (when redirect-to
             (ex/assert-valid!
              :redirect_to
@@ -680,11 +681,12 @@
                  (contains? (:body req) :redirect_to) (assoc :redirect-to redirect-to)
                  client-id (assoc :client-id client-id)
                  client-secret (assoc :client-secret client-secret)
+                 discovery-endpoint (assoc :discovery-endpoint discovery-endpoint)
                  (some? use-shared-credentials?) (assoc :use-shared-credentials? use-shared-credentials?))
         client (app-oauth-client-model/update! params)]
     (response/ok {:client (select-keys client [:id :provider_id :client_name
                                                :client_id :created_at :meta :discovery_endpoint
-                                               :use_shared_credentials])})))
+                                               :redirect_to :use_shared_credentials])})))
 
 (defn oauth-clients-delete [req]
   (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :collaborator :apps/write req)

--- a/server/src/instant/model/app_oauth_client.clj
+++ b/server/src/instant/model/app_oauth_client.clj
@@ -65,6 +65,21 @@
 (defn update!
   ([params] (update! (aurora/conn-pool :write) params))
   ([conn {:keys [id app-id] :as params}]
+   (when-let [discovery-endpoint (:discovery-endpoint params)]
+     (try
+       (when-not (-> (oauth/fetch-discovery discovery-endpoint)
+                     :data
+                     :issuer
+                     string?)
+         (ex/throw-validation-err!
+          :discovery-endpoint
+          discovery-endpoint
+          [{:message "Could not validate discovery endpoint."}]))
+       (catch Exception _e
+         (ex/throw-validation-err!
+          :discovery-endpoint
+          discovery-endpoint
+          [{:message "Could not validate discovery endpoint."}]))))
    (update-op
     conn
     {:app-id app-id
@@ -81,6 +96,9 @@
                            [[:add-triple id (resolve-id :encryptedClientSecret)
                              (crypt-util/aead-encrypt-hex (:client-secret params)
                                                           (uuid-util/->bytes id))]])
+                         (when (contains? params :discovery-endpoint)
+                           [[:add-triple id (resolve-id :discoveryEndpoint)
+                             (:discovery-endpoint params)]])
                          (when (contains? params :use-shared-credentials?)
                            [[:add-triple id (resolve-id :useSharedCredentials)
                              (boolean (:use-shared-credentials? params))]])))


### PR DESCRIPTION
Mirrors the dashboard's shared dev credentials feature (#2553) in `instant-cli`, plus a generalized `auth client update` that works across providers.

## What's new

### `auth client add` — Google web

- New `--use-shared-credentials` flag. With it, `--client-id` / `--client-secret` / `--custom-redirect-uri` may be omitted; the server fills credentials in at runtime and auto-allows `localhost` / Expo redirects.
- **Interactive:** after picking `app-type=web`, prompt _\"How do you want to set up credentials?\"_ with `Use Instant's shared dev credentials` as the default.
- **`--yes` (agent / `create-instant-app` UX):** with no creds and no flag, auto-defaults to shared and prints `Using Instant's shared dev credentials.` Native app types still require `--client-id`.
- Mutually-exclusive validation: shared rejects `--client-id` / `--client-secret` / `--custom-redirect-uri`; native app types reject `--use-shared-credentials`.

Boxen output (shared mode):

\`\`\`
Google OAuth client created: google-web
  App type: web   Mode: shared dev credentials
  ID: <id>

  Redirect origins enabled: http://localhost, https://localhost, exp://
  Capped at 100 sign-ups. Run \`instant-cli auth client update\` with --client-id and --client-secret before going to production.
\`\`\`

### `auth client update` (new) — works across providers

Identifies a client by \`--id\` or \`--name\` (mirrors \`auth client delete\`). Per-provider dispatch:

- **Google:** rotate creds, upgrade shared → custom, downgrade custom → shared, update redirect.
- **GitHub / LinkedIn:** rotate \`--client-id\` / \`--client-secret\`, update \`--custom-redirect-uri\`.
- **Apple:** rotate \`--services-id\` / \`--private-key-file\`, update \`--team-id\` / \`--key-id\` (meta), update redirect.
- **Clerk:** rotate \`--publishable-key\` (CLI re-derives the discovery endpoint).
- **Firebase:** rotate \`--project-id\` (CLI re-derives the discovery endpoint).

Interactive picker when no \`--id\` / \`--name\` is given (non-\`--yes\`). \`--yes\` is strict — pass at least one update flag or get _\"Nothing to update\"_.

### \`auth client list\`

Adds \`Mode: shared dev credentials\` under \`Client id:\` when applicable. JSON output passes the field through via the schema.

## Server changes

To make \`update\` work for Clerk / Firebase, \`update-oauth-client\` now accepts \`discovery_endpoint\`. \`redirect_to\` is also added to the response \`select-keys\` (was missing). The \`app_oauth_client\` model's \`update!\` plumbs the new field through with the same discovery validation as \`create!\`.

## Testing

- \`pnpm --filter instant-cli test\` — 132 tests pass, including:
  - 6 new tests for shared dev credentials in \`authClientAddGoogle.test.ts\` (auto-default, explicit flag, mutually-exclusive errors, native rejection, interactive selector).
  - 16 new tests in \`authClientUpdate.test.ts\` covering all six providers and identification edge cases.
- Server \`make lint\` clean (0 errors, 0 warnings).
- The pre-existing \`@instantdb/react-native\` typesTests failures on \`main\` are unrelated to these changes.

## Manual smoke matrix (against a local dev server)

- [ ] \`instant-cli auth client add --type google\` (interactive) → pick web → pick shared → confirm boxen.
- [ ] \`instant-cli auth client add --type google --app-type web --yes\` → auto-shared with log line.
- [ ] \`instant-cli auth client add --type google --app-type web --use-shared-credentials --yes\` → explicit shared.
- [ ] \`instant-cli auth client add --type google --app-type web --client-id X --client-secret Y --yes\` → custom path unchanged.
- [ ] \`instant-cli auth client add --type google --app-type ios --yes\` → existing missing-flag error.
- [ ] \`instant-cli auth client add --type google --use-shared-credentials --client-id X --yes\` → mutually-exclusive error.
- [ ] \`instant-cli auth client list\` → shared client shows \`Mode: shared dev credentials\`; custom unchanged.
- [ ] \`instant-cli auth client update --name google-web --client-id X --client-secret Y --yes\` → upgrades to custom; subsequent list drops the Mode line.
- [ ] \`instant-cli auth client update --name google-web --use-shared-credentials --yes\` → downgrades to shared.
- [ ] \`instant-cli auth client update --name clerk-web --publishable-key pk_test_... --yes\` → Clerk discovery endpoint regenerated.
- [ ] End-to-end via \`bunx create-instant-app\` + \`auth client add --type google --yes\` → sign in works on \`localhost:3000\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)