### PR TITLE
Faster db startup

### DIFF
--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -201,17 +201,29 @@
                       (catch Exception _e nil)))
      :get-config (fn [] @current-config)}))
 
+(defn build-startup-options
+  "Builds a libpq `options` startup-packet string so session settings get
+   applied during the protocol handshake. Allows us to do SET without an
+   extra round-trip"
+  [_config]
+  (let [idle-ms (flags/flag :idle-in-transaction-session-timeout (* 1000 60))]
+    (str "-c idle_in_transaction_session_timeout=" idle-ms)))
+
 (defn get-connection
-  "Creates a new connection for the connection pool and sets the idle_in_transaction_session_timeout.
-   Defaults to one minute, but can be modified with a flag in an emergency."
-  [config]
+  "Creates a new connection for the connection pool. idle_in_transaction_session_timeout
+   defaults to one minute, but can be modified with a flag in an emergency."
+  [base-config]
   (binding [socket-track/*connection-id* (random-uuid)]
-    (let [conn (next-jdbc/get-connection (assoc config
-                                                :socketFactory "instant.SocketWrapper"))]
+    (let [config (assoc base-config
+                        :options (build-startup-options base-config)
+                        ;; Setting `assumeMinServerVersion=9.0` lets pgjdbc inline `extra_float_digits`
+                        ;; and `application_name` directly into the StartupPacket instead of emitting
+                        ;; them as separate `SET` round-trips after the handshake.
+                        :assumeMinServerVersion "9.0"
+                        :socketFactory "instant.SocketWrapper")
+          conn (next-jdbc/get-connection config)]
       (socket-track/add-connection socket-track/*connection-id* conn {:cluster-id (:cluster-id config)
                                                                       :db-host (:host config)})
-      (next-jdbc/execute! conn ["select set_config('idle_in_transaction_session_timeout', ?::text, false)"
-                                (flags/flag :idle-in-transaction-session-timeout (* 1000 60))])
       conn)))
 
 (defn aurora-cluster-datasource

--- a/server/test/instant/jdbc/sql_test.clj
+++ b/server/test/instant/jdbc/sql_test.clj
@@ -1,17 +1,33 @@
 (ns instant.jdbc.sql-test
   (:require
    [honey.sql :as hsql]
+   [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
+   [instant.rate-limit :refer [parse-duration]]
    [instant.util.test :refer [wait-for]]
    [clojure.test :refer [deftest testing is]])
   (:import
    (clojure.lang ExceptionInfo)
    (instant.isn ISN)
-   (java.time Instant)
+   (java.time Duration Instant)
    (java.time.temporal ChronoUnit)
    (java.sql Timestamp)
    (org.postgresql.replication LogSequenceNumber)))
+
+(deftest connection-startup-sets-config
+  (testing "idle_in_transaction_session_timeout"
+    (is (= (Duration/ofMinutes 1)
+           (-> (sql/select-one (aurora/conn-pool :read)
+                               ["select current_setting('idle_in_transaction_session_timeout')::interval as setting"])
+               :setting
+               parse-duration))))
+
+  (testing "application name"
+    (is (= (:ApplicationName (config/get-aurora-config))
+           (-> (sql/select-one (aurora/conn-pool :read)
+                               ["select current_setting('application_name') as setting"])
+               :setting)))))
 
 (deftest in-progress-stmts
   (let [in-progress (sql/make-statement-tracker)]


### PR DESCRIPTION
Two small changes that eliminate a couple of round-trips to the db on connection startup:

1. Set `assumeMinServerVersion` in the jdbc config to `9.0`, which lets jdbc put the application name in the initial startup packet
2. Put the idle timeout in the options flag, saving a round-trip to do a `SET`.

I'm also exploring pre-warming the type-cache. jdbc makes metadata queries to the database to map oid -> typename. It's not shared across the pool, each connection fetches it individually. I have some wip code that caches that data, but it still needs a bit of work to prevent breaking things if a type name gets mapped to a new oid (e.g. drop and then add the same field).