### PR TITLE
misc cli conveniences (#2634) [bump to v1.0.25]

### DIFF
--- a/client/packages/cli/__tests__/appCommands.test.ts
+++ b/client/packages/cli/__tests__/appCommands.test.ts
@@ -1,0 +1,228 @@
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from '@effect/platform';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { Effect, Layer, Logger } from 'effect';
+import { GlobalOpts } from '../src/context/globalOpts.ts';
+import { CurrentApp } from '../src/context/currentApp.ts';
+import type { CurrentAppInfo } from '../src/context/currentApp.ts';
+import { InstantHttp, InstantHttpAuthed } from '../src/lib/http.ts';
+
+vi.mock('../src/index.ts', () => ({}));
+
+let prompts: any[] = [];
+let mockPromptReturn: any;
+
+vi.mock('../src/ui/lib.ts', async (importOriginal) => {
+  const orig: any = await importOriginal();
+  return {
+    ...orig,
+    renderUnwrap: (prompt: any) => {
+      prompts.push(prompt);
+      return Promise.resolve(mockPromptReturn);
+    },
+  };
+});
+
+const { appListCommand } = await import('../src/commands/app/list.ts');
+const { appDeleteCommand } = await import('../src/commands/app/delete.ts');
+const { infoCommand } = await import('../src/commands/info.ts');
+
+const apps = [
+  { id: 'app-1', title: 'Alpha', user_app_role: 'owner' },
+  { id: 'app-2', title: 'Beta', user_app_role: 'admin' },
+  { id: 'app-3', title: 'Gamma', user_app_role: 'collaborator' },
+];
+
+let logs: string[] = [];
+let requests: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+}[] = [];
+let dashApps = apps;
+let appInfo = { id: 'app-1', title: 'Alpha' };
+
+const makeHttp = (): any =>
+  HttpClient.make((request, url) => {
+    const path = url.pathname;
+    requests.push({
+      method: request.method,
+      url: path,
+      headers: request.headers,
+    });
+
+    const body =
+      path === '/dash'
+        ? { apps: dashApps }
+        : path === '/dash/me'
+          ? {
+              user: {
+                email: 'test@example.com',
+                id: 'user-1',
+                created_at: '2026-01-01T00:00:00Z',
+              },
+            }
+          : path === '/dash/apps/app-1'
+            ? { app: appInfo }
+            : {};
+
+    return Effect.succeed(
+      HttpClientResponse.fromWeb(
+        request,
+        new Response(JSON.stringify(body), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+  }).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl('http://test')));
+
+const loggerLayer = Logger.replace(
+  Logger.defaultLogger,
+  Logger.make(({ message }) => {
+    logs.push(String(message));
+  }),
+);
+
+const baseLayer = (opts: { yes?: boolean; currentApp?: CurrentAppInfo }) =>
+  Layer.mergeAll(
+    Layer.succeed(GlobalOpts, { yes: opts.yes ?? true }),
+    Layer.succeed(InstantHttpAuthed, makeHttp()),
+    Layer.succeed(InstantHttp, makeHttp()),
+    loggerLayer,
+    opts.currentApp ? Layer.succeed(CurrentApp, opts.currentApp) : Layer.empty,
+  );
+
+const run = (effect: Effect.Effect<any, any, any>, layer = baseLayer({})) =>
+  Effect.runPromise(effect.pipe(Effect.provide(layer as any)) as any);
+
+const runFail = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  layer = baseLayer({}),
+) =>
+  Effect.runPromise(
+    effect.pipe(Effect.flip, Effect.provide(layer as any)) as any,
+  );
+
+beforeEach(() => {
+  logs = [];
+  prompts = [];
+  requests = [];
+  dashApps = apps;
+  appInfo = { id: 'app-1', title: 'Alpha' };
+  mockPromptReturn = undefined;
+  delete process.env.INSTANT_APP_ID;
+});
+
+afterEach(() => {
+  delete process.env.INSTANT_APP_ID;
+});
+
+describe('app list', () => {
+  test('prints app titles and ids', async () => {
+    await run(appListCommand({}));
+
+    const output = logs.join('\n');
+    expect(output).toContain('Alpha');
+    expect(output).toContain('app-1');
+    expect(output).toContain('Beta');
+    expect(output).toContain('app-2');
+  });
+
+  test('--json prints raw apps', async () => {
+    await run(appListCommand({ json: true }));
+
+    expect(JSON.parse(logs.join('\n'))).toEqual([
+      { id: 'app-1', title: 'Alpha' },
+      { id: 'app-2', title: 'Beta' },
+      { id: 'app-3', title: 'Gamma' },
+    ]);
+  });
+
+  test('prints empty state', async () => {
+    dashApps = [];
+
+    await run(appListCommand({}));
+
+    expect(logs).toEqual(['No apps found.']);
+  });
+});
+
+describe('app delete', () => {
+  test('deletes app specified by --app when --yes is set', async () => {
+    await run(appDeleteCommand({ app: 'app-2' } as any));
+
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: 'GET', url: '/dash' }),
+        expect.objectContaining({ method: 'DELETE', url: '/dash/apps/app-2' }),
+      ]),
+    );
+    expect(logs.join('\n')).toContain('Deleted app "Beta" (app-2).');
+  });
+
+  test('defaults to INSTANT_APP_ID when --app is omitted', async () => {
+    process.env.INSTANT_APP_ID = 'app-1';
+
+    await run(appDeleteCommand({} as any));
+
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: 'DELETE', url: '/dash/apps/app-1' }),
+      ]),
+    );
+  });
+
+  test('prompts for app and confirmation interactively', async () => {
+    mockPromptReturn = apps[0];
+    await run(appDeleteCommand({} as any), baseLayer({ yes: false }));
+
+    expect(prompts[0].render('idle')).toContain('Select an app to delete:');
+    expect(prompts[1].render('idle')).toContain('Delete app "Alpha" (app-1)?');
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: 'DELETE', url: '/dash/apps/app-1' }),
+      ]),
+    );
+  });
+
+  test('rejects --yes without a target app', async () => {
+    const err = await runFail(appDeleteCommand({} as any));
+
+    expect((err as any).message).toBe('Must specify --app when using --yes');
+    expect(requests.some((request) => request.method === 'DELETE')).toBe(false);
+  });
+
+  test('does not delete collaborator apps', async () => {
+    const err = await runFail(appDeleteCommand({ app: 'app-3' } as any));
+
+    expect((err as any).message).toContain(
+      'App not found on your account, or you do not have permission to delete it: app-3',
+    );
+    expect(requests.some((request) => request.method === 'DELETE')).toBe(false);
+  });
+});
+
+describe('info', () => {
+  test('prints current app when available', async () => {
+    await run(
+      infoCommand(),
+      baseLayer({
+        currentApp: {
+          appId: 'app-1',
+          adminToken: 'admin-token',
+          source: 'env',
+        },
+      }),
+    );
+
+    expect(logs.join('\n')).toContain('App: Alpha (app-1)');
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: 'GET', url: '/dash/apps/app-1' }),
+      ]),
+    );
+  });
+});

--- a/client/packages/cli/src/commands/app/delete.ts
+++ b/client/packages/cli/src/commands/app/delete.ts
@@ -1,0 +1,84 @@
+import { HttpClientResponse } from '@effect/platform';
+import { Effect, Schema } from 'effect';
+import type { appDeleteDef, OptsFromCommand } from '../../index.ts';
+import { GlobalOpts } from '../../context/globalOpts.ts';
+import { InstantHttpAuthed, withCommand } from '../../lib/http.ts';
+import { runUIEffect } from '../../lib/ui.ts';
+import { UI } from '../../ui/index.ts';
+import { BadArgsError } from '../../errors.ts';
+import { potentialEnvs } from '../../context/currentApp.ts';
+
+const DashResponse = Schema.Struct({
+  apps: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      title: Schema.String,
+      user_app_role: Schema.Literal('owner', 'admin', 'collaborator'),
+    }),
+  ),
+});
+
+const getEnvAppId = () => {
+  const envName = Object.values(potentialEnvs).find((envName) =>
+    Boolean(process.env[envName]),
+  );
+  return envName ? process.env[envName] : undefined;
+};
+
+export const appDeleteCommand = Effect.fn(function* (
+  opts: OptsFromCommand<typeof appDeleteDef>,
+) {
+  const http = (yield* InstantHttpAuthed).pipe(withCommand('app delete'));
+  const { yes } = yield* GlobalOpts;
+  const targetApp = opts.app ?? getEnvAppId();
+
+  const dashData = yield* http.get('/dash').pipe(
+    Effect.flatMap(HttpClientResponse.schemaBodyJson(DashResponse)),
+    Effect.mapError((e) => new Error("Couldn't get apps.", { cause: e })),
+  );
+
+  const deletableApps = dashData.apps.filter(
+    (app) => app.user_app_role === 'owner' || app.user_app_role === 'admin',
+  );
+
+  const app = targetApp
+    ? deletableApps.find(
+        (app) => app.id === targetApp || app.title === targetApp,
+      )
+    : yes
+      ? undefined
+      : yield* runUIEffect(
+          new UI.Select({
+            options: deletableApps.map((app) => ({
+              label: `${app.title} (${app.id})`,
+              value: app,
+            })),
+            promptText: 'Select an app to delete:',
+          }),
+        );
+
+  if (!app) {
+    return yield* BadArgsError.make({
+      message: targetApp
+        ? `App not found on your account, or you do not have permission to delete it: ${targetApp}`
+        : 'Must specify --app when using --yes',
+    });
+  }
+
+  if (!yes) {
+    const confirmed = yield* runUIEffect(
+      new UI.Confirmation({
+        promptText: `Deleting an app will irreversibly delete all associated data.\nDelete app "${app.title}" (${app.id})?`,
+        defaultValue: false,
+      }),
+    );
+
+    if (!confirmed) {
+      yield* Effect.log('Cancelled.');
+      return;
+    }
+  }
+
+  yield* http.del(`/dash/apps/${app.id}`);
+  yield* Effect.log(`Deleted app "${app.title}" (${app.id}).`);
+});

--- a/client/packages/cli/src/commands/app/delete.ts
+++ b/client/packages/cli/src/commands/app/delete.ts
@@ -42,9 +42,7 @@ export const appDeleteCommand = Effect.fn(function* (
   );
 
   const app = targetApp
-    ? deletableApps.find(
-        (app) => app.id === targetApp || app.title === targetApp,
-      )
+    ? deletableApps.find((app) => app.id === targetApp)
     : yes
       ? undefined
       : yield* runUIEffect(

--- a/client/packages/cli/src/commands/app/list.ts
+++ b/client/packages/cli/src/commands/app/list.ts
@@ -1,0 +1,53 @@
+import { HttpClientResponse } from '@effect/platform';
+import { Effect, Schema } from 'effect';
+import { InstantHttpAuthed } from '../../lib/http.ts';
+import stringWidth from 'string-width';
+
+const DashResponse = Schema.Struct({
+  apps: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      title: Schema.String,
+    }),
+  ),
+});
+
+const pad = (value: string, width: number) =>
+  value + ' '.repeat(Math.max(0, width - stringWidth(value)));
+
+export const appListCommand = (opts: { json?: boolean }) =>
+  Effect.gen(function* () {
+    const http = yield* InstantHttpAuthed;
+    const dashData = yield* http.get('/dash').pipe(
+      Effect.flatMap(HttpClientResponse.schemaBodyJson(DashResponse)),
+      Effect.mapError((e) => new Error("Couldn't get apps.", { cause: e })),
+    );
+
+    if (opts.json) {
+      yield* Effect.log(JSON.stringify(dashData.apps, null, 2));
+      return;
+    }
+
+    if (dashData.apps.length === 0) {
+      yield* Effect.log('No apps found.');
+      return;
+    }
+
+    const nameHeader = 'Name';
+    const idHeader = 'App ID';
+    const nameWidth = Math.max(
+      stringWidth(nameHeader),
+      ...dashData.apps.map((app) => stringWidth(app.title)),
+    );
+    const idWidth = Math.max(
+      stringWidth(idHeader),
+      ...dashData.apps.map((app) => stringWidth(app.id)),
+    );
+
+    yield* Effect.log(`${pad(nameHeader, nameWidth)}  ${idHeader}`);
+    yield* Effect.log(`${'-'.repeat(nameWidth)}  ${'-'.repeat(idWidth)}`);
+
+    for (const app of dashData.apps) {
+      yield* Effect.log(`${pad(app.title, nameWidth)}  ${app.id}`);
+    }
+  });

--- a/client/packages/cli/src/commands/app/list.ts
+++ b/client/packages/cli/src/commands/app/list.ts
@@ -1,6 +1,7 @@
 import { HttpClientResponse } from '@effect/platform';
 import { Effect, Schema } from 'effect';
 import { InstantHttpAuthed } from '../../lib/http.ts';
+import chalk from 'chalk';
 import stringWidth from 'string-width';
 
 const DashResponse = Schema.Struct({
@@ -33,21 +34,11 @@ export const appListCommand = (opts: { json?: boolean }) =>
       return;
     }
 
-    const nameHeader = 'Name';
-    const idHeader = 'App ID';
     const nameWidth = Math.max(
-      stringWidth(nameHeader),
       ...dashData.apps.map((app) => stringWidth(app.title)),
     );
-    const idWidth = Math.max(
-      stringWidth(idHeader),
-      ...dashData.apps.map((app) => stringWidth(app.id)),
-    );
-
-    yield* Effect.log(`${pad(nameHeader, nameWidth)}  ${idHeader}`);
-    yield* Effect.log(`${'-'.repeat(nameWidth)}  ${'-'.repeat(idWidth)}`);
 
     for (const app of dashData.apps) {
-      yield* Effect.log(`${pad(app.title, nameWidth)}  ${app.id}`);
+      yield* Effect.log(`${pad(app.title, nameWidth)}  ${chalk.dim(app.id)}`);
     }
   });

--- a/client/packages/cli/src/commands/info.ts
+++ b/client/packages/cli/src/commands/info.ts
@@ -1,7 +1,12 @@
-import { HttpClientResponse } from '@effect/platform';
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from '@effect/platform';
 import { Effect, Schema, Option } from 'effect';
-import { InstantHttpAuthed } from '../lib/http.ts';
+import { InstantHttp, InstantHttpAuthed } from '../lib/http.ts';
 import { version } from '@instantdb/version';
+import { CurrentApp } from '../context/currentApp.ts';
 
 const DashMeResponse = Schema.Struct({
   user: Schema.Struct({
@@ -11,11 +16,22 @@ const DashMeResponse = Schema.Struct({
   }),
 });
 
+const DashAppResponse = Schema.Struct({
+  app: Schema.Struct({
+    id: Schema.String,
+    title: Schema.String,
+  }),
+});
+
 export const infoCommand = () =>
   Effect.gen(function* () {
     const authedHttp = yield* Effect.serviceOption(InstantHttpAuthed).pipe(
       Effect.map(Option.getOrNull),
     );
+    const http = yield* Effect.serviceOption(InstantHttp).pipe(
+      Effect.map(Option.getOrNull),
+    );
+    const maybeApp = yield* Effect.serviceOption(CurrentApp);
 
     yield* Effect.log('CLI Version:', version);
     // If logged in..
@@ -30,5 +46,37 @@ export const infoCommand = () =>
       yield* Effect.log(`Logged in as ${meData.user.email}`);
     } else {
       yield* Effect.log('Not logged in.');
+    }
+
+    if (Option.isSome(maybeApp) && (authedHttp || http)) {
+      const app = maybeApp.value;
+      const appHttp =
+        app.adminToken && http
+          ? http.pipe(
+              HttpClient.mapRequest((request) =>
+                request.pipe(
+                  HttpClientRequest.setHeader(
+                    'Authorization',
+                    `Bearer ${app.adminToken}`,
+                  ),
+                ),
+              ),
+            )
+          : authedHttp;
+
+      if (!appHttp) return;
+
+      const appInfo = yield* appHttp
+        .get(`/dash/apps/${app.appId}`)
+        .pipe(
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(DashAppResponse)),
+          Effect.option,
+        );
+
+      if (Option.isSome(appInfo)) {
+        yield* Effect.log(
+          `App: ${appInfo.value.app.title} (${appInfo.value.app.id})`,
+        );
+      }
     }
   });

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -392,13 +392,22 @@ export const infoDef = program
   .command('info')
   .description('Display CLI version and login status')
   .action(async () => {
+    const authLayer = AuthLayerLive({
+      coerce: false,
+      allowAdminToken: false,
+    });
+
     return runCommandEffect(
       infoCommand().pipe(
         Effect.provide(
-          AuthLayerLive({
-            coerce: false,
-            allowAdminToken: false,
-          }).pipe(Layer.catchAll(() => Layer.empty)), // make the auth layer optional
+          Layer.mergeAll(
+            BaseLayerLive,
+            authLayer.pipe(Layer.catchAll(() => Layer.empty)),
+            WithAppLayer({ coerce: false, allowAdminToken: true }).pipe(
+              Layer.annotateLogs('silent', true),
+              Layer.catchAll(() => Layer.empty),
+            ),
+          ),
         ),
       ),
     );

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -34,6 +34,8 @@ import { authOriginListCmd } from './commands/auth/origin/list.ts';
 import { authOriginDeleteCmd } from './commands/auth/origin/delete.ts';
 import { authOriginAddCmd } from './commands/auth/origin/add.ts';
 import { link } from './logging.ts';
+import { appListCommand } from './commands/app/list.ts';
+import { appDeleteCommand } from './commands/app/delete.ts';
 
 export type OptsFromCommand<C> =
   C extends Command<any, infer R, any> ? R : never;
@@ -88,6 +90,45 @@ export const initDef = program
   });
 
 const auth = program.command('auth');
+const app = program.command('app');
+
+export const appListDef = app
+  .command('list')
+  .description('List apps on your Instant account')
+  .option('--json', 'Output apps as JSON')
+  .action(async (opts) => {
+    return runCommandEffect(
+      appListCommand(opts).pipe(
+        Effect.provide(
+          AuthLayerLive({
+            coerce: false,
+            allowAdminToken: false,
+          }).pipe(Layer.annotateLogs('silent', !!opts.json)),
+        ),
+      ),
+    );
+  });
+
+export const appDeleteDef = app
+  .command('delete')
+  .description('Delete an app from your Instant account')
+  .option(
+    '-a --app <app-id>',
+    'App ID to delete. Defaults to *_INSTANT_APP_ID in .env',
+  )
+  .action(async (opts) => {
+    return runCommandEffect(
+      appDeleteCommand(opts).pipe(
+        Effect.provide(
+          AuthLayerLive({
+            coerce: false,
+            allowAdminToken: false,
+          }),
+        ),
+      ),
+    );
+  });
+
 const authClient = auth.command('client');
 export const authClientAddDef = authClient
   .command('add')

--- a/client/packages/cli/src/index.ts
+++ b/client/packages/cli/src/index.ts
@@ -89,8 +89,12 @@ export const initDef = program
     );
   });
 
-const auth = program.command('auth');
-const app = program.command('app');
+const auth = program
+  .command('auth')
+  .description('Manage authentication for your app');
+const app = program
+  .command('app')
+  .description('Manage individual InstantDB apps');
 
 export const appListDef = app
   .command('list')

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.24';
+const version = 'v1.0.25';
 
 export { version };


### PR DESCRIPTION
Adds:
`instant-cli app list`
`instant-cli app delete`
commands. 

Also shows the current app's name (if you are in one) in the `info` command. 

Mostly did this so that I could bulk delete apps w/ nushell

```nushell
let apps = instant-cli app list --json | from json | input list --multi
$apps | each {
    |app| instant-cli app delete --app $app.id --yes
}
```