### PR TITLE
Cleanup sessions when we encounter a connection closed error

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -6,8 +6,8 @@
 
         compojure/compojure {:mvn/version "1.6.2" :exclusions [instaparse/instaparse]}
         instaparse/instaparse {:mvn/version "1.5.0"}
-        luminus/ring-undertow-adapter {:mvn/version "1.2.8"}
-        io.undertow/undertow-core {:mvn/version "2.3.18.Final"}
+        luminus/ring-undertow-adapter {:mvn/version "1.4.4"}
+        io.undertow/undertow-core {:mvn/version "2.3.23.Final"}
         metosin/ring-http-response {:mvn/version "0.9.2"}
         org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/core.async {:mvn/version "1.6.673"}
@@ -17,7 +17,7 @@
         org.postgresql/postgresql {:mvn/version "42.7.3"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         ring/ring {:mvn/version "1.13.0"}
-        ring/ring-codec {:mvn/version "1.2.0"}
+        ring/ring-codec {:mvn/version "1.3.0"}
         ring/ring-json {:mvn/version "0.5.0"}
         com.zaxxer/HikariCP {:mvn/version "6.2.1"}
         ch.qos.logback/logback-classic {:mvn/version "1.5.6"}

--- a/server/src/instant/lib/ring/websocket.clj
+++ b/server/src/instant/lib/ring/websocket.clj
@@ -64,7 +64,7 @@
             (let [payload (.getResource pooled)]
               (on-message {:channel (channel-wrapper channel)
                            :data    (Util/toArray payload)}))
-            (finally (.free pooled)))))
+            (finally (.close pooled)))))
       (onPong [^WebSocketChannel channel ^StreamSourceFrameChannel channel]
         (when (and set-ping-latency-nanos atomic-last-ping-at)
           (set-ping-latency-nanos (- (System/nanoTime) (.get atomic-last-ping-at))))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -1035,7 +1035,8 @@
                              :hint hint
                              :session-id sess-id})
 
-        ::ex/socket-missing
+        (::ex/socket-missing
+         ::ex/connection-closed)
         (do
           (tracer/record-exception-span! instant-ex
                                          {:name "receive-worker/socket-unreachable"})

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -37,7 +37,9 @@
   (:import
    (clojure.lang PersistentQueue)
    (instant.isn ISN)
+   (java.io IOException)
    (java.lang InterruptedException)
+   (java.nio.channels ClosedChannelException)
    (java.time Instant)
    (java.util Map)
    (java.util.concurrent CancellationException CompletableFuture ConcurrentHashMap ConcurrentLinkedQueue Executors ExecutorService)
@@ -1508,6 +1510,22 @@
 ;; -----------------
 ;; Websocket Helpers
 
+(defn throw-socket-error! [sess-id ^IOException e]
+  (let [msg (.getMessage e)]
+    (if (and msg
+             (or
+              ;; ws channel is clsoed
+              ;; https://github.com/undertow-io/undertow/blob/afb53dfe9ba5407fc7488b509ea03fe6e6bd7c8d/core/src/main/java/io/undertow/websockets/core/WebSocketMessages.java#L43
+              (.startsWith msg "UT002002")
+              ;; ws connection is broken
+              ;; https://github.com/undertow-io/undertow/blob/afb53dfe9ba5407fc7488b509ea03fe6e6bd7c8d/core/src/main/java/io/undertow/websockets/core/WebSocketMessages.java#L118
+              (.startsWith msg "UT002027")
+              ;; generic channel is closed
+              ;; https://github.com/undertow-io/undertow/blob/afb53dfe9ba5407fc7488b509ea03fe6e6bd7c8d/core/src/main/java/io/undertow/UndertowMessages.java#L167
+              (.startsWith msg "UT000041")))
+      (ex/throw-connection-closed!)
+      (ex/throw-socket-error! sess-id e))))
+
 (defn send-event! [store app-id sess-id event]
   (let [socket (:session/socket (session store sess-id))
         event (assoc event :trace-id (tracer/current-trace-id))]
@@ -1516,13 +1534,17 @@
     (when-let [sse-conn (:sse-conn socket)]
       (try
         (sse/send-json! app-id event {:conn sse-conn})
-        (catch java.io.IOException e
-          (ex/throw-socket-error! sess-id e))))
+        (catch ClosedChannelException _e
+          (ex/throw-connection-closed!))
+        (catch IOException e
+          (throw-socket-error! sess-id e))))
     (when-let [ws-conn (:ws-conn socket)]
       (try
         (ws/send-json! app-id event ws-conn)
-        (catch java.io.IOException e
-          (ex/throw-socket-error! sess-id e))))))
+        (catch ClosedChannelException _e
+          (ex/throw-connection-closed!))
+        (catch IOException e
+          (throw-socket-error! sess-id e))))))
 
 (defn try-send-event!
   "Does a best-effort send. If it fails, we record and swallow the exception"

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -30,7 +30,8 @@
    [instant.util.test :as test-util])
   (:import
    (com.hazelcast.core HazelcastInstance)
-   (java.io ByteArrayOutputStream InputStream)
+   (java.io ByteArrayOutputStream IOException InputStream)
+   (java.nio.channels ClosedChannelException)
    (java.util UUID)))
 
 (test/use-fixtures :each
@@ -491,9 +492,7 @@
           ;; Reset the tx-id before we test
           (rs/transact! "store/reset-tx-id"
                         (rs/app-conn store app-id)
-                        [[:db.fn/call (fn [db]
-                                        [[:db/add (ds/entid db [:tx-meta/app-id app-id]) :tx-meta/processed-tx-id 0]
-                                         [:db/add (ds/entid db [:tx-meta/app-id app-id]) :tx-meta/processed-isn (instant.isn/test-isn 0)]])]])
+)
 
           (blocking-send-msg :add-query-ok socket
                              {:op :add-query
@@ -1341,3 +1340,56 @@
                      1000)
 
                   _ (is (= "Hello" (read-full-stream store movies-app-id stream-id slurp-file)))])))))))
+
+(deftest on-close-fires-when-send-hits-closed-connection
+  (testing "ClosedChannelException from ws/send-json! triggers on-close"
+    (with-session
+      (fn [store {:keys [socket zeneca-app-id]
+                  {:keys [id]} :socket}]
+        (is (some? (rs/session store id)))
+        (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
+                                      (throw (ClosedChannelException.)))]
+          (send-msg socket {:op :init :app-id zeneca-app-id}))
+        (test-util/wait-for #(nil? (rs/session store id)) 1000)
+        (is (nil? (rs/session store id))))))
+
+  (testing "UT002002 IOException (ws channel closed) triggers on-close"
+    (with-session
+      (fn [store {:keys [socket zeneca-app-id]
+                  {:keys [id]} :socket}]
+        (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
+                                      (throw (IOException. "UT002002: Channel is closed")))]
+          (send-msg socket {:op :init :app-id zeneca-app-id}))
+        (test-util/wait-for #(nil? (rs/session store id)) 1000)
+        (is (nil? (rs/session store id))))))
+
+  (testing "UT002027 IOException (ws connection broken) triggers on-close"
+    (with-session
+      (fn [store {:keys [socket zeneca-app-id]
+                  {:keys [id]} :socket}]
+        (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
+                                      (throw (IOException. "UT002027: connection broken"))) ]
+          (send-msg socket {:op :init :app-id zeneca-app-id}))
+        (test-util/wait-for #(nil? (rs/session store id)) 1000)
+        (is (nil? (rs/session store id))))))
+
+  (testing "UT000041 IOException (generic channel closed) triggers on-close"
+    (with-session
+      (fn [store {:keys [socket zeneca-app-id]
+                  {:keys [id]} :socket}]
+        (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
+                                      (throw (IOException. "UT000041: channel closed")))]
+          (send-msg socket {:op :init :app-id zeneca-app-id}))
+        (test-util/wait-for #(nil? (rs/session store id)) 1000)
+        (is (nil? (rs/session store id))))))
+
+  (testing "unrelated IOException does NOT trigger on-close"
+    (with-session
+      (fn [store {:keys [socket zeneca-app-id]
+                  {:keys [id]} :socket}]
+        (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
+                                      (throw (IOException. "something else went wrong")))]
+          (send-msg socket {:op :init :app-id zeneca-app-id}))
+        ;; Give the worker a chance to run, then verify the session is still present.
+        (Thread/sleep 200)
+        (is (some? (rs/session store id)))))))

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -1392,6 +1392,16 @@
         (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
                                       (throw (IOException. "something else went wrong")))]
           (send-msg socket {:op :init :app-id zeneca-app-id}))
-        ;; Give the worker a chance to run, then verify the session is still present.
-        (Thread/sleep 200)
-        (is (some? (rs/session store id)))))))
+        ;; Poll: session must remain present for the entire observation window.
+        (let [deadline (+ (System/currentTimeMillis) 500)]
+          (loop []
+            (let [s (rs/session store id)]
+              (cond
+                (nil? s)
+                (is (some? s) "session was cleaned up during observation window")
+
+                (< (System/currentTimeMillis) deadline)
+                (do (Thread/sleep 50) (recur))
+
+                :else
+                (is (some? s))))))))))

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -492,7 +492,9 @@
           ;; Reset the tx-id before we test
           (rs/transact! "store/reset-tx-id"
                         (rs/app-conn store app-id)
-)
+                        [[:db.fn/call (fn [db]
+                                        [[:db/add (ds/entid db [:tx-meta/app-id app-id]) :tx-meta/processed-tx-id 0]
+                                         [:db/add (ds/entid db [:tx-meta/app-id app-id]) :tx-meta/processed-isn (instant.isn/test-isn 0)]])]])
 
           (blocking-send-msg :add-query-ok socket
                              {:op :add-query
@@ -1368,7 +1370,7 @@
       (fn [store {:keys [socket zeneca-app-id]
                   {:keys [id]} :socket}]
         (with-redefs [ws/send-json! (fn [_app-id _msg _conn]
-                                      (throw (IOException. "UT002027: connection broken"))) ]
+                                      (throw (IOException. "UT002027: connection broken")))]
           (send-msg socket {:op :init :app-id zeneca-app-id}))
         (test-util/wait-for #(nil? (rs/session store id)) 1000)
         (is (nil? (rs/session store id))))))


### PR DESCRIPTION
This runs the `on-close` handler for the session if we encounter a connection closed handler when trying to send.

This will prevent us from repeatedly trying to send messages to connections that are closed, but didn't trigger on-close for whatever reason.

Also upgrades undertow from 2.3.18 to 2.3.23. Looking through the changelog, there is nothing that should affect us.