### PR TITLE
Webhooks dash improvements

### DIFF
--- a/client/www/components/dash/WebhookEvents.tsx
+++ b/client/www/components/dash/WebhookEvents.tsx
@@ -1,4 +1,11 @@
-import React, { useContext, useEffect, useId, useMemo, useState } from 'react';
+import React, {
+  Fragment,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
 import Link from 'next/link';
 import { ChevronRightIcon } from '@heroicons/react/24/solid';
 
@@ -19,9 +26,11 @@ import {
   InstantWebhookEventsPage,
   InstantWebhookPayload,
   InstantWebhookPayloadRecord,
+  SchemaNamespace,
 } from '@/lib/types';
 import { Button, Content, SectionHeading } from '@/components/ui';
 import { useReadyRouter } from '@/components/clientOnlyPage';
+import { CopyableText, WebhookActionsMenu } from '@/components/dash/Webhooks';
 import {
   Tabs,
   TabsContent,
@@ -29,6 +38,8 @@ import {
   TabsTrigger,
 } from '@/components/components/ui/tabs';
 import { Card, CardContent } from '@/components/components/ui/card';
+
+const ALL_ACTIONS: InstantWebhookAction[] = ['create', 'update', 'delete'];
 
 // ---- Data ----
 
@@ -684,9 +695,13 @@ function eventDetailHref(
 export function WebhookEventsPage({
   app,
   webhook,
+  namespaces,
+  onChanged,
 }: {
   app: InstantApp;
   webhook: InstantWebhook;
+  namespaces: SchemaNamespace[] | null;
+  onChanged: () => void;
 }) {
   const router = useReadyRouter();
   const focusedIsn =
@@ -703,7 +718,15 @@ export function WebhookEventsPage({
     );
   }
 
-  return <EventsListPage app={app} webhook={webhook} router={router} />;
+  return (
+    <EventsListPage
+      app={app}
+      webhook={webhook}
+      namespaces={namespaces}
+      onChanged={onChanged}
+      router={router}
+    />
+  );
 }
 
 function FocusedEventPage({
@@ -760,10 +783,14 @@ function FocusedEventPage({
 function EventsListPage({
   app,
   webhook,
+  namespaces,
+  onChanged,
   router,
 }: {
   app: InstantApp;
   webhook: InstantWebhook;
+  namespaces: SchemaNamespace[] | null;
+  onChanged: () => void;
   router: ReturnType<typeof useReadyRouter>;
 }) {
   const {
@@ -778,38 +805,57 @@ function EventsListPage({
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 p-6">
-      <div className="flex flex-row items-center gap-1">
-        <Link href={webhooksHref(router)} className="underline">
-          <SectionHeading>Webhooks</SectionHeading>
-        </Link>
-        <SectionHeading>/</SectionHeading>{' '}
-        <SectionHeading>Events</SectionHeading>
+      <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex flex-row items-center gap-1">
+          <Link href={webhooksHref(router)} className="underline">
+            <SectionHeading>Webhooks</SectionHeading>
+          </Link>
+          <SectionHeading>/</SectionHeading>{' '}
+          <SectionHeading>Events</SectionHeading>
+        </div>
+        <WebhookActionsMenu
+          app={app}
+          namespaces={namespaces}
+          webhook={webhook}
+          onChanged={onChanged}
+        />
       </div>
 
+      <h4 className="text-sm font-semibold tracking-wide text-gray-500 uppercase dark:text-neutral-400">
+        Details
+      </h4>
+
       <Card>
-        <CardContent className="flex flex-col gap-2 p-4">
-          <h4 className="text-sm font-semibold tracking-wide text-gray-500 uppercase dark:text-neutral-400">
-            Details
-          </h4>
+        <CardContent className="p-4">
           <DetailGrid
             rows={[
               {
+                label: 'ID',
+                value: (
+                  <CopyableText
+                    value={webhook.id}
+                    className="font-mono text-xs break-all"
+                  />
+                ),
+              },
+              {
                 label: 'URL',
                 value: (
-                  <span className="font-mono text-xs break-all">
-                    {webhook.sink.url}
-                  </span>
+                  <CopyableText
+                    value={webhook.sink.url}
+                    className="font-mono text-xs break-all"
+                  />
                 ),
               },
               {
                 label: 'Status',
                 value:
                   webhook.status === 'active' ? (
-                    <span className="text-green-700 dark:text-green-300">
+                    <span className="font-mono text-xs text-green-700 dark:text-green-300">
                       Active
                     </span>
                   ) : (
-                    <span className="text-red-700 dark:text-red-300">
+                    <span className="font-mono text-xs text-red-700 dark:text-red-300">
                       Disabled
                     </span>
                   ),
@@ -823,17 +869,32 @@ function EventsListPage({
                     </span>
                   ) : (
                     <span className="font-mono text-xs">
-                      {(webhook.etypes ?? []).join(', ')}
+                      {[...(webhook.etypes ?? [])].sort().map((e, i, arr) => (
+                        <Fragment key={e}>
+                          <span className="whitespace-nowrap">{e}</span>
+                          {i < arr.length - 1 ? ', ' : ''}
+                        </Fragment>
+                      ))}
                     </span>
                   ),
               },
               {
                 label: 'Actions',
-                value: webhook.actions.join(', '),
+                value: (
+                  <span className="font-mono text-xs">
+                    {ALL_ACTIONS.filter((a) =>
+                      webhook.actions.includes(a),
+                    ).join(', ')}
+                  </span>
+                ),
               },
               {
                 label: 'Created at',
-                value: formatTimestamp(webhook.created_at),
+                value: (
+                  <span className="font-mono text-xs">
+                    {formatTimestamp(webhook.created_at)}
+                  </span>
+                ),
               },
               ...(webhook.disabled_reason
                 ? [

--- a/client/www/components/dash/WebhookEvents.tsx
+++ b/client/www/components/dash/WebhookEvents.tsx
@@ -30,7 +30,11 @@ import {
 } from '@/lib/types';
 import { Button, Content, SectionHeading } from '@/components/ui';
 import { useReadyRouter } from '@/components/clientOnlyPage';
-import { CopyableText, WebhookActionsMenu } from '@/components/dash/Webhooks';
+import {
+  ALL_ACTIONS,
+  CopyableText,
+  WebhookActionsMenu,
+} from '@/components/dash/Webhooks';
 import {
   Tabs,
   TabsContent,
@@ -38,8 +42,6 @@ import {
   TabsTrigger,
 } from '@/components/components/ui/tabs';
 import { Card, CardContent } from '@/components/components/ui/card';
-
-const ALL_ACTIONS: InstantWebhookAction[] = ['create', 'update', 'delete'];
 
 // ---- Data ----
 

--- a/client/www/components/dash/Webhooks.tsx
+++ b/client/www/components/dash/Webhooks.tsx
@@ -1,4 +1,10 @@
-import { FormEventHandler, useContext, useMemo, useState } from 'react';
+import {
+  Fragment,
+  FormEventHandler,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import {
   EllipsisVerticalIcon,
   PencilIcon,
@@ -33,6 +39,9 @@ import {
   SectionHeading,
   SubsectionHeading,
   TextInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   useDialog,
 } from '@/components/ui';
 import { useFetchedDash } from '@/components/dash/MainDashLayout';
@@ -47,6 +56,40 @@ import {
 } from '@/components/components/ui/item';
 
 const ALL_ACTIONS: InstantWebhookAction[] = ['create', 'update', 'delete'];
+
+export function CopyableText({
+  value,
+  className,
+}: {
+  value: string;
+  className?: string;
+}) {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  const handleClick = () => {
+    const selection = window.getSelection();
+    if (!selection || selection.toString().length === 0) {
+      window.navigator.clipboard.writeText(value);
+      setTooltipOpen(true);
+      setTimeout(() => setTooltipOpen(false), 1000);
+    }
+  };
+
+  return (
+    <Tooltip open={tooltipOpen}>
+      <TooltipTrigger asChild>
+        <span
+          title="Click to copy"
+          className={`cursor-default ${className ?? ''}`}
+          onClick={handleClick}
+        >
+          {value}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Copied!</TooltipContent>
+    </Tooltip>
+  );
+}
 
 // ---- API ----
 
@@ -482,7 +525,7 @@ function eventsHref(
   return `${router.pathname}?${params.toString()}`;
 }
 
-function WebhookRow({
+export function WebhookActionsMenu({
   app,
   namespaces,
   webhook,
@@ -493,99 +536,53 @@ function WebhookRow({
   webhook: InstantWebhook;
   onChanged: () => void;
 }) {
-  const token = useContext(TokenContext);
-  const router = useReadyRouter();
   const editDialog = useDialog();
   const disableDialog = useDialog();
   const deleteDialog = useDialog();
-  const [isToggling, setIsToggling] = useState(false);
-
-  const handleEnable = async () => {
-    setIsToggling(true);
-    try {
-      await enableWebhook(token, app.id, webhook.id);
-      onChanged();
-    } catch (e) {
-      reportError(e, 'Error enabling webhook.');
-    } finally {
-      setIsToggling(false);
-    }
-  };
 
   return (
-    <Item variant="outline" className="bg-white dark:bg-neutral-900">
-      <ItemContent>
-        <ItemTitle className="truncate font-mono">{webhook.sink.url}</ItemTitle>
-        {webhook.disabled_reason ? (
-          <ItemDescription className="text-red-700 dark:text-red-300">
-            {webhook.disabled_reason}
-          </ItemDescription>
-        ) : null}
-        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
-          <dt className="text-gray-500 dark:text-neutral-500">Entities</dt>
-          <dd className="font-mono">
-            {(webhook.etypes ?? []).length === 0
-              ? '(none)'
-              : (webhook.etypes ?? []).join(', ')}
-          </dd>
-          <dt className="text-gray-500 dark:text-neutral-500">Actions</dt>
-          <dd>{webhook.actions.join(', ')}</dd>
-        </dl>
-      </ItemContent>
-      <ItemActions>
-        <Button
-          variant="secondary"
-          size="mini"
-          onClick={() => router.push(eventsHref(router, webhook.id))}
-        >
-          <ListBulletIcon width={14} /> Events
-        </Button>
-        {webhook.status === 'disabled' ? (
-          <Button
-            variant="secondary"
-            size="mini"
-            loading={isToggling}
-            onClick={handleEnable}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="cursor-pointer rounded p-1 hover:bg-gray-200 dark:hover:bg-neutral-700"
+            title="More"
           >
-            Enable
-          </Button>
-        ) : null}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="cursor-pointer rounded p-1 hover:bg-gray-200 dark:hover:bg-neutral-700"
-              title="More"
-            >
-              <EllipsisVerticalIcon height={18} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-fit min-w-0">
+            <EllipsisVerticalIcon height={18} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-fit min-w-0">
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={editDialog.onOpen}
+          >
+            <span className="flex items-center gap-2">
+              <PencilIcon className="size-3.5" />
+              Edit
+            </span>
+          </DropdownMenuItem>
+          {webhook.status === 'active' ? (
             <DropdownMenuItem
               className="cursor-pointer"
-              onSelect={editDialog.onOpen}
+              onSelect={disableDialog.onOpen}
             >
-              <PencilIcon width={14} />
-              Edit
-            </DropdownMenuItem>
-            {webhook.status === 'active' ? (
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onSelect={disableDialog.onOpen}
-              >
-                <NoSymbolIcon width={14} />
+              <span className="flex items-center gap-2">
+                <NoSymbolIcon className="size-3.5" />
                 Disable
-              </DropdownMenuItem>
-            ) : null}
-            <DropdownMenuItem
-              className="cursor-pointer text-red-500"
-              onSelect={deleteDialog.onOpen}
-            >
-              <TrashIcon width={14} />
-              Delete
+              </span>
             </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </ItemActions>
+          ) : null}
+          <DropdownMenuItem
+            className="cursor-pointer text-red-500"
+            onSelect={deleteDialog.onOpen}
+          >
+            <span className="flex items-center gap-2">
+              <TrashIcon className="size-3.5" />
+              Delete
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <EditDialog
         app={app}
@@ -606,6 +603,95 @@ function WebhookRow({
         dialog={deleteDialog}
         onDeleted={onChanged}
       />
+    </>
+  );
+}
+
+function WebhookRow({
+  app,
+  namespaces,
+  webhook,
+  onChanged,
+}: {
+  app: InstantApp;
+  namespaces: SchemaNamespace[] | null;
+  webhook: InstantWebhook;
+  onChanged: () => void;
+}) {
+  const token = useContext(TokenContext);
+  const router = useReadyRouter();
+  const [isToggling, setIsToggling] = useState(false);
+
+  const handleEnable = async () => {
+    setIsToggling(true);
+    try {
+      await enableWebhook(token, app.id, webhook.id);
+      onChanged();
+    } catch (e) {
+      reportError(e, 'Error enabling webhook.');
+    } finally {
+      setIsToggling(false);
+    }
+  };
+
+  return (
+    <Item variant="outline" className="bg-white dark:bg-neutral-900">
+      <ItemContent>
+        <ItemTitle className="block max-w-full truncate font-mono">
+          <CopyableText value={webhook.sink.url} className="block truncate" />
+        </ItemTitle>
+        {webhook.disabled_reason ? (
+          <ItemDescription className="text-red-700 dark:text-red-300">
+            {webhook.disabled_reason}
+          </ItemDescription>
+        ) : null}
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+          <dt className="text-gray-500 dark:text-neutral-500">ID</dt>
+          <dd>
+            <CopyableText value={webhook.id} className="font-mono break-all" />
+          </dd>
+          <dt className="text-gray-500 dark:text-neutral-500">Entities</dt>
+          <dd className="font-mono">
+            {(webhook.etypes ?? []).length === 0
+              ? '(none)'
+              : [...(webhook.etypes ?? [])].sort().map((e, i, arr) => (
+                  <Fragment key={e}>
+                    <span className="whitespace-nowrap">{e}</span>
+                    {i < arr.length - 1 ? ', ' : ''}
+                  </Fragment>
+                ))}
+          </dd>
+          <dt className="text-gray-500 dark:text-neutral-500">Actions</dt>
+          <dd className="font-mono">
+            {ALL_ACTIONS.filter((a) => webhook.actions.includes(a)).join(', ')}
+          </dd>
+        </dl>
+      </ItemContent>
+      <ItemActions>
+        <Button
+          variant="secondary"
+          size="mini"
+          onClick={() => router.push(eventsHref(router, webhook.id))}
+        >
+          <ListBulletIcon width={14} /> Events
+        </Button>
+        {webhook.status === 'disabled' ? (
+          <Button
+            variant="secondary"
+            size="mini"
+            loading={isToggling}
+            onClick={handleEnable}
+          >
+            Enable
+          </Button>
+        ) : null}
+        <WebhookActionsMenu
+          app={app}
+          namespaces={namespaces}
+          webhook={webhook}
+          onChanged={onChanged}
+        />
+      </ItemActions>
     </Item>
   );
 }
@@ -640,7 +726,14 @@ export function Webhooks({
     : undefined;
 
   if (focusedWebhook) {
-    return <WebhookEventsPage app={app} webhook={focusedWebhook} />;
+    return (
+      <WebhookEventsPage
+        app={app}
+        webhook={focusedWebhook}
+        namespaces={namespaces}
+        onChanged={refresh}
+      />
+    );
   }
 
   const activeWebhooks = webhooks.filter((w) => w.status === 'active');

--- a/client/www/components/dash/Webhooks.tsx
+++ b/client/www/components/dash/Webhooks.tsx
@@ -55,7 +55,11 @@ import {
   ItemTitle,
 } from '@/components/components/ui/item';
 
-const ALL_ACTIONS: InstantWebhookAction[] = ['create', 'update', 'delete'];
+export const ALL_ACTIONS: InstantWebhookAction[] = [
+  'create',
+  'update',
+  'delete',
+];
 
 export function CopyableText({
   value,
@@ -66,12 +70,15 @@ export function CopyableText({
 }) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     const selection = window.getSelection();
-    if (!selection || selection.toString().length === 0) {
-      window.navigator.clipboard.writeText(value);
+    if (selection && selection.toString().length > 0) return;
+    try {
+      await window.navigator.clipboard.writeText(value);
       setTooltipOpen(true);
       setTimeout(() => setTooltipOpen(false), 1000);
+    } catch (e) {
+      console.error('Failed to copy to clipboard', e);
     }
   };
 


### PR DESCRIPTION
Small improvements to the webhooks on the dashboard:

1. Sorted the etypes and actions (actions are always in `create`, `update`, `delete` order)
2. Prevented the etype name from wrapping
3. Show the webhook id (and click to copy)
4. Fixed spacing in the dropdown menu and added the menu on the events page