### PR TITLE
dual write to app_email_verifications

### DIFF
--- a/server/resources/migrations/107_add_email_verifications.down.sql
+++ b/server/resources/migrations/107_add_email_verifications.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE app_email_verifications;

--- a/server/resources/migrations/107_add_email_verifications.up.sql
+++ b/server/resources/migrations/107_add_email_verifications.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE app_email_verifications (
+  id uuid primary key,
+  app_id uuid not null references apps(id) on delete cascade,
+  sender_id uuid not null references app_email_senders(id) on delete cascade,
+  verified boolean not null default false,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  UNIQUE(app_id, sender_id)
+);
+
+create trigger update_updated_at_trigger
+before update on app_email_verifications
+for each row
+execute function update_updated_at_column();

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -1,6 +1,7 @@
 (ns instant.model.app-email-sender
   (:require [instant.jdbc.aurora :as aurora]
             [instant.jdbc.sql :as sql]
+            [instant.model.app-email-verification :as verification]
             [instant.postmark :as postmark]
             [instant.util.exception :as ex])
   (:import (java.util UUID)))
@@ -38,7 +39,7 @@
 (def sender-claimed-error-message "We can't use this email address; it's already been claimed by a different user.")
 
 (defn sync-sender!
-  "Given an email and an app id, we do our best to sync to postmark. There are a few cases to consider: 
+  "Given an email, we do our best to sync to postmark. There are a few cases to consider:
       1. The sender exists, but belongs to a different user
             a. In this case we throw
       2. The sender exists in our database, but not in postmark
@@ -81,12 +82,16 @@
 
                                   :else
                                   (throw e)))))
-        postmark-id  (-> postmark-response :body :ID)]
-    (put! {:email email
-           :name name
-           :app-id app-id
-           :user-id user-id
-           :postmark-id postmark-id})))
+        postmark-id  (-> postmark-response :body :ID)
+        sender (put! {:email email
+                      :name name
+                      :app-id app-id
+                      :user-id user-id
+                      :postmark-id postmark-id})]
+    (verification/put! {:app-id app-id
+                        :sender-id (get sender :id)
+                        :verified true})
+    sender))
 
 (comment
   (postmark/add-sender! {:email "hi@marky.fyi" :name "Marky"})

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -89,7 +89,7 @@
                       :user-id user-id
                       :postmark-id postmark-id})]
     (verification/put! {:app-id app-id
-                        :sender-id (get sender :id)
+                        :sender-id (:id sender)
                         :verified true})
     sender))
 

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -1,9 +1,7 @@
 (ns instant.model.app-email-verification
   (:require
    [instant.jdbc.aurora :as aurora]
-   [instant.jdbc.sql :as sql])
-  (:import
-   [java.util UUID]))
+   [instant.jdbc.sql :as sql]))
 
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
@@ -11,4 +9,4 @@
    (sql/execute-one! conn ["INSERT INTO
      app_email_verifications
      (id, app_id, sender_id, verified)
-     VALUES (?::uuid, ?, ?, ?) ON CONFLICT DO NOTHING" (UUID/randomUUID) app-id sender-id verified])))
+     VALUES (?::uuid, ?, ?, ?) ON CONFLICT DO NOTHING" (random-uuid) app-id sender-id verified])))

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -1,0 +1,14 @@
+(ns instant.model.app-email-verification
+  (:require
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql])
+  (:import
+   [java.util UUID]))
+
+(defn put!
+  ([params] (put! (aurora/conn-pool :write) params))
+  ([conn {:keys [app-id sender-id verified]}]
+   (sql/execute-one! conn ["INSERT INTO
+     app_email_verifications
+     (id, app_id, sender_id, verified)
+     VALUES (?::uuid, ?, ?, ?) ON CONFLICT DO NOTHING" (UUID/randomUUID) app-id sender-id verified])))


### PR DESCRIPTION
Step 1 of migrating the user based custom email sender verification to app based.

For each update / creation of a custom email template, if there is a custom sender id, create a row in a `app_id <-> postmark id` verifications table with "verified = true"