### PR TITLE
Fix delay being used as a function

### DIFF
--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -93,10 +93,9 @@
 (defn s3-storage-secret-key []
   (some-> @config-map :s3-storage-secret-key crypt-util/secret-value))
 
-(def s3-endpoint
-  (delay
-    (or (System/getenv "S3_ENDPOINT")
-        (some-> @config-map :s3-endpoint))))
+(defn s3-endpoint []
+  (or (System/getenv "S3_ENDPOINT")
+      (some-> @config-map :s3-endpoint)))
 
 (defn s3-public-endpoint []
   (or (System/getenv "S3_PUBLIC_ENDPOINT")

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -22,7 +22,7 @@
 ;; ----------------------
 
 (defn- configure-s3-endpoint-client ^S3ClientBuilder [^S3ClientBuilder builder]
-  (if-let [endpoint @config/s3-endpoint]
+  (if-let [endpoint (config/s3-endpoint)]
     (doto builder
       (.endpointOverride (URI/create endpoint))
       (.region (Region/of (config/s3-region)))
@@ -30,7 +30,7 @@
     builder))
 
 (defn- configure-s3-endpoint-async-client ^S3CrtAsyncClientBuilder [^S3CrtAsyncClientBuilder builder]
-  (if-let [endpoint @config/s3-endpoint]
+  (if-let [endpoint (config/s3-endpoint)]
     (doto builder
       (.endpointOverride (URI/create endpoint))
       (.region (Region/of (config/s3-region)))


### PR DESCRIPTION
Fixes a bug where a delay was being used as a function. 

I just made it a function again. I thought it was a good idea to make it a delay, since it will never change, but it's only used once when we create the s3 clients, so it doesn't really matter. 