### PR TITLE
Better trace propagation

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -505,7 +505,7 @@ export default class Reactor {
   /**
    * @param {'enqueued' | 'pending' | 'synced' | 'timeout' |  'error' } status
    * @param {string} eventId
-   * @param {{message?: string, type?: string, status?: number, hint?: unknown}} [errorMsg]
+   * @param {{message?: string, type?: string, status?: number, hint?: unknown, traceId?: string}} [errorMsg]
    */
   _finishTransaction(status, eventId, errorMsg) {
     const dfd = this.mutationDeferredStore.get(eventId);
@@ -537,6 +537,7 @@ export default class Reactor {
           new InstantError(
             errorMsg?.message || 'Unknown error',
             errorMsg?.hint,
+            errorMsg?.traceId,
           ),
         );
       }
@@ -931,7 +932,7 @@ export default class Reactor {
   /**
    * @param {'timeout' | 'error'} status
    * @param {string} eventId
-   * @param {{message?: string, type?: string, status?: number, hint?: unknown}} errorMsg
+   * @param {{message?: string, type?: string, status?: number, hint?: unknown, traceId?: string}} errorMsg
    */
   _handleMutationError(status, eventId, errorMsg) {
     const mut = this._pendingMutations().get(eventId);
@@ -945,6 +946,7 @@ export default class Reactor {
       const errDetails = {
         message: errorMsg.message,
         hint: errorMsg.hint,
+        traceId: errorMsg.traceId,
       };
       this.notifyAll();
       this.notifyAttrsSubs();
@@ -974,7 +976,7 @@ export default class Reactor {
     }
 
     if (prevMutation) {
-      this._handleMutationError('error', eventId, msg);
+      this._handleMutationError('error', eventId, errorMessage);
       return;
     }
 

--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -967,6 +967,12 @@ export default class Reactor {
       errorMessage.hint = msg.hint;
     }
 
+    if (msg['trace-id'] || msg['original-event']?.['trace-id']) {
+      const traceIds = [msg['trace-id'], msg['original-event']?.['trace-id']];
+      const traceId = traceIds.filter(Boolean).join(',');
+      errorMessage.traceId = traceId;
+    }
+
     if (prevMutation) {
       this._handleMutationError('error', eventId, msg);
       return;

--- a/client/packages/core/src/index.ts
+++ b/client/packages/core/src/index.ts
@@ -237,7 +237,11 @@ export type RoomHandle<PresenceShape, TopicsByKey> = {
 type AuthToken = string;
 
 type SubscriptionState<Q, Schema, WithCardinalityInference extends boolean> =
-  | { error: { message: string }; data: undefined; pageInfo: undefined }
+  | {
+      error: { message: string; traceId?: string };
+      data: undefined;
+      pageInfo: undefined;
+    }
   | {
       error: undefined;
       data: QueryResponse<Q, Schema, WithCardinalityInference>;
@@ -245,7 +249,11 @@ type SubscriptionState<Q, Schema, WithCardinalityInference extends boolean> =
     };
 
 type InstaQLSubscriptionState<Schema, Q, UseDates extends boolean> =
-  | { error: { message: string }; data: undefined; pageInfo: undefined }
+  | {
+      error: { message: string; traceId?: string };
+      data: undefined;
+      pageInfo: undefined;
+    }
   | {
       error: undefined;
       data: InstaQLResponse<Schema, Q, UseDates>;

--- a/client/packages/core/src/utils/fetch.ts
+++ b/client/packages/core/src/utils/fetch.ts
@@ -91,7 +91,11 @@ export class InstantAPIError extends InstantError {
   constructor(error: InstantIssue) {
     // Create a descriptive message based on the error
     const message = error.body?.message || `API Error (${error.status})`;
-    super(message, (error.body as any).hint, (error.body as any)['trace-id']);
+    super(
+      message,
+      (error.body as any).hint,
+      (error.body as any)?.traceId || (error.body as any)['trace-id'],
+    );
 
     const actualProto = new.target.prototype;
     if (Object.setPrototypeOf) {

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.25';
+const version = 'v1.0.26';
 
 export { version };

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -1093,7 +1093,10 @@
            :x-amzn-cf-id (rs/socket-x-amz-cf-id socket)
            :transport (if (contains? socket :sse-conn)
                         "sse"
-                        "ws"))))
+                        "ws")
+           :original-trace-id (-> event
+                                  :original-event
+                                  :trace-id))))
 
 (defn handle-receive [store session event metadata]
   (binding [*request-info* {:ip (rs/socket-ip (:session/socket session))
@@ -1101,7 +1104,8 @@
     (tracer/with-exceptions-silencer [silence-exceptions]
       (tracer/with-span! {:name "receive-worker/handle-receive"
                           :attributes (handle-receive-attrs store session event metadata)}
-        (let [in-progress-stmts (sql/make-statement-tracker)
+        (let [event (assoc event :trace-id (tracer/current-trace-id))
+              in-progress-stmts (sql/make-statement-tracker)
               debug-info (atom nil)
               app-id (-> session :session/auth :app :id)
               timeout-ms (or (when app-id


### PR DESCRIPTION
Includes traceId in the `error` we return from `useQuery` to make it easier for users to report errors.

Also makes sure that we pass the traceId through any transact errors.

Finally, we include the trace-id from the original message (separated by a `,`) to make it easier to look up the event that caused the error. In the backend, we'll also annotate the `handle-receive` with the trace-id of the original message for errors.

