### PR TITLE
Fix the dockerfile for the mcp server

### DIFF
--- a/client/Dockerfile.mcp
+++ b/client/Dockerfile.mcp
@@ -14,7 +14,7 @@ WORKDIR /app
 #  creates a directory with just the packages we need to build mcp
 FROM base AS prune
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.2.0 --activate
 
 RUN pnpm install --global turbo@2.5.4
 
@@ -29,7 +29,7 @@ FROM base AS deps
 
 WORKDIR /app
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.2.0 --activate
 
 COPY --from=prune /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=prune /app/out/json/ .
@@ -45,7 +45,7 @@ RUN ls packages/mcp/node_modules
 FROM base AS build
 
 WORKDIR /app
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.2.0 --activate
 
 # Copy pruned lockfile and package.json snapshots
 COPY --from=prune /app/out/pnpm-lock.yaml ./pnpm-lock.yaml

--- a/client/Dockerfile.mcp
+++ b/client/Dockerfile.mcp
@@ -14,7 +14,7 @@ WORKDIR /app
 #  creates a directory with just the packages we need to build mcp
 FROM base AS prune
 
-RUN corepack enable && corepack prepare pnpm@10.2.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33 --activate
 
 RUN pnpm install --global turbo@2.5.4
 
@@ -29,7 +29,7 @@ FROM base AS deps
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@10.2.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33 --activate
 
 COPY --from=prune /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=prune /app/out/json/ .
@@ -45,7 +45,7 @@ RUN ls packages/mcp/node_modules
 FROM base AS build
 
 WORKDIR /app
-RUN corepack enable && corepack prepare pnpm@10.2.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.33 --activate
 
 # Copy pruned lockfile and package.json snapshots
 COPY --from=prune /app/out/pnpm-lock.yaml ./pnpm-lock.yaml

--- a/client/Dockerfile.mcp
+++ b/client/Dockerfile.mcp
@@ -84,6 +84,9 @@ COPY --from=build --chown=mcp:nodejs /app/packages/core/dist packages/core/dist
 COPY --from=build --chown=mcp:nodejs /app/packages/admin/package.json packages/admin/package.json
 COPY --from=build --chown=mcp:nodejs /app/packages/admin/dist packages/admin/dist
 
+COPY --from=build --chown=mcp:nodejs /app/packages/webhooks/package.json packages/webhooks/package.json
+COPY --from=build --chown=mcp:nodejs /app/packages/webhooks/dist packages/webhooks/dist
+
 COPY --from=build --chown=mcp:nodejs /app/packages/platform/package.json packages/platform/package.json
 COPY --from=build --chown=mcp:nodejs /app/packages/platform/dist packages/platform/dist
 
@@ -91,6 +94,7 @@ COPY --from=build --chown=mcp:nodejs /app/packages/platform/dist packages/platfo
 COPY --from=deps --chown=mcp:nodejs  /app/packages/mcp/node_modules packages/mcp/node_modules
 COPY --from=deps --chown=mcp:nodejs  /app/packages/core/node_modules packages/core/node_modules
 COPY --from=deps --chown=mcp:nodejs  /app/packages/admin/node_modules packages/admin/node_modules
+COPY --from=deps --chown=mcp:nodejs  /app/packages/webhooks/node_modules packages/webhooks/node_modules
 COPY --from=deps --chown=mcp:nodejs  /app/packages/platform/node_modules packages/platform/node_modules
 COPY --from=deps --chown=mcp:nodejs  /app/node_modules node_modules
 


### PR DESCRIPTION
It requires us to manually copy over the new webhook dependency.

Tested locally and seemed to work. I had to add the `corepack prepare pnpm@10.2.0 --activate` lines to make it build on my machine.