### PR TITLE
Fix webhooks for system catalog attrs

### DIFF
--- a/server/resources/migrations/110_triples_triggers_include_system_catalog.down.sql
+++ b/server/resources/migrations/110_triples_triggers_include_system_catalog.down.sql
@@ -1,0 +1,220 @@
+create or replace function triples_update_batch_trigger()
+returns trigger as $$
+declare
+  ents_msg text;
+  app_id_setting uuid;
+  log_to_table_setting boolean;
+begin
+  -- Don't let this trigger cause itself to fire. We let it fire
+  -- twice because postgres 16 has some bug (fixed in 17) where
+  -- pg_column_size on insert is different than pg_column_size on
+  -- update, possibly due to how it handles nulls? If that happens,
+  -- then the second time it fires it will get the right value.
+  if pg_trigger_depth() > 2 then
+    return null;
+  end if;
+
+  if pg_trigger_depth() <= 1 then
+    -- Update sweeper with deleted files
+    with old_files as (
+      select app_id, value #>> '{}' as location_id
+       from oldrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    ), new_files as (
+      select app_id, value #>> '{}' as location_id
+       from newrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    )
+    insert into app_files_to_sweep (app_id, location_id)
+      select o.app_id, o.location_id
+      from old_files o
+      left join new_files n
+             on o.app_id = n.app_id
+            and o.location_id = n.location_id
+          where o.location_id is not null and n.location_id is null
+      on conflict do nothing;
+
+
+  end if;
+
+  select case current_setting('instant.wal_msg_app_id', true)
+           when null then null
+           when '' then null
+           else current_setting('instant.wal_msg_app_id', true)::uuid
+         end
+    into app_id_setting;
+
+  if app_id_setting is not null then
+
+    -- Write the entities to the wal
+    with by_etype as (
+      -- Forward entities
+      select a.etype, n.entity_id
+        from newrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id = app_id_setting
+      union
+      -- Ref entities
+      select a.reverse_etype etype, json_uuid_to_uuid(n.value) entity_id
+        from newrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id = app_id_setting
+       where n.vae
+    ),
+    etypes as (
+      select distinct etype from by_etype
+    ),
+    -- Map of etype to attr
+    attr_map as (
+      select a.etype, a.id
+        from attrs a
+        join etypes e on e.etype = a.etype
+       where a.app_id = app_id_setting
+         and a.cardinality = 'one'
+    ),
+    -- Get all of the ents, grouped by etype and entity_id
+    by_entity as (
+      select e.etype,
+             t.entity_id,
+             json_object_agg(t.attr_id::text, t.value) as attrs
+        from triples t
+        join by_etype e
+          on t.entity_id = e.entity_id
+        join attr_map a
+          on a.etype = e.etype
+         and t.attr_id = a.id
+       where t.app_id = app_id_setting
+         and t.ea
+       group by e.etype, t.entity_id
+    )
+    select json_agg(json_build_array(etype, entity_id, attrs))::text
+      into ents_msg
+      from by_entity;
+
+    select case current_setting('instant.wal_msg_log_to_table', true)
+             when null then null
+             when '' then null
+             else current_setting('instant.wal_msg_log_to_table', true)::boolean
+           end
+      into log_to_table_setting;
+
+
+    if ents_msg is not null then
+      if log_to_table_setting is not null and log_to_table_setting then
+        insert into wal_logs (id, created_at, hour_bucket, prefix, content)
+             values (gen_random_uuid(), now(), date_part('hour', now() at time zone 'UTC')::int % 8, 'update_ents', ents_msg);
+      else
+        perform pg_logical_emit_message(true, 'update_ents', ents_msg);
+      end if;
+    end if;
+  end if;
+
+  update triples t
+     set pg_size = public.triples_column_size(t)
+    from newrows s
+  where s.app_id = t.app_id
+    and s.entity_id = t.entity_id
+    and s.attr_id = t.attr_id
+    and s.value_md5 = t.value_md5
+    and public.triples_column_size(t) is distinct from t.pg_size;
+
+  return null;
+end;
+$$ language plpgsql;
+
+
+create or replace function triples_delete_batch_trigger()
+returns trigger as $$
+declare
+  ents_msg text;
+  app_id_setting uuid;
+  log_to_table_setting boolean;
+begin
+  -- Update sweeper with deleted files
+  insert into app_files_to_sweep (app_id, location_id)
+    select app_id, value #>> '{}' as location_id
+    from oldrows
+    -- This should match the attr_id for $files.location-id
+    where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    on conflict do nothing;
+
+  select case current_setting('instant.wal_msg_app_id', true)
+           when null then null
+           when '' then null
+           else current_setting('instant.wal_msg_app_id', true)::uuid
+         end
+    into app_id_setting;
+
+  if app_id_setting is not null then
+
+    -- Write the entities to the wal
+    with by_etype as (
+      -- Forward entities
+      select a.etype, n.entity_id
+        from oldrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id = app_id_setting
+      union
+      -- Ref entities
+      select a.reverse_etype etype, json_uuid_to_uuid(n.value) entity_id
+        from oldrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id = app_id_setting
+       where n.vae
+    ),
+    etypes as (
+      select distinct etype from by_etype
+    ),
+    -- Map of etype to attr
+    attr_map as (
+      select a.etype, a.id
+        from attrs a
+        join etypes e on e.etype = a.etype
+       where a.app_id = app_id_setting
+         and a.cardinality = 'one'
+    ),
+    -- Get all of the ents, grouped by etype and entity_id
+    by_entity as (
+      select e.etype,
+             t.entity_id,
+             json_object_agg(t.attr_id::text, t.value) as attrs
+        from triples t
+        join by_etype e
+          on t.entity_id = e.entity_id
+        join attr_map a
+          on a.etype = e.etype
+         and t.attr_id = a.id
+       where t.app_id = app_id_setting
+         and t.ea
+       group by e.etype, t.entity_id
+    )
+    select json_agg(json_build_array(etype, entity_id, attrs))::text
+      into ents_msg
+      from by_entity;
+
+    select case current_setting('instant.wal_msg_log_to_table', true)
+             when null then null
+             when '' then null
+             else current_setting('instant.wal_msg_log_to_table', true)::boolean
+           end
+      into log_to_table_setting;
+
+
+    if ents_msg is not null then
+      if log_to_table_setting is not null and log_to_table_setting then
+        insert into wal_logs (id, created_at, hour_bucket, prefix, content)
+             values (gen_random_uuid(), now(), date_part('hour', now() at time zone 'UTC')::int % 8, 'delete_ents', ents_msg);
+      else
+        perform pg_logical_emit_message(true, 'delete_ents', ents_msg);
+      end if;
+    end if;
+  end if;
+
+
+  return null;
+end;
+$$ language plpgsql;

--- a/server/resources/migrations/110_triples_triggers_include_system_catalog.up.sql
+++ b/server/resources/migrations/110_triples_triggers_include_system_catalog.up.sql
@@ -1,0 +1,220 @@
+create or replace function triples_update_batch_trigger()
+returns trigger as $$
+declare
+  ents_msg text;
+  app_id_setting uuid;
+  log_to_table_setting boolean;
+begin
+  -- Don't let this trigger cause itself to fire. We let it fire
+  -- twice because postgres 16 has some bug (fixed in 17) where
+  -- pg_column_size on insert is different than pg_column_size on
+  -- update, possibly due to how it handles nulls? If that happens,
+  -- then the second time it fires it will get the right value.
+  if pg_trigger_depth() > 2 then
+    return null;
+  end if;
+
+  if pg_trigger_depth() <= 1 then
+    -- Update sweeper with deleted files
+    with old_files as (
+      select app_id, value #>> '{}' as location_id
+       from oldrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    ), new_files as (
+      select app_id, value #>> '{}' as location_id
+       from newrows
+       where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    )
+    insert into app_files_to_sweep (app_id, location_id)
+      select o.app_id, o.location_id
+      from old_files o
+      left join new_files n
+             on o.app_id = n.app_id
+            and o.location_id = n.location_id
+          where o.location_id is not null and n.location_id is null
+      on conflict do nothing;
+
+
+  end if;
+
+  select case current_setting('instant.wal_msg_app_id', true)
+           when null then null
+           when '' then null
+           else current_setting('instant.wal_msg_app_id', true)::uuid
+         end
+    into app_id_setting;
+
+  if app_id_setting is not null then
+
+    -- Write the entities to the wal
+    with by_etype as (
+      -- Forward entities
+      select a.etype, n.entity_id
+        from newrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
+      union
+      -- Ref entities
+      select a.reverse_etype etype, json_uuid_to_uuid(n.value) entity_id
+        from newrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
+       where n.vae
+    ),
+    etypes as (
+      select distinct etype from by_etype
+    ),
+    -- Map of etype to attr
+    attr_map as (
+      select a.etype, a.id
+        from attrs a
+        join etypes e on e.etype = a.etype
+       where a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
+         and a.cardinality = 'one'
+    ),
+    -- Get all of the ents, grouped by etype and entity_id
+    by_entity as (
+      select e.etype,
+             t.entity_id,
+             json_object_agg(t.attr_id::text, t.value) as attrs
+        from triples t
+        join by_etype e
+          on t.entity_id = e.entity_id
+        join attr_map a
+          on a.etype = e.etype
+         and t.attr_id = a.id
+       where t.app_id = app_id_setting
+         and t.ea
+       group by e.etype, t.entity_id
+    )
+    select json_agg(json_build_array(etype, entity_id, attrs))::text
+      into ents_msg
+      from by_entity;
+
+    select case current_setting('instant.wal_msg_log_to_table', true)
+             when null then null
+             when '' then null
+             else current_setting('instant.wal_msg_log_to_table', true)::boolean
+           end
+      into log_to_table_setting;
+
+
+    if ents_msg is not null then
+      if log_to_table_setting is not null and log_to_table_setting then
+        insert into wal_logs (id, created_at, hour_bucket, prefix, content)
+             values (gen_random_uuid(), now(), date_part('hour', now() at time zone 'UTC')::int % 8, 'update_ents', ents_msg);
+      else
+        perform pg_logical_emit_message(true, 'update_ents', ents_msg);
+      end if;
+    end if;
+  end if;
+
+  update triples t
+     set pg_size = public.triples_column_size(t)
+    from newrows s
+  where s.app_id = t.app_id
+    and s.entity_id = t.entity_id
+    and s.attr_id = t.attr_id
+    and s.value_md5 = t.value_md5
+    and public.triples_column_size(t) is distinct from t.pg_size;
+
+  return null;
+end;
+$$ language plpgsql;
+
+
+create or replace function triples_delete_batch_trigger()
+returns trigger as $$
+declare
+  ents_msg text;
+  app_id_setting uuid;
+  log_to_table_setting boolean;
+begin
+  -- Update sweeper with deleted files
+  insert into app_files_to_sweep (app_id, location_id)
+    select app_id, value #>> '{}' as location_id
+    from oldrows
+    -- This should match the attr_id for $files.location-id
+    where attr_id = '96653230-13ff-ffff-2a34-b40fffffffff'
+    on conflict do nothing;
+
+  select case current_setting('instant.wal_msg_app_id', true)
+           when null then null
+           when '' then null
+           else current_setting('instant.wal_msg_app_id', true)::uuid
+         end
+    into app_id_setting;
+
+  if app_id_setting is not null then
+
+    -- Write the entities to the wal
+    with by_etype as (
+      -- Forward entities
+      select a.etype, n.entity_id
+        from oldrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
+      union
+      -- Ref entities
+      select a.reverse_etype etype, json_uuid_to_uuid(n.value) entity_id
+        from oldrows n
+        join attrs a
+          on n.attr_id = a.id
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
+       where n.vae
+    ),
+    etypes as (
+      select distinct etype from by_etype
+    ),
+    -- Map of etype to attr
+    attr_map as (
+      select a.etype, a.id
+        from attrs a
+        join etypes e on e.etype = a.etype
+       where a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
+         and a.cardinality = 'one'
+    ),
+    -- Get all of the ents, grouped by etype and entity_id
+    by_entity as (
+      select e.etype,
+             t.entity_id,
+             json_object_agg(t.attr_id::text, t.value) as attrs
+        from triples t
+        join by_etype e
+          on t.entity_id = e.entity_id
+        join attr_map a
+          on a.etype = e.etype
+         and t.attr_id = a.id
+       where t.app_id = app_id_setting
+         and t.ea
+       group by e.etype, t.entity_id
+    )
+    select json_agg(json_build_array(etype, entity_id, attrs))::text
+      into ents_msg
+      from by_entity;
+
+    select case current_setting('instant.wal_msg_log_to_table', true)
+             when null then null
+             when '' then null
+             else current_setting('instant.wal_msg_log_to_table', true)::boolean
+           end
+      into log_to_table_setting;
+
+
+    if ents_msg is not null then
+      if log_to_table_setting is not null and log_to_table_setting then
+        insert into wal_logs (id, created_at, hour_bucket, prefix, content)
+             values (gen_random_uuid(), now(), date_part('hour', now() at time zone 'UTC')::int % 8, 'delete_ents', ents_msg);
+      else
+        perform pg_logical_emit_message(true, 'delete_ents', ents_msg);
+      end if;
+    end if;
+  end if;
+
+
+  return null;
+end;
+$$ language plpgsql;

--- a/server/src/instant/model/webhook.clj
+++ b/server/src/instant/model/webhook.clj
@@ -9,6 +9,7 @@
    [instant.jdbc.sql :as sql]
    [instant.model.history :as history]
    [instant.reactive.topics :as topics]
+   [instant.storage.s3 :as s3]
    [instant.system-catalog :as system-catalog]
    [instant.util.cache :as cache]
    [instant.util.coll :as ucoll]
@@ -787,6 +788,21 @@
     (.update digest (isn/->bytes isn))
     (uuid-util/<-bytes (.digest digest))))
 
+(defn add-file-urls [app-id result]
+  (let [;; memoized function so that before and after
+        ;; get the same url if they have the same location-id
+        create-file-url (vmemoize (fn [location-id]
+                                    (s3/create-signed-download-url! app-id location-id)))]
+    (-> result
+        (update :before (fn [o]
+                          (if-let [location-id (get o "location-id")]
+                            (assoc o "url" (create-file-url location-id))
+                            o)))
+        (update :after (fn [o]
+                         (if-let [location-id (get o "location-id")]
+                           (assoc o "url" (create-file-url location-id))
+                           o))))))
+
 (defn webhook-data-for-wal-record
   "Returns a list of records:
    [{etype: <etype>
@@ -816,31 +832,37 @@
                         after (uuids->labels attrs ent)]
                   ;; Filters out the updates where we only add or remove a link,
                   ;; we currently don't support webhooks for linking
-                  :when (not= before after)]
-              {:etype etype
-               :action action
-               :id id
-               :before before
-               :after after
-               :idempotencyKey (record-idempotency-key {:etype etype
-                                                        :action action
-                                                        :id id
-                                                        :isn (:isn wal-record)})})
+                  :when (not= before after)
+                  :let [result {:etype etype
+                                :action action
+                                :id id
+                                :before before
+                                :after after
+                                :idempotencyKey (record-idempotency-key {:etype etype
+                                                                         :action action
+                                                                         :id id
+                                                                         :isn (:isn wal-record)})}]]
+              (if (= etype "$files")
+                (add-file-urls (:app-id wal-record) result)
+                result))
             (for [[etype ents] ents-before
                   [id ent] ents
                   :when (and (not (get-in ents-after [etype id]))
                              (etypes etype)
                              (actions "delete"))
-                  :let [id (parse-uuid id)]]
-              {:etype etype
-               :action "delete"
-               :id id
-               :before (uuids->labels attrs ent)
-               :after nil
-               :idempotencyKey (record-idempotency-key {:etype etype
-                                                        :action "delete"
-                                                        :id id
-                                                        :isn (:isn wal-record)})}))))
+                  :let [id (parse-uuid id)
+                        result {:etype etype
+                                :action "delete"
+                                :id id
+                                :before (uuids->labels attrs ent)
+                                :after nil
+                                :idempotencyKey (record-idempotency-key {:etype etype
+                                                                         :action "delete"
+                                                                         :id id
+                                                                         :isn (:isn wal-record)})}]]
+              (if (= etype "$files")
+                (add-file-urls (:app-id wal-record) result)
+                result)))))
 
 (defn webhook-data-for-isn
   "Returns a list of records:

--- a/server/test/instant/model/webhook_test.clj
+++ b/server/test/instant/model/webhook_test.clj
@@ -863,6 +863,9 @@
                         (or (= aid (:id app)) (enable-wal-entity-log? aid)))
                       flags/log-to-wal-log-table?
                       (constantly true)]
+         (test-util/with-s3-mock {:location-id-url
+                                  (fn [_app-id location-id]
+                                    (str "https://test.invalid/" location-id))}
           (let [attrs (attr-model/get-by-app-id (:id app))
                 users-id-aid (system-catalog/get-attr-id "$users" "id")
                 users-email-aid (system-catalog/get-attr-id "$users" "email")
@@ -1054,7 +1057,7 @@
                         files-only {:etypes ["$files"]
                                     :actions ["create" "update" "delete"]}]
                     (is (empty? (webhook/webhook-data-for-wal-record users-only file-insert)))
-                    (is (empty? (webhook/webhook-data-for-wal-record files-only user-insert)))))))))))))
+                    (is (empty? (webhook/webhook-data-for-wal-record files-only user-insert))))))))))))))
 
 ;; We don't support links yet
 (deftest webhook-matches?-doesn't-match-for-links

--- a/server/test/instant/model/webhook_test.clj
+++ b/server/test/instant/model/webhook_test.clj
@@ -11,6 +11,7 @@
    [instant.jdbc.sql :as sql]
    [instant.model.history :as history]
    [instant.model.webhook :as webhook]
+   [instant.system-catalog :as system-catalog]
    [instant.util.crypt :as crypt-util]
    [instant.util.hsql :as uhsql]
    [instant.util.json :as json]
@@ -852,6 +853,208 @@
                                 :actions ["delete"]}]
                       (is (empty? (webhook/webhook-data-for-wal-record hook insert-rec)))
                       (is (empty? (webhook/webhook-data-for-wal-record hook update-rec))))))))))))))
+
+(deftest webhook-matches?-system-catalog-test
+  (with-empty-app
+    (fn [app]
+      (let [enable-wal-entity-log? (var-get #'flags/enable-wal-entity-log?)]
+        (with-redefs [flags/enable-wal-entity-log?
+                      (fn [aid]
+                        (or (= aid (:id app)) (enable-wal-entity-log? aid)))
+                      flags/log-to-wal-log-table?
+                      (constantly true)]
+          (let [attrs (attr-model/get-by-app-id (:id app))
+                users-id-aid (system-catalog/get-attr-id "$users" "id")
+                users-email-aid (system-catalog/get-attr-id "$users" "email")
+                files-id-aid (system-catalog/get-attr-id "$files" "id")
+                files-path-aid (system-catalog/get-attr-id "$files" "path")
+                files-size-aid (system-catalog/get-attr-id "$files" "size")
+                files-loc-aid (system-catalog/get-attr-id "$files" "location-id")
+                user-id (test-util/stuid "ua")
+                file-id (test-util/stuid "fa")
+                other-aid (random-uuid)
+                for-app (fn [recs] (filter #(= (:id app) (:app-id %)) recs))]
+            (test-util/with-test-replication-slot [records]
+              ;; --- $users txs ---
+              ;; Tx 1: insert $users (id + email)
+              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                            [[:add-triple user-id users-id-aid (str user-id)]
+                             [:add-triple user-id users-email-aid "alice@example.com"]])
+              ;; Tx 2: update email
+              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                            [[:add-triple user-id users-email-aid "bob@example.com"]])
+              ;; Tx 3: delete user
+              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                            [[:delete-entity user-id "$users"]])
+              ;; --- $files txs ---
+              ;; Tx 4: insert $files (id + path + size + location-id)
+              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                            [[:add-triple file-id files-id-aid (str file-id)]
+                             [:add-triple file-id files-path-aid "first.png"]
+                             [:add-triple file-id files-size-aid 100]
+                             [:add-triple file-id files-loc-aid "loc-1"]])
+              ;; Tx 5: update path
+              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                            [[:add-triple file-id files-path-aid "second.png"]])
+              ;; Tx 6: delete file
+              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                            [[:delete-entity file-id "$files"]])
+              (test-util/wait-for #(<= 6 (count (for-app @records))) 5000)
+              (let [[user-insert user-update user-delete
+                     file-insert file-update file-delete] (vec (for-app @records))]
+                (testing "$users"
+                  (testing "create matches insert touching $users.id"
+                    (is (boolean (webhook/webhook-matches?
+                                  user-insert
+                                  {:id_attr_ids [users-id-aid]
+                                   :actions ["create"]}))))
+                  (testing "create does not match other txs"
+                    (is (nil? (webhook/webhook-matches?
+                               user-update
+                               {:id_attr_ids [users-id-aid]
+                                :actions ["create"]})))
+                    (is (nil? (webhook/webhook-matches?
+                               user-delete
+                               {:id_attr_ids [users-id-aid]
+                                :actions ["create"]}))))
+                  (testing "create does not match when id_attr_ids excludes touched attrs"
+                    (is (nil? (webhook/webhook-matches?
+                               user-insert
+                               {:id_attr_ids [other-aid]
+                                :actions ["create"]}))))
+                  (testing "update matches update touching $users.email"
+                    (is (boolean (webhook/webhook-matches?
+                                  user-update
+                                  {:id_attr_ids [users-email-aid]
+                                   :actions ["update"]}))))
+                  (testing "update does not match when id_attr_ids only references untouched attrs"
+                    (is (nil? (webhook/webhook-matches?
+                               user-update
+                               {:id_attr_ids [users-id-aid]
+                                :actions ["update"]}))))
+                  (testing "delete matches delete touching $users.id"
+                    (is (boolean (webhook/webhook-matches?
+                                  user-delete
+                                  {:id_attr_ids [users-id-aid]
+                                   :actions ["delete"]})))))
+
+                (testing "$files"
+                  (testing "create matches insert touching $files.id"
+                    (is (boolean (webhook/webhook-matches?
+                                  file-insert
+                                  {:id_attr_ids [files-id-aid]
+                                   :actions ["create"]}))))
+                  (testing "create does not match other txs"
+                    (is (nil? (webhook/webhook-matches?
+                               file-update
+                               {:id_attr_ids [files-id-aid]
+                                :actions ["create"]})))
+                    (is (nil? (webhook/webhook-matches?
+                               file-delete
+                               {:id_attr_ids [files-id-aid]
+                                :actions ["create"]}))))
+                  (testing "update matches update touching $files.path"
+                    (is (boolean (webhook/webhook-matches?
+                                  file-update
+                                  {:id_attr_ids [files-path-aid]
+                                   :actions ["update"]}))))
+                  (testing "update does not match when id_attr_ids only references untouched attrs"
+                    (is (nil? (webhook/webhook-matches?
+                               file-update
+                               {:id_attr_ids [files-size-aid]
+                                :actions ["update"]}))))
+                  (testing "delete matches delete touching $files.id"
+                    (is (boolean (webhook/webhook-matches?
+                                  file-delete
+                                  {:id_attr_ids [files-id-aid]
+                                   :actions ["delete"]})))))
+
+                (testing "webhook-data-for-wal-record on $users"
+                  (let [hook {:etypes ["$users"]
+                              :actions ["create" "update" "delete"]}]
+                    (testing "insert produces a create record"
+                      (let [data (webhook/webhook-data-for-wal-record hook user-insert)]
+                        (is (= 1 (count data)))
+                        (let [{:keys [etype action id before after]} (first data)]
+                          (is (= "$users" etype))
+                          (is (= "create" action))
+                          (is (= user-id id))
+                          (is (nil? before))
+                          (is (= {"id" (str user-id) "email" "alice@example.com"} after)))))
+                    (testing "update produces an update record"
+                      (let [data (webhook/webhook-data-for-wal-record hook user-update)]
+                        (is (= 1 (count data)))
+                        (let [{:keys [etype action id before after]} (first data)]
+                          (is (= "$users" etype))
+                          (is (= "update" action))
+                          (is (= user-id id))
+                          (is (= {"id" (str user-id) "email" "alice@example.com"} before))
+                          (is (= {"id" (str user-id) "email" "bob@example.com"} after)))))
+                    (testing "delete produces a delete record"
+                      (let [data (webhook/webhook-data-for-wal-record hook user-delete)]
+                        (is (= 1 (count data)))
+                        (let [{:keys [etype action id before after]} (first data)]
+                          (is (= "$users" etype))
+                          (is (= "delete" action))
+                          (is (= user-id id))
+                          (is (= {"id" (str user-id) "email" "bob@example.com"} before))
+                          (is (nil? after)))))))
+
+                (testing "webhook-data-for-wal-record on $files"
+                  (let [hook {:etypes ["$files"]
+                              :actions ["create" "update" "delete"]}
+                        full-file {"id" (str file-id)
+                                   "path" "first.png"
+                                   "size" 100
+                                   "location-id" "loc-1"}]
+                    (testing "insert produces a create record"
+                      (let [data (webhook/webhook-data-for-wal-record hook file-insert)]
+                        (is (= 1 (count data)))
+                        (let [{:keys [etype action id before after]} (first data)]
+                          (is (= "$files" etype))
+                          (is (= "create" action))
+                          (is (= file-id id))
+                          (is (nil? before))
+                          (is (string? (get after "url")))
+                          (is (= full-file (dissoc after "url"))))))
+                    (testing "update produces an update record"
+                      (let [data (webhook/webhook-data-for-wal-record hook file-update)]
+                        (is (= 1 (count data)))
+                        (let [{:keys [etype action id before after]} (first data)]
+                          (is (= "$files" etype))
+                          (is (= "update" action))
+                          (is (= file-id id))
+                          (is (string? (get before "url")))
+                          (is (= full-file (dissoc before "url")))
+                          (is (string? (get after "url")))
+                          (is (= (get after "url")
+                                 (get before "url")))
+                          (is (= (assoc full-file "path" "second.png") (dissoc after "url"))))))
+                    (testing "delete produces a delete record"
+                      (let [data (webhook/webhook-data-for-wal-record hook file-delete)]
+                        (is (= 1 (count data)))
+                        (let [{:keys [etype action id before after]} (first data)]
+                          (is (= "$files" etype))
+                          (is (= "delete" action))
+                          (is (= file-id id))
+                          (is (string? (get before "url")))
+                          (is (= (assoc full-file "path" "second.png") (dissoc before "url")))
+                          (is (nil? after)))))))
+
+                (testing "non-matching etype returns no records"
+                  (let [hook {:etypes ["other"]
+                              :actions ["create" "update" "delete"]}]
+                    (doseq [rec [user-insert user-update user-delete
+                                 file-insert file-update file-delete]]
+                      (is (empty? (webhook/webhook-data-for-wal-record hook rec))))))
+
+                (testing "etype filter isolates $users from $files"
+                  (let [users-only {:etypes ["$users"]
+                                    :actions ["create" "update" "delete"]}
+                        files-only {:etypes ["$files"]
+                                    :actions ["create" "update" "delete"]}]
+                    (is (empty? (webhook/webhook-data-for-wal-record users-only file-insert)))
+                    (is (empty? (webhook/webhook-data-for-wal-record files-only user-insert)))))))))))))
 
 ;; We don't support links yet
 (deftest webhook-matches?-doesn't-match-for-links


### PR DESCRIPTION
Fixes the webhooks for $files and $users. 

The wal log wasn't getting the attrs that belonged to the system catalog app, which caused us to think that there were no changes.

This also adds the `url` field to the `$files` records.

Here is the diff against the current functions:

```diff
diff -u 97_wal_logs_table.up.sql 110_triples_triggers_include_system_catalog.up.sql
--- 97_wal_logs_table.up.sql 
+++ 110_triples_triggers_include_system_catalog.up.sql
@@ -53,14 +53,14 @@
         from newrows n
         join attrs a
           on n.attr_id = a.id
-         and a.app_id = app_id_setting
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
       union
       -- Ref entities
       select a.reverse_etype etype, json_uuid_to_uuid(n.value) entity_id
         from newrows n
         join attrs a
           on n.attr_id = a.id
-         and a.app_id = app_id_setting
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
        where n.vae
     ),
     etypes as (
@@ -71,7 +71,7 @@
       select a.etype, a.id
         from attrs a
         join etypes e on e.etype = a.etype
-       where a.app_id = app_id_setting
+       where a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
          and a.cardinality = 'one'
     ),
     -- Get all of the ents, grouped by etype and entity_id
@@ -156,14 +156,14 @@
         from oldrows n
         join attrs a
           on n.attr_id = a.id
-         and a.app_id = app_id_setting
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
       union
       -- Ref entities
       select a.reverse_etype etype, json_uuid_to_uuid(n.value) entity_id
         from oldrows n
         join attrs a
           on n.attr_id = a.id
-         and a.app_id = app_id_setting
+         and a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
        where n.vae
     ),
     etypes as (
@@ -174,7 +174,7 @@
       select a.etype, a.id
         from attrs a
         join etypes e on e.etype = a.etype
-       where a.app_id = app_id_setting
+       where a.app_id in (app_id_setting, 'a1111111-1111-1111-1111-111111111ca7')
          and a.cardinality = 'one'
     ),
     -- Get all of the ents, grouped by etype and entity_id
```     