### PR TITLE
docs: fix manual setup guide to use import.meta.env for a public env on a vite project

### DIFF
--- a/client/www/app/docs/start-tanstack/page.md
+++ b/client/www/app/docs/start-tanstack/page.md
@@ -46,7 +46,7 @@ import { init } from '@instantdb/react';
 import schema from '../instant.schema';
 
 export const db = init({
-  appId: process.env.VITE_INSTANT_APP_ID!,
+  appId: import.meta.env.VITE_INSTANT_APP_ID!,
   schema,
   useDateObjects: true,
 });


### PR DESCRIPTION
the issue

> Something went wrong!
Instant must be initialized with an appId.

the fix:
in tanstack start which is a vite project, public env with prefix `VITE_` should be read with `import.meta.env`.

more on this here

https://tanstack.com/start/v0/docs/framework/react/guide/environment-variables

this will reduce confusion/issue on manual setup.

