### PR TITLE
Validate fields is an array

### DIFF
--- a/server/src/instant/db/instaql.clj
+++ b/server/src/instant/db/instaql.clj
@@ -478,6 +478,16 @@
                   :before :after :beforeInclusive :afterInclusive
                   :aggregate :fields)]
 
+    (when (and fields
+               (or (not (sequential? fields))
+                   (map? fields)))
+      (ex/throw-validation-err!
+       :query
+       (:root state)
+       [{:expected 'array?
+         :in (conj (:in state) :fields)
+         :message "The `fields` property should be an array of field names."}]))
+
     (when (seq x)
       (ex/throw-validation-err!
        :query

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -315,7 +315,14 @@
                  (validation-err (assoc ctx :admin? true)
                                  {:users
                                   {:$ {:aggregate :count}
-                                   :bookshelves {}}}))))))))
+                                   :bookshelves {}}}))))
+
+        (testing "fields"
+          (is (= {:expected 'array?,
+                  :in [:users :$ :fields],
+                  :message "The `fields` property should be an array of field names."}
+                 (validation-err ctx
+                                 {:users {:$ {:fields {}}}}))))))))
 
 (deftest validations-on-checked-data
   (with-empty-app


### PR DESCRIPTION
Fixes a bug where throw an unknown error if we get a `map` for fields, e.g.

```js
{books: {$: {fields: {}}}}
```

Saw this error pop up in production early this morning.