### PR TITLE
backfill email verifications migration

### DIFF
--- a/server/resources/migrations/108_backfill_email_verifications.down.sql
+++ b/server/resources/migrations/108_backfill_email_verifications.down.sql
@@ -1,0 +1,1 @@
+delete from app_email_verifications;

--- a/server/resources/migrations/108_backfill_email_verifications.up.sql
+++ b/server/resources/migrations/108_backfill_email_verifications.up.sql
@@ -1,0 +1,9 @@
+INSERT INTO app_email_verifications (id, app_id, sender_id, verified)
+SELECT
+    gen_random_uuid(),
+    app_id,
+    sender_id,
+    true
+FROM app_email_templates
+WHERE sender_id IS NOT NULL
+ON CONFLICT DO NOTHING


### PR DESCRIPTION
Creates a new migration that fills existing app <-> sender_id pairs that were created via the user-level email sender authentication into the new `app_email_verifications` table. 

# Important!
Do not run migration until https://github.com/instantdb/instant/pull/2647 has been fully deployed. 