### PR TITLE
[docs] dev credentials and CLI auth docs

### DIFF
--- a/client/www/__tests__/markdoc.test.ts
+++ b/client/www/__tests__/markdoc.test.ts
@@ -86,3 +86,66 @@ title: Magic Code Auth
   expect(result).toContain('- **Web**: For Next.js or other React frameworks');
   expect(result).toContain('- **Mobile**: For Expo and React Native');
 });
+
+test('converts blank-link tags to markdown links', () => {
+  const input = `---
+title: Test
+---
+
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard.`;
+
+  const result = transformContent(input);
+  expect(result).toContain(
+    'From the [Auth](/dash?s=main&t=auth) tab on the Instant dashboard.',
+  );
+  expect(result).not.toContain('blank-link');
+});
+
+test('renders blank-link label as plain text when href is missing', () => {
+  const input = `---
+title: Test
+---
+
+See {% blank-link label="the docs" /%} for details.`;
+
+  const result = transformContent(input);
+  expect(result).toContain('See the docs for details.');
+  expect(result).not.toContain('blank-link');
+});
+
+test('emits "From the dashboard" / "From the terminal" headings for setup-paths', () => {
+  const input = `---
+title: Test
+---
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab:
+
+- Click "Set up Google"
+- Click "Add Client"
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+\`\`\`shell
+npx instant-cli@latest auth client add --type google --name google-web
+\`\`\`
+
+{% /terminal-path %}
+
+{% /setup-paths %}`;
+
+  const result = transformContent(input);
+  expect(result).toContain('**From the dashboard**');
+  expect(result).toContain('**From the terminal**');
+  expect(result).toContain('From the [Auth](/dash?s=main&t=auth) tab:');
+  expect(result).toContain('- Click "Set up Google"');
+  expect(result).toContain('npx instant-cli@latest auth client add');
+  expect(result).not.toContain('setup-paths');
+  expect(result).not.toContain('dashboard-path');
+  expect(result).not.toContain('terminal-path');
+});

--- a/client/www/app/docs/auth/apple/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/apple/[[...tab]]/page.md
@@ -87,7 +87,7 @@ This step is not needed for Expo.
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Add Apple Client_
 - Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
@@ -119,7 +119,7 @@ npx instant-cli@latest auth client add \
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Add Apple Client_
 - Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
@@ -150,7 +150,7 @@ npx instant-cli@latest auth client add \
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Redirect Origins_ → _Add an origin_
 - Add your app's domain (e.g. `myapp.com`)
@@ -270,7 +270,7 @@ Add `exp://` as a redirect origin for development with Expo:
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Redirect Origins_ → _Add an origin_
 - Add `exp://`

--- a/client/www/app/docs/auth/apple/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/apple/[[...tab]]/page.md
@@ -83,22 +83,61 @@ This step is not needed for Expo.
 
 {% conditional param="method" value="web-redirect" %}
 
-- Go to the Instant dashboard and select _Auth_ tab.
-- Select _Add Apple Client_
-- Select unique _clientName_ (`apple` by default, will be used in `db.auth` calls)
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the Instant dashboard, select the _Auth_ tab and:
+
+- Click _Add Apple Client_
+- Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
 - Fill in _Services ID_ from Step 2
 - Fill in _Team ID_ from [Membership details](https://developer.apple.com/account#MembershipDetailsCard)
 - Fill in _Key ID_ from Step 3.5
 - Fill in _Private Key_ by copying file content from Step 3.5
 - Click `Add Apple Client`
 
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type apple --name apple \
+  --services-id <services-id> \
+  --team-id <team-id> --key-id <key-id> \
+  --private-key-file <path-to-key.p8>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
+
 {% else %}
 
-- Go to the Instant dashboard and select _Auth_ tab.
-- Select _Add Apple Client_
-- Select unique _clientName_ (`apple` by default, will be used in `db.auth` calls)
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the Instant dashboard, select the _Auth_ tab and:
+
+- Click _Add Apple Client_
+- Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
 - Fill in _Services ID_ from Step 2
 - Click `Add Apple Client`
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type apple --name apple --services-id <services-id>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /else %}
 {% /conditional %}
@@ -107,8 +146,26 @@ This step is not needed for Expo.
 
 ## Step 4.5: Whitelist your domain in Instant (Web Redirect flow only)
 
-- In Instant Dashboard, Click _Redirect Origins_ → _Add an origin_
-- Add your app’s domain (e.g. `myapp.com`)
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the Instant dashboard's _Auth_ tab:
+
+- Click _Redirect Origins_ → _Add an origin_
+- Add your app's domain (e.g. `myapp.com`)
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type website --url myapp.com
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /conditional %}
 
@@ -207,9 +264,28 @@ Update `app.json` by adding:
 }
 ```
 
-Go to Instant dashboard → Auth tab → Redirect Origins → Add an origin.
+Add `exp://` as a redirect origin for development with Expo:
 
-Add `exp://` for development with Expo.
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the Instant dashboard's _Auth_ tab:
+
+- Click _Redirect Origins_ → _Add an origin_
+- Add `exp://`
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type custom-scheme --scheme exp://
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 Authenticate with Apple and then pass identityToken to Instant along with `clientName` from Step 4:
 

--- a/client/www/app/docs/auth/apple/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/apple/[[...tab]]/page.md
@@ -87,15 +87,15 @@ This step is not needed for Expo.
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
-- Click _Add Apple Client_
-- Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
-- Fill in _Services ID_ from Step 2
-- Fill in _Team ID_ from [Membership details](https://developer.apple.com/account#MembershipDetailsCard)
-- Fill in _Key ID_ from Step 3.5
-- Fill in _Private Key_ by copying file content from Step 3.5
-- Click `Add Apple Client`
+- Click "Add Apple Client"
+- Select a unique client name (`apple` by default, used in `db.auth` calls)
+- Fill in your "Services ID" from Step 2
+- Fill in your "Team ID" from [Membership details](https://developer.apple.com/account#MembershipDetailsCard)
+- Fill in your "Key ID" from Step 3.5
+- Fill in your "Private Key" by copying the file content from Step 3.5
+- Click "Add Apple Client"
 
 {% /dashboard-path %}
 
@@ -119,12 +119,12 @@ npx instant-cli@latest auth client add \
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
-- Click _Add Apple Client_
-- Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
-- Fill in _Services ID_ from Step 2
-- Click `Add Apple Client`
+- Click "Add Apple Client"
+- Select a unique client name (`apple` by default, used in `db.auth` calls)
+- Fill in your "Services ID" from Step 2
+- Click "Add Apple Client"
 
 {% /dashboard-path %}
 
@@ -150,9 +150,9 @@ npx instant-cli@latest auth client add \
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
-- Click _Redirect Origins_ → _Add an origin_
+- Click "Redirect Origins" → "Add an origin"
 - Add your app's domain (e.g. `myapp.com`)
 
 {% /dashboard-path %}
@@ -270,9 +270,9 @@ Add `exp://` as a redirect origin for development with Expo:
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
-- Click _Redirect Origins_ → _Add an origin_
+- Click "Redirect Origins" → "Add an origin"
 - Add `exp://`
 
 {% /dashboard-path %}

--- a/client/www/app/docs/auth/apple/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/apple/[[...tab]]/page.md
@@ -87,7 +87,7 @@ This step is not needed for Expo.
 
 {% dashboard-path %}
 
-From the Instant dashboard, select the _Auth_ tab and:
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Add Apple Client_
 - Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
@@ -119,7 +119,7 @@ npx instant-cli@latest auth client add \
 
 {% dashboard-path %}
 
-From the Instant dashboard, select the _Auth_ tab and:
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Add Apple Client_
 - Select a unique _clientName_ (`apple` by default, used in `db.auth` calls)
@@ -150,7 +150,7 @@ npx instant-cli@latest auth client add \
 
 {% dashboard-path %}
 
-From the Instant dashboard's _Auth_ tab:
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Redirect Origins_ → _Add an origin_
 - Add your app's domain (e.g. `myapp.com`)
@@ -270,7 +270,7 @@ Add `exp://` as a redirect origin for development with Expo:
 
 {% dashboard-path %}
 
-From the Instant dashboard's _Auth_ tab:
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click _Redirect Origins_ → _Add an origin_
 - Add `exp://`

--- a/client/www/app/docs/auth/clerk/page.md
+++ b/client/www/app/docs/auth/clerk/page.md
@@ -36,7 +36,7 @@ On the Clerk dashboard, navigate to [`API keys`](https://dashboard.clerk.com/las
 
 {% dashboard-path %}
 
-From the Instant dashboard's `Auth` tab, add a new Clerk client with the publishable key you copied.
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Clerk client with the publishable key you copied.
 
 {% /dashboard-path %}
 
@@ -44,7 +44,7 @@ From the Instant dashboard's `Auth` tab, add a new Clerk client with the publish
 
 ```shell
 npx instant-cli@latest auth client add \
-  --type clerk --name clerk --publishable-key pk_...
+  --type clerk --name clerk --publishable-key <publishable-key>
 ```
 
 {% /terminal-path %}

--- a/client/www/app/docs/auth/clerk/page.md
+++ b/client/www/app/docs/auth/clerk/page.md
@@ -32,7 +32,24 @@ On the Clerk dashboard, navigate to [`API keys`](https://dashboard.clerk.com/las
 
 **Step 3: Register your Clerk Publishable key with your instant app**
 
-Go to the Instant dashboard, navigate to the `Auth` tab and add a new clerk app with the publishable key you copied.
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the Instant dashboard's `Auth` tab, add a new Clerk client with the publishable key you copied.
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type clerk --name clerk --publishable-key pk_...
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 ## Usage
 

--- a/client/www/app/docs/auth/clerk/page.md
+++ b/client/www/app/docs/auth/clerk/page.md
@@ -36,7 +36,7 @@ On the Clerk dashboard, navigate to [`API keys`](https://dashboard.clerk.com/las
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Clerk client with the publishable key you copied.
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Clerk client with the publishable key you copied.
 
 {% /dashboard-path %}
 

--- a/client/www/app/docs/auth/clerk/page.md
+++ b/client/www/app/docs/auth/clerk/page.md
@@ -36,7 +36,7 @@ On the Clerk dashboard, navigate to [`API keys`](https://dashboard.clerk.com/las
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Clerk client with the publishable key you copied.
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Clerk client with the publishable key you copied.
 
 {% /dashboard-path %}
 

--- a/client/www/app/docs/auth/firebase/page.md
+++ b/client/www/app/docs/auth/firebase/page.md
@@ -19,7 +19,7 @@ On the [Firebase dashboard](https://console.firebase.google.com/), open your pro
 
 {% dashboard-path %}
 
-From the Instant dashboard's `Auth` tab, add a new Firebase client with the Project ID you copied.
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Firebase client with the Project ID you copied.
 
 {% /dashboard-path %}
 

--- a/client/www/app/docs/auth/firebase/page.md
+++ b/client/www/app/docs/auth/firebase/page.md
@@ -19,7 +19,7 @@ On the [Firebase dashboard](https://console.firebase.google.com/), open your pro
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Firebase client with the Project ID you copied.
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Firebase client with the Project ID you copied.
 
 {% /dashboard-path %}
 

--- a/client/www/app/docs/auth/firebase/page.md
+++ b/client/www/app/docs/auth/firebase/page.md
@@ -15,7 +15,24 @@ On the [Firebase dashboard](https://console.firebase.google.com/), open your pro
 
 **Step 2: Register your Firebase Project ID with your instant app**
 
-Go to the Instant dashboard, navigate to the `Auth` tab and add a new firebase auth app with the Project ID you copied.
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the Instant dashboard's `Auth` tab, add a new Firebase client with the Project ID you copied.
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type firebase --name firebase --project-id <project-id>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 ## Usage
 

--- a/client/www/app/docs/auth/firebase/page.md
+++ b/client/www/app/docs/auth/firebase/page.md
@@ -19,7 +19,7 @@ On the [Firebase dashboard](https://console.firebase.google.com/), open your pro
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Firebase client with the Project ID you copied.
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a new Firebase client with the Project ID you copied.
 
 {% /dashboard-path %}
 

--- a/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
@@ -67,7 +67,7 @@ Let's dive deeper into each step:
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up GitHub"
 - Enter a unique name for your client (e.g., "github-web")
@@ -99,7 +99,7 @@ If you're testing from localhost, add `http://localhost:3000` (replacing `3000` 
 
 {% dashboard-path %}
 
-In the `Auth` tab, add your URL to the **Redirect Origins** list.
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
 
 {% /dashboard-path %}
 
@@ -210,7 +210,7 @@ Now that you have your App Scheme, it's time to tell Instant about it. For devel
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
 

--- a/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
@@ -61,9 +61,13 @@ Let's dive deeper into each step:
 
 ## 2. Connect your OAuth App to Instant
 
-Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Instant dashboard" /%} and select the `Auth` tab for your app.
-
 **Add your OAuth App on Instant**
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up GitHub"
 - Enter a unique name for your client (e.g., "github-web")
@@ -71,13 +75,43 @@ Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="In
 - Enter your "Client Secret" from GitHub
 - Click "Add Client"
 
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type github --name github-web \
+  --client-id <id> --client-secret <secret>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
+
 {% conditional param="method" value="web-redirect" %}
 
 **Register your website with Instant**
 
-In the `Auth` tab, add the URL of the websites where you are using Instant to the Redirect Origins.
-If you're testing from localhost, add `http://localhost:3000`, replacing `3000` with the port you use.
-For production, add your website's domain.
+If you're testing from localhost, add `http://localhost:3000` (replacing `3000` with the port you use). For production, add your website's domain.
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+In the `Auth` tab, add your URL to the **Redirect Origins** list.
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type website --url example.com
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /conditional %}
 
@@ -170,11 +204,28 @@ Update your app.json with your scheme:
 
 **Register your app with Instant**
 
-Now that you have your App Scheme, it's time to tell Instant about it.
+Now that you have your App Scheme, it's time to tell Instant about it. For development with expo, add `exp://` and your scheme (e.g. `mycoolredirect://`) as redirect origins.
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme". For development with expo add `exp://` and your scheme, e.g. `mycoolredirect://`.
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type custom-scheme --scheme exp://
+npx instant-cli@latest auth origin add --type custom-scheme --scheme mycoolredirect://
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 **Use AuthSession to log in with GitHub!**
 

--- a/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
@@ -106,7 +106,7 @@ In the `Auth` tab, add your URL to the **Redirect Origins** list.
 {% terminal-path %}
 
 ```shell
-npx instant-cli@latest auth origin add --type website --url example.com
+npx instant-cli@latest auth origin add --type website --url <your-domain>
 ```
 
 {% /terminal-path %}

--- a/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/github-oauth/[[...tab]]/page.md
@@ -67,7 +67,7 @@ Let's dive deeper into each step:
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up GitHub"
 - Enter a unique name for your client (e.g., "github-web")
@@ -99,7 +99,7 @@ If you're testing from localhost, add `http://localhost:3000` (replacing `3000` 
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
 
 {% /dashboard-path %}
 
@@ -210,7 +210,7 @@ Now that you have your App Scheme, it's time to tell Instant about it. For devel
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
 

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -58,7 +58,56 @@ There are three main steps:
 
 Let's dive deeper in each step:
 
+{% conditional
+   param="method"
+   value=["web-redirect", "rn-web"] %}
+
+## Quick start: dev credentials
+
+If you're just testing Google sign-in, you can skip Google Console entirely. Instant provides shared dev credentials for web flows so you can get going in seconds.
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+
+- Click "Set up Google"
+- Toggle "Use dev credentials"
+- Give your client a name (e.g. `google-web`)
+- Click "Add Client"
+
+`localhost` and `exp://` are allowed as redirect origins automatically, so you can jump straight to **Step 3** below and start coding.
+
+{% callout type="note" %}
+
+Dev credentials are for development only:
+
+- Capped at 100 sign-ups per app
+- Web flows only (not the Google Button, not native iOS/Android)
+- Consent screen reads "Instant Shared Dev Credentials" instead of your app name
+
+When you're ready for production, return to "Set up Google" on the dashboard and click "Set custom credentials" to switch over.
+
+{% /callout %}
+
+Prefer the terminal? Run:
+
+```shell
+npx instant-cli@latest auth client add --type google --app-type web --name google-web --dev-credentials
+```
+
+{% /conditional %}
+
 ## 1. Set up your consent screen and create an Oauth client
+
+{% conditional
+   param="method"
+   value=["web-redirect", "rn-web"] %}
+
+{% callout type="note" %}
+
+Already using dev credentials from the quick start? You can skip this step until you're ready for production.
+
+{% /callout %}
+
+{% /conditional %}
 
 Head on over to {% blank-link href="https://console.cloud.google.com/apis/credentials" label="Google Console" /%}. You should be in the "Credentials" section.
 

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -18,13 +18,13 @@ Choose the option that sounds best to you, and the rest of the document will sho
 {% div className="grid grid-cols-2 md:grid-cols-1 md:grid-rows-2 flex-1 gap-4" %}
 {% nav-button
   title="Google Button"
-  description="Use Google's pre-styled button to sign in. Using this method you can render your custom app name in the consent screen"
+  description="Use Google's pre-styled button to sign in. This is what Google recommends."
   param="method"
   value="web-google-button"
   recommended=true /%}
 {% nav-button
   title="Web Redirect"
-  description="Easier to integrate, but doesn't let you render your custom app name."
+  description="Easier to integrate, but doesn't have the same bells and whistles as the Google Button."
   param="method"
   value="web-redirect" /%}
 {% /div %}

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -24,7 +24,7 @@ Choose the option that sounds best to you, and the rest of the document will sho
   recommended=true /%}
 {% nav-button
   title="Web Redirect"
-  description="Easier to integrate, but doesn't have the same bells and whistles as the Google Button."
+  description="Easier to integrate, but requires a redirect rule to render your custom app name."
   param="method"
   value="web-redirect" /%}
 {% /div %}

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -64,9 +64,9 @@ Let's dive deeper in each step:
 
 ## Quick start: developer credentials
 
-If you're testing Google sign-in locally, we have a fast option for you. Instant provides developer credentials that you can use for local development. 
+If you're testing Google sign-in locally, we have a fast option for you. Instant provides developer credentials that you can use for local development.
 
-You don't need to go the Google Cloud Console, and you can log in within minutes. 
+You don't need to go the Google Cloud Console, and you can log in within minutes.
 
 {% setup-paths %}
 
@@ -99,7 +99,6 @@ npx instant-cli@latest auth client add \
 Developer credentials are meant only for local development. You're limited to 100 sign-ups. Once you're ready for production, follow the steps below.
 
 {% /callout %}
-
 
 {% /conditional %}
 

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -220,7 +220,7 @@ In the `Auth` tab, add your URL to the **Redirect Origins** list.
 {% terminal-path %}
 
 ```shell
-npx instant-cli@latest auth origin add --type website --url example.com
+npx instant-cli@latest auth origin add --type website --url <your-domain>
 ```
 
 {% /terminal-path %}

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -66,13 +66,13 @@ Let's dive deeper in each step:
 
 If you're testing Google sign-in locally, we have a fast option for you. Instant provides developer credentials that you can use for local development.
 
-You don't need to go the Google Cloud Console, and you can log in within minutes.
+You don't need to go to the Google Cloud Console, and you can log in within minutes.
 
 {% setup-paths %}
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Toggle "Use dev credentials"
@@ -177,7 +177,7 @@ Save your Client IDs -- you'll need it for the next step!
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Enter your "Client ID"
@@ -213,7 +213,7 @@ If you're testing from localhost, add `http://localhost:3000` (replacing `3000` 
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
 
 {% /dashboard-path %}
 
@@ -241,7 +241,7 @@ For each Oauth Client you created, add it to Instant:
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Enter your "Client ID"
@@ -466,7 +466,7 @@ Now that you have your App Scheme, it's time to tell Instant about it. For devel
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
 

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -72,7 +72,7 @@ You don't need to go the Google Cloud Console, and you can log in within minutes
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Toggle "Use dev credentials"
@@ -92,7 +92,7 @@ npx instant-cli@latest auth client add \
 
 {% /setup-paths %}
 
-**And you're done. You can go [**straight to code**](#3-add-some-code)**.
+**And you're done. You can go [straight to code](#3-add-some-code).**
 
 {% callout type="note" %}
 
@@ -177,7 +177,7 @@ Save your Client IDs -- you'll need it for the next step!
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Enter your "Client ID"
@@ -213,7 +213,7 @@ If you're testing from localhost, add `http://localhost:3000` (replacing `3000` 
 
 {% dashboard-path %}
 
-In the `Auth` tab, add your URL to the **Redirect Origins** list.
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
 
 {% /dashboard-path %}
 
@@ -241,7 +241,7 @@ For each Oauth Client you created, add it to Instant:
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Enter your "Client ID"
@@ -466,7 +466,7 @@ Now that you have your App Scheme, it's time to tell Instant about it. For devel
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
 

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -62,52 +62,31 @@ Let's dive deeper in each step:
    param="method"
    value=["web-redirect", "rn-web"] %}
 
-## Quick start: dev credentials
+## Quick start: developer credentials
 
-If you're just testing Google sign-in, you can skip Google Console entirely. Instant provides shared dev credentials for web flows so you can get going in seconds.
+If you're testing Google sign-in locally, we have a fast option for you. Instant provides developer credentials that you can use for local development. 
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+You don't need to go the Google Cloud Console, and you can log in within minutes. 
+
+Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard and create your client:
 
 - Click "Set up Google"
 - Toggle "Use dev credentials"
 - Give your client a name (e.g. `google-web`)
 - Click "Add Client"
 
-`localhost` and `exp://` are allowed as redirect origins automatically, so you can jump straight to **Step 3** below and start coding.
+**And you're done. You can go [**straight to code**](#3-add-some-code)**.
 
 {% callout type="note" %}
 
-Dev credentials are for development only:
-
-- Capped at 100 sign-ups per app
-- Web flows only (not the Google Button, not native iOS/Android)
-- Consent screen reads "Instant Shared Dev Credentials" instead of your app name
-
-When you're ready for production, return to "Set up Google" on the dashboard and click "Set custom credentials" to switch over.
+Developer credentials are meant only for local development. You're limited to 100 sign-ups. Once you're ready for production, follow the steps below.
 
 {% /callout %}
 
-Prefer the terminal? Run:
-
-```shell
-npx instant-cli@latest auth client add --type google --app-type web --name google-web --dev-credentials
-```
 
 {% /conditional %}
 
 ## 1. Set up your consent screen and create an Oauth client
-
-{% conditional
-   param="method"
-   value=["web-redirect", "rn-web"] %}
-
-{% callout type="note" %}
-
-Already using dev credentials from the quick start? You can skip this step until you're ready for production.
-
-{% /callout %}
-
-{% /conditional %}
 
 Head on over to {% blank-link href="https://console.cloud.google.com/apis/credentials" label="Google Console" /%}. You should be in the "Credentials" section.
 

--- a/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/google-oauth/[[...tab]]/page.md
@@ -68,12 +68,29 @@ If you're testing Google sign-in locally, we have a fast option for you. Instant
 
 You don't need to go the Google Cloud Console, and you can log in within minutes. 
 
-Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard and create your client:
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Toggle "Use dev credentials"
 - Give your client a name (e.g. `google-web`)
 - Click "Add Client"
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type google --app-type web --name google-web --dev-credentials
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 **And you're done. You can go [**straight to code**](#3-add-some-code)**.
 
@@ -155,9 +172,13 @@ Save your Client IDs -- you'll need it for the next step!
    param="method"
    value=["web-google-button", "web-redirect", "rn-web"] %}
 
-Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Instant dashboard" /%} and select the `Auth` tab for your app.
-
 **Add your Oauth Client on Instant**
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Enter your "Client ID"
@@ -165,7 +186,19 @@ Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="In
 - Check "I added the redirect to Google" (make sure you actually did this!)
 - Click "Add Client"
 
-And voila, you are connected!
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type google --app-type web --name google-web \
+  --client-id <id> --client-secret <secret>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /conditional %}
 
@@ -175,9 +208,25 @@ And voila, you are connected!
 
 **Register your website with Instant**
 
-In the `Auth` tab, add the url of the websites where you are using Instant to the Redirect Origins.
-If you're testing from localhost, add `http://localhost:3000`, replacing `3000` with the port you use.
-For production, add your website's domain.
+If you're testing from localhost, add `http://localhost:3000` (replacing `3000` with the port you use). For production, add your website's domain.
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+In the `Auth` tab, add your URL to the **Redirect Origins** list.
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type website --url example.com
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /conditional %}
 
@@ -185,13 +234,34 @@ For production, add your website's domain.
    param="method"
    value=["rn-native"] %}
 
-Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Instant dashboard" /%} and select the `Auth` tab for your app. For each Oauth Client you created, add it to Instant:
+**Add your Oauth Client on Instant**
+
+For each Oauth Client you created, add it to Instant:
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up Google"
 - Enter your "Client ID"
 - Click "Add Client"
 
-And voila, you are connected!
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type google --app-type ios --name google-ios --client-id <ios-id>
+npx instant-cli@latest auth client add \
+  --type google --app-type android --name google-android --client-id <android-id>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /conditional %}
 
@@ -391,11 +461,28 @@ Update your app.json with your scheme:
 
 **Register your app with Instant**
 
-Now that you have you App Scheme, it's time to tell Instant about it.
+Now that you have your App Scheme, it's time to tell Instant about it. For development with expo, add `exp://` and your scheme (e.g. `mycoolredirect://`) as redirect origins.
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme". For development with expo add `exp://` and your scheme, e.g. `mycoolredirect://`.
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type custom-scheme --scheme exp://
+npx instant-cli@latest auth origin add --type custom-scheme --scheme mycoolredirect://
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 **Use AuthSession to log in with Google!**
 

--- a/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
@@ -70,7 +70,7 @@ Save your Client ID and your Client Secret -- you'll need it for the next step!
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up LinkedIn"
 - Enter a unique name for your client (e.g., "linkedin-web")
@@ -102,7 +102,7 @@ If you're testing from localhost, add `http://localhost:3000` (replacing `3000` 
 
 {% dashboard-path %}
 
-In the `Auth` tab, add your URL to the **Redirect Origins** list.
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
 
 {% /dashboard-path %}
 
@@ -215,7 +215,7 @@ Now that you have your App Scheme, it's time to tell Instant about it. For devel
 
 {% dashboard-path %}
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
+From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
 

--- a/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
@@ -64,22 +64,57 @@ Save your Client ID and your Client Secret -- you'll need it for the next step!
 
 ## 2. Connect your Oauth client to Instant
 
-Go to the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Instant dashboard" /%} and select the `Auth` tab for your app.
-
 **Add your Oauth Client on Instant**
 
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+
 - Click "Set up LinkedIn"
+- Enter a unique name for your client (e.g., "linkedin-web")
 - Enter your "Client ID"
 - Enter your "Client Secret"
 - Click "Add Client"
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth client add \
+  --type linkedin --name linkedin-web \
+  --client-id <id> --client-secret <secret>
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% conditional param="method" value="web-redirect" %}
 
 **Register your website with Instant**
 
-In the `Auth` tab, add the url of the websites where you are using Instant to the Redirect Origins.
-If you're testing from localhost, add `http://localhost:3000`, replacing `3000` with the port you use.
-For production, add your website's domain.
+If you're testing from localhost, add `http://localhost:3000` (replacing `3000` with the port you use). For production, add your website's domain.
+
+{% setup-paths %}
+
+{% dashboard-path %}
+
+In the `Auth` tab, add your URL to the **Redirect Origins** list.
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type website --url example.com
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 {% /conditional %}
 
@@ -174,11 +209,28 @@ Update your app.json with your scheme:
 
 **Register your app with Instant**
 
-Now that you have you App Scheme, it's time to tell Instant about it.
+Now that you have your App Scheme, it's time to tell Instant about it. For development with expo, add `exp://` and your scheme (e.g. `mycoolredirect://`) as redirect origins.
 
-From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme". For development with expo add `exp://` and your scheme, e.g. `mycoolredirect://`.
+{% setup-paths %}
+
+{% dashboard-path %}
+
+From the {% blank-link href="http://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
+
+{% /dashboard-path %}
+
+{% terminal-path %}
+
+```shell
+npx instant-cli@latest auth origin add --type custom-scheme --scheme exp://
+npx instant-cli@latest auth origin add --type custom-scheme --scheme mycoolredirect://
+```
+
+{% /terminal-path %}
+
+{% /setup-paths %}
 
 **Use AuthSession to log in with LinkedIn!**
 

--- a/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
@@ -70,7 +70,7 @@ Save your Client ID and your Client Secret -- you'll need it for the next step!
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard:
 
 - Click "Set up LinkedIn"
 - Enter a unique name for your client (e.g., "linkedin-web")
@@ -102,7 +102,7 @@ If you're testing from localhost, add `http://localhost:3000` (replacing `3000` 
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add your URL to the **Redirect Origins** list.
 
 {% /dashboard-path %}
 
@@ -215,7 +215,7 @@ Now that you have your App Scheme, it's time to tell Instant about it. For devel
 
 {% dashboard-path %}
 
-From the {% blank-link href="https://instantdb.com/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
+From the {% blank-link href="/dash?s=main&t=auth" label="Auth" /%} tab on the Instant dashboard, add a redirect origin of type "App scheme".
 
 {% screenshot src="/img/docs/rn-web-redirect-origins.png" /%}
 

--- a/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
+++ b/client/www/app/docs/auth/linkedin-oauth/[[...tab]]/page.md
@@ -109,7 +109,7 @@ In the `Auth` tab, add your URL to the **Redirect Origins** list.
 {% terminal-path %}
 
 ```shell
-npx instant-cli@latest auth origin add --type website --url example.com
+npx instant-cli@latest auth origin add --type website --url <your-domain>
 ```
 
 {% /terminal-path %}

--- a/client/www/app/docs/cli/page.md
+++ b/client/www/app/docs/cli/page.md
@@ -226,3 +226,23 @@ fi
 appId=$(echo "$output" | jq -r '.appId')
 adminToken=$(echo "$output" | jq -r '.adminToken')
 ```
+
+## OAuth clients and redirect origins
+
+You can manage OAuth clients and redirect origins from the CLI in addition to the dashboard. Run `--help` on any subcommand for the full list of provider-specific flags.
+
+```shell
+# Add a Google web client using Instant's dev credentials (no Google Console needed)
+npx instant-cli@latest auth client add --type google --app-type web --name google-web --dev-credentials
+
+# Add a custom client (works for github, linkedin, apple, clerk, firebase too)
+npx instant-cli@latest auth client add --type github --name github-web --client-id <id> --client-secret <secret>
+
+# Upgrade a Google dev client to your own credentials
+npx instant-cli@latest auth client update --name google-web --client-id <id> --client-secret <secret>
+
+# Add a redirect origin
+npx instant-cli@latest auth origin add --type website --url example.com
+```
+
+Run `auth client --help` and `auth origin --help` to see the full set of available commands.

--- a/client/www/app/docs/cli/page.md
+++ b/client/www/app/docs/cli/page.md
@@ -242,7 +242,7 @@ npx instant-cli@latest auth client add --type github --name github-web --client-
 npx instant-cli@latest auth client update --name google-web --client-id <id> --client-secret <secret>
 
 # Add a redirect origin
-npx instant-cli@latest auth origin add --type website --url example.com
+npx instant-cli@latest auth origin add --type website --url <your-domain>
 ```
 
 Run `auth client --help` and `auth origin --help` to see the full set of available commands.

--- a/client/www/app/docs/cli/page.md
+++ b/client/www/app/docs/cli/page.md
@@ -232,17 +232,20 @@ adminToken=$(echo "$output" | jq -r '.adminToken')
 You can manage OAuth clients and redirect origins from the CLI in addition to the dashboard. Run `--help` on any subcommand for the full list of provider-specific flags.
 
 ```shell
-# Add a Google web client using Instant's dev credentials (no Google Console needed)
-npx instant-cli@latest auth client add --type google --app-type web --name google-web --dev-credentials
+# Add a Google web client using Instant's dev credentials
+npx instant-cli@latest auth client add \
+  --type google --app-type web \
+  --name google-web --dev-credentials
 
-# Add a custom client (works for github, linkedin, apple, clerk, firebase too)
-npx instant-cli@latest auth client add --type github --name github-web --client-id <id> --client-secret <secret>
+# List existing clients
+npx instant-cli@latest auth client list
 
 # Upgrade a Google dev client to your own credentials
-npx instant-cli@latest auth client update --name google-web --client-id <id> --client-secret <secret>
+npx instant-cli@latest auth client update \
+  --name google-web \
+  --client-id <id> --client-secret <secret>
 
 # Add a redirect origin
-npx instant-cli@latest auth origin add --type website --url <your-domain>
+npx instant-cli@latest auth origin add \
+  --type website --url <your-domain>
 ```
-
-Run `auth client --help` and `auth origin --help` to see the full set of available commands.

--- a/client/www/components/docs/SetupPaths.tsx
+++ b/client/www/components/docs/SetupPaths.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export function SetupPaths({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}
+
+export function DashboardPath({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <h4>Via the dashboard</h4>
+      {children}
+    </div>
+  );
+}
+
+export function TerminalPath({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <h4>Via the terminal</h4>
+      {children}
+    </div>
+  );
+}

--- a/client/www/components/docs/SetupPaths.tsx
+++ b/client/www/components/docs/SetupPaths.tsx
@@ -1,23 +1,49 @@
-import React from 'react';
+import { type ReactNode } from 'react';
+import {
+  CommandLineIcon,
+  ComputerDesktopIcon,
+} from '@heroicons/react/24/outline';
 
-export function SetupPaths({ children }: { children: React.ReactNode }) {
-  return <div>{children}</div>;
-}
-
-export function DashboardPath({ children }: { children: React.ReactNode }) {
+export function SetupPaths({ children }: { children: ReactNode }) {
   return (
-    <div>
-      <h4>Via the dashboard</h4>
+    <div className="my-6 border border-gray-200 dark:border-slate-800">
       {children}
     </div>
   );
 }
 
-export function TerminalPath({ children }: { children: React.ReactNode }) {
+function HeaderBar({ icon, label }: { icon: ReactNode; label: string }) {
   return (
-    <div>
-      <h4>Via the terminal</h4>
-      {children}
+    <div className="not-prose flex items-center gap-2 bg-gray-50/80 px-4 py-1.5 text-sm font-medium text-gray-700 dark:bg-slate-900 dark:text-slate-300">
+      <span className="text-gray-500 dark:text-slate-400">{icon}</span>
+      {label}
     </div>
+  );
+}
+
+const contentClass =
+  'px-5 py-3 prose-p:my-1 prose-ul:my-1 prose-li:my-0 prose-pre:my-0 [&_pre]:rounded-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0';
+
+export function DashboardPath({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <HeaderBar
+        icon={<ComputerDesktopIcon className="h-4 w-4" />}
+        label="From the dashboard"
+      />
+      <div className={contentClass}>{children}</div>
+    </>
+  );
+}
+
+export function TerminalPath({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <HeaderBar
+        icon={<CommandLineIcon className="h-4 w-4" />}
+        label="From the terminal"
+      />
+      <div className={contentClass}>{children}</div>
+    </>
   );
 }

--- a/client/www/lib/markdoc.ts
+++ b/client/www/lib/markdoc.ts
@@ -35,12 +35,31 @@ function navButtonToMarkdown(tag: string): string | null {
   return desc ? `- **${title}**: ${desc}` : `- **${title}**`;
 }
 
+// Convert a self-closing blank-link tag into a markdown link so the
+// label/href survives in the LLM-facing export.
+function blankLinkToMarkdown(tag: string): string | null {
+  const href = tag.match(/href="([^"]*)"/)?.[1];
+  const label = tag.match(/label="([^"]*)"/)?.[1];
+  if (!label) return null;
+  if (!href) return label;
+  return `[${label}](${href})`;
+}
+
 // Remove `{% ... %}` tags from markdown content, converting known tags
 // like nav-button into plain markdown equivalents
 function sanitizeMarkdown(content: string): string {
   return content.replace(/{%[\s\S]*?%}/g, (match) => {
     if (/nav-button\s/.test(match)) {
       return navButtonToMarkdown(match) ?? '';
+    }
+    if (/blank-link\s/.test(match)) {
+      return blankLinkToMarkdown(match) ?? '';
+    }
+    if (/^{%\s*dashboard-path[\s\S]*?%}$/.test(match)) {
+      return '**From the dashboard**\n';
+    }
+    if (/^{%\s*terminal-path[\s\S]*?%}$/.test(match)) {
+      return '**From the terminal**\n';
     }
     return '';
   });

--- a/client/www/markdoc/tags.js
+++ b/client/www/markdoc/tags.js
@@ -10,6 +10,11 @@ import { Tag, transformer } from '@markdoc/markdoc';
 import { HasAppID } from '../components/docs/Fence';
 import { TabbedSingle } from '../components/docs/TabbedSingle';
 import { YouTube } from '../components/docs/YouTube';
+import {
+  SetupPaths,
+  DashboardPath,
+  TerminalPath,
+} from '../components/docs/SetupPaths';
 
 function CustomDiv({ className, children }) {
   return <div className={className}>{children}</div>;
@@ -164,6 +169,16 @@ const tags = {
       defaultTab: { type: String },
       storageKey: { type: String, required: true },
     },
+  },
+
+  'setup-paths': {
+    render: SetupPaths,
+  },
+  'dashboard-path': {
+    render: DashboardPath,
+  },
+  'terminal-path': {
+    render: TerminalPath,
   },
 };
 


### PR DESCRIPTION
**Context** 

We added (1) support for updating auth clients and origins in the CLI, and (2) support for dev credentials. 

**This PR updates the docs**. There's three changes: 

1. Dev Credentials Instructions
  a. In Google Oauth I added a section calling out dev credentials 
2. Terminal commands across oauth tutorials
  a. Wherever we had dashboard instructions, we now _also_ have  terminal instructions
3. Call out the auth methods in the CLI docs
  a. I also added a callout on auth methods if the user visits the CLI page 

<img width="1376" height="970" alt="CleanShot 2026-05-05 at 16 30 23@2x" src="https://github.com/user-attachments/assets/6f29ae98-de2b-4e10-b022-cef4c66697df" />

**Note:** You may wonder, why do we show _both_ dashboard instructions and cli instructions at once? We _could_ have made a tabbed picker. If we did, SSR would get annoying, since then we would have to dynamically render the docs pages. Right now we statically render them.

**Preview Links**

Take a gander at the changes in each doc section 

- [Google OAuth](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/auth/google-oauth/web-redirect#quick-start-developer-credentials) — quick start dev creds, setup-paths in step 2 + redirect origin step + rn-web app scheme step
- [GitHub OAuth](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/auth/github-oauth) — setup-paths in step 2 + redirect origin step + rn-web app scheme step
- [LinkedIn OAuth](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/auth/linkedin-oauth) — setup-paths in step 2 + redirect origin step + rn-web app scheme step
- [Sign In with Apple](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/auth/apple) — setup-paths in step 4 (web-redirect + else), step 4.5 domain whitelist, native step 5 `exp://` origin
- [Clerk](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/auth/clerk) — setup-paths in step 3
- [Firebase Auth](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/auth/firebase) — setup-paths in step 2
- [Instant CLI](https://instant-www-js-docs-dev-credentials-and-cli-auth-jsv.vercel.app/docs/cli) — new "OAuth clients and redirect origins" section at the bottom

@dwwoelfel @nezaj @drew-harris 