### PR TITLE
[getadb] use Sec-Fetch-Mode to detect browser navigation

### DIFF
--- a/client/www/middleware.ts
+++ b/client/www/middleware.ts
@@ -19,8 +19,12 @@ export function middleware(request: NextRequest) {
 
   if (url.pathname === '/') {
     // Browser → human page; curl/agent → markdown guide.
-    const accept = request.headers.get('accept') ?? '';
-    url.pathname = accept.includes('text/html') ? '/getadb' : '/getadb/guide';
+    // Sec-Fetch-Mode is sent by all modern browsers on navigation
+    // (Chrome 76+, Firefox 90+, Safari 16.4+); agents like curl and
+    // Claude's fetch tool don't send it.
+    const isBrowserNav =
+      request.headers.get('sec-fetch-mode') === 'navigate';
+    url.pathname = isBrowserNav ? '/getadb' : '/getadb/guide';
   } else {
     url.pathname = `/getadb${url.pathname}`;
   }

--- a/client/www/middleware.ts
+++ b/client/www/middleware.ts
@@ -19,12 +19,11 @@ export function middleware(request: NextRequest) {
 
   if (url.pathname === '/') {
     // Browser → human page; curl/agent → markdown guide.
-    // Sec-Fetch-Mode is sent by all modern browsers on navigation
+    // Sec-Fetch-Mode is sent by all modern browsers
     // (Chrome 76+, Firefox 90+, Safari 16.4+); agents like curl and
     // Claude's fetch tool don't send it.
-    const isBrowserNav =
-      request.headers.get('sec-fetch-mode') === 'navigate';
-    url.pathname = isBrowserNav ? '/getadb' : '/getadb/guide';
+    const isBrowser = request.headers.has('sec-fetch-mode');
+    url.pathname = isBrowser ? '/getadb' : '/getadb/guide';
   } else {
     url.pathname = `/getadb${url.pathname}`;
   }


### PR DESCRIPTION
- Replace the `Accept: text/html` heuristic with `Sec-Fetch-Mode` for routing the getadb.com root between the HTML page and the markdown guide.
- The old check misclassified Claude's fetch tool (and other agents that accept `text/html`) as humans, so they got the HTML page instead of the markdown guide.
- `Sec-Fetch-Mode` is only sent by browsers on top-level navigation (Chrome 76+, Firefox 90+, Safari 16.4+). JS `fetch()` sends `cors`, and agents/curl don't send the header at all — both fall through to the guide.


@dwwoelfel @nezaj @drew-harris 