### PR TITLE
Fix self-hosted Sandbox websocket connecting to api.instantdb.com

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -391,6 +391,7 @@ export function Sandbox({
     const coreDb = initCore({
       appId: app.id,
       apiURI: config.apiURI,
+      websocketURI: config.websocketURI,
     });
 
     const unsubAttrs = coreDb._reactor.subscribeAttrs((_oAttrs: any) => {


### PR DESCRIPTION
## Summary

When running a self-hosted dashboard, the Sandbox page subscribes to the schema via `@instantdb/core`, but the websocket ends up connecting to `wss://api.instantdb.com/runtime/session` instead of the configured backend.

## Root cause

`Sandbox.tsx` passes only `apiURI` to `initCore`:

```ts
const coreDb = initCore({
  appId: app.id,
  apiURI: config.apiURI,
});
```

`@instantdb/core`'s `init` merges over a hardcoded default:

```ts
const defaultConfig = {
  apiURI: 'https://api.instantdb.com',
  websocketURI: 'wss://api.instantdb.com/runtime/session',
};
```

Since `websocketURI` isn't overridden, it stays on the public default. REST traffic from `initAdmin` correctly hits the self-hosted backend (HTTP-only path), but the schema subscription goes to `api.instantdb.com`, fails, and the Sandbox never renders.

`lib/config.ts` already derives `websocketURI` from the runtime `apiURI` (via `websocketURIFromApiURI`) when `window.__instantConfig` is populated by `publicSelfHostedVariables.js`. This change just passes that through.

## Repro

1. Run the self-hosted dashboard image with `INSTANT_BACKEND_URL=https://your-backend`.
2. Open any app → Sandbox.
3. DevTools → Network → WS: observe `wss://api.instantdb.com/runtime/session?app_id=...` rather than `wss://your-backend/runtime/session?app_id=...`.

After this change the websocket connects to the configured backend and the Sandbox loads.

## Test plan

- [x] Self-hosted: Sandbox loads schema and runs queries against the self-hosted backend.
- [ ] Hosted (instantdb.com): no behavior change — `config.websocketURI` already resolves to `wss://api.instantdb.com/runtime/session`.

## Notes

- `initAdmin` is intentionally left alone; `@instantdb/admin` has no `websocketURI` field and is HTTP-only.