### PR TITLE
[2/3] Add Vue to create-instant-app

### DIFF
--- a/client/packages/create-instant-app/scripts/copyExamples.ts
+++ b/client/packages/create-instant-app/scripts/copyExamples.ts
@@ -10,6 +10,7 @@ const EXAMPLES_TO_COPY = [
   'vite-react',
   'vite-vanilla',
   'tanstack-start',
+  'vue-vite',
 ] as const;
 
 async function main() {

--- a/client/packages/create-instant-app/src/cli.ts
+++ b/client/packages/create-instant-app/src/cli.ts
@@ -16,6 +16,7 @@ export type Project = {
     | 'bun-react'
     | 'solidjs-vite'
     | 'sveltekit'
+    | 'vue-vite'
     | 'vercel-ai-sdk'
     | 'ai-chat';
   ruleFiles:
@@ -63,6 +64,7 @@ const baseFromFlags = (flags: Record<string, any>): Project['base'] | null =>
   (flags.next && 'next-js-app-dir') ||
   (flags.expo && 'expo') ||
   (flags.sv && 'sveltekit') ||
+  (flags.vue && 'vue-vite') ||
   null;
 
 const ruleFilesFromFlags = (
@@ -99,6 +101,7 @@ export const runCli = async (): Promise<Project> => {
         'tanstack-start-with-tanstack-query',
         'solidjs-vite',
         'sveltekit',
+        'vue-vite',
         'vercel-ai-sdk',
         'ai-chat',
       ]),
@@ -127,6 +130,9 @@ export const runCli = async (): Promise<Project> => {
     )
     .addOption(
       new Option('--sv', 'Use the SvelteKit starter template').default(false),
+    )
+    .addOption(
+      new Option('--vue', 'Use the Vue + Vite starter template').default(false),
     )
     .addOption(
       new Option('--no-git', "Don't create a git repo in the new project"),
@@ -312,6 +318,11 @@ export const runCli = async (): Promise<Project> => {
               {
                 value: 'sveltekit',
                 label: 'SvelteKit',
+                secondary: true,
+              },
+              {
+                value: 'vue-vite',
+                label: 'Vite: Vue',
                 secondary: true,
               },
               {

--- a/client/packages/create-instant-app/src/env.ts
+++ b/client/packages/create-instant-app/src/env.ts
@@ -11,6 +11,7 @@ const envNames: Record<Project['base'], string> = {
   'bun-react': 'BUN_PUBLIC_INSTANT_APP_ID',
   'solidjs-vite': 'VITE_INSTANT_APP_ID',
   sveltekit: 'VITE_INSTANT_APP_ID',
+  'vue-vite': 'VITE_INSTANT_APP_ID',
   'tanstack-start-with-tanstack-query': 'VITE_INSTANT_APP_ID',
   'vercel-ai-sdk': 'NEXT_PUBLIC_INSTANT_APP_ID',
   'ai-chat': 'NEXT_PUBLIC_INSTANT_APP_ID',

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -1410,6 +1410,52 @@ importers:
         specifier: ^5.2.0
         version: 5.4.14(@types/node@22.13.0)(lightningcss@1.30.2)(terser@5.46.2)
 
+  sandbox/vue-vite:
+    dependencies:
+      '@instantdb/vue':
+        specifier: workspace:*
+        version: link:../../packages/vue
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.13(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.4.0
+        version: 4.5.1(vue@3.5.13(typescript@5.9.3))
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.13
+        version: 4.1.17(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))
+      '@tsconfig/node22':
+        specifier: ^22.0.0
+        version: 22.0.5
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.13.0
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.0
+        version: 5.2.3(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))
+      '@vue/tsconfig':
+        specifier: ^0.7.0
+        version: 0.7.0(typescript@5.9.3)(vue@3.5.13(typescript@5.9.3))
+      npm-run-all2:
+        specifier: ^7.0.0
+        version: 7.0.2
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.1.17
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
+      vite-plugin-vue-devtools:
+        specifier: ^7.7.0
+        version: 7.7.9(rollup@4.59.0)(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))
+      vue-tsc:
+        specifier: ^2.2.0
+        version: 2.2.12(typescript@5.9.3)
+
   www:
     dependencies:
       '@ai-sdk/anthropic':
@@ -2461,12 +2507,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-typescript@7.25.9':
-    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-typescript@7.28.6':
     resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     engines: {node: '>=6.9.0'}
@@ -2859,12 +2899,6 @@ packages:
 
   '@babel/plugin-transform-typeof-symbol@7.26.7':
     resolution: {integrity: sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-typescript@7.26.7':
-    resolution: {integrity: sha512-5cJurntg+AT+cgelGP9Bt788DKiAw9gIMSMU2NJrLAilnj0m8WZWUNZPSLOmadYsujHutpgElO+50foX+ib/Wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -7276,6 +7310,9 @@ packages:
   '@rushstack/ts-command-line@5.1.4':
     resolution: {integrity: sha512-H0I6VdJ6sOUbktDFpP2VW5N29w8v4hRoNZOQz02vtEi6ZTYL1Ju8u+TcFiFawUDrUsx/5MQTUhd79uwZZVwVlA==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
 
@@ -7327,6 +7364,10 @@ packages:
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
   '@sindresorhus/slugify@2.2.1':
@@ -7780,6 +7821,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@tsconfig/node22@22.0.5':
+    resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -8523,11 +8567,22 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@vue/devtools-core@7.7.9':
+    resolution: {integrity: sha512-48jrBSwG4GVQRvVeeXn9p9+dlx+ISgasM7SxZZKczseohB0cBz+ITKr4YbLWjmJdy45UHL7UMPlR4Y0CWTRcSQ==}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@vue/devtools-kit@7.7.6':
     resolution: {integrity: sha512-geu7ds7tem2Y7Wz+WgbnbZ6T5eadOvozHZ23Atk/8tksHMFOFylKi1xgGlQlVn0wlkEf4hu+vd5ctj1G4kFtwA==}
 
+  '@vue/devtools-kit@7.7.9':
+    resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
+
   '@vue/devtools-shared@7.7.6':
     resolution: {integrity: sha512-yFEgJZ/WblEsojQQceuyK6FzpFDx4kqrz2ohInxNj5/DnhoX023upTv4OD6lNPLAA5LLkbwPVb10o/7b+Y4FVA==}
+
+  '@vue/devtools-shared@7.7.9':
+    resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
   '@vue/language-core@2.2.12':
     resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
@@ -8562,6 +8617,17 @@ packages:
       vue: 3.x
     peerDependenciesMeta:
       '@vue/server-renderer':
+        optional: true
+
+  '@vue/tsconfig@0.7.0':
+    resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
+    peerDependencies:
+      typescript: 5.x
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vue:
         optional: true
 
   '@web3-storage/multipart-parser@1.0.0':
@@ -10527,6 +10593,9 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  error-stack-parser-es@0.1.5:
+    resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -10902,6 +10971,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
@@ -11191,6 +11264,10 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -11475,6 +11552,10 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -11812,6 +11893,10 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
@@ -12412,6 +12497,10 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -13796,9 +13885,18 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  npm-normalize-package-bin@4.0.0:
+    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  npm-run-all2@7.0.2:
+    resolution: {integrity: sha512-7tXR+r9hzRNOPNTvXegM+QzCuMjzUIIq66VDunL6j60O4RrExx32XUhlrS7UK4VcdGw5/Wxzb3kfNcFix9JKDA==}
+    engines: {node: ^18.17.0 || >=20.5.0, npm: '>= 9'}
+    hasBin: true
 
   npm-run-all@4.1.5:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
@@ -14137,6 +14235,10 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
 
@@ -14271,6 +14373,11 @@ packages:
 
   pidtree@0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
 
@@ -14738,6 +14845,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   prism-react-renderer@1.3.5:
     resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
     peerDependencies:
@@ -15107,6 +15218,10 @@ packages:
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  read-package-json-fast@4.0.0:
+    resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   read-package-up@11.0.0:
     resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
@@ -16006,6 +16121,10 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -17068,6 +17187,16 @@ packages:
       vue-tsc:
         optional: true
 
+  vite-plugin-inspect@0.8.9:
+    resolution: {integrity: sha512-22/8qn+LYonzibb1VeFZmISdVao5kC22jmEKm24vfFE8siEn47EpVcCLYMv6iKOYMJfjSvSJfueOwcFCkUnV3A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': '*'
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.1
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
   vite-plugin-inspect@11.0.1:
     resolution: {integrity: sha512-aABw7eGTr9Cmbn9RAs76e0BztVUFDl6a2R+/IJXpoUZxjx5YHB0P+Em3ZTWzpIPZzuRj28tAMblvcUyhgJc4aQ==}
     engines: {node: '>=14'}
@@ -17087,6 +17216,17 @@ packages:
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
+
+  vite-plugin-vue-devtools@7.7.9:
+    resolution: {integrity: sha512-08DvePf663SxqLFJeMVNW537zzVyakp9KIrI2K7lwgaTqA5R/ydN/N2K8dgZO34tg/Qmw0ch84fOKoBtCEdcGg==}
+    engines: {node: '>=v14.21.3'}
+    peerDependencies:
+      vite: ^3.1.0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0
+
+  vite-plugin-vue-inspector@5.4.0:
+    resolution: {integrity: sha512-Iq/024CydcE46FZqWPU4t4lw4uYOdLnFSO1RNxJVt2qY9zxIjmnkBqhHnYaReWM82kmNnaXs7OkfgRrV2GEjyw==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite-plugin-vue-tracer@0.1.3:
     resolution: {integrity: sha512-+fN6oo0//dwZP9Ax9gRKeUroCqpQ43P57qlWgL0ljCIxAs+Rpqn/L4anIPZPgjDPga5dZH+ZJsshbF0PNJbm3Q==}
@@ -17817,6 +17957,10 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
   yoga-wasm-web@0.3.3:
     resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
@@ -18296,7 +18440,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
-    optional: true
 
   '@babel/helper-compilation-targets@7.26.5':
     dependencies:
@@ -18348,19 +18491,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.28.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
@@ -18373,7 +18503,19 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
+
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-create-regexp-features-plugin@7.26.3(@babel/core@7.26.7)':
     dependencies:
@@ -18423,7 +18565,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.28.6
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -18434,7 +18576,6 @@ snapshots:
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
@@ -18523,7 +18664,6 @@ snapshots:
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
       '@babel/types': 7.29.0
-    optional: true
 
   '@babel/helper-plugin-utils@7.26.5': {}
 
@@ -18567,15 +18707,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.26.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.28.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-replace-supers@7.28.6(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
@@ -18584,7 +18715,15 @@ snapshots:
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
@@ -18599,7 +18738,6 @@ snapshots:
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -18620,7 +18758,7 @@ snapshots:
   '@babel/helper-wrap-function@7.25.9':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.28.6
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -18740,36 +18878,45 @@ snapshots:
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.7)
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.7)
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-export-default-from@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
@@ -18849,27 +18996,32 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-export-default-from@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.7)':
     dependencies:
@@ -18895,7 +19047,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.7)':
     dependencies:
@@ -18911,7 +19062,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-    optional: true
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.7)':
     dependencies:
@@ -18932,18 +19082,17 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
       '@babel/helper-plugin-utils': 7.28.6
-    optional: true
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -18969,17 +19118,17 @@ snapshots:
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.7)':
     dependencies:
@@ -19032,17 +19181,17 @@ snapshots:
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.7)':
     dependencies:
@@ -19076,21 +19225,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.7)':
-    dependencies:
-      '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
       '@babel/helper-plugin-utils': 7.28.6
-    optional: true
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.7)':
     dependencies:
@@ -19343,13 +19486,13 @@ snapshots:
   '@babel/plugin-transform-flow-strip-types@7.26.5(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.26.7)
 
   '@babel/plugin-transform-flow-strip-types@7.26.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.29.0)
 
   '@babel/plugin-transform-for-of@7.25.9(@babel/core@7.26.7)':
@@ -19681,7 +19824,7 @@ snapshots:
   '@babel/plugin-transform-react-display-name@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx-development@7.25.9(@babel/core@7.26.7)':
     dependencies:
@@ -19723,10 +19866,10 @@ snapshots:
   '@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.7)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.26.7)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -19734,8 +19877,8 @@ snapshots:
   '@babel/plugin-transform-react-pure-annotations@7.25.9(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regenerator@7.25.9(@babel/core@7.26.7)':
     dependencies:
@@ -19775,7 +19918,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.7
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       babel-plugin-polyfill-corejs2: 0.4.12(@babel/core@7.26.7)
       babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.26.7)
       babel-plugin-polyfill-regenerator: 0.6.3(@babel/core@7.26.7)
@@ -19851,28 +19994,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-typescript@7.26.7(@babel/core@7.26.7)':
-    dependencies:
-      '@babel/core': 7.26.7
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.7)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.7)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-typescript@7.26.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.26.7)':
     dependencies:
       '@babel/core': 7.26.7
@@ -19883,7 +20004,17 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.26.7)
     transitivePeerDependencies:
       - supports-color
-    optional: true
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.26.7)':
     dependencies:
@@ -20091,7 +20222,7 @@ snapshots:
   '@babel/preset-flow@7.25.9(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-transform-flow-strip-types': 7.26.5(@babel/core@7.29.0)
 
@@ -20128,7 +20259,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.26.7)
-      '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.26.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.26.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -20139,7 +20270,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21010,7 +21141,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -21046,7 +21177,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -21139,7 +21270,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
       lodash.debounce: 4.0.8
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       node-forge: 1.3.1
       npm-package-arg: 11.0.3
       ora: 3.4.0
@@ -21291,7 +21422,7 @@ snapshots:
       debug: 4.4.3
       find-up: 5.0.0
       getenv: 1.0.0
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       p-limit: 3.1.0
       resolve-from: 5.0.0
       semver: 7.7.2
@@ -21334,7 +21465,7 @@ snapshots:
       glob: 10.4.5
       jsc-safe-url: 0.2.4
       lightningcss: 1.27.0
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       postcss: 8.4.49
       resolve-from: 5.0.0
     transitivePeerDependencies:
@@ -22590,7 +22721,7 @@ snapshots:
 
   '@netlify/zip-it-and-ship-it@10.0.7(rollup@4.40.2)':
     dependencies:
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.2
       '@babel/types': 7.26.10
       '@netlify/binary-info': 1.0.0
       '@netlify/serverless-functions-api': 1.38.0
@@ -24113,7 +24244,7 @@ snapshots:
       ora: 5.4.1
       prompts: 2.4.2
       semver: 7.7.2
-      shell-quote: 1.8.2
+      shell-quote: 1.8.3
       sudo-prompt: 9.2.1
 
   '@react-native-community/cli-types@15.1.3':
@@ -24206,7 +24337,7 @@ snapshots:
       '@babel/plugin-transform-shorthand-properties': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-spread': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-sticky-regex': 7.25.9(@babel/core@7.26.7)
-      '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.26.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.26.7)
       '@babel/plugin-transform-unicode-regex': 7.25.9(@babel/core@7.26.7)
       '@babel/template': 7.28.6
       '@react-native/babel-plugin-codegen': 0.76.1(@babel/preset-env@7.26.7(@babel/core@7.26.7))
@@ -24257,7 +24388,7 @@ snapshots:
       '@babel/plugin-transform-shorthand-properties': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-spread': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-sticky-regex': 7.25.9(@babel/core@7.26.7)
-      '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.26.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.26.7)
       '@babel/plugin-transform-unicode-regex': 7.25.9(@babel/core@7.26.7)
       '@babel/template': 7.27.2
       '@react-native/babel-plugin-codegen': 0.76.6(@babel/preset-env@7.26.7(@babel/core@7.26.7))
@@ -24887,6 +25018,8 @@ snapshots:
       - '@types/node'
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@segment/loosely-validate-event@2.0.0':
     dependencies:
       component-type: 1.2.2
@@ -24945,6 +25078,8 @@ snapshots:
   '@sindresorhus/is@7.0.1': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sindresorhus/slugify@2.2.1':
     dependencies:
@@ -25370,6 +25505,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@tsconfig/node22@22.0.5': {}
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -25988,7 +26125,7 @@ snapshots:
   '@vitejs/plugin-vue-jsx@4.1.2(vite@6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/plugin-transform-typescript': 7.26.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.29.0)
       vite: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
       vue: 3.5.13(typescript@5.9.3)
@@ -26003,6 +26140,11 @@ snapshots:
   '@vitejs/plugin-vue@5.2.3(vite@6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))':
     dependencies:
       vite: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
+      vue: 3.5.13(typescript@5.9.3)
+
+  '@vitejs/plugin-vue@5.2.3(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))':
+    dependencies:
+      vite: 6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
       vue: 3.5.13(typescript@5.9.3)
 
   '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@18.19.74)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vitest@4.0.18)':
@@ -26365,8 +26507,8 @@ snapshots:
   '@vue/babel-plugin-jsx@1.4.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -26438,6 +26580,18 @@ snapshots:
     transitivePeerDependencies:
       - vite
 
+  '@vue/devtools-core@7.7.9(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))':
+    dependencies:
+      '@vue/devtools-kit': 7.7.9
+      '@vue/devtools-shared': 7.7.9
+      mitt: 3.0.1
+      nanoid: 5.1.6
+      pathe: 2.0.3
+      vite-hot-client: 2.0.4(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))
+      vue: 3.5.13(typescript@5.9.3)
+    transitivePeerDependencies:
+      - vite
+
   '@vue/devtools-kit@7.7.6':
     dependencies:
       '@vue/devtools-shared': 7.7.6
@@ -26448,7 +26602,21 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.2
 
+  '@vue/devtools-kit@7.7.9':
+    dependencies:
+      '@vue/devtools-shared': 7.7.9
+      birpc: 2.3.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.2
+
   '@vue/devtools-shared@7.7.6':
+    dependencies:
+      rfdc: 1.4.1
+
+  '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
 
@@ -26497,6 +26665,11 @@ snapshots:
       vue-component-type-helpers: 3.2.8
     optionalDependencies:
       '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.9.3))
+
+  '@vue/tsconfig@0.7.0(typescript@5.9.3)(vue@3.5.13(typescript@5.9.3))':
+    optionalDependencies:
+      typescript: 5.9.3
+      vue: 3.5.13(typescript@5.9.3)
 
   '@web3-storage/multipart-parser@1.0.0': {}
 
@@ -26883,7 +27056,7 @@ snapshots:
 
   ast-kit@1.4.3:
     dependencies:
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.2
       pathe: 2.0.3
 
   ast-module-types@5.0.0: {}
@@ -28709,6 +28882,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  error-stack-parser-es@0.1.5: {}
+
   error-stack-parser-es@1.0.5: {}
 
   error-stack-parser@2.1.4:
@@ -29299,6 +29474,21 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   expect-type@1.2.2: {}
 
   expect-type@1.3.0: {}
@@ -29684,6 +29874,10 @@ snapshots:
 
   fflate@0.8.2: {}
 
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -29887,7 +30081,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-    optional: true
 
   fs-extra@8.1.0:
     dependencies:
@@ -29899,14 +30092,14 @@ snapshots:
     dependencies:
       at-least-node: 1.0.0
       graceful-fs: 4.2.11
-      jsonfile: 6.1.0
+      jsonfile: 6.2.1
       universalify: 1.0.0
 
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
       graceful-fs: 4.2.11
-      jsonfile: 6.1.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs-minipass@2.1.0:
@@ -30007,6 +30200,11 @@ snapshots:
 
   get-stream@8.0.1: {}
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.3
@@ -30074,7 +30272,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -30445,6 +30643,8 @@ snapshots:
   human-signals@4.3.1: {}
 
   human-signals@5.0.0: {}
+
+  human-signals@8.0.1: {}
 
   hyphenate-style-name@1.1.0: {}
 
@@ -30903,7 +31103,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.28.6
+      '@babel/code-frame': 7.29.0
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -31076,6 +31276,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-parse-even-better-errors@4.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -31101,7 +31303,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    optional: true
 
   junk@4.0.1: {}
 
@@ -31150,7 +31351,7 @@ snapshots:
   launch-editor@2.10.0:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.2
+      shell-quote: 1.8.3
 
   layout-base@1.0.2: {}
 
@@ -32017,7 +32218,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       metro: 0.81.1
@@ -32955,12 +33156,25 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  npm-normalize-package-bin@4.0.0: {}
+
   npm-package-arg@11.0.3:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
       semver: 7.7.4
       validate-npm-package-name: 5.0.1
+
+  npm-run-all2@7.0.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      minimatch: 9.0.5
+      pidtree: 0.6.0
+      read-package-json-fast: 4.0.0
+      shell-quote: 1.8.3
+      which: 5.0.0
 
   npm-run-all@4.1.5:
     dependencies:
@@ -33427,7 +33641,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.28.6
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -33437,6 +33651,8 @@ snapshots:
       '@babel/code-frame': 7.29.0
       index-to-position: 1.1.0
       type-fest: 4.41.0
+
+  parse-ms@4.0.0: {}
 
   parse-path@7.1.0:
     dependencies:
@@ -33535,6 +33751,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.3.1: {}
+
+  pidtree@0.6.0: {}
 
   pify@2.3.0: {}
 
@@ -33975,6 +34193,10 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   prism-react-renderer@1.3.5(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -34138,7 +34360,7 @@ snapshots:
 
   react-devtools-core@5.3.2:
     dependencies:
-      shell-quote: 1.8.2
+      shell-quote: 1.8.3
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -34518,6 +34740,11 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  read-package-json-fast@4.0.0:
+    dependencies:
+      json-parse-even-better-errors: 4.0.0
+      npm-normalize-package-bin: 4.0.0
 
   read-package-up@11.0.0:
     dependencies:
@@ -35731,6 +35958,8 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
+  strip-final-newline@4.0.0: {}
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -36793,6 +37022,10 @@ snapshots:
     dependencies:
       vite: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
 
+  vite-hot-client@2.0.4(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)):
+    dependencies:
+      vite: 6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
+
   vite-node@1.6.1(@types/node@18.19.74)(lightningcss@1.30.2)(terser@5.46.2):
     dependencies:
       cac: 6.7.14
@@ -36910,6 +37143,22 @@ snapshots:
       typescript: 5.9.3
       vue-tsc: 2.2.12(typescript@5.9.3)
 
+  vite-plugin-inspect@0.8.9(rollup@4.59.0)(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
+      debug: 4.4.3
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.3.4
+      open: 10.1.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.1.1
+      sirv: 3.0.2
+      vite: 6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   vite-plugin-inspect@11.0.1(@nuxt/kit@3.17.2(magicast@0.3.5))(vite@6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)):
     dependencies:
       ansis: 3.17.0
@@ -36937,6 +37186,37 @@ snapshots:
       solid-refresh: 0.6.3(solid-js@1.9.11)
       vite: 5.4.14(@types/node@22.13.0)(lightningcss@1.30.2)(terser@5.46.2)
       vitefu: 1.1.2(vite@5.4.14(@types/node@22.13.0)(lightningcss@1.30.2)(terser@5.46.2))
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-devtools@7.7.9(rollup@4.59.0)(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 7.7.9(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.13(typescript@5.9.3))
+      '@vue/devtools-kit': 7.7.9
+      '@vue/devtools-shared': 7.7.9
+      execa: 9.6.1
+      sirv: 3.0.2
+      vite: 6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
+      vite-plugin-inspect: 0.8.9(rollup@4.59.0)(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.4.0(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - rollup
+      - supports-color
+      - vue
+
+  vite-plugin-vue-inspector@5.4.0(vite@6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.13
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 6.3.5(@types/node@22.13.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.19.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -37719,6 +37999,8 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  yoctocolors@2.1.2: {}
 
   yoga-wasm-web@0.3.3: {}
 

--- a/client/sandbox/vue-vite/.gitignore
+++ b/client/sandbox/vue-vite/.gitignore
@@ -1,0 +1,43 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+.DS_Store
+dist
+dist-ssr
+coverage
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+*.tsbuildinfo
+
+.eslintcache
+
+# Cypress
+/cypress/videos/
+/cypress/screenshots/
+
+# Vitest
+__screenshots__/
+
+# Vite
+*.timestamp-*-*.mjs
+
+# Environment
+.env

--- a/client/sandbox/vue-vite/README.md
+++ b/client/sandbox/vue-vite/README.md
@@ -1,0 +1,29 @@
+<p align="center">
+  <a href="#">
+    <img alt="Shows the Instant logo" src="https://instantdb.com/img/icon/android-chrome-512x512.png" width="10%">
+  </a>
+  <h1 align="center">sandbox/vue-vite</h1>
+</p>
+
+This is a sandbox app to play with [@instantdb/vue](../../packages/vue/).
+
+# Development
+
+Make sure you have a local backend running on port 8888. Then:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Load [localhost:5173](http://localhost:5173) and the app will automatically create an ephemeral app against your local backend. No `.env` setup needed.
+
+Routes:
+
+- `/` — todo CRUD
+- `/auth` — SignedIn / SignedOut component test
+- `/cursors` — Cursors component test
+
+# Questions?
+
+If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE)!

--- a/client/sandbox/vue-vite/env.d.ts
+++ b/client/sandbox/vue-vite/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client/sandbox/vue-vite/index.html
+++ b/client/sandbox/vue-vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vue Sandbox</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/client/sandbox/vue-vite/package.json
+++ b/client/sandbox/vue-vite/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "sb-vue-vite",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "run-p type-check \"build-only {@}\" --",
+    "preview": "vite preview",
+    "build-only": "vite build",
+    "type-check": "vue-tsc --build"
+  },
+  "dependencies": {
+    "@instantdb/vue": "workspace:*",
+    "vue": "^3.5.0",
+    "vue-router": "^4.4.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.13",
+    "@tsconfig/node22": "^22.0.0",
+    "@types/node": "^22.0.0",
+    "@vitejs/plugin-vue": "^5.2.0",
+    "@vue/tsconfig": "^0.7.0",
+    "npm-run-all2": "^7.0.0",
+    "tailwindcss": "^4.1.13",
+    "typescript": "^5.9.2",
+    "vite": "^6.0.0",
+    "vite-plugin-vue-devtools": "^7.7.0",
+    "vue-tsc": "^2.2.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/client/sandbox/vue-vite/src/App.vue
+++ b/client/sandbox/vue-vite/src/App.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import { RouterView } from 'vue-router';
+</script>
+
+<template>
+  <RouterView />
+</template>

--- a/client/sandbox/vue-vite/src/assets/main.css
+++ b/client/sandbox/vue-vite/src/assets/main.css
@@ -1,0 +1,17 @@
+@import "tailwindcss";
+
+@layer base {
+    :root {
+        @apply font-sans;
+    }
+
+    body {
+        background: linear-gradient(
+            120deg,
+            #e7e7e7 40%,
+            #fee7de 70%,
+            #e4e4e4 100%
+        );
+        min-height: 100dvh;
+    }
+}

--- a/client/sandbox/vue-vite/src/lib/config.ts
+++ b/client/sandbox/vue-vite/src/lib/config.ts
@@ -1,0 +1,8 @@
+const localPort = import.meta.env.VITE_LOCAL_SERVER_PORT || '8888';
+
+const config = {
+  apiURI: `http://localhost:${localPort}`,
+  websocketURI: `ws://localhost:${localPort}/runtime/session`,
+};
+
+export default config;

--- a/client/sandbox/vue-vite/src/lib/db.ts
+++ b/client/sandbox/vue-vite/src/lib/db.ts
@@ -1,0 +1,86 @@
+import { ref, shallowRef } from 'vue';
+import { init, i, type InstantSchemaDef } from '@instantdb/vue';
+import config from './config';
+
+const STORAGE_KEY = 'sb-vue-vite-ephemeral-app';
+
+type EphemeralApp = { id: string; 'admin-token': string };
+
+const schema = i.schema({
+  entities: {
+    todos: i.entity({
+      text: i.string(),
+      done: i.boolean(),
+      createdAt: i.number(),
+    }),
+    items: i.entity({
+      value: i.number().indexed(),
+    }),
+  },
+});
+
+type AppSchema = typeof schema;
+
+async function provisionEphemeralApp(schema: InstantSchemaDef<any, any, any>) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Vue Sandbox', schema }),
+  });
+  return r.json();
+}
+
+async function verifyEphemeralApp(appId: string) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+}
+
+async function getOrCreateApp(): Promise<EphemeralApp> {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    try {
+      const app = JSON.parse(saved) as EphemeralApp;
+      await verifyEphemeralApp(app.id);
+      return app;
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  const res = await provisionEphemeralApp(schema);
+  if (!res.app) throw new Error('Could not create ephemeral app');
+  const app: EphemeralApp = res.app;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(app));
+  return app;
+}
+
+export type DB = ReturnType<typeof init<AppSchema>>;
+
+export const isLoading = ref(true);
+export const error = ref<string | null>(null);
+export const db = shallowRef<DB | null>(null);
+
+getOrCreateApp()
+  .then((app) => {
+    db.value = init({
+      ...config,
+      appId: app.id,
+      schema,
+      devtool: false,
+    });
+    isLoading.value = false;
+  })
+  .catch((e) => {
+    error.value = (e as Error).message;
+    isLoading.value = false;
+  });
+
+export function resetEphemeralApp() {
+  localStorage.removeItem(STORAGE_KEY);
+  location.reload();
+}
+
+export type { AppSchema };

--- a/client/sandbox/vue-vite/src/main.ts
+++ b/client/sandbox/vue-vite/src/main.ts
@@ -1,0 +1,7 @@
+import './assets/main.css';
+
+import { createApp } from 'vue';
+import App from './App.vue';
+import { router } from './router';
+
+createApp(App).use(router).mount('#app');

--- a/client/sandbox/vue-vite/src/pages/Auth.vue
+++ b/client/sandbox/vue-vite/src/pages/Auth.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SignedIn, SignedOut } from '@instantdb/vue';
+import { db, isLoading, error } from '../lib/db';
+
+const email = ref('');
+const code = ref('');
+const sentTo = ref('');
+
+function sendCode() {
+  if (!email.value || !db.value) return;
+  const target = email.value;
+  db.value.auth.sendMagicCode({ email: target }).then(() => {
+    sentTo.value = target;
+  });
+}
+
+function verifyCode() {
+  if (!code.value || !sentTo.value || !db.value) return;
+  db.value.auth
+    .signInWithMagicCode({ email: sentTo.value, code: code.value })
+    .catch(() => {
+      code.value = '';
+    });
+}
+</script>
+
+<template>
+  <div v-if="isLoading" class="p-8 flex justify-center">
+    Creating ephemeral app...
+  </div>
+  <div v-else-if="error" class="p-8 text-red-500">Error: {{ error }}</div>
+  <div v-else-if="db" class="p-8 max-w-md mx-auto flex flex-col gap-4">
+    <h1 class="text-2xl text-[#F54A00] tracking-wide">Auth Components Test</h1>
+
+    <SignedOut :db="db">
+      <div
+        class="bg-white rounded-lg p-6 border border-neutral-200 shadow flex flex-col gap-4"
+      >
+        <h2 class="text-lg font-semibold">Signed Out</h2>
+        <p class="text-sm text-neutral-500">
+          This content is rendered by the SignedOut component.
+        </p>
+        <form v-if="!sentTo" class="flex flex-col gap-2" @submit.prevent="sendCode">
+          <input
+            v-model="email"
+            type="email"
+            placeholder="Enter your email"
+            class="border border-neutral-300 rounded px-3 py-2 outline-none"
+          />
+          <button
+            type="submit"
+            class="bg-[#F54A00] text-white rounded px-3 py-2"
+          >
+            Send Magic Code
+          </button>
+        </form>
+        <form v-else class="flex flex-col gap-2" @submit.prevent="verifyCode">
+          <p class="text-sm">Code sent to {{ sentTo }}</p>
+          <input
+            v-model="code"
+            type="text"
+            placeholder="Enter code"
+            class="border border-neutral-300 rounded px-3 py-2 outline-none"
+          />
+          <button
+            type="submit"
+            class="bg-[#F54A00] text-white rounded px-3 py-2"
+          >
+            Verify Code
+          </button>
+        </form>
+      </div>
+    </SignedOut>
+
+    <SignedIn :db="db">
+      <div
+        class="bg-white rounded-lg p-6 border border-neutral-200 shadow flex flex-col gap-4"
+      >
+        <h2 class="text-lg font-semibold">Signed In</h2>
+        <p class="text-sm text-neutral-500">
+          This content is rendered by the SignedIn component.
+        </p>
+        <button
+          class="bg-neutral-200 rounded px-3 py-2 hover:bg-neutral-300"
+          @click="db.auth.signOut()"
+        >
+          Sign Out
+        </button>
+      </div>
+    </SignedIn>
+  </div>
+</template>

--- a/client/sandbox/vue-vite/src/pages/Cursors.vue
+++ b/client/sandbox/vue-vite/src/pages/Cursors.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Cursors } from '@instantdb/vue';
+import { db, isLoading, error } from '../lib/db';
+
+const room = computed(() => db.value?.room('main' as any, 'cursors-demo'));
+</script>
+
+<template>
+  <div v-if="isLoading" class="p-8 flex justify-center">
+    Creating ephemeral app...
+  </div>
+  <div v-else-if="error" class="p-8 text-red-500">Error: {{ error }}</div>
+  <Cursors v-else-if="room" :room="room" class="min-h-screen">
+    <div class="p-8 flex flex-col gap-4">
+      <h1 class="text-2xl text-[#F54A00] tracking-wide">Cursors Test</h1>
+      <p class="text-neutral-500">
+        Open this page in multiple tabs to see cursors from other users. Move
+        your mouse around to broadcast your cursor position.
+      </p>
+      <div class="grid grid-cols-3 gap-4">
+        <div
+          v-for="i in 6"
+          :key="i"
+          class="bg-white rounded-lg p-8 border border-neutral-200 shadow flex items-center justify-center text-neutral-400"
+        >
+          Box {{ i }}
+        </div>
+      </div>
+    </div>
+  </Cursors>
+</template>

--- a/client/sandbox/vue-vite/src/pages/Home.vue
+++ b/client/sandbox/vue-vite/src/pages/Home.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+const routes = [
+  { href: '/todos', label: 'todos' },
+  { href: '/infinite-scroll', label: 'infinite-scroll' },
+  { href: '/cursors', label: 'cursors' },
+  { href: '/auth', label: 'auth' },
+];
+</script>
+
+<template>
+  <div class="p-8">
+    <h1 class="text-2xl mb-3">Vue + Vite + Instant Sandbox</h1>
+    <ul class="list-disc pl-6">
+      <li v-for="route in routes" :key="route.href">
+        <RouterLink class="underline text-blue-600" :to="route.href">
+          {{ route.label }}
+        </RouterLink>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/client/sandbox/vue-vite/src/pages/InfiniteScroll.vue
+++ b/client/sandbox/vue-vite/src/pages/InfiniteScroll.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { db, isLoading, error } from '../lib/db';
+import InfiniteScrollDemo from './InfiniteScrollDemo.vue';
+</script>
+
+<template>
+  <div v-if="isLoading" class="p-8 flex justify-center">
+    Creating ephemeral app...
+  </div>
+  <div v-else-if="error" class="p-8 text-red-500">Error: {{ error }}</div>
+  <InfiniteScrollDemo v-else-if="db" :db="db" />
+</template>

--- a/client/sandbox/vue-vite/src/pages/InfiniteScrollDemo.vue
+++ b/client/sandbox/vue-vite/src/pages/InfiniteScrollDemo.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { id } from '@instantdb/vue';
+import { resetEphemeralApp, type DB } from '../lib/db';
+
+const props = defineProps<{ db: DB }>();
+
+const pageSize = 4;
+let writeQueue: Promise<unknown> = Promise.resolve();
+const numberInput = ref('');
+
+function enqueue(work: () => Promise<unknown>) {
+  writeQueue = writeQueue.then(work, work);
+}
+
+const scrollResult = props.db.useInfiniteQuery({
+  items: {
+    $: { limit: pageSize, order: { value: 'asc' } },
+  },
+});
+const allNumbersResult = props.db.useQuery({ items: {} });
+
+const numberLineValues = computed(() =>
+  [...(allNumbersResult.data.value?.items || [])].sort(
+    (a, b) => a.value - b.value,
+  ),
+);
+const loadedItems = computed(() => scrollResult.data.value?.items || []);
+
+function addNumberItem(value: number) {
+  enqueue(() =>
+    props.db.transact([props.db.tx.items[id()].update({ value })]),
+  );
+}
+
+function submitNumber() {
+  const parsed = Number(numberInput.value);
+  if (!Number.isFinite(parsed)) return;
+  addNumberItem(parsed);
+  numberInput.value = '';
+}
+
+function addNewLowest() {
+  enqueue(async () => {
+    const snapshot = await props.db.queryOnce({ items: {} });
+    const existing = snapshot.data.items || [];
+    const minValue = existing.reduce(
+      (min, item) => Math.min(min, item.value),
+      Number.POSITIVE_INFINITY,
+    );
+    const nextValue = Number.isFinite(minValue) ? minValue - 1 : -1;
+    await props.db.transact([
+      props.db.tx.items[id()].update({ value: nextValue }),
+    ]);
+  });
+}
+
+function addNewHighest() {
+  enqueue(async () => {
+    const snapshot = await props.db.queryOnce({ items: {} });
+    const existing = snapshot.data.items || [];
+    const maxValue = existing.reduce(
+      (max, item) => Math.max(max, item.value),
+      Number.NEGATIVE_INFINITY,
+    );
+    const nextValue = Number.isFinite(maxValue) ? maxValue + 1 : 1;
+    await props.db.transact([
+      props.db.tx.items[id()].update({ value: nextValue }),
+    ]);
+  });
+}
+
+async function deleteAll() {
+  const snapshot = await props.db.queryOnce({ items: {} });
+  const existing = snapshot.data.items || [];
+  if (existing.length === 0) return;
+  await props.db.transact(
+    existing.map((item) => props.db.tx.items[item.id].delete()),
+  );
+}
+</script>
+
+<template>
+  <div class="p-4">
+    <div class="flex flex-wrap items-center gap-2">
+      <input
+        class="border border-gray-400 p-2"
+        type="number"
+        v-model="numberInput"
+        @keydown.enter="submitNumber"
+        placeholder="Type a number"
+      />
+      <button class="bg-black p-2 text-white" @click="submitNumber">
+        Add number
+      </button>
+      <button class="bg-black p-2 text-white" @click="addNewLowest">
+        Add new lowest
+      </button>
+      <button class="bg-black p-2 text-white" @click="addNumberItem(0)">
+        Add zero
+      </button>
+      <button class="bg-black p-2 text-white" @click="addNewHighest">
+        Add new highest
+      </button>
+      <button class="bg-black p-2 text-white" @click="deleteAll">
+        Delete all
+      </button>
+      <button class="bg-black p-2 text-white" @click="resetEphemeralApp">
+        Start over
+      </button>
+    </div>
+
+    <button
+      class="my-2 bg-black p-2 text-white disabled:opacity-50"
+      :disabled="!scrollResult.canLoadNextPage.value"
+      @click="scrollResult.loadNextPage()"
+    >
+      Load more
+    </button>
+
+    <div class="my-2 border border-gray-300 p-3">
+      <h3 class="font-bold">Number line ({{ numberLineValues.length }})</h3>
+      <div v-if="numberLineValues.length === 0" class="mt-2 text-sm">
+        No numbers yet.
+      </div>
+      <div v-else class="mt-3 overflow-x-auto">
+        <div class="min-w-max border-t-2 border-black px-4 pb-2">
+          <div class="flex gap-6">
+            <div
+              v-for="item in numberLineValues"
+              :key="item.id"
+              class="-mt-4 flex flex-col items-center"
+            >
+              <div class="h-4 w-px bg-black"></div>
+              <div class="mt-1 font-mono text-sm">{{ item.value }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid gap-2 md:grid-cols-2">
+      <div class="border border-gray-300 bg-gray-100 p-3 text-xs">
+        <h3 class="font-bold">Infinite Query Diagnostics</h3>
+        <pre>canLoadNextPage: {{ String(scrollResult.canLoadNextPage.value) }}</pre>
+        <pre>isLoading: {{ String(scrollResult.isLoading.value) }}</pre>
+        <pre>loaded: {{ loadedItems.length }}</pre>
+      </div>
+
+      <div class="border border-gray-300 p-3">
+        <h3 class="font-bold">Loaded items ({{ loadedItems.length }})</h3>
+        <div v-if="loadedItems.length === 0">No items loaded yet.</div>
+        <template v-else>
+          <div
+            v-for="item in loadedItems"
+            :key="item.id"
+            class="font-mono text-sm"
+          >
+            {{ item.value }}
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/sandbox/vue-vite/src/pages/TodoApp.vue
+++ b/client/sandbox/vue-vite/src/pages/TodoApp.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { id, type InstaQLEntity } from '@instantdb/vue';
+import type { AppSchema, DB } from '../lib/db';
+
+type Todo = InstaQLEntity<AppSchema, 'todos'>;
+
+const props = defineProps<{ db: DB }>();
+
+const text = ref('');
+
+const { isLoading, error, data } = props.db.useQuery({ todos: {} });
+const todos = computed(() => data.value?.todos ?? []);
+const remaining = computed(() => todos.value.filter((t) => !t.done).length);
+
+function addTodo() {
+  const value = text.value.trim();
+  if (!value) return;
+  props.db.transact(
+    props.db.tx.todos[id()].update({
+      text: value,
+      done: false,
+      createdAt: Date.now(),
+    }),
+  );
+  text.value = '';
+}
+
+function toggleDone(todo: Todo) {
+  props.db.transact(props.db.tx.todos[todo.id].update({ done: !todo.done }));
+}
+
+function deleteTodo(todo: Todo) {
+  props.db.transact(props.db.tx.todos[todo.id].delete());
+}
+
+function deleteCompleted() {
+  const completed = todos.value.filter((t) => t.done);
+  if (!completed.length) return;
+  props.db.transact(completed.map((t) => props.db.tx.todos[t.id].delete()));
+}
+</script>
+
+<template>
+  <div class="p-8 grid grid-cols-2 items-start gap-2">
+    <div
+      class="bg-white p-6 rounded-lg border border-neutral-200 shadow flex flex-col gap-2"
+    >
+      <h2 class="tracking-wide text-[#F54A00] text-2xl text-center">
+        Vue + Vite + Instant DB
+      </h2>
+    </div>
+
+    <div
+      class="bg-white rounded-lg p-6 border border-neutral-200 shadow flex flex-col"
+    >
+      <h2 class="tracking-wide text-[#F54A00] text-2xl">Todos</h2>
+      <div class="text-xs pb-4">
+        Open another tab to see todos update in realtime!
+      </div>
+
+      <div v-if="isLoading">Loading...</div>
+      <div v-else-if="error" class="text-red-500">
+        Error: {{ error.message }}
+      </div>
+      <div v-else class="border rounded border-neutral-300">
+        <form
+          class="flex items-center h-10 border-neutral-300"
+          @submit.prevent="addTodo"
+        >
+          <input
+            v-model="text"
+            class="w-full h-full placeholder-neutral-300 px-2 outline-none bg-transparent"
+            placeholder="What needs to be done?"
+            type="text"
+          />
+        </form>
+
+        <div class="divide-y divide-neutral-300">
+          <div
+            v-for="todo in todos"
+            :key="todo.id"
+            class="flex items-center h-10"
+          >
+            <div class="h-full px-2 flex items-center justify-center">
+              <input
+                type="checkbox"
+                class="cursor-pointer w-5 h-5"
+                :checked="todo.done"
+                @change="toggleDone(todo)"
+              />
+            </div>
+            <div class="flex-1 px-2 overflow-hidden flex items-center">
+              <span :class="{ 'line-through': todo.done }">{{ todo.text }}</span>
+            </div>
+            <button
+              class="h-full px-2 text-neutral-300 hover:text-neutral-500"
+              @click="deleteTodo(todo)"
+            >
+              X
+            </button>
+          </div>
+        </div>
+
+        <div
+          class="flex justify-between items-center h-10 px-2 text-xs border-t border-neutral-300"
+        >
+          <div>Remaining todos: {{ remaining }}</div>
+          <button
+            class="text-neutral-300 hover:text-neutral-500"
+            @click="deleteCompleted"
+          >
+            Delete Completed
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/sandbox/vue-vite/src/pages/Todos.vue
+++ b/client/sandbox/vue-vite/src/pages/Todos.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { db, isLoading, error } from '../lib/db';
+import TodoApp from './TodoApp.vue';
+</script>
+
+<template>
+  <div v-if="isLoading" class="p-8 flex justify-center">
+    Creating ephemeral app...
+  </div>
+  <div v-else-if="error" class="p-8 text-red-500">Error: {{ error }}</div>
+  <TodoApp v-else-if="db" :db="db" />
+</template>

--- a/client/sandbox/vue-vite/src/router.ts
+++ b/client/sandbox/vue-vite/src/router.ts
@@ -1,0 +1,17 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import Home from './pages/Home.vue';
+import Todos from './pages/Todos.vue';
+import InfiniteScroll from './pages/InfiniteScroll.vue';
+import Auth from './pages/Auth.vue';
+import Cursors from './pages/Cursors.vue';
+
+export const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', component: Home },
+    { path: '/todos', component: Todos },
+    { path: '/infinite-scroll', component: InfiniteScroll },
+    { path: '/auth', component: Auth },
+    { path: '/cursors', component: Cursors },
+  ],
+});

--- a/client/sandbox/vue-vite/tsconfig.app.json
+++ b/client/sandbox/vue-vite/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"],
+  "compilerOptions": {
+    // Path mapping for cleaner imports.
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  }
+}

--- a/client/sandbox/vue-vite/tsconfig.json
+++ b/client/sandbox/vue-vite/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/client/sandbox/vue-vite/tsconfig.node.json
+++ b/client/sandbox/vue-vite/tsconfig.node.json
@@ -1,0 +1,27 @@
+// TSConfig for modules that run in Node.js environment via either transpilation or type-stripping.
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "include": [
+    "vite.config.*",
+    "vitest.config.*",
+    "cypress.config.*",
+    "playwright.config.*",
+    "eslint.config.*"
+  ],
+  "compilerOptions": {
+    // Most tools use transpilation instead of Node.js's native type-stripping.
+    // Bundler mode provides a smoother developer experience.
+    "module": "preserve",
+    "moduleResolution": "bundler",
+
+    // Include Node.js types and avoid accidentally including other `@types/*` packages.
+    "types": ["node"],
+
+    // Disable emitting output during `vue-tsc --build`, which is used for type-checking only.
+    "noEmit": true,
+
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
+  }
+}

--- a/client/sandbox/vue-vite/vite.config.ts
+++ b/client/sandbox/vue-vite/vite.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueDevTools from 'vite-plugin-vue-devtools';
+import tailwindcss from '@tailwindcss/vite';
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [vue(), vueDevTools(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});

--- a/examples/vue-vite/.gitignore
+++ b/examples/vue-vite/.gitignore
@@ -1,0 +1,43 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+.DS_Store
+dist
+dist-ssr
+coverage
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+*.tsbuildinfo
+
+.eslintcache
+
+# Cypress
+/cypress/videos/
+/cypress/screenshots/
+
+# Vitest
+__screenshots__/
+
+# Vite
+*.timestamp-*-*.mjs
+
+# Environment
+.env

--- a/examples/vue-vite/README.md
+++ b/examples/vue-vite/README.md
@@ -1,0 +1,15 @@
+# Welcome to your InstantDB Vue + Vite app
+
+To install dependencies:
+`npm install`
+
+To run the development server:
+`npm run dev`
+
+To push schema changes:
+`npx instant-cli push`
+
+To pull schema changes:
+`npx instant-cli pull`
+
+Set `VITE_INSTANT_APP_ID` in an `.env` file before running the app.

--- a/examples/vue-vite/env.d.ts
+++ b/examples/vue-vite/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/vue-vite/index.html
+++ b/examples/vue-vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Instant + Vue + Vite</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/vue-vite/package.json
+++ b/examples/vue-vite/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "vue-vite",
+  "version": "0.1.0",
+  "private": true,
+  "description": "InstantDB + Vue + Vite example",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "run-p type-check \"build-only {@}\" --",
+    "preview": "vite preview",
+    "build-only": "vite build",
+    "type-check": "vue-tsc --build"
+  },
+  "dependencies": {
+    "@instantdb/vue": "latest",
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.13",
+    "@tsconfig/node22": "^22.0.0",
+    "@types/node": "^22.0.0",
+    "@vitejs/plugin-vue": "^5.2.0",
+    "@vue/tsconfig": "^0.7.0",
+    "npm-run-all2": "^7.0.0",
+    "tailwindcss": "^4.1.13",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.4",
+    "vite-plugin-vue-devtools": "^7.7.0",
+    "vue-tsc": "^2.2.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/examples/vue-vite/src/App.vue
+++ b/examples/vue-vite/src/App.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { id, type InstaQLEntity } from "@instantdb/vue";
+import { db } from "./lib/db";
+import type { AppSchema } from "./instant.schema";
+
+type Todo = InstaQLEntity<AppSchema, "todos">;
+
+const { isLoading: authLoading, user } = db.useAuth();
+const { isLoading: queryLoading, error, data } = db.useQuery({ todos: {} });
+
+const todos = computed(() => data.value?.todos ?? []);
+const remaining = computed(() => todos.value.filter((t) => !t.done).length);
+
+const text = ref("");
+const email = ref("");
+const code = ref("");
+const sentEmail = ref("");
+
+function addTodo() {
+  const value = text.value.trim();
+  if (!value) return;
+  db.transact(
+    db.tx.todos[id()].update({
+      text: value,
+      done: false,
+      createdAt: Date.now(),
+    }),
+  );
+  text.value = "";
+}
+
+function toggleDone(todo: Todo) {
+  db.transact(db.tx.todos[todo.id].update({ done: !todo.done }));
+}
+
+function deleteTodo(todo: Todo) {
+  db.transact(db.tx.todos[todo.id].delete());
+}
+
+function deleteCompleted() {
+  const completed = todos.value.filter((t) => t.done);
+  if (!completed.length) return;
+  db.transact(completed.map((t) => db.tx.todos[t.id].delete()));
+}
+
+function sendCode() {
+  if (!email.value) return;
+  const target = email.value;
+  db.auth
+    .sendMagicCode({ email: target })
+    .then(() => {
+      sentEmail.value = target;
+    })
+    .catch((err: any) => {
+      alert("Error sending code: " + (err.body?.message ?? err.message));
+    });
+}
+
+function verifyCode() {
+  if (!code.value || !sentEmail.value) return;
+  db.auth
+    .signInWithMagicCode({ email: sentEmail.value, code: code.value })
+    .catch((err: any) => {
+      alert("Error verifying code: " + (err.body?.message ?? err.message));
+      code.value = "";
+    });
+}
+
+function resetEmail() {
+  sentEmail.value = "";
+  code.value = "";
+}
+</script>
+
+<template>
+  <div v-if="authLoading" class="p-8 flex justify-center">Loading...</div>
+
+  <div v-else-if="user" class="p-8 grid grid-cols-2 items-start gap-2">
+    <div
+      class="bg-white p-6 rounded-lg border border-neutral-200 shadow flex justify-center flex-col gap-2"
+    >
+      <h2 class="tracking-wide text-[#F54A00] text-2xl text-center">
+        Vue + Vite + Instant DB
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 grow gap-2">
+        <a
+          href="https://vuejs.org/guide/introduction.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="border hover:bg-neutral-100 py-8 shadow flex flex-col gap-2 items-center justify-center font-semibold border-neutral-200 rounded"
+        >
+          <img
+            src="https://vuejs.org/images/logo.png"
+            width="34"
+            alt="Vue logo"
+          />
+          Vue Docs
+        </a>
+        <a
+          href="https://www.instantdb.com/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="border shadow flex flex-col py-8 gap-2 hover:bg-neutral-100 items-center justify-center font-semibold border-neutral-200 rounded"
+        >
+          <img
+            src="https://www.instantdb.com/img/icon/logo-512.svg"
+            width="34"
+            alt="Instant logo"
+          />
+          Instant Docs
+        </a>
+      </div>
+    </div>
+
+    <div
+      class="bg-white rounded-lg p-6 border border-neutral-200 shadow flex flex-col"
+    >
+      <div class="flex justify-between items-center">
+        <h2 class="tracking-wide text-[#F54A00] text-2xl">Todos</h2>
+        <button
+          class="text-xs text-neutral-400 hover:text-neutral-600"
+          @click="db.auth.signOut()"
+        >
+          Sign out
+        </button>
+      </div>
+      <div class="text-xs pb-4">
+        Open another tab to see todos update in realtime!
+      </div>
+
+      <div v-if="queryLoading">Loading...</div>
+      <div v-else-if="error" class="text-red-500">
+        Error: {{ error.message }}
+      </div>
+      <div v-else class="border rounded border-neutral-300">
+        <form
+          class="flex items-center h-10 border-neutral-300"
+          @submit.prevent="addTodo"
+        >
+          <input
+            v-model="text"
+            class="w-full h-full placeholder-neutral-300 px-2 outline-none bg-transparent"
+            placeholder="What needs to be done?"
+            type="text"
+          />
+        </form>
+
+        <div class="divide-y divide-neutral-300">
+          <div
+            v-for="todo in todos"
+            :key="todo.id"
+            class="flex items-center h-10"
+          >
+            <div class="h-full px-2 flex items-center justify-center">
+              <input
+                type="checkbox"
+                class="cursor-pointer w-5 h-5"
+                :checked="todo.done"
+                @change="toggleDone(todo)"
+              />
+            </div>
+            <div class="flex-1 px-2 overflow-hidden flex items-center">
+              <span :class="{ 'line-through': todo.done }">{{ todo.text }}</span>
+            </div>
+            <button
+              class="h-full px-2 flex items-center justify-center text-neutral-300 hover:text-neutral-500"
+              @click="deleteTodo(todo)"
+            >
+              X
+            </button>
+          </div>
+        </div>
+
+        <div
+          class="flex justify-between items-center h-10 px-2 text-xs border-t border-neutral-300"
+        >
+          <div>Remaining todos: {{ remaining }}</div>
+          <button
+            class="text-neutral-300 hover:text-neutral-500"
+            @click="deleteCompleted"
+          >
+            Delete Completed
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div v-else class="p-8 flex justify-center">
+    <div
+      class="bg-white rounded-lg p-6 border border-neutral-200 shadow max-w-sm w-full"
+    >
+      <h2 class="tracking-wide text-[#F54A00] text-2xl mb-4">Sign in</h2>
+
+      <form
+        v-if="!sentEmail"
+        @submit.prevent="sendCode"
+        class="flex flex-col gap-2"
+      >
+        <input
+          v-model="email"
+          type="email"
+          placeholder="Enter your email"
+          class="border border-neutral-300 rounded px-3 py-2 outline-none"
+        />
+        <button
+          type="submit"
+          class="bg-[#F54A00] text-white rounded px-3 py-2 hover:bg-[#d94300]"
+        >
+          Send Code
+        </button>
+      </form>
+
+      <form
+        v-else
+        @submit.prevent="verifyCode"
+        class="flex flex-col gap-2"
+      >
+        <p class="text-sm text-neutral-500">We sent a code to {{ sentEmail }}</p>
+        <input
+          v-model="code"
+          type="text"
+          placeholder="Enter code"
+          class="border border-neutral-300 rounded px-3 py-2 outline-none"
+        />
+        <button
+          type="submit"
+          class="bg-[#F54A00] text-white rounded px-3 py-2 hover:bg-[#d94300]"
+        >
+          Verify Code
+        </button>
+        <button
+          type="button"
+          class="text-sm text-neutral-400 hover:text-neutral-600"
+          @click="resetEmail"
+        >
+          Use a different email
+        </button>
+      </form>
+    </div>
+  </div>
+</template>

--- a/examples/vue-vite/src/assets/main.css
+++ b/examples/vue-vite/src/assets/main.css
@@ -1,0 +1,25 @@
+@import "tailwindcss";
+
+@layer base {
+    :root {
+        @apply font-sans;
+    }
+
+    body {
+        background: linear-gradient(
+            120deg,
+            #e7e7e7 40%,
+            #fee7de 70%,
+            #e4e4e4 100%
+        );
+        min-height: 100dvh;
+    }
+}
+
+@media (prefers-reduced-motion) {
+    *,
+    ::before,
+    ::after {
+        animation: none !important;
+    }
+}

--- a/examples/vue-vite/src/instant.perms.ts
+++ b/examples/vue-vite/src/instant.perms.ts
@@ -1,0 +1,24 @@
+// Docs: https://www.instantdb.com/docs/permissions
+
+import type { InstantRules } from "@instantdb/vue";
+
+const rules = {
+  /**
+   * Welcome to Instant's permission system!
+   * Right now your rules are empty. To start filling them in, check out the docs:
+   * https://www.instantdb.com/docs/permissions
+   *
+   * Here's an example to give you a feel:
+   * posts: {
+   *   allow: {
+   *     view: "true",
+   *     create: "isOwner",
+   *     update: "isOwner",
+   *     delete: "isOwner",
+   *   },
+   *   bind: {"isOwner": "auth.id != null && auth.id == data.ownerId"},
+   * },
+   */
+} satisfies InstantRules;
+
+export default rules;

--- a/examples/vue-vite/src/instant.schema.ts
+++ b/examples/vue-vite/src/instant.schema.ts
@@ -1,0 +1,46 @@
+// Docs: https://www.instantdb.com/docs/modeling-data
+
+import { i } from "@instantdb/vue";
+
+const _schema = i.schema({
+  entities: {
+    $files: i.entity({
+      path: i.string().unique().indexed(),
+      url: i.string(),
+    }),
+    $users: i.entity({
+      email: i.string().unique().indexed().optional(),
+      imageURL: i.string().optional(),
+      type: i.string().optional(),
+    }),
+    todos: i.entity({
+      createdAt: i.number(),
+      done: i.boolean(),
+      text: i.string(),
+    }),
+  },
+  links: {
+    $usersLinkedPrimaryUser: {
+      forward: {
+        on: "$users",
+        has: "one",
+        label: "linkedPrimaryUser",
+        onDelete: "cascade",
+      },
+      reverse: {
+        on: "$users",
+        has: "many",
+        label: "linkedGuestUsers",
+      },
+    },
+  },
+  rooms: {},
+});
+
+// This helps TypeScript display nicer intellisense
+type _AppSchema = typeof _schema;
+interface AppSchema extends _AppSchema {}
+const schema: AppSchema = _schema;
+
+export type { AppSchema };
+export default schema;

--- a/examples/vue-vite/src/lib/db.ts
+++ b/examples/vue-vite/src/lib/db.ts
@@ -1,0 +1,8 @@
+import { init } from "@instantdb/vue";
+import schema from "../instant.schema";
+
+export const db = init({
+  appId: import.meta.env.VITE_INSTANT_APP_ID!,
+  schema,
+  useDateObjects: true,
+});

--- a/examples/vue-vite/src/main.ts
+++ b/examples/vue-vite/src/main.ts
@@ -1,0 +1,6 @@
+import './assets/main.css';
+
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/vue-vite/tsconfig.app.json
+++ b/examples/vue-vite/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"],
+  "compilerOptions": {
+    // Path mapping for cleaner imports.
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  }
+}

--- a/examples/vue-vite/tsconfig.json
+++ b/examples/vue-vite/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/examples/vue-vite/tsconfig.node.json
+++ b/examples/vue-vite/tsconfig.node.json
@@ -1,0 +1,27 @@
+// TSConfig for modules that run in Node.js environment via either transpilation or type-stripping.
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "include": [
+    "vite.config.*",
+    "vitest.config.*",
+    "cypress.config.*",
+    "playwright.config.*",
+    "eslint.config.*"
+  ],
+  "compilerOptions": {
+    // Most tools use transpilation instead of Node.js's native type-stripping.
+    // Bundler mode provides a smoother developer experience.
+    "module": "preserve",
+    "moduleResolution": "bundler",
+
+    // Include Node.js types and avoid accidentally including other `@types/*` packages.
+    "types": ["node"],
+
+    // Disable emitting output during `vue-tsc --build`, which is used for type-checking only.
+    "noEmit": true,
+
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
+  }
+}

--- a/examples/vue-vite/vite.config.ts
+++ b/examples/vue-vite/vite.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueDevTools from 'vite-plugin-vue-devtools';
+import tailwindcss from '@tailwindcss/vite';
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [vue(), vueDevTools(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
Adds the public Vue + Vite example, the internal sandbox for testing against a local backend, and wires Vue into both `create-instant-app` and `instant-cli`.

Both apps mirror the structure of `npm create vue@latest --default --ts` (multi-tsconfig setup + `@vue/tsconfig` base + `vite-plugin-vue-devtools` + `@/` path alias + parallel `type-check`/`build-only` scripts via `npm-run-all2`), so future Vue scaffolding upgrades stay easy. Tailwind + InstantDB integration is layered on top.

## Example app (`examples/vue-vite/`)

Single-page Vue 3 + Vite SPA with todo CRUD and magic-code auth. Mirrors `examples/solidjs-vite/` and `examples/sveltekit/`:

- `<script setup>` Composition API
- `instant.schema.ts`, `instant.perms.ts`, `lib/db.ts`
- `VITE_INSTANT_APP_ID` env var
- Tailwind via `@tailwindcss/vite`
- `@instantdb/vue: "latest"` (resolves once published)

## Sandbox (`client/sandbox/vue-vite/`)

Vue 3 + Vite + `vue-router` SPA for testing against a local backend. Ephemeral app provisioning, no `.env` needed. Modeled after `sandbox/sveltekit/`:

| Route | Demo |
|---|---|
| `/` | Index with links to all routes |
| `/todos` | Todo CRUD |
| `/infinite-scroll` | `db.useInfiniteQuery` exercise (mirrors the Svelte one from #2654) |
| `/auth` | `SignedIn` / `SignedOut` component test with magic-code flow |
| `/cursors` | Multiplayer `Cursors` component test |

Uses `@instantdb/vue: "workspace:*"` to develop against the local SDK.

| | Example (`examples/vue-vite/`) | Sandbox (`sandbox/vue-vite/`) |
|---|---|---|
| Purpose | Public template for `create-instant-app` | Local dev testing against port 8888 |
| DB setup | `init()` with env var app ID | Ephemeral app provisioning |
| Package ref | `@instantdb/vue: "latest"` | `workspace:*` |
| Routing | None (single-page todo app) | `vue-router` with 5 routes |

## `create-instant-app` integration

- `cli.ts`: added `'vue-vite'` to `Project['base']` union, `.choices()` array, `Vite: Vue` UI selector entry, and `--vue` shorthand flag
- `env.ts`: mapped `vue-vite` → `VITE_INSTANT_APP_ID`
- `copyExamples.ts`: added `'vue-vite'` to `EXAMPLES_TO_COPY`

`npx create-instant-app --vue` will scaffold this template once published.

## `instant-cli` integration

When a user runs `npx instant-cli init` in a Vue project, the CLI now offers `@instantdb/vue` in the SDK picker and can load `instant.schema.ts` files that import from it. Three small changes:

- `packages/cli/src/context/projectInfo.ts`: added `vue: '@instantdb/vue'` to `PACKAGE_ALIAS_AND_FULL_NAMES`, added an option to the SDK Select prompt, and added `@instantdb/vue` to the auto-detect list (`getInstantModuleName`).
- `packages/cli/src/util/findConfigCandidates.ts`: added a rewrite rule so schema files that `import { i } from '@instantdb/vue'` are routed through `@instantdb/vue/dist/cli` when loaded in Node — same pattern as Svelte/React Native, needed because our `index.ts` re-exports `.vue` SFCs that Node can't parse.
- `packages/cli/src/util/loadConfig.ts`: added `@instantdb/vue` to the Deno alias map so Deno projects also resolve cleanly.

The matching shim (`@instantdb/vue/dist/cli`) is added in PR 1 as a single-line `export * from '@instantdb/core'` file.

## Test plan

- [x] `pnpm test` still passes in `packages/vue/` (32 tests)
- [x] `pnpm type-check` clean in both sandbox and example (`vue-tsc --build` via project references)
- [x] `pnpm build` succeeds in the sandbox (Vite production build)
- [x] Sandbox dev server boots and all routes return 200
- [ ] `/auth` route: SignedIn/SignedOut components toggle correctly with magic code flow
- [ ] `/cursors` route: cursors appear across multiple tabs
- [ ] `/infinite-scroll` route: pagination and "Load more" behave as expected
- [ ] `npx create-instant-app --vue` scaffolds a working Vue project (once published)
- [ ] `npx instant-cli init` in a Vue project shows `@instantdb/vue` in the SDK picker and can `pull`/`push` schema files that import from `@instantdb/vue` (once published)