### PR TITLE
fix dark mode email screen

### DIFF
--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -46,8 +46,9 @@ function CodeStep(props: {
     >
       <ScreenHeading>Enter your code</ScreenHeading>
       <Content>
-        We sent an email to <strong>{props.sentEmail}</strong>. Check your
-        email, and paste the code you see.
+        We sent an email to{' '}
+        <strong className="dark:text-white">{props.sentEmail}</strong>. Check
+        your email, and paste the code you see.
       </Content>
       <TextInput
         autoFocus


### PR DESCRIPTION
BEFORE:
<img width="1035" height="643" alt="image" src="https://github.com/user-attachments/assets/e907baf2-c5f5-403b-8d1e-e2f3ea230870" />

AFTER:
<img width="1115" height="703" alt="image" src="https://github.com/user-attachments/assets/b14c9454-7ba4-43cd-a2eb-9d54c8d25c90" />
(still works in light mode)
<img width="623" height="475" alt="image" src="https://github.com/user-attachments/assets/2edb0b8c-f20f-434c-a6da-33f8f6a81e76" />
