### PR TITLE
Rename etype to namespace for user-facing webhooks code

### DIFF
--- a/client/packages/platform/src/api.ts
+++ b/client/packages/platform/src/api.ts
@@ -1861,7 +1861,7 @@ export class PlatformApi {
    * is transparently refreshed.
    *
    * Pass `schema` (e.g. from {@link apiSchemaToInstantSchemaDef}) for typed
-   * handler records and typed `etypes` on `manager.create`/`update`.
+   * handler records and typed `namespaces` on `manager.create`/`update`.
    */
   webhooks<
     Schema extends InstantSchemaDef<any, any, any> = InstantUnknownSchema,

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.32';
+const version = 'v1.0.33';
 
 export { version };

--- a/client/packages/webhooks/README.md
+++ b/client/packages/webhooks/README.md
@@ -93,7 +93,7 @@ const webhooksWithManager = new Webhooks<typeof schema>({
 
 - `appId` — required for `manager.*`; recommended for the receiving side so error messages and helpers are scoped.
 - `adminToken` (or `token`) — required for `manager.*`. Not needed to verify signatures or dispatch handlers.
-- `schema` — optional. Pass your schema to get fully typed `record.before` / `record.after` in handlers and typed `etypes` on `manager.create` / `manager.update`.
+- `schema` — optional. Pass your schema to get fully typed `record.before` / `record.after` in handlers and typed `namespaces` on `manager.create` / `manager.update`.
 - `apiURI` — defaults to `https://api.instantdb.com`. Override for self-hosted or local development.
 - `withAuth` — advanced hook used by the platform SDK to inject a fresh OAuth token per request; you generally won't pass this directly.
 
@@ -146,7 +146,7 @@ Options:
 - `tolerance` — max signature age in seconds (default `300`). Protects against replays; raising this weakens that.
 - `receivedAt` — override the "now" used when checking signature age. Mostly useful in tests.
 
-Handler resolution is most-specific-wins: `etype` + `action` → that etype's `$default` → top-level `$default`. Records with no matching handler are skipped.
+Handler resolution is most-specific-wins: `namespace` + `action` → that namespace's `$default` → top-level `$default`. Records with no matching handler are skipped.
 
 Handlers run concurrently. `processRequest` resolves once all of them settle. If any handler rejects, the call rejects — return a non-2xx response so Instant retries the event.
 
@@ -267,7 +267,7 @@ console.log(payload.idempotencyKey, payload.data.length);
 
 Schema-bound helpers for building typed handler maps:
 
-- `typedHandlers(etype, action, handler)` — typed entry for one `etype` + `action`. Pass `'$default'` for `action` to handle every action for that etype.
+- `typedHandlers(namespace, action, handler)` — typed entry for one `namespace` + `action`. Pass `'$default'` for `action` to handle every action for that namespace.
 - `typedHandlers('$default', handler)` — top-level catch-all.
 - `combineHandlers(...entries)` — merges entries into a single `WebhookHandlers` object suitable for `processRequest` / `processPayload`.
 
@@ -295,23 +295,23 @@ Returns every webhook configured on the app, newest first. Includes both active 
 const webhooks = await db.webhooks.manager.list();
 ```
 
-## `manager.create({ url, etypes, actions })`
+## `manager.create({ url, namespaces, actions })`
 
 Creates a webhook in the `active` state. It starts receiving matching events immediately.
 
 ```ts
 const webhook = await db.webhooks.manager.create({
   url: 'https://example.com/instant',
-  etypes: ['posts', 'comments'],
+  namespaces: ['posts', 'comments'],
   actions: ['create', 'update'],
 });
 ```
 
-The server rejects the request if `url` isn't an HTTPS URL pointing at a public host, if `etypes` doesn't reference any entity in the app's schema, if `actions` is empty, or if the app has hit its **100 active webhooks** limit.
+The server rejects the request if `url` isn't an HTTPS URL pointing at a public host, if `namespaces` doesn't reference any entity in the app's schema, if `actions` is empty, or if the app has hit its **100 active webhooks** limit.
 
 ## `manager.update(webhookId, params)`
 
-Patches `url`, `etypes`, and/or `actions`. Omitted fields keep their current value. Does not affect status — use `enable` / `disable` for that.
+Patches `url`, `namespaces`, and/or `actions`. Omitted fields keep their current value. Does not affect status — use `enable` / `disable` for that.
 
 ```ts
 await db.webhooks.manager.update(webhook.id, {

--- a/client/packages/webhooks/__tests__/src/helpers.test.ts
+++ b/client/packages/webhooks/__tests__/src/helpers.test.ts
@@ -14,14 +14,14 @@ type Schema = typeof schema;
 const { typedHandlers, combineHandlers } = Webhooks.helpers<Schema>();
 
 describe('typedHandlers', () => {
-  test('builds a single etype.action entry', () => {
+  test('builds a single namespace.action entry', () => {
     const fn = () => {};
     expect(typedHandlers('posts', 'create', fn)).toEqual({
       posts: { create: fn },
     });
   });
 
-  test('builds an etype $default entry', () => {
+  test('builds a namespace $default entry', () => {
     const fn = () => {};
     expect(typedHandlers('posts', '$default', fn)).toEqual({
       posts: { $default: fn },
@@ -35,7 +35,7 @@ describe('typedHandlers', () => {
 });
 
 describe('combineHandlers', () => {
-  test('merges entries for different etypes', () => {
+  test('merges entries for different namespaces', () => {
     const onPostCreate = () => {};
     const onCommentDelete = () => {};
 
@@ -50,27 +50,27 @@ describe('combineHandlers', () => {
     });
   });
 
-  test('merges actions within the same etype', () => {
+  test('merges actions within the same namespace', () => {
     const onCreate = () => {};
     const onUpdate = () => {};
-    const onEtypeDefault = () => {};
+    const onNamespaceDefault = () => {};
 
     const handlers = combineHandlers(
       typedHandlers('posts', 'create', onCreate),
       typedHandlers('posts', 'update', onUpdate),
-      typedHandlers('posts', '$default', onEtypeDefault),
+      typedHandlers('posts', '$default', onNamespaceDefault),
     );
 
     expect(handlers).toEqual({
       posts: {
         create: onCreate,
         update: onUpdate,
-        $default: onEtypeDefault,
+        $default: onNamespaceDefault,
       },
     });
   });
 
-  test('later entries override earlier ones for the same etype.action', () => {
+  test('later entries override earlier ones for the same namespace.action', () => {
     const first = () => {};
     const second = () => {};
 
@@ -94,7 +94,7 @@ describe('combineHandlers', () => {
     expect(handlers.$default).toBe(secondDefault);
   });
 
-  test('top-level $default does not affect per-etype handlers', () => {
+  test('top-level $default does not affect per-namespace handlers', () => {
     const onPostCreate = () => {};
     const topDefault = () => {};
 

--- a/client/packages/webhooks/__tests__/src/processPayload.test.ts
+++ b/client/packages/webhooks/__tests__/src/processPayload.test.ts
@@ -16,17 +16,17 @@ function makeWebhooks() {
 }
 
 function record(
-  etype: 'posts' | 'comments',
+  namespace: 'posts' | 'comments',
   action: 'create' | 'update' | 'delete',
   id = 'r1',
 ) {
   return {
-    etype,
+    namespace,
     id,
     action,
     before: action === 'create' ? null : { id, title: 'b', body: 'b' },
     after: action === 'delete' ? null : { id, title: 'a', body: 'a' },
-    idempotencyKey: `${etype}-${action}-${id}`,
+    idempotencyKey: `${namespace}-${action}-${id}`,
   };
 }
 
@@ -35,43 +35,43 @@ function payload(records: any[]): WebhookPayload<Schema> {
 }
 
 describe('processPayload dispatch precedence', () => {
-  test('exact etype+action wins over etype $default and top-level $default', async () => {
+  test('exact namespace+action wins over namespace $default and top-level $default', async () => {
     const wh = makeWebhooks();
     const exact = vi.fn();
-    const etypeDefault = vi.fn();
+    const namespaceDefault = vi.fn();
     const topDefault = vi.fn();
 
     await wh.processPayload(
       {
-        posts: { create: exact, $default: etypeDefault },
+        posts: { create: exact, $default: namespaceDefault },
         $default: topDefault,
       },
       payload([record('posts', 'create')]),
     );
 
     expect(exact).toHaveBeenCalledTimes(1);
-    expect(etypeDefault).not.toHaveBeenCalled();
+    expect(namespaceDefault).not.toHaveBeenCalled();
     expect(topDefault).not.toHaveBeenCalled();
   });
 
-  test('etype $default wins over top-level $default when no exact handler', async () => {
+  test('namespace $default wins over top-level $default when no exact handler', async () => {
     const wh = makeWebhooks();
-    const etypeDefault = vi.fn();
+    const namespaceDefault = vi.fn();
     const topDefault = vi.fn();
 
     await wh.processPayload(
       {
-        posts: { $default: etypeDefault },
+        posts: { $default: namespaceDefault },
         $default: topDefault,
       },
       payload([record('posts', 'update')]),
     );
 
-    expect(etypeDefault).toHaveBeenCalledTimes(1);
+    expect(namespaceDefault).toHaveBeenCalledTimes(1);
     expect(topDefault).not.toHaveBeenCalled();
   });
 
-  test('top-level $default catches records with no etype match', async () => {
+  test('top-level $default catches records with no namespace match', async () => {
     const wh = makeWebhooks();
     const topDefault = vi.fn();
 
@@ -84,7 +84,7 @@ describe('processPayload dispatch precedence', () => {
     );
 
     expect(topDefault).toHaveBeenCalledTimes(1);
-    expect(topDefault.mock.calls[0][0].etype).toBe('comments');
+    expect(topDefault.mock.calls[0][0].namespace).toBe('comments');
   });
 
   test('records with no matching handler are skipped without error', async () => {

--- a/client/packages/webhooks/src/__types__/typesTests.ts
+++ b/client/packages/webhooks/src/__types__/typesTests.ts
@@ -18,14 +18,14 @@ type Schema = typeof schema;
 function _typedRecordWithSchemaCreate() {
   const { typedHandlers } = Webhooks.helpers<Schema>();
   typedHandlers('users', 'create', (record) => {
-    type Etype = typeof record.etype;
+    type Namespace = typeof record.namespace;
     type Action = typeof record.action;
     type Before = typeof record.before;
     type After = typeof record.after;
 
     type _cases = [
       Expect<NotAny<typeof record>>,
-      Expect<Equal<Etype, 'users'>>,
+      Expect<Equal<Namespace, 'users'>>,
       Expect<Equal<Action, 'create'>>,
       Expect<Equal<Before, null>>,
       Expect<NotAny<After>>,
@@ -43,7 +43,7 @@ function _typedRecordWithSchemaUpdate() {
     type Before = typeof record.before;
     type After = typeof record.after;
     type _cases = [
-      Expect<Equal<typeof record.etype, 'users'>>,
+      Expect<Equal<typeof record.namespace, 'users'>>,
       Expect<Equal<typeof record.action, 'update'>>,
       // Both before and after are present for updates.
       Expect<Equal<Before['id'], string>>,
@@ -58,7 +58,7 @@ function _typedRecordWithSchemaDelete() {
   const { typedHandlers } = Webhooks.helpers<Schema>();
   typedHandlers('users', 'delete', (record) => {
     type _cases = [
-      Expect<Equal<typeof record.etype, 'users'>>,
+      Expect<Equal<typeof record.namespace, 'users'>>,
       Expect<Equal<typeof record.action, 'delete'>>,
       // `after` is null for deletes; `before` carries the entity.
       Expect<Equal<typeof record.after, null>>,
@@ -71,11 +71,11 @@ function _typedRecordWithSchemaDelete() {
 function _defaultHandlerWithSchema() {
   const { typedHandlers } = Webhooks.helpers<Schema>();
   typedHandlers('$default', (record) => {
-    type Etype = typeof record.etype;
+    type Namespace = typeof record.namespace;
     type Action = typeof record.action;
     type _cases = [
-      // The $default form spans all etypes and actions in the schema.
-      Expect<Equal<Etype, 'users'>>,
+      // The $default form spans all namespaces and actions in the schema.
+      Expect<Equal<Namespace, 'users'>>,
       Expect<Equal<Action, 'create' | 'update' | 'delete'>>,
     ];
   });
@@ -87,15 +87,15 @@ function _typedRecordNoSchemaCreate() {
   // Helpers default to InstantUnknownSchema when no schema is given.
   const { typedHandlers } = Webhooks.helpers();
   typedHandlers('$users', 'create', (record) => {
-    type Etype = typeof record.etype;
+    type Namespace = typeof record.namespace;
     type Action = typeof record.action;
     type After = typeof record.after;
     type _cases = [
       Expect<NotAny<typeof record>>,
       Expect<NotNever<typeof record>>,
-      // The literal etype passed at the call site is preserved even without
+      // The literal namespace passed at the call site is preserved even without
       // a schema — this is the regression we just fixed.
-      Expect<Equal<Etype, '$users'>>,
+      Expect<Equal<Namespace, '$users'>>,
       Expect<Equal<Action, 'create'>>,
       Expect<Equal<typeof record.before, null>>,
       // `after` is an entity reachable without a schema (the regression we
@@ -114,7 +114,7 @@ function _typedRecordNoSchemaUpdate() {
   const { typedHandlers } = Webhooks.helpers();
   typedHandlers('posts', 'update', (record) => {
     type _cases = [
-      Expect<Equal<typeof record.etype, 'posts'>>,
+      Expect<Equal<typeof record.namespace, 'posts'>>,
       Expect<Equal<typeof record.action, 'update'>>,
       Expect<NotNever<typeof record.before>>,
       Expect<NotNever<typeof record.after>>,
@@ -126,7 +126,7 @@ function _typedRecordNoSchemaDelete() {
   const { typedHandlers } = Webhooks.helpers();
   typedHandlers('comments', 'delete', (record) => {
     type _cases = [
-      Expect<Equal<typeof record.etype, 'comments'>>,
+      Expect<Equal<typeof record.namespace, 'comments'>>,
       Expect<Equal<typeof record.action, 'delete'>>,
       Expect<Equal<typeof record.after, null>>,
       Expect<NotNever<typeof record.before>>,
@@ -137,13 +137,13 @@ function _typedRecordNoSchemaDelete() {
 function _defaultHandlerNoSchema() {
   const { typedHandlers } = Webhooks.helpers();
   typedHandlers('$default', (record) => {
-    type Etype = typeof record.etype;
+    type Namespace = typeof record.namespace;
     type Action = typeof record.action;
     type _cases = [
-      // Without a schema, etype is exactly `string` — not `string | number`
+      // Without a schema, namespace is exactly `string` — not `string | number`
       // (which would leak the TS index-signature `keyof` artifact, since
-      // etypes are always strings on the wire).
-      Expect<Equal<Etype, string>>,
+      // namespaces are always strings on the wire).
+      Expect<Equal<Namespace, string>>,
       Expect<Equal<Action, 'create' | 'update' | 'delete'>>,
     ];
   });
@@ -171,16 +171,16 @@ function _combineHandlersAcceptsTypedEntriesNoSchema() {
   type _cases = [Expect<NotAny<typeof handlers>>];
 }
 
-// ---------- Unknown etype is rejected when a schema is supplied ----------
+// ---------- Unknown namespace is rejected when a schema is supplied ----------
 
-function _typedHandlersRejectsUnknownEtypeWithSchema() {
+function _typedHandlersRejectsUnknownNamespaceWithSchema() {
   const { typedHandlers } = Webhooks.helpers<Schema>();
-  // The schema only declares `users`. Passing an etype not in the schema
+  // The schema only declares `users`. Passing a namespace not in the schema
   // should fail typecheck.
   // @ts-expect-error - 'posts' is not in Schema['entities']
   typedHandlers('posts', 'create', (_record) => {});
 
-  // Sanity: the known etype still typechecks.
+  // Sanity: the known namespace still typechecks.
   typedHandlers('users', 'create', (_record) => {});
 }
 

--- a/client/packages/webhooks/src/index.ts
+++ b/client/packages/webhooks/src/index.ts
@@ -45,34 +45,34 @@ export type WebhookBody = {
 
 export type WebhookEntity<
   Schema extends InstantSchemaDef<any, any, any>,
-  EtypeName extends keyof Schema['entities'] & string,
-> = { id: string } & ResolveAttrs<Schema['entities'], EtypeName, false>;
+  NamespaceName extends keyof Schema['entities'] & string,
+> = { id: string } & ResolveAttrs<Schema['entities'], NamespaceName, false>;
 
 export type WebhookPayloadRecord<
   Schema extends InstantSchemaDef<any, any, any>,
 > = {
-  [EtypeName in keyof Schema['entities'] & string]:
+  [NamespaceName in keyof Schema['entities'] & string]:
     | {
-        etype: EtypeName;
+        namespace: NamespaceName;
         id: string;
         action: 'create';
         before: null;
-        after: WebhookEntity<Schema, EtypeName>;
+        after: WebhookEntity<Schema, NamespaceName>;
         idempotencyKey: string;
       }
     | {
-        etype: EtypeName;
+        namespace: NamespaceName;
         id: string;
         action: 'update';
-        before: WebhookEntity<Schema, EtypeName>;
-        after: WebhookEntity<Schema, EtypeName>;
+        before: WebhookEntity<Schema, NamespaceName>;
+        after: WebhookEntity<Schema, NamespaceName>;
         idempotencyKey: string;
       }
     | {
-        etype: EtypeName;
+        namespace: NamespaceName;
         id: string;
         action: 'delete';
-        before: WebhookEntity<Schema, EtypeName>;
+        before: WebhookEntity<Schema, NamespaceName>;
         after: null;
         idempotencyKey: string;
       };
@@ -116,8 +116,8 @@ export type WebhookInfo = {
     /** HTTPS endpoint that Instant POSTs to. */
     url: string;
   };
-  /** The entity types (namespaces) this webhook listens to. */
-  etypes: string[];
+  /** The namespaces this webhook listens to. */
+  namespaces: string[];
   /** Which write actions trigger delivery. */
   actions: WebhookAction[];
   /** Whether the webhook is currently delivering events. */
@@ -211,10 +211,10 @@ export type CreateWebhookParams<
    */
   url: string;
   /**
-   * Entity types (namespaces) the webhook will listen to. Must reference at
-   * least one entity in the app's schema.
+   * Namespaces the webhook will listen to. Must reference at least one entity
+   * in the app's schema.
    */
-  etypes: (keyof Schema['entities'] & string)[];
+  namespaces: (keyof Schema['entities'] & string)[];
   /** Write actions that should trigger delivery. Must contain at least one. */
   actions: WebhookAction[];
 };
@@ -224,40 +224,40 @@ export type UpdateWebhookParams<
 > = {
   /** New delivery URL. Omit to leave unchanged. */
   url?: string;
-  /** New set of entity types. Omit to leave unchanged. */
-  etypes?: (keyof Schema['entities'] & string)[];
+  /** New set of namespaces. Omit to leave unchanged. */
+  namespaces?: (keyof Schema['entities'] & string)[];
   /** New set of actions. Omit to leave unchanged. */
   actions?: WebhookAction[];
 };
 
 export type WebhookPayloadRecordFor<
   Schema extends InstantSchemaDef<any, any, any>,
-  EtypeName extends keyof Schema['entities'] & string,
+  NamespaceName extends keyof Schema['entities'] & string,
   Action extends WebhookAction,
 > = Action extends 'create'
   ? {
-      etype: EtypeName;
+      namespace: NamespaceName;
       id: string;
       action: 'create';
       before: null;
-      after: WebhookEntity<Schema, EtypeName>;
+      after: WebhookEntity<Schema, NamespaceName>;
       idempotencyKey: string;
     }
   : Action extends 'update'
     ? {
-        etype: EtypeName;
+        namespace: NamespaceName;
         id: string;
         action: 'update';
-        before: WebhookEntity<Schema, EtypeName>;
-        after: WebhookEntity<Schema, EtypeName>;
+        before: WebhookEntity<Schema, NamespaceName>;
+        after: WebhookEntity<Schema, NamespaceName>;
         idempotencyKey: string;
       }
     : Action extends 'delete'
       ? {
-          etype: EtypeName;
+          namespace: NamespaceName;
           id: string;
           action: 'delete';
-          before: WebhookEntity<Schema, EtypeName>;
+          before: WebhookEntity<Schema, NamespaceName>;
           after: null;
           idempotencyKey: string;
         }
@@ -265,11 +265,11 @@ export type WebhookPayloadRecordFor<
 
 export type WebhookHandlerFn<
   Schema extends InstantSchemaDef<any, any, any>,
-  EtypeName extends keyof Schema['entities'] & string,
+  NamespaceName extends keyof Schema['entities'] & string,
   Action extends WebhookAction,
   Result = any,
 > = (
-  record: WebhookPayloadRecordFor<Schema, EtypeName, Action>,
+  record: WebhookPayloadRecordFor<Schema, NamespaceName, Action>,
 ) => Result | Promise<Result>;
 
 export type DefaultKey = '$default';
@@ -281,10 +281,10 @@ export type ResolveHandlerAction<Action> = Action extends DefaultKey
     : never;
 
 export type WebhookHandlers<Schema extends InstantSchemaDef<any, any, any>> = {
-  [EtypeName in keyof Schema['entities'] & string]?: {
+  [NamespaceName in keyof Schema['entities'] & string]?: {
     [Action in WebhookAction | DefaultKey]?: WebhookHandlerFn<
       Schema,
-      EtypeName,
+      NamespaceName,
       ResolveHandlerAction<Action>,
       any
     >;
@@ -300,13 +300,13 @@ export type WebhookHandlers<Schema extends InstantSchemaDef<any, any, any>> = {
 
 export type TypedHandlerEntry<
   Schema extends InstantSchemaDef<any, any, any>,
-  EtypeName extends keyof Schema['entities'] & string,
+  NamespaceName extends keyof Schema['entities'] & string,
   Action extends WebhookAction | DefaultKey,
 > = {
-  [E in EtypeName]: {
+  [N in NamespaceName]: {
     [A in Action]: WebhookHandlerFn<
       Schema,
-      EtypeName,
+      NamespaceName,
       ResolveHandlerAction<Action>,
       any
     >;
@@ -326,7 +326,7 @@ export type TypedDefaultEntry<Schema extends InstantSchemaDef<any, any, any>> =
 export type WebhookHelpers<Schema extends InstantSchemaDef<any, any, any>> = {
   typedHandlers: {
     (
-      etype: DefaultKey,
+      namespace: DefaultKey,
       handler: WebhookHandlerFn<
         Schema,
         keyof Schema['entities'] & string,
@@ -335,18 +335,18 @@ export type WebhookHelpers<Schema extends InstantSchemaDef<any, any, any>> = {
       >,
     ): TypedDefaultEntry<Schema>;
     <
-      EtypeName extends keyof Schema['entities'] & string,
+      NamespaceName extends keyof Schema['entities'] & string,
       Action extends WebhookAction | DefaultKey,
     >(
-      etype: EtypeName,
+      namespace: NamespaceName,
       action: Action,
       handler: WebhookHandlerFn<
         Schema,
-        EtypeName,
+        NamespaceName,
         ResolveHandlerAction<Action>,
         any
       >,
-    ): TypedHandlerEntry<Schema, EtypeName, Action>;
+    ): TypedHandlerEntry<Schema, NamespaceName, Action>;
   };
   combineHandlers: (
     ...entries: Array<
@@ -546,7 +546,7 @@ function toWebhookInfo(raw: any): WebhookInfo {
   return {
     id: raw.id,
     sink: raw.sink,
-    etypes: raw.etypes ?? [],
+    namespaces: raw.namespaces ?? [],
     actions: raw.actions,
     status: raw.status,
     disabledReason: raw.disabled_reason ?? null,
@@ -646,7 +646,7 @@ export class WebhooksManager<Schema extends InstantSchemaDef<any, any, any>> {
    * starts receiving matching events immediately.
    *
    * The server rejects the request if `url` is not an HTTPS URL pointing at a
-   * public host, if `etypes` doesn't reference any entity in the app's
+   * public host, if `namespaces` doesn't reference any entity in the app's
    * schema, if `actions` is empty, or if the app has hit its webhook limit.
    *
    * An app may have at most **100 active webhooks** at a time; {@link delete}
@@ -655,7 +655,7 @@ export class WebhooksManager<Schema extends InstantSchemaDef<any, any, any>> {
    * @example
    * const webhook = await db.webhooks.manager.create({
    *   url: 'https://example.com/instant',
-   *   etypes: ['posts', 'comments'],
+   *   namespaces: ['posts', 'comments'],
    *   actions: ['create', 'update'],
    * });
    */
@@ -668,7 +668,7 @@ export class WebhooksManager<Schema extends InstantSchemaDef<any, any, any>> {
   }
 
   /**
-   * Updates a webhook's `url`, `etypes`, and/or `actions`. Pass only the
+   * Updates a webhook's `url`, `namespaces`, and/or `actions`. Pass only the
    * fields you want to change; omitted fields keep their current value.
    *
    * Does not affect the webhook's status — use {@link enable} or
@@ -816,8 +816,8 @@ export class Webhooks<Schema extends InstantSchemaDef<any, any, any>> {
   /**
    * Schema-bound helpers for building typed handler maps.
    *
-   * - `typedHandlers(etype, action, handler)` builds a single typed entry.
-   *   Pass `'$default'` for `etype` to register a catch-all handler.
+   * - `typedHandlers(namespace, action, handler)` builds a single typed entry.
+   *   Pass `'$default'` for `namespace` to register a catch-all handler.
    * - `combineHandlers(...entries)` merges entries into a
    *   {@link WebhookHandlers} object suitable for {@link processPayload} and
    *   {@link processRequest}.
@@ -840,8 +840,8 @@ export class Webhooks<Schema extends InstantSchemaDef<any, any, any>> {
       if (args.length === 2) {
         return { $default: args[1] };
       }
-      const [etype, action, handler] = args;
-      return { [etype]: { [action]: handler } };
+      const [namespace, action, handler] = args;
+      return { [namespace]: { [action]: handler } };
     }
     function combineHandlers(...entries: any[]): any {
       const result: any = {};
@@ -1016,8 +1016,8 @@ export class Webhooks<Schema extends InstantSchemaDef<any, any, any>> {
 
   /**
    * Dispatches each record in `payload` to its matching handler in
-   * `handlers`. Resolution order per record: exact `etype` + `action` →
-   * `etype`'s `$default` → top-level `$default`. Records with no matching
+   * `handlers`. Resolution order per record: exact `namespace` + `action` →
+   * `namespace`'s `$default` → top-level `$default`. Records with no matching
    * handler are skipped.
    *
    * Handlers run concurrently. If any handler rejects, the call rejects so
@@ -1030,15 +1030,15 @@ export class Webhooks<Schema extends InstantSchemaDef<any, any, any>> {
   ): Promise<void> {
     const results: any[] = [];
     for (const record of payload.data) {
-      const { etype, action } = record;
+      const { namespace, action } = record;
       const handler =
-        handlers?.[etype]?.[action] ||
-        handlers?.[etype]?.$default ||
+        handlers?.[namespace]?.[action] ||
+        handlers?.[namespace]?.$default ||
         handlers?.$default;
       if (handler) {
         // We need the as any here because typescript
         // has trouble correlating the handler to the
-        // record etype and action
+        // record namespace and action
         results.push(handler(record as any));
       }
     }

--- a/client/sandbox/react-nextjs/app/api/webhooks/route.ts
+++ b/client/sandbox/react-nextjs/app/api/webhooks/route.ts
@@ -25,7 +25,7 @@ export const POST = async (req: Request) => {
             await guestDb.transact(
               db.tx.webhookEvents[id()].update({
                 receivedAt: Date.now(),
-                etype: record.etype,
+                namespace: record.namespace,
                 action: record.action,
                 payload: record,
               }),

--- a/client/sandbox/react-nextjs/pages/api/webhooks-pages.ts
+++ b/client/sandbox/react-nextjs/pages/api/webhooks-pages.ts
@@ -30,7 +30,7 @@ export default async function handler(
         await guestDb.transact(
           db.tx.webhookEvents[id()].update({
             receivedAt: Date.now(),
-            etype: record.etype,
+            namespace: record.namespace,
             action: record.action,
             payload: record,
           }),

--- a/client/sandbox/react-nextjs/pages/play/webhooks.tsx
+++ b/client/sandbox/react-nextjs/pages/play/webhooks.tsx
@@ -22,7 +22,7 @@ const schema = i.schema({
     }),
     webhookEvents: i.entity({
       receivedAt: i.number().indexed(),
-      etype: i.string(),
+      namespace: i.string(),
       action: i.string(),
       payload: i.json(),
     }),
@@ -33,7 +33,7 @@ const schema = i.schema({
 });
 
 type Schema = typeof schema;
-type EtypeName = Exclude<keyof Schema['entities'] & string, 'webhookEvents'>;
+type NamespaceName = Exclude<keyof Schema['entities'] & string, 'webhookEvents'>;
 
 const NGROK_KEY = 'webhooks-ngrok';
 const CONFIG_ID = '11111111-1111-4111-9111-111111111111';
@@ -49,7 +49,7 @@ const dangerBtn =
 const subtleBtn =
   'px-2 py-0.5 text-xs bg-white text-gray-700 border rounded hover:bg-gray-50 disabled:opacity-50';
 
-const ALL_ETYPES: EtypeName[] = ['colors', 'items'];
+const ALL_NAMESPACES: NamespaceName[] = ['colors', 'items'];
 const ALL_ACTIONS: WebhookAction[] = ['create', 'update', 'delete'];
 
 function statusColor(status: WebhookEventInfo['status']) {
@@ -166,7 +166,7 @@ function App({
     wrap(async () => {
       await manager.create({
         url: webhookUrl,
-        etypes: ['colors'],
+        namespaces: ['colors'],
         actions: ['create', 'update', 'delete'],
       });
       await refreshWebhooks();
@@ -192,7 +192,11 @@ function App({
 
   const saveEdit = (
     webhookId: string,
-    params: { url: string; etypes: EtypeName[]; actions: WebhookAction[] },
+    params: {
+      url: string;
+      namespaces: NamespaceName[];
+      actions: WebhookAction[];
+    },
   ) =>
     wrap(async () => {
       await manager.update(webhookId, params);
@@ -210,10 +214,10 @@ function App({
     webhookEvents: { $: { order: { receivedAt: 'desc' }, limit: 50 } },
   });
 
-  const addRow = (etype: EtypeName) =>
+  const addRow = (namespace: NamespaceName) =>
     tryFire(async () => {
       const createdAt = Date.now();
-      if (etype === 'colors') {
+      if (namespace === 'colors') {
         await adminDb.transact(
           adminDb.tx.colors[id()].update({
             color: pick(colorOptions),
@@ -230,9 +234,9 @@ function App({
       }
     });
 
-  const updateFirstRow = (etype: EtypeName) =>
+  const updateFirstRow = (namespace: NamespaceName) =>
     tryFire(async () => {
-      if (etype === 'colors') {
+      if (namespace === 'colors') {
         const first = colorsData?.colors?.[0];
         if (!first) return;
         await adminDb.transact(
@@ -249,9 +253,9 @@ function App({
       }
     });
 
-  const deleteFirstRow = (etype: EtypeName) =>
+  const deleteFirstRow = (namespace: NamespaceName) =>
     tryFire(async () => {
-      if (etype === 'colors') {
+      if (namespace === 'colors') {
         const first = colorsData?.colors?.[0];
         if (!first) return;
         await adminDb.transact(adminDb.tx.colors[first.id].delete());
@@ -413,7 +417,7 @@ function App({
                         {w.status}
                       </span>
                       {' · '}
-                      etypes: {(w.etypes ?? []).join(', ') || '—'}
+                      namespaces: {(w.namespaces ?? []).join(', ') || '—'}
                       {' · '}
                       actions: {w.actions.join(', ')}
                       {w.disabledReason && (
@@ -469,7 +473,7 @@ function App({
       <section className="rounded border p-4">
         <h2 className="font-semibold">3. Trigger some events</h2>
         <div className="mt-3 grid grid-cols-2 gap-4">
-          <EtypeControls
+          <NamespaceControls
             label="colors"
             rows={(colorsData?.colors ?? []).map((c: any) => ({
               id: c.id,
@@ -479,7 +483,7 @@ function App({
             onUpdate={() => updateFirstRow('colors')}
             onDelete={() => deleteFirstRow('colors')}
           />
-          <EtypeControls
+          <NamespaceControls
             label="items"
             rows={(itemsData?.items ?? []).map((it: any) => ({
               id: it.id,
@@ -546,7 +550,7 @@ function App({
           {(handlerEventsData?.webhookEvents ?? []).map((e: any) => (
             <li key={e.id} className="rounded border bg-gray-50 p-2">
               <div>
-                <span className="font-mono">{e.etype}</span> /{' '}
+                <span className="font-mono">{e.namespace}</span> /{' '}
                 <span className="font-mono">{e.action}</span>{' '}
                 <span className="text-xs text-gray-500">
                   {new Date(e.receivedAt).toLocaleTimeString()}
@@ -569,7 +573,7 @@ function App({
   );
 }
 
-function EtypeControls({
+function NamespaceControls({
   label,
   rows,
   onAdd,
@@ -621,16 +625,16 @@ function WebhookEditor({
   webhook: WebhookInfo;
   onSave: (params: {
     url: string;
-    etypes: EtypeName[];
+    namespaces: NamespaceName[];
     actions: WebhookAction[];
   }) => void;
   onCancel: () => void;
   disabled: boolean;
 }) {
   const [url, setUrl] = useState(webhook.sink.url);
-  const [etypes, setEtypes] = useState<Set<EtypeName>>(
-    () => new Set((webhook.etypes ?? []) as EtypeName[]),
-  );
+  const [selectedNamespaces, setSelectedNamespaces] = useState<
+    Set<NamespaceName>
+  >(() => new Set((webhook.namespaces ?? []) as NamespaceName[]));
   const [actions, setActions] = useState<Set<WebhookAction>>(
     () => new Set(webhook.actions),
   );
@@ -652,14 +656,16 @@ function WebhookEditor({
       />
       <div className="flex flex-wrap gap-3">
         <div>
-          <div className="text-xs text-gray-600">etypes</div>
+          <div className="text-xs text-gray-600">namespaces</div>
           <div className="mt-1 flex gap-2">
-            {ALL_ETYPES.map((e) => (
+            {ALL_NAMESPACES.map((e) => (
               <label key={e} className="text-xs">
                 <input
                   type="checkbox"
-                  checked={etypes.has(e)}
-                  onChange={() => setEtypes((s) => toggle(s, e))}
+                  checked={selectedNamespaces.has(e)}
+                  onChange={() =>
+                    setSelectedNamespaces((s) => toggle(s, e))
+                  }
                 />{' '}
                 {e}
               </label>
@@ -689,7 +695,7 @@ function WebhookEditor({
           onClick={() =>
             onSave({
               url,
-              etypes: Array.from(etypes),
+              namespaces: Array.from(selectedNamespaces),
               actions: Array.from(actions),
             })
           }

--- a/client/sandbox/react-nextjs/pages/play/webhooks.tsx
+++ b/client/sandbox/react-nextjs/pages/play/webhooks.tsx
@@ -33,7 +33,10 @@ const schema = i.schema({
 });
 
 type Schema = typeof schema;
-type NamespaceName = Exclude<keyof Schema['entities'] & string, 'webhookEvents'>;
+type NamespaceName = Exclude<
+  keyof Schema['entities'] & string,
+  'webhookEvents'
+>;
 
 const NGROK_KEY = 'webhooks-ngrok';
 const CONFIG_ID = '11111111-1111-4111-9111-111111111111';
@@ -663,9 +666,7 @@ function WebhookEditor({
                 <input
                   type="checkbox"
                   checked={selectedNamespaces.has(e)}
-                  onChange={() =>
-                    setSelectedNamespaces((s) => toggle(s, e))
-                  }
+                  onChange={() => setSelectedNamespaces((s) => toggle(s, e))}
                 />{' '}
                 {e}
               </label>

--- a/client/www/app/api/webhooks/config/route.ts
+++ b/client/www/app/api/webhooks/config/route.ts
@@ -16,7 +16,7 @@ const getDb = () => {
 type Action = 'create' | 'update' | 'delete';
 
 type Record_ = {
-  etype: string;
+  namespace: string;
   action: Action;
   id: string;
   before: Record<string, unknown> | null;
@@ -76,7 +76,7 @@ const codeBlock = (lang: string, body: string) =>
 
 const baseEmbed = (record: Record_): Embed => ({
   title: 'instant-config changed',
-  footer: { text: `${record.etype} • ${record.action}` },
+  footer: { text: `${record.namespace} • ${record.action}` },
   timestamp: new Date().toISOString(),
 });
 
@@ -125,7 +125,7 @@ const flagEmbed = (record: Record_): Embed | null => {
 };
 
 const defaultEmbed = (record: Record_): Embed => {
-  const header = `\`${record.etype}\` ${record.action}`;
+  const header = `\`${record.namespace}\` ${record.action}`;
   let codeBody = '';
   if (record.action === 'create' && record.after) {
     codeBody = Object.entries(record.after)

--- a/client/www/components/dash/WebhookEvents.tsx
+++ b/client/www/components/dash/WebhookEvents.tsx
@@ -871,12 +871,14 @@ function EventsListPage({
                     </span>
                   ) : (
                     <span className="font-mono text-xs">
-                      {[...(webhook.namespaces ?? [])].sort().map((e, i, arr) => (
-                        <Fragment key={e}>
-                          <span className="whitespace-nowrap">{e}</span>
-                          {i < arr.length - 1 ? ', ' : ''}
-                        </Fragment>
-                      ))}
+                      {[...(webhook.namespaces ?? [])]
+                        .sort()
+                        .map((e, i, arr) => (
+                          <Fragment key={e}>
+                            <span className="whitespace-nowrap">{e}</span>
+                            {i < arr.length - 1 ? ', ' : ''}
+                          </Fragment>
+                        ))}
                     </span>
                   ),
               },

--- a/client/www/components/dash/WebhookEvents.tsx
+++ b/client/www/components/dash/WebhookEvents.tsx
@@ -397,7 +397,7 @@ function RecordRow({ record }: { record: InstantWebhookPayloadRecord }) {
           className={`shrink-0 text-gray-400 transition-transform ${open ? 'rotate-90' : ''}`}
         />
         <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-sm font-medium text-gray-700 dark:bg-neutral-700 dark:text-neutral-200">
-          {record.etype}
+          {record.namespace}
         </span>
         <ActionBadge action={record.action} />
         <span className="font-mono text-sm break-all text-gray-500 dark:text-neutral-500">
@@ -407,8 +407,8 @@ function RecordRow({ record }: { record: InstantWebhookPayloadRecord }) {
       {open ? (
         <div id={panelId} className="flex flex-col gap-1 pl-5 text-sm">
           <div>
-            <span className="font-semibold">etype</span>:{' '}
-            <span className="font-mono">{record.etype}</span>
+            <span className="font-semibold">namespace</span>:{' '}
+            <span className="font-mono">{record.namespace}</span>
           </div>
           <div>
             <span className="font-semibold">id</span>:{' '}
@@ -496,7 +496,7 @@ function EventPayload({
               <div className="flex flex-col gap-2">
                 {records.map((r) => (
                   <RecordRow
-                    key={`${r.etype}:${r.id}:${r.action}`}
+                    key={`${r.namespace}:${r.id}:${r.action}`}
                     record={r}
                   />
                 ))}
@@ -865,13 +865,13 @@ function EventsListPage({
               {
                 label: 'Entities',
                 value:
-                  (webhook.etypes ?? []).length === 0 ? (
+                  (webhook.namespaces ?? []).length === 0 ? (
                     <span className="text-gray-400 dark:text-neutral-500">
                       (none)
                     </span>
                   ) : (
                     <span className="font-mono text-xs">
-                      {[...(webhook.etypes ?? [])].sort().map((e, i, arr) => (
+                      {[...(webhook.namespaces ?? [])].sort().map((e, i, arr) => (
                         <Fragment key={e}>
                           <span className="whitespace-nowrap">{e}</span>
                           {i < arr.length - 1 ? ', ' : ''}

--- a/client/www/components/dash/WebhookEvents.tsx
+++ b/client/www/components/dash/WebhookEvents.tsx
@@ -863,7 +863,7 @@ function EventsListPage({
                   ),
               },
               {
-                label: 'Entities',
+                label: 'Namespaces',
                 value:
                   (webhook.namespaces ?? []).length === 0 ? (
                     <span className="text-gray-400 dark:text-neutral-500">

--- a/client/www/components/dash/Webhooks.tsx
+++ b/client/www/components/dash/Webhooks.tsx
@@ -249,7 +249,7 @@ function WebhookForm({
       return;
     }
     if (selectedNamespaces.size === 0) {
-      errorToast('Select at least one entity.', { autoClose: 5000 });
+      errorToast('Select at least one namespace.', { autoClose: 5000 });
       return;
     }
     if (actions.size === 0) {
@@ -280,10 +280,10 @@ function WebhookForm({
       </div>
 
       <div className="flex flex-col gap-1">
-        <Label>Entities</Label>
+        <Label>Namespaces</Label>
         {allOptions.length === 0 ? (
           <Content className="text-xs text-gray-500 dark:text-neutral-500">
-            Define entities in your schema to enable webhooks.
+            Define namespaces in your schema to enable webhooks.
           </Content>
         ) : (
           <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded-sm border bg-gray-50 p-2 dark:border-neutral-700 dark:bg-neutral-800/50">
@@ -661,7 +661,7 @@ function WebhookRow({
           <dd>
             <CopyableText value={webhook.id} className="font-mono break-all" />
           </dd>
-          <dt className="text-gray-500 dark:text-neutral-500">Entities</dt>
+          <dt className="text-gray-500 dark:text-neutral-500">Namespaces</dt>
           <dd className="font-mono">
             {(webhook.namespaces ?? []).length === 0
               ? '(none)'
@@ -756,8 +756,8 @@ export function Webhooks({
         <div className="flex flex-col gap-1">
           <SectionHeading>Webhooks</SectionHeading>
           <Content className="text-sm text-gray-500 dark:text-neutral-500">
-            Receive HTTP callbacks when entities are created, updated, or
-            deleted.
+            Receive HTTP callbacks when entries in a namespace are created,
+            updated, or deleted.
           </Content>
         </div>
         <Button variant="primary" onClick={createDialog.onOpen}>

--- a/client/www/components/dash/Webhooks.tsx
+++ b/client/www/components/dash/Webhooks.tsx
@@ -102,7 +102,7 @@ export function CopyableText({
 
 type CreateBody = {
   url: string;
-  etypes: string[];
+  namespaces: string[];
   actions: InstantWebhookAction[];
 };
 
@@ -186,15 +186,19 @@ function WebhookForm({
 }: {
   heading: string;
   namespaces: SchemaNamespace[] | null;
-  initial?: { url: string; etypes: string[]; actions: InstantWebhookAction[] };
+  initial?: {
+    url: string;
+    namespaces: string[];
+    actions: InstantWebhookAction[];
+  };
   submitLabel: string;
   onSubmit: (body: CreateBody) => Promise<void>;
   onCancel: () => void;
   isLoading: boolean;
 }) {
   const [url, setUrl] = useState(initial?.url ?? '');
-  const [etypes, setEtypes] = useState<Set<string>>(
-    () => new Set(initial?.etypes ?? []),
+  const [selectedNamespaces, setSelectedNamespaces] = useState<Set<string>>(
+    () => new Set(initial?.namespaces ?? []),
   );
   const [actions, setActions] = useState<Set<InstantWebhookAction>>(
     () => new Set(initial?.actions ?? ['create']),
@@ -205,13 +209,13 @@ function WebhookForm({
     [namespaces],
   );
 
-  // Show any etype the webhook already references even if it's no longer in
-  // the schema (renamed/deleted), so the user can deselect it intentionally.
+  // Show any namespace the webhook already references even if it's no longer
+  // in the schema (renamed/deleted), so the user can deselect it intentionally.
   const allOptions = useMemo(() => {
     const set = new Set<string>(namespaceNames);
-    for (const e of initial?.etypes ?? []) set.add(e);
+    for (const e of initial?.namespaces ?? []) set.add(e);
     return [...set].sort();
-  }, [namespaceNames, initial?.etypes]);
+  }, [namespaceNames, initial?.namespaces]);
 
   const toggle = <T,>(set: Set<T>, value: T) => {
     const next = new Set(set);
@@ -244,7 +248,7 @@ function WebhookForm({
       });
       return;
     }
-    if (etypes.size === 0) {
+    if (selectedNamespaces.size === 0) {
       errorToast('Select at least one entity.', { autoClose: 5000 });
       return;
     }
@@ -254,7 +258,7 @@ function WebhookForm({
     }
     await onSubmit({
       url: trimmed,
-      etypes: [...etypes],
+      namespaces: [...selectedNamespaces],
       actions: [...actions],
     });
   };
@@ -286,8 +290,8 @@ function WebhookForm({
             {allOptions.map((n) => (
               <Checkbox
                 key={n}
-                checked={etypes.has(n)}
-                onChange={() => setEtypes((s) => toggle(s, n))}
+                checked={selectedNamespaces.has(n)}
+                onChange={() => setSelectedNamespaces((s) => toggle(s, n))}
                 label={n}
               />
             ))}
@@ -399,7 +403,7 @@ function EditDialog({
         namespaces={namespaces}
         initial={{
           url: webhook.sink.url,
-          etypes: webhook.etypes ?? [],
+          namespaces: webhook.namespaces ?? [],
           actions: webhook.actions,
         }}
         submitLabel="Save"
@@ -659,9 +663,9 @@ function WebhookRow({
           </dd>
           <dt className="text-gray-500 dark:text-neutral-500">Entities</dt>
           <dd className="font-mono">
-            {(webhook.etypes ?? []).length === 0
+            {(webhook.namespaces ?? []).length === 0
               ? '(none)'
-              : [...(webhook.etypes ?? [])].sort().map((e, i, arr) => (
+              : [...(webhook.namespaces ?? [])].sort().map((e, i, arr) => (
                   <Fragment key={e}>
                     <span className="whitespace-nowrap">{e}</span>
                     {i < arr.length - 1 ? ', ' : ''}

--- a/client/www/lib/types.ts
+++ b/client/www/lib/types.ts
@@ -29,7 +29,7 @@ export type InstantWebhookStatus = 'active' | 'disabled';
 export type InstantWebhook = {
   id: string;
   sink: { url: string };
-  etypes: string[] | null;
+  namespaces: string[] | null;
   actions: InstantWebhookAction[];
   status: InstantWebhookStatus;
   disabled_reason: string | null;
@@ -74,7 +74,7 @@ export type InstantWebhookEventsPage = {
 export type InstantWebhookPayloadAction = 'create' | 'update' | 'delete';
 
 export type InstantWebhookPayloadRecord = {
-  etype: string;
+  namespace: string;
   id: string;
   action: InstantWebhookPayloadAction;
   before: Record<string, unknown> | null;

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1626,7 +1626,7 @@
 ;; Webhooks
 
 (defn webhook-row->response [webhook]
-  (select-keys webhook [:id :sink :etypes :actions :status
+  (select-keys webhook [:id :sink :namespaces :actions :status
                         :disabled_reason :created_at :updated_at]))
 
 (defn coerce-string-vec [x]
@@ -1646,11 +1646,11 @@
                                                                          :data/write
                                                                          req)
         url (ex/get-param! req [:body :url] string-util/coerce-non-blank-str)
-        etypes (ex/get-param! req [:body :etypes] coerce-string-vec)
+        namespaces (ex/get-param! req [:body :namespaces] coerce-string-vec)
         actions (ex/get-param! req [:body :actions] coerce-string-vec)
         {webhook-id :id} (webhook-model/create! {:app-id app-id
                                                  :url url
-                                                 :etypes etypes
+                                                 :namespaces namespaces
                                                  :actions actions})
         webhook (webhook-model/get-by-app-id-and-webhook-id! {:app-id app-id
                                                               :webhook-id webhook-id})]
@@ -1667,8 +1667,8 @@
                  (contains? body :url)
                  (assoc :url (ex/get-param! req [:body :url] string-util/coerce-non-blank-str))
 
-                 (contains? body :etypes)
-                 (assoc :etypes (ex/get-param! req [:body :etypes] coerce-string-vec))
+                 (contains? body :namespaces)
+                 (assoc :namespaces (ex/get-param! req [:body :namespaces] coerce-string-vec))
 
                  (contains? body :actions)
                  (assoc :actions (ex/get-param! req [:body :actions] coerce-string-vec)))]

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -192,13 +192,13 @@
                                       [:json_build_object
                                        [:inline "id"] :w.id
                                        [:inline "sink"] :w.sink
-                                       [:inline "etypes"] {:select [[[:array_agg :attrs.etype]]]
-                                                           :from [:attrs]
-                                                           :where [:and
-                                                                   [:or
-                                                                    [:= :attrs.app-id :w.app-id]
-                                                                    [:= :attrs.app-id [:cast [:inline (str system-catalog/system-catalog-app-id)] :uuid]]]
-                                                                   [:= :attrs.id [:any :w.id-attr-ids]]]}
+                                       [:inline "namespaces"] {:select [[[:array_agg :attrs.etype]]]
+                                                               :from [:attrs]
+                                                               :where [:and
+                                                                       [:or
+                                                                        [:= :attrs.app-id :w.app-id]
+                                                                        [:= :attrs.app-id [:cast [:inline (str system-catalog/system-catalog-app-id)] :uuid]]]
+                                                                       [:= :attrs.id [:any :w.id-attr-ids]]]}
                                        [:inline "actions"] :w.actions
                                        [:inline "status"] :w.status
                                        [:inline "disabled_reason"] :w.disabled_reason

--- a/server/src/instant/model/webhook.clj
+++ b/server/src/instant/model/webhook.clj
@@ -54,14 +54,14 @@
                                          (when-not (.isEmpty webhook-ids)
                                            webhook-ids))))))
 
-(def ^{:tag Cache} webhook-with-etypes-cache
+(def ^{:tag Cache} webhook-with-namespaces-cache
   (cache/make {:max-size 2048
                :on-remove (fn [_k webhook _]
                             (remove-attr-listener webhook))}))
 
 (defn evict-webhook-from-cache [{:keys [app-id webhook-id]}]
-  (cache/invalidate webhook-with-etypes-cache {:app-id app-id
-                                               :webhook-id webhook-id}))
+  (cache/invalidate webhook-with-namespaces-cache {:app-id app-id
+                                                   :webhook-id webhook-id}))
 
 (defmacro with-cache-invalidation [cache-key & body]
   `(let [cache-key# ~cache-key]
@@ -82,7 +82,7 @@
                                            [:= :app_id :?app-id]
                                            [:= :app_id [:cast [:inline (str system-catalog/system-catalog-app-id)] :uuid]]]
                                           [:= :id [:any :id-attr-ids]]]}
-                                 :etypes]]
+                                 :namespaces]]
                     :from :webhooks
                     :where [:and
                             [:= :app_id :?app-id]
@@ -102,9 +102,9 @@
 (defn get-by-app-id-and-webhook-id!
   ([params]
    ;; Use this approach so that we can invalidate the webhook if the
-   ;; attrs changes, since we rely on the attrs to get the etype
+   ;; attrs changes, since we rely on the attrs to get the namespace
    ;; https://github.com/ben-manes/caffeine/wiki/Compute
-   (->  webhook-with-etypes-cache
+   (->  webhook-with-namespaces-cache
         (.asMap)
         (.computeIfAbsent params (fn [params]
                                    (let [res (get-by-app-id-and-webhook-id!* params)]
@@ -124,7 +124,7 @@
                                            [:= :app_id :?app-id]
                                            [:= :app_id [:cast [:inline (str system-catalog/system-catalog-app-id)] :uuid]]]
                                           [:= :id [:any :id-attr-ids]]]}
-                                 :etypes]]
+                                 :namespaces]]
                     :from :webhooks
                     :where [:= :app_id :?app-id]
                     :order-by [[:created-at :desc]]}))
@@ -302,37 +302,37 @@
                               :status [:inline [:cast [:inline "active"] :webhook_status]]
                               :sink :?sink}]}))
 
-(defn etypes->id-attr-ids+topics!
-  "Resolves etypes to a set of id-attr-ids (the `id` attr for each etype) and a
-   bloom-filter `topics` value. Throws a validation error if any etype is unknown."
-  [app-id etypes]
+(defn namespaces->id-attr-ids+topics!
+  "Resolves namespaces to a set of id-attr-ids (the `id` attr for each namespace) and a
+   bloom-filter `topics` value. Throws a validation error if any namespace is unknown."
+  [app-id namespaces]
   (let [attrs (attr-model/get-by-app-id app-id)
-        id-attr-ids (reduce (fn [attr-ids etype]
-                              (let [attr-id (:id (attr-model/seek-by-fwd-ident-name [etype "id"] attrs))]
+        id-attr-ids (reduce (fn [attr-ids namespace]
+                              (let [attr-id (:id (attr-model/seek-by-fwd-ident-name [namespace "id"] attrs))]
                                 (when-not attr-id
                                   (ex/throw-validation-err!
                                    :webhook
-                                   {:etype etype}
-                                   [{:message (format "Could not find matching table for %s" etype)}]))
+                                   {:namespace namespace}
+                                   [{:message (format "Could not find matching table for %s" namespace)}]))
                                 (conj attr-ids attr-id)))
                             #{}
-                            etypes)
+                            namespaces)
         topics (reduce (fn [acc id]
                          (bit-or acc (history/bloom-bit id)))
                        0
                        id-attr-ids)]
     (when-not (seq id-attr-ids)
-      (ex/throw-validation-err! :webhook {:etypes etypes} [{:message "Webhook must have at least one table."}]))
+      (ex/throw-validation-err! :webhook {:namespaces namespaces} [{:message "Webhook must have at least one table."}]))
     {:id-attr-ids id-attr-ids
      :topics topics}))
 
 (defn create!
-  "Creates a new webhook, validating that the etypes are valid, the webhook url is valid,
+  "Creates a new webhook, validating that the namespaces are valid, the webhook url is valid,
    and that the app has not exceeded the maximum number of webhooks."
   ([params] (create! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id etypes actions url]}]
+  ([conn {:keys [app-id namespaces actions url]}]
    (assert-valid-url! url)
-   (let [{:keys [id-attr-ids topics]} (etypes->id-attr-ids+topics! app-id etypes)]
+   (let [{:keys [id-attr-ids topics]} (namespaces->id-attr-ids+topics! app-id namespaces)]
      (when-not (seq actions)
        (ex/throw-validation-err! :webhook {:actions actions} [{:message "Webhook must have at least one action."}]))
      (next.jdbc/with-transaction [conn conn]
@@ -408,10 +408,10 @@
             [:= :id :?webhook-id]]}))
 
 (defn update!
-  "Partial update of a webhook's url, etypes, and/or actions. Pass only the
+  "Partial update of a webhook's url, namespaces, and/or actions. Pass only the
    fields you want to change. Does not touch status — use disable!/enable!."
   ([params] (update! (aurora/conn-pool :write) params))
-  ([conn {:keys [app-id webhook-id url etypes actions] :as params}]
+  ([conn {:keys [app-id webhook-id url namespaces actions] :as params}]
    (when (contains? params :url)
      (assert-valid-url! url))
    (when (contains? params :actions)
@@ -420,8 +420,8 @@
                                  {:actions actions}
                                  [{:message "Webhook must have at least one action."}])))
    (let [{new-id-attr-ids :id-attr-ids
-          new-topics :topics} (when (contains? params :etypes)
-                                (etypes->id-attr-ids+topics! app-id etypes))]
+          new-topics :topics} (when (contains? params :namespaces)
+                                (namespaces->id-attr-ids+topics! app-id namespaces))]
      (with-cache-invalidation {:app-id app-id
                                :webhook-id webhook-id}
        (next.jdbc/with-transaction [conn conn]
@@ -770,9 +770,9 @@
   "Creates a sha-256 hash of the inputs and generates a UUID from the first
    128 bits. Clients can use it to ensure that they don't handle the same
    record twice."
-  [{:keys [^String etype ^String action ^UUID id ^ISN isn]}]
+  [{:keys [^String namespace ^String action ^UUID id ^ISN isn]}]
   (let [digest (MessageDigest/getInstance "SHA-256")]
-    (.update digest (.getBytes etype StandardCharsets/UTF_8))
+    (.update digest (.getBytes namespace StandardCharsets/UTF_8))
     (.update digest (.getBytes action StandardCharsets/UTF_8))
     (.update digest (uuid-util/->bytes id))
     (.update digest (isn/->bytes isn))
@@ -805,7 +805,7 @@
 
 (defn webhook-data-for-wal-record
   "Returns a list of records:
-   [{etype: <etype>
+   [{namespace: <namespace>
      id: <uuid>
      action: <create|update|delete>}
      before: <?ent>
@@ -816,15 +816,15 @@
         ents-before (topics/extract-entities-before attrs
                                                     ents-after
                                                     wal-record)
-        etypes (fn [etype]
-                 (not (nil? (ucoll/index-of etype (:etypes webhook)))))
+        namespaces (fn [namespace]
+                     (not (nil? (ucoll/index-of namespace (:namespaces webhook)))))
         actions (fn [action]
                   (not (nil? (ucoll/index-of action (:actions webhook)))))]
-    (concat (for [[etype ents] ents-after
+    (concat (for [[namespace ents] ents-after
                   [id ent] ents
-                  :let [ent-before (get-in ents-before [etype id])
+                  :let [ent-before (get-in ents-before [namespace id])
                         action (if ent-before "update" "create")]
-                  :when (and (etypes etype)
+                  :when (and (namespaces namespace)
                              (actions action))
                   :let [id (parse-uuid id)
                         before (when (= action "update")
@@ -833,40 +833,40 @@
                   ;; Filters out the updates where we only add or remove a link,
                   ;; we currently don't support webhooks for linking
                   :when (not= before after)
-                  :let [result {:etype etype
+                  :let [result {:namespace namespace
                                 :action action
                                 :id id
                                 :before before
                                 :after after
-                                :idempotencyKey (record-idempotency-key {:etype etype
+                                :idempotencyKey (record-idempotency-key {:namespace namespace
                                                                          :action action
                                                                          :id id
                                                                          :isn (:isn wal-record)})}]]
-              (if (= etype "$files")
+              (if (= namespace "$files")
                 (add-file-urls (:app-id wal-record) result)
                 result))
-            (for [[etype ents] ents-before
+            (for [[namespace ents] ents-before
                   [id ent] ents
-                  :when (and (not (get-in ents-after [etype id]))
-                             (etypes etype)
+                  :when (and (not (get-in ents-after [namespace id]))
+                             (namespaces namespace)
                              (actions "delete"))
                   :let [id (parse-uuid id)
-                        result {:etype etype
+                        result {:namespace namespace
                                 :action "delete"
                                 :id id
                                 :before (uuids->labels attrs ent)
                                 :after nil
-                                :idempotencyKey (record-idempotency-key {:etype etype
+                                :idempotencyKey (record-idempotency-key {:namespace namespace
                                                                          :action "delete"
                                                                          :id id
                                                                          :isn (:isn wal-record)})}]]
-              (if (= etype "$files")
+              (if (= namespace "$files")
                 (add-file-urls (:app-id wal-record) result)
                 result)))))
 
 (defn webhook-data-for-isn
   "Returns a list of records:
-   [{etype: <etype>
+   [{namespace: <namespace>
      id: <uuid>
      action: <create|update|delete>}
      before: <?ent>

--- a/server/test/instant/model/webhook_test.clj
+++ b/server/test/instant/model/webhook_test.clj
@@ -140,8 +140,8 @@
                                           :webhook-id webhook-id
                                           :isn isn})]
             (is (= 1 (count data)))
-            (let [{:keys [etype action id before after idempotencyKey]} (first data)]
-              (is (= "users" etype))
+            (let [{:keys [namespace action id before after idempotencyKey]} (first data)]
+              (is (= "users" namespace))
               (is (= "create" action))
               (is (= user-a-id id))
               (is (nil? before))
@@ -196,8 +196,8 @@
                                           :webhook-id webhook-id
                                           :isn isn})]
             (is (= 1 (count data)))
-            (let [{:keys [etype action id before after idempotencyKey]} (first data)]
-              (is (= "users" etype))
+            (let [{:keys [namespace action id before after idempotencyKey]} (first data)]
+              (is (= "users" namespace))
               (is (= "update" action))
               (is (= user-a-id id))
               (is (= {"id" (str user-a-id) "name" "old-alice"} before))
@@ -250,8 +250,8 @@
                                           :webhook-id webhook-id
                                           :isn isn})]
             (is (= 1 (count data)))
-            (let [{:keys [etype action id before after idempotencyKey]} (first data)]
-              (is (= "users" etype))
+            (let [{:keys [namespace action id before after idempotencyKey]} (first data)]
+              (is (= "users" namespace))
               (is (= "delete" action))
               (is (= user-a-id id))
               (is (= {"id" (str user-a-id) "name" "alice"} before))
@@ -265,7 +265,7 @@
                                              :webhook-id webhook-id
                                              :isn isn}))))))))))
 
-(deftest webhook-data-for-isn-mixed-etypes-and-webhooks
+(deftest webhook-data-for-isn-mixed-namespaces-and-webhooks
   (with-empty-app
     (fn [app]
       (let [attrs (test-util/make-attrs
@@ -347,32 +347,32 @@
                                                   :isn isn}))
                 summarize (fn [data]
                             (->> data
-                                 (map (fn [r] (select-keys r [:etype :action :id :idempotencyKey])))
+                                 (map (fn [r] (select-keys r [:namespace :action :id :idempotencyKey])))
                                  set))]
             ;; users + all actions: create u1, update u2, delete u3
-            (is (= #{{:etype "users" :action "create" :id u1-id
+            (is (= #{{:namespace "users" :action "create" :id u1-id
                       :idempotencyKey #uuid "f9a00dff-7d6b-7d56-161a-6b8fbfca5551"}
-                     {:etype "users" :action "update" :id u2-id
+                     {:namespace "users" :action "update" :id u2-id
                       :idempotencyKey #uuid "84d64dec-f9b4-9787-c3e9-907334861f06"}
-                     {:etype "users" :action "delete" :id u3-id
+                     {:namespace "users" :action "delete" :id u3-id
                       :idempotencyKey #uuid "e68d0121-4503-d213-6a53-a87de0c1b505"}}
                    (summarize (fetch-data users-all-id))))
             ;; books + all actions: create b1, update b2, delete b3
-            (is (= #{{:etype "books" :action "create" :id b1-id
+            (is (= #{{:namespace "books" :action "create" :id b1-id
                       :idempotencyKey #uuid "414a797c-83ec-2c0c-e57d-4f54caad348e"}
-                     {:etype "books" :action "update" :id b2-id
+                     {:namespace "books" :action "update" :id b2-id
                       :idempotencyKey #uuid "65bfa883-7b21-ab05-0fd0-48ff3a0fac60"}
-                     {:etype "books" :action "delete" :id b3-id
+                     {:namespace "books" :action "delete" :id b3-id
                       :idempotencyKey #uuid "6e09fde1-c661-d3a3-7968-7de191b36a18"}}
                    (summarize (fetch-data books-all-id))))
             ;; users + update only
-            (is (= #{{:etype "users" :action "update" :id u2-id
+            (is (= #{{:namespace "users" :action "update" :id u2-id
                       :idempotencyKey #uuid "84d64dec-f9b4-9787-c3e9-907334861f06"}}
                    (summarize (fetch-data users-update-only-id))))
             ;; users + create/delete only
-            (is (= #{{:etype "users" :action "create" :id u1-id
+            (is (= #{{:namespace "users" :action "create" :id u1-id
                       :idempotencyKey #uuid "f9a00dff-7d6b-7d56-161a-6b8fbfca5551"}
-                     {:etype "users" :action "delete" :id u3-id
+                     {:namespace "users" :action "delete" :id u3-id
                       :idempotencyKey #uuid "e68d0121-4503-d213-6a53-a87de0c1b505"}}
                    (summarize (fetch-data users-create-delete-id))))
             ;; calling it twice returns the same idempotency keys
@@ -404,7 +404,7 @@
         (test-util/make-attrs (:id app) [[:users/id :unique? :index?]])
         (let [params (fn []
                        {:app-id (:id app)
-                        :etypes ["users"]
+                        :namespaces ["users"]
                         :actions ["create"]
                         :url (str "https://example.com/" (crypt-util/random-hex 16))})
               start-promise (promise)
@@ -439,7 +439,7 @@
         (test-util/make-attrs (:id app) [[:users/id :unique? :index?]
                                          [:books/id :unique? :index?]])
         (let [params {:app-id (:id app)
-                      :etypes ["users"]
+                      :namespaces ["users"]
                       :actions ["create"]
                       :url "https://example.com/hook"}
               {original-id :id} (webhook/create! params)]
@@ -449,9 +449,9 @@
             (is (some? e))
             (is (re-find #"webhook already exists"
                          (.getMessage ^Exception e))))
-          ;; Differing on any one of url / etypes / actions is not a duplicate.
+          ;; Differing on any one of url / namespaces / actions is not a duplicate.
           (is (webhook/create! (assoc params :url "https://example.com/other")))
-          (is (webhook/create! (assoc params :etypes ["books"])))
+          (is (webhook/create! (assoc params :namespaces ["books"])))
           (is (webhook/create! (assoc params :actions ["update"])))
           ;; A disabled webhook with matching params does not block creation.
           (webhook/disable! {:app-id (:id app)
@@ -465,7 +465,7 @@
       (fn [app]
         (test-util/make-attrs (:id app) [[:users/id :unique? :index?]])
         (let [params {:app-id (:id app)
-                      :etypes ["users"]
+                      :namespaces ["users"]
                       :actions ["create"]
                       :url "https://example.com/hook"}
               {webhook-a-id :id} (webhook/create! params)]
@@ -536,7 +536,7 @@
       (fn [app]
         (test-util/make-attrs (:id app) [[:users/id :unique? :index?]])
         (let [base {:app-id (:id app)
-                    :etypes ["users"]
+                    :namespaces ["users"]
                     :actions ["create"]
                     :url "https://example.com/hook"}
               {a-id :id} (webhook/create! base)
@@ -813,13 +813,13 @@
                                 :actions ["delete"]})))))
 
                 (testing "webhook-data-for-wal-record"
-                  (let [hook {:etypes ["users"]
+                  (let [hook {:namespaces ["users"]
                               :actions ["create" "update" "delete"]}]
                     (testing "insert produces a create record"
                       (let [data (webhook/webhook-data-for-wal-record hook insert-rec)]
                         (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "users" etype))
+                        (let [{:keys [namespace action id before after]} (first data)]
+                          (is (= "users" namespace))
                           (is (= "create" action))
                           (is (= user-id id))
                           (is (nil? before))
@@ -827,8 +827,8 @@
                     (testing "update produces an update record"
                       (let [data (webhook/webhook-data-for-wal-record hook update-rec)]
                         (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "users" etype))
+                        (let [{:keys [namespace action id before after]} (first data)]
+                          (is (= "users" namespace))
                           (is (= "update" action))
                           (is (= user-id id))
                           (is (= {"id" (str user-id) "name" "alice"} before))
@@ -836,20 +836,20 @@
                     (testing "delete produces a delete record"
                       (let [data (webhook/webhook-data-for-wal-record hook delete-rec)]
                         (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "users" etype))
+                        (let [{:keys [namespace action id before after]} (first data)]
+                          (is (= "users" namespace))
                           (is (= "delete" action))
                           (is (= user-id id))
                           (is (= {"id" (str user-id) "name" "bob"} before))
                           (is (nil? after))))))
-                  (testing "non-matching etype returns no records"
-                    (let [hook {:etypes ["books"]
+                  (testing "non-matching namespace returns no records"
+                    (let [hook {:namespaces ["books"]
                                 :actions ["create" "update" "delete"]}]
                       (is (empty? (webhook/webhook-data-for-wal-record hook insert-rec)))
                       (is (empty? (webhook/webhook-data-for-wal-record hook update-rec)))
                       (is (empty? (webhook/webhook-data-for-wal-record hook delete-rec)))))
                   (testing "non-matching action returns no records"
-                    (let [hook {:etypes ["users"]
+                    (let [hook {:namespaces ["users"]
                                 :actions ["delete"]}]
                       (is (empty? (webhook/webhook-data-for-wal-record hook insert-rec)))
                       (is (empty? (webhook/webhook-data-for-wal-record hook update-rec))))))))))))))
@@ -863,201 +863,201 @@
                         (or (= aid (:id app)) (enable-wal-entity-log? aid)))
                       flags/log-to-wal-log-table?
                       (constantly true)]
-         (test-util/with-s3-mock {:location-id-url
-                                  (fn [_app-id location-id]
-                                    (str "https://test.invalid/" location-id))}
-          (let [attrs (attr-model/get-by-app-id (:id app))
-                users-id-aid (system-catalog/get-attr-id "$users" "id")
-                users-email-aid (system-catalog/get-attr-id "$users" "email")
-                files-id-aid (system-catalog/get-attr-id "$files" "id")
-                files-path-aid (system-catalog/get-attr-id "$files" "path")
-                files-size-aid (system-catalog/get-attr-id "$files" "size")
-                files-loc-aid (system-catalog/get-attr-id "$files" "location-id")
-                user-id (test-util/stuid "ua")
-                file-id (test-util/stuid "fa")
-                other-aid (random-uuid)
-                for-app (fn [recs] (filter #(= (:id app) (:app-id %)) recs))]
-            (test-util/with-test-replication-slot [records]
+          (test-util/with-s3-mock {:location-id-url
+                                   (fn [_app-id location-id]
+                                     (str "https://test.invalid/" location-id))}
+            (let [attrs (attr-model/get-by-app-id (:id app))
+                  users-id-aid (system-catalog/get-attr-id "$users" "id")
+                  users-email-aid (system-catalog/get-attr-id "$users" "email")
+                  files-id-aid (system-catalog/get-attr-id "$files" "id")
+                  files-path-aid (system-catalog/get-attr-id "$files" "path")
+                  files-size-aid (system-catalog/get-attr-id "$files" "size")
+                  files-loc-aid (system-catalog/get-attr-id "$files" "location-id")
+                  user-id (test-util/stuid "ua")
+                  file-id (test-util/stuid "fa")
+                  other-aid (random-uuid)
+                  for-app (fn [recs] (filter #(= (:id app) (:app-id %)) recs))]
+              (test-util/with-test-replication-slot [records]
               ;; --- $users txs ---
               ;; Tx 1: insert $users (id + email)
-              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
-                            [[:add-triple user-id users-id-aid (str user-id)]
-                             [:add-triple user-id users-email-aid "alice@example.com"]])
+                (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                              [[:add-triple user-id users-id-aid (str user-id)]
+                               [:add-triple user-id users-email-aid "alice@example.com"]])
               ;; Tx 2: update email
-              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
-                            [[:add-triple user-id users-email-aid "bob@example.com"]])
+                (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                              [[:add-triple user-id users-email-aid "bob@example.com"]])
               ;; Tx 3: delete user
-              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
-                            [[:delete-entity user-id "$users"]])
+                (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                              [[:delete-entity user-id "$users"]])
               ;; --- $files txs ---
               ;; Tx 4: insert $files (id + path + size + location-id)
-              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
-                            [[:add-triple file-id files-id-aid (str file-id)]
-                             [:add-triple file-id files-path-aid "first.png"]
-                             [:add-triple file-id files-size-aid 100]
-                             [:add-triple file-id files-loc-aid "loc-1"]])
+                (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                              [[:add-triple file-id files-id-aid (str file-id)]
+                               [:add-triple file-id files-path-aid "first.png"]
+                               [:add-triple file-id files-size-aid 100]
+                               [:add-triple file-id files-loc-aid "loc-1"]])
               ;; Tx 5: update path
-              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
-                            [[:add-triple file-id files-path-aid "second.png"]])
+                (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                              [[:add-triple file-id files-path-aid "second.png"]])
               ;; Tx 6: delete file
-              (tx/transact! (aurora/conn-pool :write) attrs (:id app)
-                            [[:delete-entity file-id "$files"]])
-              (test-util/wait-for #(<= 6 (count (for-app @records))) 5000)
-              (let [[user-insert user-update user-delete
-                     file-insert file-update file-delete] (vec (for-app @records))]
-                (testing "$users"
-                  (testing "create matches insert touching $users.id"
-                    (is (boolean (webhook/webhook-matches?
-                                  user-insert
-                                  {:id_attr_ids [users-id-aid]
-                                   :actions ["create"]}))))
-                  (testing "create does not match other txs"
-                    (is (nil? (webhook/webhook-matches?
-                               user-update
-                               {:id_attr_ids [users-id-aid]
-                                :actions ["create"]})))
-                    (is (nil? (webhook/webhook-matches?
-                               user-delete
-                               {:id_attr_ids [users-id-aid]
-                                :actions ["create"]}))))
-                  (testing "create does not match when id_attr_ids excludes touched attrs"
-                    (is (nil? (webhook/webhook-matches?
-                               user-insert
-                               {:id_attr_ids [other-aid]
-                                :actions ["create"]}))))
-                  (testing "update matches update touching $users.email"
-                    (is (boolean (webhook/webhook-matches?
-                                  user-update
-                                  {:id_attr_ids [users-email-aid]
-                                   :actions ["update"]}))))
-                  (testing "update does not match when id_attr_ids only references untouched attrs"
-                    (is (nil? (webhook/webhook-matches?
-                               user-update
-                               {:id_attr_ids [users-id-aid]
-                                :actions ["update"]}))))
-                  (testing "delete matches delete touching $users.id"
-                    (is (boolean (webhook/webhook-matches?
-                                  user-delete
-                                  {:id_attr_ids [users-id-aid]
-                                   :actions ["delete"]})))))
+                (tx/transact! (aurora/conn-pool :write) attrs (:id app)
+                              [[:delete-entity file-id "$files"]])
+                (test-util/wait-for #(<= 6 (count (for-app @records))) 5000)
+                (let [[user-insert user-update user-delete
+                       file-insert file-update file-delete] (vec (for-app @records))]
+                  (testing "$users"
+                    (testing "create matches insert touching $users.id"
+                      (is (boolean (webhook/webhook-matches?
+                                    user-insert
+                                    {:id_attr_ids [users-id-aid]
+                                     :actions ["create"]}))))
+                    (testing "create does not match other txs"
+                      (is (nil? (webhook/webhook-matches?
+                                 user-update
+                                 {:id_attr_ids [users-id-aid]
+                                  :actions ["create"]})))
+                      (is (nil? (webhook/webhook-matches?
+                                 user-delete
+                                 {:id_attr_ids [users-id-aid]
+                                  :actions ["create"]}))))
+                    (testing "create does not match when id_attr_ids excludes touched attrs"
+                      (is (nil? (webhook/webhook-matches?
+                                 user-insert
+                                 {:id_attr_ids [other-aid]
+                                  :actions ["create"]}))))
+                    (testing "update matches update touching $users.email"
+                      (is (boolean (webhook/webhook-matches?
+                                    user-update
+                                    {:id_attr_ids [users-email-aid]
+                                     :actions ["update"]}))))
+                    (testing "update does not match when id_attr_ids only references untouched attrs"
+                      (is (nil? (webhook/webhook-matches?
+                                 user-update
+                                 {:id_attr_ids [users-id-aid]
+                                  :actions ["update"]}))))
+                    (testing "delete matches delete touching $users.id"
+                      (is (boolean (webhook/webhook-matches?
+                                    user-delete
+                                    {:id_attr_ids [users-id-aid]
+                                     :actions ["delete"]})))))
 
-                (testing "$files"
-                  (testing "create matches insert touching $files.id"
-                    (is (boolean (webhook/webhook-matches?
-                                  file-insert
-                                  {:id_attr_ids [files-id-aid]
-                                   :actions ["create"]}))))
-                  (testing "create does not match other txs"
-                    (is (nil? (webhook/webhook-matches?
-                               file-update
-                               {:id_attr_ids [files-id-aid]
-                                :actions ["create"]})))
-                    (is (nil? (webhook/webhook-matches?
-                               file-delete
-                               {:id_attr_ids [files-id-aid]
-                                :actions ["create"]}))))
-                  (testing "update matches update touching $files.path"
-                    (is (boolean (webhook/webhook-matches?
-                                  file-update
-                                  {:id_attr_ids [files-path-aid]
-                                   :actions ["update"]}))))
-                  (testing "update does not match when id_attr_ids only references untouched attrs"
-                    (is (nil? (webhook/webhook-matches?
-                               file-update
-                               {:id_attr_ids [files-size-aid]
-                                :actions ["update"]}))))
-                  (testing "delete matches delete touching $files.id"
-                    (is (boolean (webhook/webhook-matches?
-                                  file-delete
-                                  {:id_attr_ids [files-id-aid]
-                                   :actions ["delete"]})))))
+                  (testing "$files"
+                    (testing "create matches insert touching $files.id"
+                      (is (boolean (webhook/webhook-matches?
+                                    file-insert
+                                    {:id_attr_ids [files-id-aid]
+                                     :actions ["create"]}))))
+                    (testing "create does not match other txs"
+                      (is (nil? (webhook/webhook-matches?
+                                 file-update
+                                 {:id_attr_ids [files-id-aid]
+                                  :actions ["create"]})))
+                      (is (nil? (webhook/webhook-matches?
+                                 file-delete
+                                 {:id_attr_ids [files-id-aid]
+                                  :actions ["create"]}))))
+                    (testing "update matches update touching $files.path"
+                      (is (boolean (webhook/webhook-matches?
+                                    file-update
+                                    {:id_attr_ids [files-path-aid]
+                                     :actions ["update"]}))))
+                    (testing "update does not match when id_attr_ids only references untouched attrs"
+                      (is (nil? (webhook/webhook-matches?
+                                 file-update
+                                 {:id_attr_ids [files-size-aid]
+                                  :actions ["update"]}))))
+                    (testing "delete matches delete touching $files.id"
+                      (is (boolean (webhook/webhook-matches?
+                                    file-delete
+                                    {:id_attr_ids [files-id-aid]
+                                     :actions ["delete"]})))))
 
-                (testing "webhook-data-for-wal-record on $users"
-                  (let [hook {:etypes ["$users"]
-                              :actions ["create" "update" "delete"]}]
-                    (testing "insert produces a create record"
-                      (let [data (webhook/webhook-data-for-wal-record hook user-insert)]
-                        (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "$users" etype))
-                          (is (= "create" action))
-                          (is (= user-id id))
-                          (is (nil? before))
-                          (is (= {"id" (str user-id) "email" "alice@example.com"} after)))))
-                    (testing "update produces an update record"
-                      (let [data (webhook/webhook-data-for-wal-record hook user-update)]
-                        (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "$users" etype))
-                          (is (= "update" action))
-                          (is (= user-id id))
-                          (is (= {"id" (str user-id) "email" "alice@example.com"} before))
-                          (is (= {"id" (str user-id) "email" "bob@example.com"} after)))))
-                    (testing "delete produces a delete record"
-                      (let [data (webhook/webhook-data-for-wal-record hook user-delete)]
-                        (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "$users" etype))
-                          (is (= "delete" action))
-                          (is (= user-id id))
-                          (is (= {"id" (str user-id) "email" "bob@example.com"} before))
-                          (is (nil? after)))))))
+                  (testing "webhook-data-for-wal-record on $users"
+                    (let [hook {:namespaces ["$users"]
+                                :actions ["create" "update" "delete"]}]
+                      (testing "insert produces a create record"
+                        (let [data (webhook/webhook-data-for-wal-record hook user-insert)]
+                          (is (= 1 (count data)))
+                          (let [{:keys [namespace action id before after]} (first data)]
+                            (is (= "$users" namespace))
+                            (is (= "create" action))
+                            (is (= user-id id))
+                            (is (nil? before))
+                            (is (= {"id" (str user-id) "email" "alice@example.com"} after)))))
+                      (testing "update produces an update record"
+                        (let [data (webhook/webhook-data-for-wal-record hook user-update)]
+                          (is (= 1 (count data)))
+                          (let [{:keys [namespace action id before after]} (first data)]
+                            (is (= "$users" namespace))
+                            (is (= "update" action))
+                            (is (= user-id id))
+                            (is (= {"id" (str user-id) "email" "alice@example.com"} before))
+                            (is (= {"id" (str user-id) "email" "bob@example.com"} after)))))
+                      (testing "delete produces a delete record"
+                        (let [data (webhook/webhook-data-for-wal-record hook user-delete)]
+                          (is (= 1 (count data)))
+                          (let [{:keys [namespace action id before after]} (first data)]
+                            (is (= "$users" namespace))
+                            (is (= "delete" action))
+                            (is (= user-id id))
+                            (is (= {"id" (str user-id) "email" "bob@example.com"} before))
+                            (is (nil? after)))))))
 
-                (testing "webhook-data-for-wal-record on $files"
-                  (let [hook {:etypes ["$files"]
-                              :actions ["create" "update" "delete"]}
-                        full-file {"id" (str file-id)
-                                   "path" "first.png"
-                                   "size" 100
-                                   "location-id" "loc-1"}]
-                    (testing "insert produces a create record"
-                      (let [data (webhook/webhook-data-for-wal-record hook file-insert)]
-                        (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "$files" etype))
-                          (is (= "create" action))
-                          (is (= file-id id))
-                          (is (nil? before))
-                          (is (string? (get after "url")))
-                          (is (= full-file (dissoc after "url"))))))
-                    (testing "update produces an update record"
-                      (let [data (webhook/webhook-data-for-wal-record hook file-update)]
-                        (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "$files" etype))
-                          (is (= "update" action))
-                          (is (= file-id id))
-                          (is (string? (get before "url")))
-                          (is (= full-file (dissoc before "url")))
-                          (is (string? (get after "url")))
-                          (is (= (get after "url")
-                                 (get before "url")))
-                          (is (= (assoc full-file "path" "second.png") (dissoc after "url"))))))
-                    (testing "delete produces a delete record"
-                      (let [data (webhook/webhook-data-for-wal-record hook file-delete)]
-                        (is (= 1 (count data)))
-                        (let [{:keys [etype action id before after]} (first data)]
-                          (is (= "$files" etype))
-                          (is (= "delete" action))
-                          (is (= file-id id))
-                          (is (string? (get before "url")))
-                          (is (= (assoc full-file "path" "second.png") (dissoc before "url")))
-                          (is (nil? after)))))))
+                  (testing "webhook-data-for-wal-record on $files"
+                    (let [hook {:namespaces ["$files"]
+                                :actions ["create" "update" "delete"]}
+                          full-file {"id" (str file-id)
+                                     "path" "first.png"
+                                     "size" 100
+                                     "location-id" "loc-1"}]
+                      (testing "insert produces a create record"
+                        (let [data (webhook/webhook-data-for-wal-record hook file-insert)]
+                          (is (= 1 (count data)))
+                          (let [{:keys [namespace action id before after]} (first data)]
+                            (is (= "$files" namespace))
+                            (is (= "create" action))
+                            (is (= file-id id))
+                            (is (nil? before))
+                            (is (string? (get after "url")))
+                            (is (= full-file (dissoc after "url"))))))
+                      (testing "update produces an update record"
+                        (let [data (webhook/webhook-data-for-wal-record hook file-update)]
+                          (is (= 1 (count data)))
+                          (let [{:keys [namespace action id before after]} (first data)]
+                            (is (= "$files" namespace))
+                            (is (= "update" action))
+                            (is (= file-id id))
+                            (is (string? (get before "url")))
+                            (is (= full-file (dissoc before "url")))
+                            (is (string? (get after "url")))
+                            (is (= (get after "url")
+                                   (get before "url")))
+                            (is (= (assoc full-file "path" "second.png") (dissoc after "url"))))))
+                      (testing "delete produces a delete record"
+                        (let [data (webhook/webhook-data-for-wal-record hook file-delete)]
+                          (is (= 1 (count data)))
+                          (let [{:keys [namespace action id before after]} (first data)]
+                            (is (= "$files" namespace))
+                            (is (= "delete" action))
+                            (is (= file-id id))
+                            (is (string? (get before "url")))
+                            (is (= (assoc full-file "path" "second.png") (dissoc before "url")))
+                            (is (nil? after)))))))
 
-                (testing "non-matching etype returns no records"
-                  (let [hook {:etypes ["other"]
-                              :actions ["create" "update" "delete"]}]
-                    (doseq [rec [user-insert user-update user-delete
-                                 file-insert file-update file-delete]]
-                      (is (empty? (webhook/webhook-data-for-wal-record hook rec))))))
+                  (testing "non-matching namespace returns no records"
+                    (let [hook {:namespaces ["other"]
+                                :actions ["create" "update" "delete"]}]
+                      (doseq [rec [user-insert user-update user-delete
+                                   file-insert file-update file-delete]]
+                        (is (empty? (webhook/webhook-data-for-wal-record hook rec))))))
 
-                (testing "etype filter isolates $users from $files"
-                  (let [users-only {:etypes ["$users"]
-                                    :actions ["create" "update" "delete"]}
-                        files-only {:etypes ["$files"]
-                                    :actions ["create" "update" "delete"]}]
-                    (is (empty? (webhook/webhook-data-for-wal-record users-only file-insert)))
-                    (is (empty? (webhook/webhook-data-for-wal-record files-only user-insert))))))))))))))
+                  (testing "namespace filter isolates $users from $files"
+                    (let [users-only {:namespaces ["$users"]
+                                      :actions ["create" "update" "delete"]}
+                          files-only {:namespaces ["$files"]
+                                      :actions ["create" "update" "delete"]}]
+                      (is (empty? (webhook/webhook-data-for-wal-record users-only file-insert)))
+                      (is (empty? (webhook/webhook-data-for-wal-record files-only user-insert))))))))))))))
 
 ;; We don't support links yet
 (deftest webhook-matches?-doesn't-match-for-links

--- a/server/test/instant/webhook_routes_test.clj
+++ b/server/test/instant/webhook_routes_test.clj
@@ -74,8 +74,8 @@
                   records (-> resp :body :data)]
               (is (= 200 (:status resp)))
               (is (= 1 (count records)))
-              (let [{:keys [etype action id after]} (first records)]
-                (is (= "users" etype))
+              (let [{:keys [namespace action id after]} (first records)]
+                (is (= "users" namespace))
                 (is (= "create" action))
                 (is (= (str user-id) id))
                 (is (= {:id (str user-id) :name "alice"} after)))))


### PR DESCRIPTION
Uses `namespaces` instead of `etypes` for webhooks, since we don't ever call them `etypes` anywhere public-facing.

Technically a breaking change, but we haven't announced webhooks and nobody is using them yet.

After this is merged, I'll update the docs PR and the cli PR