### PR TITLE
Add useInfiniteQuery to Solid and Svelte SDKs

### DIFF
--- a/client/packages/solidjs/src/InstantSolidDatabase.ts
+++ b/client/packages/solidjs/src/InstantSolidDatabase.ts
@@ -10,6 +10,7 @@ import {
   type PageInfoResponse,
   type InstaQLLifecycleState,
   type InstaQLResponse,
+  type InfiniteQuerySubscription,
   type ValidQuery,
   // classes
   Auth,
@@ -18,6 +19,7 @@ import {
   InstantCoreDatabase,
   init as core_init,
   coerceQuery,
+  getInfiniteQueryInitialSnapshot,
   InstantSchemaDef,
   RoomsOf,
   InstantError,
@@ -36,6 +38,18 @@ const defaultState = {
   pageInfo: undefined,
   error: undefined,
 } as const;
+
+export type InfiniteQueryState<
+  Schema extends InstantSchemaDef<any, any, any>,
+  Q extends ValidQuery<Q, Schema>,
+  UseDates extends boolean,
+> = {
+  isLoading: boolean;
+  error: { message: string } | undefined;
+  data: InstaQLResponse<Schema, Q, UseDates> | undefined;
+  canLoadNextPage: boolean;
+  loadNextPage: () => void;
+};
 
 const defaultAuthState: AuthState = {
   isLoading: true,
@@ -189,6 +203,89 @@ export class InstantSolidDatabase<
       });
 
       onCleanup(unsub);
+    });
+
+    return state;
+  };
+
+  /**
+   * Subscribe to a query and incrementally load more items.
+   *
+   * Only one top level namespace in the query is allowed.
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *   const state = db.useInfiniteQuery({
+   *     posts: {
+   *       $: {
+   *         limit: 20,
+   *         order: { createdAt: 'desc' },
+   *       },
+   *     },
+   *   });
+   *   // state().data, state().isLoading, state().error,
+   *   // state().canLoadNextPage, state().loadNextPage()
+   */
+  useInfiniteQuery = <Q extends ValidQuery<Q, Schema>>(
+    query: (() => null | Q) | null | Q,
+    opts?: InstaQLOptions,
+  ): Accessor<InfiniteQueryState<Schema, Q, UseDates>> => {
+    let sub: InfiniteQuerySubscription | null = null;
+    const loadNextPage = () => sub?.loadNextPage();
+
+    const [state, setState] = createSignal<
+      InfiniteQueryState<Schema, Q, UseDates>
+    >({
+      isLoading: true,
+      error: undefined,
+      data: undefined,
+      canLoadNextPage: false,
+      loadNextPage,
+    });
+
+    createEffect(() => {
+      const resolvedQuery = typeof query === 'function' ? query() : query;
+
+      if (!resolvedQuery) {
+        sub = null;
+        setState(() => ({
+          isLoading: true,
+          error: undefined,
+          data: undefined,
+          canLoadNextPage: false,
+          loadNextPage,
+        }));
+        return;
+      }
+
+      const snapshot = getInfiniteQueryInitialSnapshot<Schema, Q, UseDates>(
+        this.core,
+        resolvedQuery,
+        opts,
+      );
+      setState(() => ({
+        ...snapshot,
+        isLoading: !snapshot.data && !snapshot.error,
+        loadNextPage,
+      }));
+
+      sub = this.core.subscribeInfiniteQuery<Q>(
+        resolvedQuery,
+        (resp) => {
+          setState(() => ({
+            ...resp,
+            isLoading: false,
+            loadNextPage,
+          }));
+        },
+        opts,
+      );
+
+      onCleanup(() => {
+        sub?.unsubscribe();
+        sub = null;
+      });
     });
 
     return state;

--- a/client/packages/svelte/src/lib/InstantSvelteDatabase.svelte.ts
+++ b/client/packages/svelte/src/lib/InstantSvelteDatabase.svelte.ts
@@ -10,6 +10,7 @@ import {
   type PageInfoResponse,
   type InstaQLLifecycleState,
   type InstaQLResponse,
+  type InfiniteQuerySubscription,
   type ValidQuery,
   // classes
   Auth,
@@ -18,6 +19,7 @@ import {
   InstantCoreDatabase,
   init as core_init,
   coerceQuery,
+  getInfiniteQueryInitialSnapshot,
   InstantSchemaDef,
   RoomsOf,
   InstantError,
@@ -33,6 +35,18 @@ const defaultState = {
   pageInfo: undefined,
   error: undefined,
 } as const;
+
+export type InfiniteQueryState<
+  Schema extends InstantSchemaDef<any, any, any>,
+  Q extends ValidQuery<Q, Schema>,
+  UseDates extends boolean,
+> = {
+  isLoading: boolean;
+  error: { message: string } | undefined;
+  data: InstaQLResponse<Schema, Q, UseDates> | undefined;
+  canLoadNextPage: boolean;
+  loadNextPage: () => void;
+};
 
 const defaultAuthState: AuthState = {
   isLoading: true,
@@ -194,6 +208,81 @@ export class InstantSvelteDatabase<
       });
 
       return unsub;
+    });
+
+    return result;
+  };
+
+  /**
+   * Subscribe to a query and incrementally load more items.
+   *
+   * Only one top level namespace in the query is allowed.
+   *
+   * @see https://instantdb.com/docs/instaql
+   *
+   * @example
+   *   const state = db.useInfiniteQuery({
+   *     posts: {
+   *       $: {
+   *         limit: 20,
+   *         order: { createdAt: 'desc' },
+   *       },
+   *     },
+   *   });
+   *   // state.data, state.isLoading, state.error,
+   *   // state.canLoadNextPage, state.loadNextPage()
+   */
+  useInfiniteQuery = <Q extends ValidQuery<Q, Schema>>(
+    query: (() => null | Q) | null | Q,
+    opts?: InstaQLOptions,
+  ): InfiniteQueryState<Schema, Q, UseDates> => {
+    let sub: InfiniteQuerySubscription | null = null;
+
+    let result: InfiniteQueryState<Schema, Q, UseDates> = $state({
+      isLoading: true,
+      error: undefined,
+      data: undefined,
+      canLoadNextPage: false,
+      loadNextPage: () => sub?.loadNextPage(),
+    });
+
+    $effect(() => {
+      const resolvedQuery = typeof query === 'function' ? query() : query;
+
+      if (!resolvedQuery) {
+        sub = null;
+        result.isLoading = true;
+        result.error = undefined;
+        result.data = undefined;
+        result.canLoadNextPage = false;
+        return;
+      }
+
+      const snapshot = getInfiniteQueryInitialSnapshot<Schema, Q, UseDates>(
+        this.core,
+        resolvedQuery,
+        opts,
+      );
+      result.isLoading = !snapshot.data && !snapshot.error;
+      result.error = snapshot.error;
+      result.data = snapshot.data;
+      result.canLoadNextPage = snapshot.canLoadNextPage;
+
+      sub = this.core.subscribeInfiniteQuery<Q>(
+        resolvedQuery,
+        (resp) => {
+          result.isLoading = false;
+          result.data = resp.data;
+          result.error = resp.error;
+          result.canLoadNextPage = resp.canLoadNextPage;
+        },
+        opts,
+      );
+
+      return () => {
+        sub?.unsubscribe();
+        sub = null;
+      };
     });
 
     return result;

--- a/client/packages/svelte/src/tests/InstantSvelteDatabase.svelte.test.ts
+++ b/client/packages/svelte/src/tests/InstantSvelteDatabase.svelte.test.ts
@@ -32,6 +32,11 @@ function createMockCore() {
     subscribeQuery: vi.fn((_query: any, _cb: (result: any) => void) => {
       return () => {};
     }),
+    subscribeInfiniteQuery: vi.fn(
+      (_query: any, _cb: (result: any) => void) => {
+        return { unsubscribe: vi.fn(), loadNextPage: vi.fn() };
+      },
+    ),
     subscribeAuth: vi.fn((_cb: (auth: any) => void) => {
       return () => {};
     }),
@@ -230,6 +235,138 @@ describe('InstantSvelteDatabase', () => {
 
       expect(state.isLoading).toBe(false);
       expect(state.data).toEqual({ goals: [{ id: '1' }] });
+      cleanup();
+    });
+  });
+
+  describe('useInfiniteQuery', () => {
+    it('starts in loading state', () => {
+      let state: any;
+      const cleanup = $effect.root(() => {
+        state = db.useInfiniteQuery({ goals: {} } as any);
+      });
+
+      expect(state.isLoading).toBe(true);
+      expect(state.data).toBeUndefined();
+      expect(state.error).toBeUndefined();
+      expect(state.canLoadNextPage).toBe(false);
+      expect(typeof state.loadNextPage).toBe('function');
+      cleanup();
+    });
+
+    it('subscribes to core on mount', async () => {
+      const cleanup = $effect.root(() => {
+        db.useInfiniteQuery({ goals: {} } as any);
+      });
+      await tick();
+
+      expect(mockCore.subscribeInfiniteQuery).toHaveBeenCalled();
+      cleanup();
+    });
+
+    it('updates state when result arrives', async () => {
+      let queryCb: ((resp: any) => void) | undefined;
+      mockCore.subscribeInfiniteQuery.mockImplementation(
+        (_q: any, cb: any) => {
+          queryCb = cb;
+          return { unsubscribe: vi.fn(), loadNextPage: vi.fn() };
+        },
+      );
+
+      let state: any;
+      const cleanup = $effect.root(() => {
+        state = db.useInfiniteQuery({ goals: {} } as any);
+      });
+      await tick();
+
+      expect(queryCb).toBeDefined();
+      queryCb!({
+        data: { goals: [{ id: '1', title: 'Test' }] },
+        canLoadNextPage: true,
+      });
+
+      expect(state.isLoading).toBe(false);
+      expect(state.data).toEqual({ goals: [{ id: '1', title: 'Test' }] });
+      expect(state.canLoadNextPage).toBe(true);
+      cleanup();
+    });
+
+    it('loadNextPage delegates to the active subscription', async () => {
+      const loadNextPage = vi.fn();
+      mockCore.subscribeInfiniteQuery.mockImplementation(() => ({
+        unsubscribe: vi.fn(),
+        loadNextPage,
+      }));
+
+      let state: any;
+      const cleanup = $effect.root(() => {
+        state = db.useInfiniteQuery({ goals: {} } as any);
+      });
+      await tick();
+
+      state.loadNextPage();
+      expect(loadNextPage).toHaveBeenCalled();
+      cleanup();
+    });
+
+    it('unsubscribes on cleanup', async () => {
+      const unsubscribe = vi.fn();
+      mockCore.subscribeInfiniteQuery.mockImplementation(() => ({
+        unsubscribe,
+        loadNextPage: vi.fn(),
+      }));
+
+      const cleanup = $effect.root(() => {
+        db.useInfiniteQuery({ goals: {} } as any);
+      });
+      await tick();
+
+      cleanup();
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    it('handles null query', async () => {
+      let state: any;
+      const cleanup = $effect.root(() => {
+        state = db.useInfiniteQuery(null);
+      });
+      await tick();
+
+      expect(state.isLoading).toBe(true);
+      expect(state.data).toBeUndefined();
+      expect(state.canLoadNextPage).toBe(false);
+      expect(mockCore.subscribeInfiniteQuery).not.toHaveBeenCalled();
+      cleanup();
+    });
+
+    it('re-subscribes when function query changes', async () => {
+      const unsubscribe = vi.fn();
+      mockCore.subscribeInfiniteQuery.mockImplementation(() => ({
+        unsubscribe,
+        loadNextPage: vi.fn(),
+      }));
+
+      let queryFilter = $state<string | null>(null);
+
+      const cleanup = $effect.root(() => {
+        db.useInfiniteQuery(() =>
+          queryFilter
+            ? ({ goals: { $: { where: { status: queryFilter } } } } as any)
+            : null,
+        );
+      });
+      await tick();
+
+      expect(mockCore.subscribeInfiniteQuery).not.toHaveBeenCalled();
+
+      queryFilter = 'active';
+      await tick();
+      expect(mockCore.subscribeInfiniteQuery).toHaveBeenCalledTimes(1);
+
+      queryFilter = 'done';
+      await tick();
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(mockCore.subscribeInfiniteQuery).toHaveBeenCalledTimes(2);
       cleanup();
     });
   });

--- a/client/packages/svelte/src/tests/InstantSvelteDatabase.svelte.test.ts
+++ b/client/packages/svelte/src/tests/InstantSvelteDatabase.svelte.test.ts
@@ -32,11 +32,9 @@ function createMockCore() {
     subscribeQuery: vi.fn((_query: any, _cb: (result: any) => void) => {
       return () => {};
     }),
-    subscribeInfiniteQuery: vi.fn(
-      (_query: any, _cb: (result: any) => void) => {
-        return { unsubscribe: vi.fn(), loadNextPage: vi.fn() };
-      },
-    ),
+    subscribeInfiniteQuery: vi.fn((_query: any, _cb: (result: any) => void) => {
+      return { unsubscribe: vi.fn(), loadNextPage: vi.fn() };
+    }),
     subscribeAuth: vi.fn((_cb: (auth: any) => void) => {
       return () => {};
     }),
@@ -266,12 +264,10 @@ describe('InstantSvelteDatabase', () => {
 
     it('updates state when result arrives', async () => {
       let queryCb: ((resp: any) => void) | undefined;
-      mockCore.subscribeInfiniteQuery.mockImplementation(
-        (_q: any, cb: any) => {
-          queryCb = cb;
-          return { unsubscribe: vi.fn(), loadNextPage: vi.fn() };
-        },
-      );
+      mockCore.subscribeInfiniteQuery.mockImplementation((_q: any, cb: any) => {
+        queryCb = cb;
+        return { unsubscribe: vi.fn(), loadNextPage: vi.fn() };
+      });
 
       let state: any;
       const cleanup = $effect.root(() => {


### PR DESCRIPTION
The Solid and Svelte SDKs were missing `useInfiniteQuery`. #2334 added `subscribeInfiniteQuery` to core and `useInfiniteQuery` to React, but the same hook hasn't been wired up to the other framework SDKs. This brings all three to parity.

**API**

Both implementations mirror React's signature: pass a query (or a function returning a query) plus optional opts, get back `data` / `error` / `isLoading` / `canLoadNextPage` / `loadNextPage()`. Function-form queries re-subscribe when their reactive dependencies change, and subscriptions clean up on unmount.

```ts
// Solid
const state = db.useInfiniteQuery({
  posts: { $: { limit: 20, order: { createdAt: 'desc' } } },
});
// state().data, state().canLoadNextPage, state().loadNextPage()

// Svelte
const state = db.useInfiniteQuery({
  posts: { $: { limit: 20, order: { createdAt: 'desc' } } },
});
// state.data, state.canLoadNextPage, state.loadNextPage()
```

**Tests**

Added some Svelte tests for the new hook in the existing mocked test suite. Solid has no wrapper test infrastructure in this package yet so not tests there. Instead in #2654 I add sandbox apps to verify both work as expected