### PR TITLE
Expose db.streams on Svelte and Solid databases

### DIFF
--- a/client/packages/solidjs/src/InstantSolidDatabase.ts
+++ b/client/packages/solidjs/src/InstantSolidDatabase.ts
@@ -15,6 +15,7 @@ import {
   // classes
   Auth,
   Storage,
+  Streams,
   txInit,
   InstantCoreDatabase,
   init as core_init,
@@ -77,12 +78,14 @@ export class InstantSolidDatabase<
 
   public auth: Auth;
   public storage: Storage;
+  public streams: Streams;
   public core: InstantCoreDatabase<Schema, UseDates>;
 
   constructor(core: InstantCoreDatabase<Schema, UseDates>) {
     this.core = core;
     this.auth = this.core.auth;
     this.storage = this.core.storage;
+    this.streams = this.core.streams;
   }
 
   /**

--- a/client/packages/svelte/src/lib/InstantSvelteDatabase.svelte.ts
+++ b/client/packages/svelte/src/lib/InstantSvelteDatabase.svelte.ts
@@ -15,6 +15,7 @@ import {
   // classes
   Auth,
   Storage,
+  Streams,
   txInit,
   InstantCoreDatabase,
   init as core_init,
@@ -74,12 +75,14 @@ export class InstantSvelteDatabase<
 
   public auth: Auth;
   public storage: Storage;
+  public streams: Streams;
   public core: InstantCoreDatabase<Schema, UseDates>;
 
   constructor(core: InstantCoreDatabase<Schema, UseDates>) {
     this.core = core;
     this.auth = this.core.auth;
     this.storage = this.core.storage;
+    this.streams = this.core.streams;
   }
 
   /**

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.28';
+const version = 'v1.0.29';
 
 export { version };

--- a/client/sandbox/solid-vite/src/App.tsx
+++ b/client/sandbox/solid-vite/src/App.tsx
@@ -1,12 +1,14 @@
 import { Router, Route } from '@solidjs/router';
 import Home from './pages/Home';
 import InfiniteScroll from './pages/InfiniteScroll';
+import Streams from './pages/Streams';
 
 export default function App() {
   return (
     <Router>
       <Route path="/" component={Home} />
       <Route path="/infinite-scroll" component={InfiniteScroll} />
+      <Route path="/streams" component={Streams} />
     </Router>
   );
 }

--- a/client/sandbox/solid-vite/src/lib/db.ts
+++ b/client/sandbox/solid-vite/src/lib/db.ts
@@ -14,13 +14,26 @@ const schema = i.schema({
   },
 });
 
+const perms = {
+  $streams: {
+    allow: {
+      create: 'true',
+      view: 'true',
+    },
+  },
+};
+
 type AppSchema = typeof schema;
 
 async function provisionEphemeralApp(schema: InstantSchemaDef<any, any, any>) {
   const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title: 'Solid Sandbox', schema }),
+    body: JSON.stringify({
+      title: 'Solid Sandbox',
+      schema,
+      rules: { code: perms },
+    }),
   });
   return r.json();
 }

--- a/client/sandbox/solid-vite/src/pages/Home.tsx
+++ b/client/sandbox/solid-vite/src/pages/Home.tsx
@@ -10,6 +10,9 @@ export default function Home() {
         <li>
           <A href="/infinite-scroll">infinite-scroll</A>
         </li>
+        <li>
+          <A href="/streams">streams</A>
+        </li>
       </ul>
     </div>
   );

--- a/client/sandbox/solid-vite/src/pages/Streams.tsx
+++ b/client/sandbox/solid-vite/src/pages/Streams.tsx
@@ -1,0 +1,369 @@
+import { Show, createSignal } from 'solid-js';
+import { dbState, resetEphemeralApp, type DB } from '../lib/db';
+
+const btnStyle = {
+  margin: '4px',
+  padding: '8px',
+  background: 'black',
+  color: 'white',
+  border: 'none',
+  cursor: 'pointer',
+} as const;
+
+const inputStyle = {
+  padding: '6px',
+  border: '1px solid #999',
+  'font-family': 'monospace',
+  'font-size': '12px',
+} as const;
+
+const panelStyle = {
+  border: '1px solid #ccc',
+  padding: '12px',
+  display: 'flex',
+  'flex-direction': 'column',
+  gap: '8px',
+} as const;
+
+function Demo({ db }: { db: DB }) {
+  const [clientId, setClientId] = createSignal<string>(crypto.randomUUID());
+
+  const [writerStatus, setWriterStatus] = createSignal<
+    'idle' | 'open' | 'closed' | 'error'
+  >('idle');
+  const [writerError, setWriterError] = createSignal<string | null>(null);
+  const [writer, setWriter] =
+    createSignal<WritableStreamDefaultWriter<string> | null>(null);
+  const [sentLines, setSentLines] = createSignal<string[]>([]);
+  const [customInput, setCustomInput] = createSignal('');
+
+  const [readerClientId, setReaderClientId] = createSignal<string>(clientId());
+  const [readerStatus, setReaderStatus] = createSignal<
+    'idle' | 'reading' | 'done' | 'error'
+  >('idle');
+  const [readerError, setReaderError] = createSignal<string | null>(null);
+  const [reader, setReader] =
+    createSignal<ReadableStreamDefaultReader<string> | null>(null);
+  const [receivedLines, setReceivedLines] = createSignal<string[]>([]);
+
+  const regenerateClientId = () => {
+    const next = crypto.randomUUID();
+    setClientId(next);
+    setReaderClientId(next);
+  };
+
+  const createWriter = () => {
+    setWriterError(null);
+    setSentLines([]);
+    try {
+      const stream = db.streams.createWriteStream({ clientId: clientId() });
+      setWriter(stream.getWriter());
+      setWriterStatus('open');
+    } catch (e) {
+      setWriterError((e as Error).message);
+      setWriterStatus('error');
+    }
+  };
+
+  const writeChunk = async (chunk: string) => {
+    const w = writer();
+    if (!w) return;
+    try {
+      await w.write(chunk + '\n');
+      setSentLines((prev) => [...prev, chunk]);
+    } catch (e) {
+      setWriterError((e as Error).message);
+    }
+  };
+
+  const closeWriter = async () => {
+    const w = writer();
+    if (!w) return;
+    try {
+      await w.close();
+      setWriter(null);
+      setWriterStatus('closed');
+    } catch (e) {
+      setWriterError((e as Error).message);
+    }
+  };
+
+  const startReading = async () => {
+    setReaderError(null);
+    setReceivedLines([]);
+    setReaderStatus('reading');
+    try {
+      const stream: ReadableStream<string> = db.streams.createReadStream({
+        clientId: readerClientId(),
+      });
+      const r = stream.getReader();
+      setReader(r);
+      let buffer = '';
+      while (true) {
+        const { value, done } = await r.read();
+        if (done) break;
+        if (value !== undefined) {
+          buffer += value;
+          const parts = buffer.split('\n');
+          buffer = parts.pop()!;
+          const nonEmpty = parts.filter((p) => p.length > 0);
+          if (nonEmpty.length > 0) {
+            setReceivedLines((prev) => [...prev, ...nonEmpty]);
+          }
+        }
+      }
+      if (buffer) setReceivedLines((prev) => [...prev, buffer]);
+      setReader(null);
+      setReaderStatus('done');
+    } catch (e) {
+      setReader(null);
+      setReaderStatus('error');
+      setReaderError((e as Error).message);
+    }
+  };
+
+  const cancelReader = async () => {
+    const r = reader();
+    if (!r) return;
+    try {
+      await r.cancel('User cancelled');
+      setReader(null);
+      setReaderStatus('done');
+    } catch (e) {
+      setReaderError((e as Error).message);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        padding: '16px',
+        'font-family': 'sans-serif',
+        display: 'flex',
+        'flex-direction': 'column',
+        gap: '16px',
+      }}
+    >
+      <div style={{ display: 'flex', 'align-items': 'center', gap: '8px' }}>
+        <span style={{ 'font-size': '14px' }}>Client ID</span>
+        <input
+          style={{ ...inputStyle, flex: 1 }}
+          value={clientId()}
+          onInput={(e) => setClientId(e.currentTarget.value)}
+          disabled={writerStatus() === 'open'}
+        />
+        <button
+          style={btnStyle}
+          onClick={regenerateClientId}
+          disabled={writerStatus() === 'open'}
+        >
+          New ID
+        </button>
+        <button style={btnStyle} onClick={resetEphemeralApp}>
+          Start over
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          'grid-template-columns': '1fr 1fr',
+          gap: '16px',
+        }}
+      >
+        <div style={panelStyle}>
+          <h2 style={{ 'font-size': '18px', 'font-weight': 'bold' }}>Writer</h2>
+          <div style={{ 'font-size': '14px' }}>Status: {writerStatus()}</div>
+          <Show when={writerError()}>
+            <div style={{ 'font-size': '14px', color: 'red' }}>
+              Error: {writerError()}
+            </div>
+          </Show>
+
+          <Show
+            when={writerStatus() === 'open'}
+            fallback={
+              <button
+                style={{ ...btnStyle, background: '#2563eb', width: 'fit-content' }}
+                onClick={createWriter}
+              >
+                Create stream
+              </button>
+            }
+          >
+            <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '4px' }}>
+              <button
+                style={{ ...btnStyle, background: '#374151' }}
+                onClick={() => writeChunk('Hello, world!')}
+              >
+                "Hello, world!"
+              </button>
+              <button
+                style={{ ...btnStyle, background: '#374151' }}
+                onClick={() =>
+                  writeChunk(JSON.stringify({ event: 'ping', ts: Date.now() }))
+                }
+              >
+                JSON ping
+              </button>
+            </div>
+            <div style={{ display: 'flex', gap: '4px' }}>
+              <input
+                style={{ ...inputStyle, flex: 1 }}
+                value={customInput()}
+                onInput={(e) => setCustomInput(e.currentTarget.value)}
+                placeholder="Type a custom string..."
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && customInput()) {
+                    writeChunk(customInput());
+                    setCustomInput('');
+                  }
+                }}
+              />
+              <button
+                style={{
+                  ...btnStyle,
+                  background: '#374151',
+                  opacity: customInput() ? 1 : 0.5,
+                }}
+                disabled={!customInput()}
+                onClick={() => {
+                  writeChunk(customInput());
+                  setCustomInput('');
+                }}
+              >
+                Write
+              </button>
+            </div>
+            <button
+              style={{ ...btnStyle, background: '#dc2626', width: 'fit-content' }}
+              onClick={closeWriter}
+            >
+              Close
+            </button>
+          </Show>
+
+          <Show when={sentLines().length > 0}>
+            <div style={{ 'font-size': '14px', 'font-weight': 500 }}>
+              Sent ({sentLines().length}):
+            </div>
+            <div
+              style={{
+                background: '#f3f4f6',
+                padding: '8px',
+                'font-family': 'monospace',
+                'font-size': '12px',
+                'max-height': '192px',
+                'overflow-y': 'auto',
+              }}
+            >
+              {[...sentLines()].reverse().map((line) => (
+                <div>{line}</div>
+              ))}
+            </div>
+          </Show>
+        </div>
+
+        <div style={panelStyle}>
+          <h2 style={{ 'font-size': '18px', 'font-weight': 'bold' }}>Reader</h2>
+          <label
+            style={{
+              display: 'flex',
+              'align-items': 'center',
+              gap: '8px',
+              'font-size': '14px',
+            }}
+          >
+            Client ID
+            <input
+              style={{ ...inputStyle, flex: 1, 'font-size': '11px' }}
+              value={readerClientId()}
+              onInput={(e) => setReaderClientId(e.currentTarget.value)}
+              disabled={readerStatus() === 'reading'}
+            />
+          </label>
+          <div style={{ 'font-size': '14px' }}>Status: {readerStatus()}</div>
+          <Show when={readerError()}>
+            <div style={{ 'font-size': '14px', color: 'red' }}>
+              Error: {readerError()}
+            </div>
+          </Show>
+          <div style={{ display: 'flex', gap: '4px' }}>
+            <button
+              style={{
+                ...btnStyle,
+                background: '#16a34a',
+                opacity: readerStatus() === 'reading' ? 0.5 : 1,
+              }}
+              disabled={readerStatus() === 'reading'}
+              onClick={startReading}
+            >
+              Start reading
+            </button>
+            <button
+              style={{
+                ...btnStyle,
+                background: '#dc2626',
+                opacity: readerStatus() === 'reading' ? 1 : 0.5,
+              }}
+              disabled={readerStatus() !== 'reading'}
+              onClick={cancelReader}
+            >
+              Cancel
+            </button>
+          </div>
+
+          <Show when={receivedLines().length > 0}>
+            <div style={{ 'font-size': '14px', 'font-weight': 500 }}>
+              Received ({receivedLines().length}):
+            </div>
+            <div
+              style={{
+                background: '#f3f4f6',
+                padding: '8px',
+                'font-family': 'monospace',
+                'font-size': '12px',
+                'max-height': '192px',
+                'overflow-y': 'auto',
+              }}
+            >
+              {[...receivedLines()].reverse().map((line) => (
+                <div>{line}</div>
+              ))}
+            </div>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Streams() {
+  return (
+    <Show
+      when={!dbState().isLoading}
+      fallback={
+        <div
+          style={{
+            padding: '32px',
+            display: 'flex',
+            'justify-content': 'center',
+          }}
+        >
+          Creating ephemeral app...
+        </div>
+      }
+    >
+      <Show
+        when={!dbState().error}
+        fallback={
+          <div style={{ padding: '32px', color: 'red' }}>
+            Error: {dbState().error}
+          </div>
+        }
+      >
+        <Demo db={dbState().db!} />
+      </Show>
+    </Show>
+  );
+}

--- a/client/sandbox/solid-vite/src/pages/Streams.tsx
+++ b/client/sandbox/solid-vite/src/pages/Streams.tsx
@@ -184,7 +184,11 @@ function Demo({ db }: { db: DB }) {
             when={writerStatus() === 'open'}
             fallback={
               <button
-                style={{ ...btnStyle, background: '#2563eb', width: 'fit-content' }}
+                style={{
+                  ...btnStyle,
+                  background: '#2563eb',
+                  width: 'fit-content',
+                }}
                 onClick={createWriter}
               >
                 Create stream
@@ -236,7 +240,11 @@ function Demo({ db }: { db: DB }) {
               </button>
             </div>
             <button
-              style={{ ...btnStyle, background: '#dc2626', width: 'fit-content' }}
+              style={{
+                ...btnStyle,
+                background: '#dc2626',
+                width: 'fit-content',
+              }}
               onClick={closeWriter}
             >
               Close

--- a/client/sandbox/sveltekit/src/lib/db.svelte.ts
+++ b/client/sandbox/sveltekit/src/lib/db.svelte.ts
@@ -18,13 +18,26 @@ const schema = i.schema({
   },
 });
 
+const perms = {
+  $streams: {
+    allow: {
+      create: 'true',
+      view: 'true',
+    },
+  },
+};
+
 export type AppSchema = typeof schema;
 
 async function provisionEphemeralApp(schema: InstantSchemaDef<any, any, any>) {
   const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title: 'SvelteKit Sandbox', schema }),
+    body: JSON.stringify({
+      title: 'SvelteKit Sandbox',
+      schema,
+      rules: { code: perms },
+    }),
   });
   return r.json();
 }

--- a/client/sandbox/sveltekit/src/routes/+page.svelte
+++ b/client/sandbox/sveltekit/src/routes/+page.svelte
@@ -4,6 +4,7 @@
     { href: '/infinite-scroll', label: 'infinite-scroll' },
     { href: '/cursors', label: 'cursors' },
     { href: '/auth', label: 'auth' },
+    { href: '/streams', label: 'streams' },
   ];
 </script>
 

--- a/client/sandbox/sveltekit/src/routes/streams/+page.svelte
+++ b/client/sandbox/sveltekit/src/routes/streams/+page.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+  import { dbState, resetEphemeralApp } from '$lib/db.svelte';
+
+  let clientId = $state(crypto.randomUUID());
+
+  let writerStatus = $state<'idle' | 'open' | 'closed' | 'error'>('idle');
+  let writerError = $state<string | null>(null);
+  let writer = $state<WritableStreamDefaultWriter<string> | null>(null);
+  let sentLines = $state<string[]>([]);
+  let customInput = $state('');
+
+  let readerClientId = $state(clientId);
+  let readerStatus = $state<'idle' | 'reading' | 'done' | 'error'>('idle');
+  let readerError = $state<string | null>(null);
+  let reader = $state<ReadableStreamDefaultReader<string> | null>(null);
+  let receivedLines = $state<string[]>([]);
+
+  function regenerateClientId() {
+    const next = crypto.randomUUID();
+    clientId = next;
+    readerClientId = next;
+  }
+
+  function createWriter(db: any) {
+    writerError = null;
+    sentLines = [];
+    try {
+      const stream = db.streams.createWriteStream({ clientId });
+      writer = stream.getWriter();
+      writerStatus = 'open';
+    } catch (e) {
+      writerError = (e as Error).message;
+      writerStatus = 'error';
+    }
+  }
+
+  async function writeChunk(chunk: string) {
+    if (!writer) return;
+    try {
+      await writer.write(chunk + '\n');
+      sentLines = [...sentLines, chunk];
+    } catch (e) {
+      writerError = (e as Error).message;
+    }
+  }
+
+  async function closeWriter() {
+    if (!writer) return;
+    try {
+      await writer.close();
+      writer = null;
+      writerStatus = 'closed';
+    } catch (e) {
+      writerError = (e as Error).message;
+    }
+  }
+
+  async function startReading(db: any) {
+    readerError = null;
+    receivedLines = [];
+    readerStatus = 'reading';
+    try {
+      const stream: ReadableStream<string> = db.streams.createReadStream({
+        clientId: readerClientId,
+      });
+      const r = stream.getReader();
+      reader = r;
+      let buffer = '';
+      while (true) {
+        const { value, done } = await r.read();
+        if (done) break;
+        if (value !== undefined) {
+          buffer += value;
+          const parts = buffer.split('\n');
+          buffer = parts.pop()!;
+          const nonEmpty = parts.filter((p) => p.length > 0);
+          if (nonEmpty.length > 0) {
+            receivedLines = [...receivedLines, ...nonEmpty];
+          }
+        }
+      }
+      if (buffer) receivedLines = [...receivedLines, buffer];
+      reader = null;
+      readerStatus = 'done';
+    } catch (e) {
+      reader = null;
+      readerStatus = 'error';
+      readerError = (e as Error).message;
+    }
+  }
+
+  async function cancelReader() {
+    if (!reader) return;
+    try {
+      await reader.cancel('User cancelled');
+      reader = null;
+      readerStatus = 'done';
+    } catch (e) {
+      readerError = (e as Error).message;
+    }
+  }
+</script>
+
+{#if dbState.isLoading}
+  <div class="p-8 flex justify-center">Creating ephemeral app...</div>
+{:else if dbState.error}
+  <div class="p-8 text-red-500">Error: {dbState.error}</div>
+{:else}
+  {@const db = dbState.db!}
+
+  <div class="p-4 flex flex-col gap-4">
+    <div class="flex items-center gap-2">
+      <span class="text-sm">Client ID</span>
+      <input
+        class="flex-1 border border-gray-400 p-2 font-mono text-sm"
+        bind:value={clientId}
+        disabled={writerStatus === 'open'}
+      />
+      <button
+        class="bg-black p-2 text-white"
+        onclick={regenerateClientId}
+        disabled={writerStatus === 'open'}
+      >
+        New ID
+      </button>
+      <button class="bg-black p-2 text-white" onclick={resetEphemeralApp}>
+        Start over
+      </button>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="border border-gray-300 p-3 flex flex-col gap-2">
+        <h2 class="text-lg font-bold">Writer</h2>
+        <div class="text-sm">Status: {writerStatus}</div>
+        {#if writerError}
+          <div class="text-sm text-red-600">Error: {writerError}</div>
+        {/if}
+
+        {#if writerStatus !== 'open'}
+          <button
+            class="bg-blue-600 p-2 text-white w-fit"
+            onclick={() => createWriter(db)}
+          >
+            Create stream
+          </button>
+        {:else}
+          <div class="flex flex-wrap gap-2">
+            <button
+              class="bg-gray-700 p-2 text-white"
+              onclick={() => writeChunk('Hello, world!')}
+            >
+              "Hello, world!"
+            </button>
+            <button
+              class="bg-gray-700 p-2 text-white"
+              onclick={() =>
+                writeChunk(JSON.stringify({ event: 'ping', ts: Date.now() }))}
+            >
+              JSON ping
+            </button>
+          </div>
+          <div class="flex gap-2">
+            <input
+              class="flex-1 border border-gray-400 p-2 text-sm"
+              bind:value={customInput}
+              placeholder="Type a custom string..."
+              onkeydown={(e) => {
+                if (e.key === 'Enter' && customInput) {
+                  writeChunk(customInput);
+                  customInput = '';
+                }
+              }}
+            />
+            <button
+              class="bg-gray-700 p-2 text-white disabled:opacity-50"
+              disabled={!customInput}
+              onclick={() => {
+                writeChunk(customInput);
+                customInput = '';
+              }}
+            >
+              Write
+            </button>
+          </div>
+          <button class="bg-red-600 p-2 text-white w-fit" onclick={closeWriter}>
+            Close
+          </button>
+        {/if}
+
+        {#if sentLines.length > 0}
+          <div class="text-sm font-medium mt-2">
+            Sent ({sentLines.length}):
+          </div>
+          <div class="bg-gray-100 p-2 font-mono text-xs max-h-48 overflow-auto">
+            {#each [...sentLines].reverse() as line, i (i)}
+              <div>{line}</div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+      <div class="border border-gray-300 p-3 flex flex-col gap-2">
+        <h2 class="text-lg font-bold">Reader</h2>
+        <label class="flex items-center gap-2 text-sm">
+          Client ID
+          <input
+            class="flex-1 border border-gray-400 p-1 font-mono text-xs"
+            bind:value={readerClientId}
+            disabled={readerStatus === 'reading'}
+          />
+        </label>
+        <div class="text-sm">Status: {readerStatus}</div>
+        {#if readerError}
+          <div class="text-sm text-red-600">Error: {readerError}</div>
+        {/if}
+        <div class="flex gap-2">
+          <button
+            class="bg-green-600 p-2 text-white disabled:opacity-50"
+            disabled={readerStatus === 'reading'}
+            onclick={() => startReading(db)}
+          >
+            Start reading
+          </button>
+          <button
+            class="bg-red-600 p-2 text-white disabled:opacity-50"
+            disabled={readerStatus !== 'reading'}
+            onclick={cancelReader}
+          >
+            Cancel
+          </button>
+        </div>
+
+        {#if receivedLines.length > 0}
+          <div class="text-sm font-medium mt-2">
+            Received ({receivedLines.length}):
+          </div>
+          <div class="bg-gray-100 p-2 font-mono text-xs max-h-48 overflow-auto">
+            {#each [...receivedLines].reverse() as line, i (i)}
+              <div>{line}</div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/client/sandbox/sveltekit/src/routes/streams/+page.ts
+++ b/client/sandbox/sveltekit/src/routes/streams/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
## Summary
- Surfaces the `Streams` API (`createReadStream`/`createWriteStream`) as `db.streams` on `InstantSvelteDatabase` and `InstantSolidDatabase`, matching `@instantdb/react` and `@instantdb/react-native`.
- Three-line passthrough in each package, identical to the existing pattern for `auth` and `storage`. Previously users had to reach through `db.core.streams`.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean in both packages
- [x] Smoke test `db.streams.createReadStream` / `createWriteStream` in a Svelte sandbox app
- [x] Smoke test `db.streams.createReadStream` / `createWriteStream` in a Solid sandbox app

🤖 Generated with [Claude Code](https://claude.com/claude-code)