### PR TITLE
[codex] proposal

### DIFF
--- a/client/www/__tests__/generateMarkdown.test.ts
+++ b/client/www/__tests__/generateMarkdown.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from 'vitest';
-import { detectRequester } from '../app/getadb/generateMarkdown';
+import generateMarkdown, {
+  detectRequester,
+} from '../app/getadb/generateMarkdown';
 
 const figmaMakeRequest = new Request('https://www.getadb.com', {
   headers: {
@@ -27,4 +29,32 @@ test('detects figma make from the observed curl user-agent', () => {
 
 test('detects a browser request as unknown', () => {
   expect(detectRequester(browserRequest)).toBe('unknown');
+});
+
+test('can force figma make notes for the make route', async () => {
+  const markdown = await generateMarkdown(
+    browserRequest,
+    {
+      id: 'app-id',
+      adminToken: 'admin-token',
+    },
+    { requester: 'figmaMake' },
+  );
+
+  expect(markdown).toContain('Additional rules for Figma Make');
+  expect(markdown).toContain('Do not use the Supabase skill.');
+});
+
+test('can include the full docs bundle for the make route', async () => {
+  const markdown = await generateMarkdown(
+    browserRequest,
+    {
+      id: 'app-id',
+      adminToken: 'admin-token',
+    },
+    { includeFullDocs: true },
+  );
+
+  expect(markdown).toContain('Current Instant docs:');
+  expect(markdown).toContain('Instant - The Modern Firebase');
 });

--- a/client/www/app/getadb/GetadbLanding.tsx
+++ b/client/www/app/getadb/GetadbLanding.tsx
@@ -1,0 +1,88 @@
+import { HumanForm } from './HumanForm';
+
+type GetadbLandingProps = {
+  guideHref?: string;
+  guideLabel?: string;
+  guideVerb?: string;
+  humanFormSuffix?: string;
+  agentCommand?: string;
+};
+
+const DEFAULT_GUIDE_HREF = 'https://www.getadb.com/guide';
+const DEFAULT_GUIDE_LABEL = 'getadb.com/guide';
+
+export function GetadbLanding({
+  guideHref = DEFAULT_GUIDE_HREF,
+  guideLabel = DEFAULT_GUIDE_LABEL,
+  guideVerb = 'fetches',
+  humanFormSuffix,
+  agentCommand = `curl '${DEFAULT_GUIDE_HREF}'`,
+}: GetadbLandingProps) {
+  return (
+    <main className="text-off-black min-h-screen bg-[#FBF9F6]">
+      <div className="landing-width mx-auto pt-8 pb-24 sm:pt-12">
+        <div className="mx-auto max-w-3xl">
+          <img
+            src="/img/icon/logo-512.svg"
+            alt="Instant"
+            className="mb-5 h-10 w-10 sm:mb-6 sm:h-12 sm:w-12"
+          />
+          <h1 className="text-3xl leading-snug font-normal sm:text-4xl">
+            Give your agent a full-stack backend
+          </h1>
+          <p className="mt-3 text-lg text-gray-500 sm:text-xl">
+            No sign-up necessary.
+          </p>
+
+          <p className="mt-6 text-lg leading-relaxed text-gray-700">
+            Got an idea for an app? Type your idea out. Copy the prompt, and
+            your AI has all it needs to build you a full-stack app.
+          </p>
+
+          <HumanForm className="mt-8" suffix={humanFormSuffix} />
+
+          <div className="mt-8 space-y-5 text-lg leading-relaxed text-gray-700">
+            <p>
+              Pass this on to your Claude, Codex, Opencode, Pi, or your favorite
+              agent.
+            </p>
+            <p>
+              When your AI {guideVerb}{' '}
+              <a
+                href={guideHref}
+                className="underline underline-offset-4 hover:text-orange-600"
+              >
+                {guideLabel}
+              </a>
+              , it gets the credentials for a full{' '}
+              <a
+                href="/"
+                className="underline underline-offset-4 hover:text-orange-600"
+              >
+                Instant
+              </a>{' '}
+              backend. This includes a relational database, a sync engine, and
+              abstractions for auth, presence, and streams. Your agent can build
+              your app and won't be blocked with sign-up screens or dashboards.
+            </p>
+            <p>
+              Once you're happy with your app, you can simply claim it with{' '}
+              <code className="rounded-md border border-gray-200 bg-gray-100 px-1.5 py-0.5 font-mono text-[0.92em]">
+                npx instant-cli claim
+              </code>
+              .
+            </p>
+          </div>
+
+          <p className="mt-10 text-lg leading-relaxed text-gray-700">
+            <strong className="font-semibold text-gray-900">
+              Are you an agent?
+            </strong>{' '}
+            Your human wants you to build an app with Instant. {agentCommand}{' '}
+            for credentials and instructions.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/client/www/app/getadb/HumanForm.tsx
+++ b/client/www/app/getadb/HumanForm.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/solid';
 import { AnimatePresence, motion } from 'motion/react';
 import copy from 'copy-to-clipboard';
 
 const PLACEHOLDER = '<your app idea here>';
 const FRIENDLY_DEFAULT = `I want you to build me an app. Ask me for an app idea, then follow the instructions below.`;
-const SUFFIX = `Use InstantDB for your backend. For credentials and instructions, fetch https://www.getadb.com/guide and follow the steps.`;
+const DEFAULT_SUFFIX = `Use InstantDB for your backend. For credentials and instructions, fetch https://www.getadb.com/guide and follow the steps.`;
 
 const TERM = {
   bg: '#1e1e2e',
@@ -60,16 +60,22 @@ function ConfettiParticle({
 //   2. If the user copies without typing anything, we substitute a friendly
 //      default ("I want you to build me an app...") so the prompt is still
 //      useful.
-export function HumanForm({ className = '' }: { className?: string }) {
+export function HumanForm({
+  className = '',
+  suffix = DEFAULT_SUFFIX,
+}: {
+  className?: string;
+  suffix?: string;
+}) {
   const [copied, setCopied] = useState(false);
   const editorRef = useRef<HTMLDivElement>(null);
   const ideaRef = useRef<HTMLDivElement>(null);
   const suffixRef = useRef<HTMLDivElement>(null);
 
-  function buildPromptText() {
+  const buildPromptText = useCallback(() => {
     const idea = (ideaRef.current?.innerText ?? '').trim();
-    return `${idea || FRIENDLY_DEFAULT}\n\n${SUFFIX}`;
-  }
+    return `${idea || FRIENDLY_DEFAULT}\n\n${suffix}`;
+  }, [suffix]);
 
   useEffect(() => {
     editorRef.current?.focus();
@@ -111,7 +117,7 @@ export function HumanForm({ className = '' }: { className?: string }) {
       editor.removeEventListener('beforeinput', onBeforeInput);
       editor.removeEventListener('copy', onCopy);
     };
-  }, []);
+  }, [buildPromptText]);
 
   function handleCopyClick() {
     copy(buildPromptText());
@@ -159,7 +165,7 @@ export function HumanForm({ className = '' }: { className?: string }) {
               className="min-h-[1.5em] empty:before:pointer-events-none empty:before:text-[#7f849c] empty:before:content-[attr(data-placeholder)]"
             />
             <div ref={suffixRef} className="mt-6 whitespace-pre-wrap">
-              {SUFFIX}
+              {suffix}
             </div>
           </div>
         </div>

--- a/client/www/app/getadb/README.md
+++ b/client/www/app/getadb/README.md
@@ -9,4 +9,7 @@ to a `getadb.*` host and rewrites them under this folder.
 You can use `getadb.localhost:3000` to load the getadb micro-site.
 
 - http://getadb.localhost:3000/ — human landing page (browser)
+- http://getadb.localhost:3000/figma — Figma Make landing page (browser)
 - `curl http://getadb.localhost:3000/` — markdown guide (curl/agents)
+- `curl http://getadb.localhost:3000/make` — provisions credentials with
+  Figma Make notes and the full Instant docs

--- a/client/www/app/getadb/figma/page.tsx
+++ b/client/www/app/getadb/figma/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import { GetadbLanding } from '../GetadbLanding';
+
+const MAKE_URL = 'https://www.getadb.com/make';
+
+const FIGMA_MAKE_SUFFIX = `Use InstantDB for your backend. For credentials, Figma Make notes, and current Instant docs, curl ${MAKE_URL} and follow the steps.`;
+
+export const metadata: Metadata = {
+  title: 'getadb for Figma Make',
+  description:
+    'Give Figma Make fresh InstantDB credentials, Figma-specific notes, and the current Instant docs.',
+};
+
+export default function FigmaGetadbHome() {
+  return (
+    <GetadbLanding
+      guideHref={MAKE_URL}
+      guideLabel="getadb.com/make"
+      guideVerb="curls"
+      humanFormSuffix={FIGMA_MAKE_SUFFIX}
+      agentCommand={`curl '${MAKE_URL}'`}
+    />
+  );
+}

--- a/client/www/app/getadb/generateMarkdown.ts
+++ b/client/www/app/getadb/generateMarkdown.ts
@@ -6,12 +6,20 @@ type Requester = 'figmaMake' | 'unknown';
 export default async function generateMarkdown(
   request: Request,
   app: { id: string; adminToken: string },
+  opts: {
+    requester?: Requester;
+    includeFullDocs?: boolean;
+  } = {},
 ): Promise<string> {
-  const requester = detectRequester(request);
+  const requester = opts.requester ?? detectRequester(request);
   const baseRules = await loadBaseRules();
+  const fullDocs = opts.includeFullDocs ? await loadFullDocs() : null;
 
   const extraRules =
     requester === 'figmaMake' ? `\n${FIGMA_MAKE_EXTRA_RULES}\n` : '';
+  const docsSection = fullDocs
+    ? `\n---\n\nCurrent Instant docs:\n\n${fullDocs}`
+    : '';
 
   return `
 A new Instant app has just been provisioned for you!
@@ -31,7 +39,7 @@ ${extraRules}
 What follows are instructions for using Instant. Follow them, and you are golden!
 ---
 
-${baseRules}`;
+${baseRules}${docsSection}`;
 }
 
 // ----------
@@ -50,10 +58,10 @@ const FIGMA_MAKE_EXTRA_RULES = `
 Additional rules for Figma Make:
 
 - Do not use the Supabase skill.
-- Do not use environment variables for the app id, just hardcode it
-- When you need auth, make sure to use Instant's Guest Auth (\`signInAsGuest\`)
-- Use \`pnpm dlx\` instead of \`npx\`
-- Do not hallucinate methods about Instant. Read the relevant docs to understand how to use it
+- Do not use environment variables for the app id. Hardcode the Instant app id directly in the client setup.
+- When you need auth, use Instant's Guest Auth (\`signInAsGuest\`) unless the human asks for a different auth provider.
+- Use \`pnpm dlx\` instead of \`npx\`.
+- Do not hallucinate Instant APIs. Read the relevant docs before writing schema, permissions, queries, transactions, auth, storage, presence, or streams.
 `;
 
 // ----------
@@ -65,11 +73,20 @@ const RULES_PATH = path.join(
   'intern',
   'instant-rules.md',
 );
+const FULL_DOCS_PATH = path.join(process.cwd(), 'public', 'llms-full.txt');
 
 let cachedBaseRules: string | null = null;
 async function loadBaseRules(): Promise<string> {
   if (cachedBaseRules !== null) return cachedBaseRules;
   const contents = await fs.readFile(RULES_PATH, 'utf8');
   cachedBaseRules = contents;
+  return contents;
+}
+
+let cachedFullDocs: string | null = null;
+async function loadFullDocs(): Promise<string> {
+  if (cachedFullDocs !== null) return cachedFullDocs;
+  const contents = await fs.readFile(FULL_DOCS_PATH, 'utf8');
+  cachedFullDocs = contents;
   return contents;
 }

--- a/client/www/app/getadb/make/route.ts
+++ b/client/www/app/getadb/make/route.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from 'crypto';
+import { createGDBApp } from '../createGDBApp';
+import generateMarkdown from '../generateMarkdown';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: Request) {
+  const title =
+    new URL(request.url).searchParams.get('title')?.trim() || DEFAULT_APP_TITLE;
+  const app = await createGDBApp(title);
+  const markdown = await generateMarkdown(request, app, {
+    requester: 'figmaMake',
+    includeFullDocs: true,
+  });
+
+  return new Response(markdown, {
+    headers: {
+      'Cache-Control':
+        'private, no-store, no-cache, max-age=0, must-revalidate, proxy-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
+      Vary: '*',
+      ETag: `"${randomUUID()}"`,
+      'Content-Disposition': 'inline; filename="AGENTS.md"',
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });
+}
+
+const DEFAULT_APP_TITLE = 'Instant Figma Make App';

--- a/client/www/app/getadb/page.tsx
+++ b/client/www/app/getadb/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { HumanForm } from './HumanForm';
+import { GetadbLanding } from './GetadbLanding';
 
 export const metadata: Metadata = {
   title: 'getadb — give your agent a backend',
@@ -8,71 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function GetadbHome() {
-  return (
-    <main className="text-off-black min-h-screen bg-[#FBF9F6]">
-      <div className="landing-width mx-auto pt-8 pb-24 sm:pt-12">
-        <div className="mx-auto max-w-3xl">
-          <img
-            src="/img/icon/logo-512.svg"
-            alt="Instant"
-            className="mb-5 h-10 w-10 sm:mb-6 sm:h-12 sm:w-12"
-          />
-          <h1 className="text-3xl leading-snug font-normal sm:text-4xl">
-            Give your agent a full-stack backend
-          </h1>
-          <p className="mt-3 text-lg text-gray-500 sm:text-xl">
-            No sign-up necessary.
-          </p>
-
-          <p className="mt-6 text-lg leading-relaxed text-gray-700">
-            Got an idea for an app? Type your idea out. Copy the prompt, and
-            your AI has all it needs to build you a full-stack app.
-          </p>
-
-          <HumanForm className="mt-8" />
-
-          <div className="mt-8 space-y-5 text-lg leading-relaxed text-gray-700">
-            <p>
-              Pass this on to your Claude, Codex, Opencode, Pi, or your favorite
-              agent.
-            </p>
-            <p>
-              When your AI fetches{' '}
-              <a
-                href="https://www.getadb.com/guide"
-                className="underline underline-offset-4 hover:text-orange-600"
-              >
-                getadb.com/guide
-              </a>
-              , it gets the credentials for a full{' '}
-              <a
-                href="/"
-                className="underline underline-offset-4 hover:text-orange-600"
-              >
-                Instant
-              </a>{' '}
-              backend. This includes a relational database, a sync engine, and
-              abstractions for auth, presence, and streams. Your agent can build
-              your app and won't be blocked with sign-up screens or dashboards.
-            </p>
-            <p>
-              Once you're happy with your app, you can simply claim it with{' '}
-              <code className="rounded-md border border-gray-200 bg-gray-100 px-1.5 py-0.5 font-mono text-[0.92em]">
-                npx instant-cli claim
-              </code>
-              .
-            </p>
-          </div>
-
-          <p className="mt-10 text-lg leading-relaxed text-gray-700">
-            <strong className="font-semibold text-gray-900">
-              Are you an agent?
-            </strong>{' '}
-            Your human wants you to build an app with Instant. curl
-            'https://www.getadb.com/guide' for credentials and instructions.
-          </p>
-        </div>
-      </div>
-    </main>
-  );
+  return <GetadbLanding />;
 }


### PR DESCRIPTION
Summary:
- Add a getadb Figma Make landing page at /figma.
- Add /make provisioning with Figma Make notes and the full Instant docs bundle.
- Share the existing getadb landing UI and add markdown generation coverage.

Verification:
- pnpm exec vitest run __tests__/generateMarkdown.test.ts
- pnpm exec tsc --noEmit 2>&1