### PR TITLE
fix dark mode webhook ui colors

### DIFF
--- a/client/www/components/components/ui/card.tsx
+++ b/client/www/components/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-xl border border-gray-200 bg-white text-gray-950 shadow dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50',
+      'rounded-xl border border-gray-200 bg-white text-gray-950 shadow dark:border-neutral-700 dark:bg-neutral-800 dark:text-gray-50',
       className,
     )}
     {...props}

--- a/client/www/components/components/ui/item.tsx
+++ b/client/www/components/components/ui/item.tsx
@@ -31,13 +31,13 @@ function ItemSeparator({
 }
 
 const itemVariants = cva(
-  'group/item [a]:hover:bg-gray-100/50 focus-visible:border-gray-950 focus-visible:ring-gray-950/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-gray-200 border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px] dark:[a]:hover:bg-gray-800/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50 dark:border-gray-800',
+  'group/item [a]:hover:bg-gray-100/50 focus-visible:border-gray-950 focus-visible:ring-gray-950/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-gray-200 border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px] dark:[a]:hover:bg-neutral-800/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50 dark:border-neutral-800',
   {
     variants: {
       variant: {
         default: 'bg-transparent',
-        outline: 'border-gray-200 dark:border-gray-800',
-        muted: 'bg-gray-100/50 dark:bg-gray-800/50',
+        outline: 'border-gray-200 dark:border-neutral-800',
+        muted: 'bg-gray-100/50 dark:bg-neutral-800/50',
       },
       size: {
         default: 'gap-4 p-4',

--- a/client/www/components/components/ui/tabs.tsx
+++ b/client/www/components/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-9 items-center justify-center rounded-lg bg-gray-100 p-1 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
+      'inline-flex h-9 items-center justify-center rounded-lg bg-gray-100 p-1 text-gray-500 dark:bg-neutral-800 dark:text-gray-400',
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-gray-950 data-[state=active]:shadow dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300 dark:data-[state=active]:bg-gray-950 dark:data-[state=active]:text-gray-50',
+      'inline-flex items-center justify-center rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap ring-offset-white transition-all focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-neutral-950 data-[state=active]:shadow dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300 dark:data-[state=active]:bg-neutral-700 dark:data-[state=active]:text-neutral-50',
       className,
     )}
     {...props}
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-white focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none dark:ring-offset-gray-950 dark:focus-visible:ring-gray-300',
+      'mt-2 ring-offset-white focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 focus-visible:outline-none dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300',
       className,
     )}
     {...props}

--- a/client/www/components/dash/Webhooks.tsx
+++ b/client/www/components/dash/Webhooks.tsx
@@ -642,7 +642,10 @@ function WebhookRow({
   };
 
   return (
-    <Item variant="outline" className="bg-white dark:bg-neutral-900">
+    <Item
+      variant="outline"
+      className="bg-white dark:border-neutral-700 dark:bg-neutral-800"
+    >
       <ItemContent>
         <ItemTitle className="block max-w-full truncate font-mono">
           <CopyableText value={webhook.sink.url} className="block truncate" />


### PR DESCRIPTION
Use "neutral" color palette in dark mode + value tweaks. 

BEFORE:
<img width="1469" height="503" alt="image" src="https://github.com/user-attachments/assets/861b9e21-70e3-4f61-993f-ddda5d27fd75" />
<img width="1500" height="665" alt="image" src="https://github.com/user-attachments/assets/3a58c5ec-d3ed-4e82-bf31-dee0abfc2e00" />
<img width="1027" height="753" alt="image" src="https://github.com/user-attachments/assets/f52bfa43-7fa8-48fb-91ef-d7f7406d31be" />

AFTER
<img width="1072" height="407" alt="image" src="https://github.com/user-attachments/assets/a8deccbc-212d-4ff0-9a13-dfec90fa5d09" />
<img width="1139" height="804" alt="image" src="https://github.com/user-attachments/assets/69a6054d-f02b-46d2-9e90-977a017ac5d1" />
<img width="1086" height="562" alt="image" src="https://github.com/user-attachments/assets/e2f7e346-1d7b-47df-8d8c-c2c16e1c98bb" />

