### PR TITLE
explorer: save dialog states in uri

### DIFF
--- a/client/packages/components/src/components/explorer/edit-namespace-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-namespace-dialog.tsx
@@ -188,125 +188,120 @@ export function EditNamespaceDialog({
       </form>
     </div>
   ) : screen.kind === 'main' ? (
-        <div className="flex flex-col gap-4 px-2">
-          <div className="mr-8 flex gap-1">
-            <h5 className="flex items-center text-lg font-bold">
-              {namespace.name}
-            </h5>
-            <IconButton
-              variant="subtle"
-              onClick={() => {
-                setScreen({ kind: 'rename' });
-              }}
-              icon={
-                <PencilSquareIcon className="h-4 w-4 opacity-50"></PencilSquareIcon>
-              }
-              label="Rename"
-            ></IconButton>
-
-            <Button
-              className="ml-4"
-              disabled={isSystemCatalogNs}
-              title={
-                isSystemCatalogNs
-                  ? `The ${namespace.name} namespace can't be deleted.`
-                  : undefined
-              }
-              size="mini"
-              variant="secondary"
-              onClick={() => setIsDeleting(true)}
-            >
-              <TrashIcon className="inline" height="1rem" />
-              Delete
-            </Button>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            {namespace.attrs.map((attr) => (
-              <div
-                key={attr.id + '-' + attr.name}
-                className="flex justify-between"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="py-0.5 font-bold">{attr.name}</span>
-                  {notes.notes[attr.id]?.message && (
-                    <InfoTip>
-                      <div className="px-2 text-xs text-gray-500 dark:text-neutral-400">
-                        {notes.notes[attr.id].message}
-                      </div>
-                    </InfoTip>
-                  )}
-                </div>
-                {attr.name !== 'id' ? (
-                  <Button
-                    className="px-2"
-                    size="mini"
-                    variant="subtle"
-                    onClick={() => {
-                      notes.removeNote(attr.id);
-                      setScreen({
-                        kind: 'edit-attr',
-                        attrId: attr.id,
-                        isForward: attr.isForward,
-                      });
-                    }}
-                  >
-                    Edit
-                  </Button>
-                ) : null}
-              </div>
-            ))}
-          </div>
-
-          <div>
-            <Button
-              size="mini"
-              variant="secondary"
-              onClick={() =>
-                setScreen({ kind: 'add-attr', attrKind: 'data' })
-              }
-            >
-              <PlusIcon className="inline" height="12px" />
-              New attribute
-            </Button>
-          </div>
-          <RecentlyDeletedAttrs
-            notes={notes}
-            db={db}
-            appId={appId}
-            namespace={namespace}
-          />
-        </div>
-      ) : screen.kind === 'add-attr' ? (
-        <AddAttrForm
-          db={db}
-          namespace={namespace}
-          namespaces={namespaces}
-          onClose={() => setScreen({ kind: 'main' })}
-          constraints={getSystemConstraints({
-            namespaceName: namespace.name,
-            isSystemCatalogNs,
-          })}
-          attrType={screen.attrKind === 'link' ? 'ref' : 'blob'}
-          onAttrTypeChange={(t) =>
-            onScreenChange({
-              kind: 'add-attr',
-              attrKind: t === 'ref' ? 'link' : 'data',
-            })
+    <div className="flex flex-col gap-4 px-2">
+      <div className="mr-8 flex gap-1">
+        <h5 className="flex items-center text-lg font-bold">
+          {namespace.name}
+        </h5>
+        <IconButton
+          variant="subtle"
+          onClick={() => {
+            setScreen({ kind: 'rename' });
+          }}
+          icon={
+            <PencilSquareIcon className="h-4 w-4 opacity-50"></PencilSquareIcon>
           }
-        />
-      ) : screen.kind === 'edit-attr' && screenAttr ? (
-        <EditAttrForm
-          db={db}
-          attr={screenAttr}
-          onClose={() => setScreen({ kind: 'main' })}
-          constraints={getSystemConstraints({
-            namespaceName: namespace.name,
-            isSystemCatalogNs: isSystemCatalogNs,
-            attr: screenAttr,
-          })}
-        />
-      ) : null;
+          label="Rename"
+        ></IconButton>
+
+        <Button
+          className="ml-4"
+          disabled={isSystemCatalogNs}
+          title={
+            isSystemCatalogNs
+              ? `The ${namespace.name} namespace can't be deleted.`
+              : undefined
+          }
+          size="mini"
+          variant="secondary"
+          onClick={() => setIsDeleting(true)}
+        >
+          <TrashIcon className="inline" height="1rem" />
+          Delete
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {namespace.attrs.map((attr) => (
+          <div key={attr.id + '-' + attr.name} className="flex justify-between">
+            <div className="flex items-center gap-3">
+              <span className="py-0.5 font-bold">{attr.name}</span>
+              {notes.notes[attr.id]?.message && (
+                <InfoTip>
+                  <div className="px-2 text-xs text-gray-500 dark:text-neutral-400">
+                    {notes.notes[attr.id].message}
+                  </div>
+                </InfoTip>
+              )}
+            </div>
+            {attr.name !== 'id' ? (
+              <Button
+                className="px-2"
+                size="mini"
+                variant="subtle"
+                onClick={() => {
+                  notes.removeNote(attr.id);
+                  setScreen({
+                    kind: 'edit-attr',
+                    attrId: attr.id,
+                    isForward: attr.isForward,
+                  });
+                }}
+              >
+                Edit
+              </Button>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <Button
+          size="mini"
+          variant="secondary"
+          onClick={() => setScreen({ kind: 'add-attr', attrKind: 'data' })}
+        >
+          <PlusIcon className="inline" height="12px" />
+          New attribute
+        </Button>
+      </div>
+      <RecentlyDeletedAttrs
+        notes={notes}
+        db={db}
+        appId={appId}
+        namespace={namespace}
+      />
+    </div>
+  ) : screen.kind === 'add-attr' ? (
+    <AddAttrForm
+      db={db}
+      namespace={namespace}
+      namespaces={namespaces}
+      onClose={() => setScreen({ kind: 'main' })}
+      constraints={getSystemConstraints({
+        namespaceName: namespace.name,
+        isSystemCatalogNs,
+      })}
+      attrType={screen.attrKind === 'link' ? 'ref' : 'blob'}
+      onAttrTypeChange={(t) =>
+        onScreenChange({
+          kind: 'add-attr',
+          attrKind: t === 'ref' ? 'link' : 'data',
+        })
+      }
+    />
+  ) : screen.kind === 'edit-attr' && screenAttr ? (
+    <EditAttrForm
+      db={db}
+      attr={screenAttr}
+      onClose={() => setScreen({ kind: 'main' })}
+      constraints={getSystemConstraints({
+        namespaceName: namespace.name,
+        isSystemCatalogNs: isSystemCatalogNs,
+        attr: screenAttr,
+      })}
+    />
+  ) : null;
 }
 
 function DeleteForm({
@@ -461,9 +456,7 @@ function AddAttrForm({
             { id: 'blob', label: 'Data' },
             { id: 'ref', label: 'Link' },
           ]}
-          onChange={(item) =>
-            onAttrTypeChange(item.id as 'blob' | 'ref')
-          }
+          onChange={(item) => onAttrTypeChange(item.id as 'blob' | 'ref')}
         />
       </div>
       {attrType === 'blob' ? (

--- a/client/packages/components/src/components/explorer/edit-namespace-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-namespace-dialog.tsx
@@ -52,7 +52,7 @@ import {
   jobIsCompleted,
   jobIsErrored,
 } from '@lib/utils/indexingJobs';
-import { useExplorerProps, useExplorerState } from './index';
+import { EditSchemaScreen, useExplorerProps, useExplorerState } from './index';
 import { useClose } from '@headlessui/react';
 import {
   PendingJob,
@@ -69,6 +69,8 @@ export function EditNamespaceDialog({
   namespaces,
   onClose,
   isSystemCatalogNs,
+  screen,
+  onScreenChange,
 }: {
   db: InstantReactWebDatabase<any>;
   namespace: SchemaNamespace;
@@ -76,18 +78,20 @@ export function EditNamespaceDialog({
   onClose: (p?: { ok: boolean }) => void;
   readOnly: boolean;
   isSystemCatalogNs: boolean;
+  screen: EditSchemaScreen;
+  onScreenChange: (screen: EditSchemaScreen) => void;
 }) {
   const props = useExplorerProps();
   const appId = props.appId;
   const { history, explorerState } = useExplorerState();
   const { mutate } = useSWRConfig();
-  const [screen, setScreen] = useState<
-    | { type: 'main' }
-    | { type: 'delete' }
-    | { type: 'rename' }
-    | { type: 'add' }
-    | { type: 'edit'; attrId: string; isForward: boolean }
-  >({ type: 'main' });
+
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const setScreen = (s: EditSchemaScreen) => {
+    setIsDeleting(false);
+    onScreenChange(s);
+  };
 
   const [renameNsInput, setRenameNsInput] = useState(namespace.name);
   const [renameNsErrorText, setRenameNsErrorText] = useState<string | null>(
@@ -121,70 +125,69 @@ export function EditNamespaceDialog({
     );
     successToast('Renamed namespace to ' + newName);
     setRenameNsInput('');
-    setScreen({ type: 'main' });
+    setScreen({ kind: 'main' });
   }
 
   const notes = useAttrNotes();
 
   const screenAttr = useMemo(() => {
-    return (
-      screen.type === 'edit' &&
-      namespace.attrs.find(
-        (a) => a.id === screen.attrId && a.isForward === screen.isForward,
-      )
+    if (screen.kind !== 'edit-attr') return undefined;
+    return namespace.attrs.find(
+      (a) => a.id === screen.attrId && a.isForward === screen.isForward,
     );
   }, [
-    screen.type === 'edit' ? screen.attrId : null,
-    screen.type === 'edit' ? screen.isForward : null,
+    screen.kind === 'edit-attr' ? screen.attrId : null,
+    screen.kind === 'edit-attr' ? screen.isForward : null,
     namespace.attrs,
   ]);
 
-  return (
-    <>
-      {screen.type === 'rename' && (
-        <div className="px-2">
-          <button
-            onClick={() => {
-              setScreen({
-                type: 'main',
-              });
-            }}
-            className="mb-3"
+  return isDeleting ? (
+    <DeleteForm
+      name={namespace.name}
+      type="namespace"
+      onClose={onClose}
+      onConfirm={deleteNs}
+    />
+  ) : screen.kind === 'rename' ? (
+    <div className="px-2">
+      <button
+        onClick={() => {
+          setScreen({ kind: 'main' });
+        }}
+        className="mb-3"
+      >
+        <ArrowLeftIcon className="h-4 w-4 cursor-pointer" />
+      </button>
+      <h6 className="text-md pb-2 font-bold">Rename {namespace.name}</h6>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          renameNs(renameNsInput);
+        }}
+      >
+        <Content className="pb-2 text-sm">
+          This will immediately rename the namespace. You'll need to{' '}
+          <strong className="dark:text-white">update your code</strong> to the
+          new name.
+        </Content>
+        <TextInput
+          disabled={isSystemCatalogNs}
+          value={renameNsInput}
+          onChange={(n) => setRenameNsInput(n)}
+        />
+        <div className="flex flex-col gap-2 rounded-sm py-2">
+          <Button
+            type="submit"
+            disabled={
+              renameNsInput.startsWith('$') || renameNsInput.length === 0
+            }
           >
-            <ArrowLeftIcon className="h-4 w-4 cursor-pointer" />
-          </button>
-          <h6 className="text-md pb-2 font-bold">Rename {namespace.name}</h6>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              renameNs(renameNsInput);
-            }}
-          >
-            <Content className="pb-2 text-sm">
-              This will immediately rename the namespace. You'll need to{' '}
-              <strong className="dark:text-white">update your code</strong> to
-              the new name.
-            </Content>
-            <TextInput
-              disabled={isSystemCatalogNs}
-              value={renameNsInput}
-              onChange={(n) => setRenameNsInput(n)}
-            />
-            <div className="flex flex-col gap-2 rounded-sm py-2">
-              <Button
-                type="submit"
-                disabled={
-                  renameNsInput.startsWith('$') || renameNsInput.length === 0
-                }
-              >
-                Rename {namespace.name} → {renameNsInput}
-              </Button>
-            </div>
-          </form>{' '}
+            Rename {namespace.name} → {renameNsInput}
+          </Button>
         </div>
-      )}
-
-      {screen.type === 'main' ? (
+      </form>
+    </div>
+  ) : screen.kind === 'main' ? (
         <div className="flex flex-col gap-4 px-2">
           <div className="mr-8 flex gap-1">
             <h5 className="flex items-center text-lg font-bold">
@@ -193,7 +196,7 @@ export function EditNamespaceDialog({
             <IconButton
               variant="subtle"
               onClick={() => {
-                setScreen({ type: 'rename' });
+                setScreen({ kind: 'rename' });
               }}
               icon={
                 <PencilSquareIcon className="h-4 w-4 opacity-50"></PencilSquareIcon>
@@ -211,7 +214,7 @@ export function EditNamespaceDialog({
               }
               size="mini"
               variant="secondary"
-              onClick={() => setScreen({ type: 'delete' })}
+              onClick={() => setIsDeleting(true)}
             >
               <TrashIcon className="inline" height="1rem" />
               Delete
@@ -242,7 +245,7 @@ export function EditNamespaceDialog({
                     onClick={() => {
                       notes.removeNote(attr.id);
                       setScreen({
-                        type: 'edit',
+                        kind: 'edit-attr',
                         attrId: attr.id,
                         isForward: attr.isForward,
                       });
@@ -259,7 +262,9 @@ export function EditNamespaceDialog({
             <Button
               size="mini"
               variant="secondary"
-              onClick={() => setScreen({ type: 'add' })}
+              onClick={() =>
+                setScreen({ kind: 'add-attr', attrKind: 'data' })
+              }
             >
               <PlusIcon className="inline" height="12px" />
               New attribute
@@ -272,38 +277,36 @@ export function EditNamespaceDialog({
             namespace={namespace}
           />
         </div>
-      ) : screen.type === 'add' ? (
+      ) : screen.kind === 'add-attr' ? (
         <AddAttrForm
           db={db}
           namespace={namespace}
           namespaces={namespaces}
-          onClose={() => setScreen({ type: 'main' })}
+          onClose={() => setScreen({ kind: 'main' })}
           constraints={getSystemConstraints({
             namespaceName: namespace.name,
             isSystemCatalogNs,
           })}
+          attrType={screen.attrKind === 'link' ? 'ref' : 'blob'}
+          onAttrTypeChange={(t) =>
+            onScreenChange({
+              kind: 'add-attr',
+              attrKind: t === 'ref' ? 'link' : 'data',
+            })
+          }
         />
-      ) : screen.type === 'delete' ? (
-        <DeleteForm
-          name={namespace.name}
-          type="namespace"
-          onClose={onClose}
-          onConfirm={deleteNs}
-        />
-      ) : screen.type === 'edit' && screenAttr ? (
+      ) : screen.kind === 'edit-attr' && screenAttr ? (
         <EditAttrForm
           db={db}
           attr={screenAttr}
-          onClose={() => setScreen({ type: 'main' })}
+          onClose={() => setScreen({ kind: 'main' })}
           constraints={getSystemConstraints({
             namespaceName: namespace.name,
             isSystemCatalogNs: isSystemCatalogNs,
             attr: screenAttr,
           })}
         />
-      ) : null}
-    </>
-  );
+      ) : null;
 }
 
 function DeleteForm({
@@ -350,12 +353,16 @@ function AddAttrForm({
   namespaces,
   onClose,
   constraints,
+  attrType,
+  onAttrTypeChange,
 }: {
   db: InstantReactWebDatabase<any>;
   namespace: SchemaNamespace;
   namespaces: SchemaNamespace[];
   onClose: () => void;
   constraints: SystemConstraints;
+  attrType: 'blob' | 'ref';
+  onAttrTypeChange: (attrType: 'blob' | 'ref') => void;
 }) {
   const [isRequired, setIsRequired] = useState(false);
   const [isIndex, setIsIndex] = useState(false);
@@ -364,7 +371,6 @@ function AddAttrForm({
   const [isCascadeReverse, setIsCascadeReverse] = useState(false);
   const [checkedDataType, setCheckedDataType] =
     useState<CheckedDataType | null>(null);
-  const [attrType, setAttrType] = useState<'blob' | 'ref'>('blob');
   const [relationship, setRelationship] =
     useState<RelationshipKinds>('many-many');
 
@@ -455,7 +461,9 @@ function AddAttrForm({
             { id: 'blob', label: 'Data' },
             { id: 'ref', label: 'Link' },
           ]}
-          onChange={(item) => setAttrType(item.id as 'blob' | 'ref')}
+          onChange={(item) =>
+            onAttrTypeChange(item.id as 'blob' | 'ref')
+          }
         />
       </div>
       {attrType === 'blob' ? (

--- a/client/packages/components/src/components/explorer/explorer-layout.tsx
+++ b/client/packages/components/src/components/explorer/explorer-layout.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { ExplorerDialog, useExplorerProps } from '.';
+import { useExplorerDialog, useExplorerProps } from '.';
 import { SchemaNamespace } from '@lib/types';
 import { Button, cn, Dialog, ToggleCollection } from '../ui';
 import {
@@ -28,22 +28,16 @@ export const ExplorerLayout = ({
   appId: string;
 }) => {
   const props = useExplorerProps();
-
-  const setDialog = (dialog: ExplorerDialog | null) => {
-    props.setExplorerState((prev) => ({
-      ...(prev ?? { namespace: '' }),
-      dialog,
-    }));
-  };
+  const { dialog, setDialog } = useExplorerDialog();
 
   const recentlyDeletedNsDialog = {
-    open: props.explorerState?.dialog?.type === 'recently-deleted-ns',
+    open: dialog?.type === 'recently-deleted-ns',
     onOpen: () => setDialog({ type: 'recently-deleted-ns' }),
     onClose: () => setDialog(null),
   };
 
   const newNsDialog = {
-    open: props.explorerState?.dialog?.type === 'new-namespace',
+    open: dialog?.type === 'new-namespace',
     onOpen: () => setDialog({ type: 'new-namespace' }),
     onClose: () => setDialog(null),
   };
@@ -74,18 +68,24 @@ export const ExplorerLayout = ({
   );
 
   // Auto-select first namespace if none selected
+  const { setExplorerState } = props;
   useEffect(() => {
     if (!selectedNamespace && namespaces.length > 0) {
       const savedNamespace = recentExplorerNamespaceId
         ? namespaces.find((ns) => ns.id === recentExplorerNamespaceId)
         : undefined;
       const namespaceId = savedNamespace?.id ?? namespaces[0].id;
-      props.setExplorerState((prev) => ({
+      setExplorerState((prev) => ({
         ...(prev ?? {}),
         namespace: namespaceId,
       }));
     }
-  }, [selectedNamespace, namespaces, props]);
+  }, [
+    selectedNamespace,
+    namespaces,
+    recentExplorerNamespaceId,
+    setExplorerState,
+  ]);
 
   const deletedNamespaces = useRecentlyDeletedNamespaces(props.appId);
 
@@ -103,10 +103,9 @@ export const ExplorerLayout = ({
         <NewNamespaceDialog
           db={db}
           onClose={(p) => {
+            newNsDialog.onClose();
             if (p?.name) {
               props.setExplorerState({ namespace: p.name });
-            } else {
-              newNsDialog.onClose();
             }
           }}
         />
@@ -191,9 +190,7 @@ export const ExplorerLayout = ({
         </button>
       </div>
 
-      {props.explorerState?.namespace && (
-        <InnerExplorer namespaces={namespaces} db={db} />
-      )}
+      {props.explorerState && <InnerExplorer namespaces={namespaces} db={db} />}
     </div>
   );
 };

--- a/client/packages/components/src/components/explorer/explorer-layout.tsx
+++ b/client/packages/components/src/components/explorer/explorer-layout.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useExplorerProps } from '.';
+import { ExplorerDialog, useExplorerProps } from '.';
 import { SchemaNamespace } from '@lib/types';
-import { Button, cn, Dialog, ToggleCollection, useDialog } from '../ui';
+import { Button, cn, Dialog, ToggleCollection } from '../ui';
 import {
   RecentlyDeletedNamespaces,
   useRecentlyDeletedNamespaces,
@@ -29,8 +29,24 @@ export const ExplorerLayout = ({
 }) => {
   const props = useExplorerProps();
 
-  const recentlyDeletedNsDialog = useDialog();
-  const newNsDialog = useDialog();
+  const setDialog = (dialog: ExplorerDialog | null) => {
+    props.setExplorerState((prev) => ({
+      ...(prev ?? { namespace: '' }),
+      dialog,
+    }));
+  };
+
+  const recentlyDeletedNsDialog = {
+    open: props.explorerState?.dialog?.type === 'recently-deleted-ns',
+    onOpen: () => setDialog({ type: 'recently-deleted-ns' }),
+    onClose: () => setDialog(null),
+  };
+
+  const newNsDialog = {
+    open: props.explorerState?.dialog?.type === 'new-namespace',
+    onOpen: () => setDialog({ type: 'new-namespace' }),
+    onClose: () => setDialog(null),
+  };
 
   const selectedNamespace = namespaces.find(
     (ns) => ns.id === props.explorerState?.namespace,
@@ -60,16 +76,14 @@ export const ExplorerLayout = ({
   // Auto-select first namespace if none selected
   useEffect(() => {
     if (!selectedNamespace && namespaces.length > 0) {
-      if (recentExplorerNamespaceId) {
-        const savedNamespace = namespaces.find(
-          (ns) => ns.id === recentExplorerNamespaceId,
-        );
-        if (savedNamespace) {
-          props.setExplorerState({ namespace: savedNamespace.id });
-        }
-      } else {
-        props.setExplorerState({ namespace: namespaces[0].id });
-      }
+      const savedNamespace = recentExplorerNamespaceId
+        ? namespaces.find((ns) => ns.id === recentExplorerNamespaceId)
+        : undefined;
+      const namespaceId = savedNamespace?.id ?? namespaces[0].id;
+      props.setExplorerState((prev) => ({
+        ...(prev ?? {}),
+        namespace: namespaceId,
+      }));
     }
   }, [selectedNamespace, namespaces, props]);
 
@@ -89,10 +103,10 @@ export const ExplorerLayout = ({
         <NewNamespaceDialog
           db={db}
           onClose={(p) => {
-            newNsDialog.onClose();
-
             if (p?.name) {
               props.setExplorerState({ namespace: p.name });
+            } else {
+              newNsDialog.onClose();
             }
           }}
         />
@@ -177,7 +191,9 @@ export const ExplorerLayout = ({
         </button>
       </div>
 
-      {props.explorerState && <InnerExplorer namespaces={namespaces} db={db} />}
+      {props.explorerState?.namespace && (
+        <InnerExplorer namespaces={namespaces} db={db} />
+      )}
     </div>
   );
 };

--- a/client/packages/components/src/components/explorer/index.tsx
+++ b/client/packages/components/src/components/explorer/index.tsx
@@ -16,6 +16,17 @@ import { useSchemaQuery } from '@lib/hooks/explorer';
 import { useStableDB } from '@lib/hooks/useStableDB';
 import ErrorBoundary from '@lib/components/error-boundary';
 
+export type SetExplorerStateOptions = {
+  // Use 'replace' for transitions that shouldn't add a back-button step,
+  // such as switching screens within an already-open dialog. Defaults to 'push'.
+  history?: 'push' | 'replace';
+};
+
+export type SetExplorerState = (
+  action: React.SetStateAction<ExplorerNav | null>,
+  options?: SetExplorerStateOptions,
+) => void;
+
 interface ExplorerProps {
   appId: string;
   adminToken: string;
@@ -30,9 +41,7 @@ interface ExplorerProps {
   // When null: controlled mode with no selection
   // When ExplorerNav: controlled mode with a selection
   explorerState: HasDefault<ExplorerNav | null | undefined>;
-  setExplorerState: HasDefault<
-    React.Dispatch<React.SetStateAction<ExplorerNav | null>>
-  >;
+  setExplorerState: HasDefault<SetExplorerState>;
   useShadowDOM: HasDefault<boolean>;
 }
 
@@ -78,8 +87,11 @@ export const useExplorerDialog = () => {
   const props = ctx.props;
   const dialog = props.explorerState?.dialog ?? null;
   const setDialog = useCallback(
-    (d: ExplorerDialog | null) => {
-      props.setExplorerState((prev) => (prev ? { ...prev, dialog: d } : prev));
+    (d: ExplorerDialog | null, options?: SetExplorerStateOptions) => {
+      props.setExplorerState(
+        (prev) => (prev ? { ...prev, dialog: d } : prev),
+        options,
+      );
     },
     [props],
   );
@@ -97,7 +109,7 @@ const isControlled = (props: WithOptional<ExplorerProps>): boolean => {
 const fillPropsWithDefaults = (
   input: WithOptional<ExplorerProps>,
   _explorerState: ExplorerNav | null,
-  setExplorerState: React.Dispatch<React.SetStateAction<ExplorerNav | null>>,
+  setExplorerState: SetExplorerState,
 ): WithDefaults<ExplorerProps> => {
   const controlled = isControlled(input);
   return {

--- a/client/packages/components/src/components/explorer/index.tsx
+++ b/client/packages/components/src/components/explorer/index.tsx
@@ -105,6 +105,13 @@ export type SearchFilterOp =
 
 export type SearchFilter = [string, SearchFilterOp, any];
 
+export type ExplorerDialog =
+  | { type: 'add-row' }
+  | { type: 'edit-row'; rowId: string }
+  | { type: 'edit-schema' }
+  | { type: 'new-namespace' }
+  | { type: 'recently-deleted-ns' };
+
 export interface ExplorerNav {
   namespace: string;
   where?: [string, any];
@@ -113,6 +120,7 @@ export interface ExplorerNav {
   filters?: SearchFilter[];
   limit?: number;
   page?: number;
+  dialog?: ExplorerDialog | null;
 }
 
 export const Explorer = (_props: WithOptional<ExplorerProps>) => {

--- a/client/packages/components/src/components/explorer/index.tsx
+++ b/client/packages/components/src/components/explorer/index.tsx
@@ -68,6 +68,24 @@ export const useExplorerState = () => {
   return { explorerState: ctx.props.explorerState, history: ctx.history };
 };
 
+export const useExplorerDialog = () => {
+  const ctx = useContext(ExplorerPropsContext);
+  if (!ctx.props) {
+    throw new Error(
+      'useExplorerDialog must be used within an Explorer component',
+    );
+  }
+  const props = ctx.props;
+  const dialog = props.explorerState?.dialog ?? null;
+  const setDialog = useCallback(
+    (d: ExplorerDialog | null) => {
+      props.setExplorerState((prev) => (prev ? { ...prev, dialog: d } : prev));
+    },
+    [props],
+  );
+  return { dialog, setDialog };
+};
+
 const isControlled = (props: WithOptional<ExplorerProps>): boolean => {
   // Component is controlled if explorerState prop is explicitly provided
   // (even if null - that means "no selection" in controlled mode)
@@ -105,10 +123,16 @@ export type SearchFilterOp =
 
 export type SearchFilter = [string, SearchFilterOp, any];
 
+export type EditSchemaScreen =
+  | { kind: 'main' }
+  | { kind: 'rename' }
+  | { kind: 'add-attr'; attrKind: 'data' | 'link' }
+  | { kind: 'edit-attr'; attrId: string; isForward: boolean };
+
 export type ExplorerDialog =
   | { type: 'add-row' }
   | { type: 'edit-row'; rowId: string }
-  | { type: 'edit-schema' }
+  | { type: 'edit-schema'; screen: EditSchemaScreen }
   | { type: 'new-namespace' }
   | { type: 'recently-deleted-ns' };
 

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -47,7 +47,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useExplorerProps, useExplorerState } from '.';
+import { ExplorerDialog, useExplorerProps, useExplorerState } from '.';
 import { SearchInput } from './search-input';
 
 import { errorToast, successToast } from '@lib/components/toast';
@@ -256,9 +256,17 @@ export const InnerExplorer: React.FC<{
   const [customPath, setCustomPath] = useState('');
   const [deleteDataConfirmationOpen, setDeleteDataConfirmationOpen] =
     useState(false);
-  const [editNs, setEditNs] = useState<SchemaNamespace | null>(null);
-  const [editableRowId, setEditableRowId] = useState<string | null>(null);
-  const [addItemDialogOpen, setAddItemDialogOpen] = useState(false);
+  const setDialog = (d: ExplorerDialog | null) => {
+    explorerProps.setExplorerState((prev) => ({
+      ...(prev ?? { namespace: '' }),
+      dialog: d,
+    }));
+  };
+  const dialog = currentNav?.dialog ?? null;
+  const editNs =
+    dialog?.type === 'edit-schema' ? (selectedNamespace ?? null) : null;
+  const editableRowId = dialog?.type === 'edit-row' ? dialog.rowId : null;
+  const addItemDialogOpen = dialog?.type === 'add-row';
   const lastSelectedIdRef = useRef<string | null>(null);
   const [offsets, setOffsets] = useState<{ [namespace: string]: number }>({});
 
@@ -457,7 +465,9 @@ export const InnerExplorer: React.FC<{
             {readOnlyNs ? null : (
               <button
                 className="translate-y-0.5 opacity-0 transition-opacity group-hover:opacity-100"
-                onClick={() => setEditableRowId(row.id)}
+                onClick={() =>
+                  setDialog({ type: 'edit-row', rowId: row.id })
+                }
               >
                 <PencilSquareIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
               </button>
@@ -895,28 +905,28 @@ export const InnerExplorer: React.FC<{
       <Dialog
         title="Edit Row"
         open={addItemDialogOpen}
-        onClose={() => setAddItemDialogOpen(false)}
+        onClose={() => setDialog(null)}
       >
         {selectedNamespace ? (
           <EditRowDialog
             db={db}
             item={{}}
             namespace={selectedNamespace}
-            onClose={() => setAddItemDialogOpen(false)}
+            onClose={() => setDialog(null)}
           />
         ) : null}
       </Dialog>
       <Dialog
         title="Edit Row"
         open={!!selectedEditableItem}
-        onClose={() => setEditableRowId(null)}
+        onClose={() => setDialog(null)}
       >
         {!!selectedNamespace && !!selectedEditableItem ? (
           <EditRowDialog
             db={db}
             namespace={selectedNamespace}
             item={selectedEditableItem}
-            onClose={() => setEditableRowId(null)}
+            onClose={() => setDialog(null)}
           />
         ) : null}
       </Dialog>
@@ -924,7 +934,7 @@ export const InnerExplorer: React.FC<{
         title="Edit Namespace"
         stopFocusPropagation={true}
         open={Boolean(editNs)}
-        onClose={() => setEditNs(null)}
+        onClose={() => setDialog(null)}
       >
         {selectedNamespace ? (
           <EditNamespaceDialog
@@ -934,7 +944,7 @@ export const InnerExplorer: React.FC<{
             namespace={selectedNamespace}
             namespaces={namespaces ?? []}
             onClose={(p) => {
-              setEditNs(null);
+              setDialog(null);
               if (p?.ok) {
                 history.push({ namespace: namespaces?.[0].id });
               }
@@ -1005,7 +1015,7 @@ export const InnerExplorer: React.FC<{
                 variant="secondary"
                 size="mini"
                 onClick={() => {
-                  setEditNs(selectedNamespace);
+                  setDialog({ type: 'edit-schema' });
                 }}
               >
                 Edit Schema
@@ -1082,7 +1092,7 @@ export const InnerExplorer: React.FC<{
               size="mini"
               variant="secondary"
               onClick={() => {
-                setAddItemDialogOpen(true);
+                setDialog({ type: 'add-row' });
               }}
             >
               <PlusIcon width={12} />

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -459,9 +459,7 @@ export const InnerExplorer: React.FC<{
             {readOnlyNs ? null : (
               <button
                 className="translate-y-0.5 opacity-0 transition-opacity group-hover:opacity-100"
-                onClick={() =>
-                  setDialog({ type: 'edit-row', rowId: row.id })
-                }
+                onClick={() => setDialog({ type: 'edit-row', rowId: row.id })}
               >
                 <PencilSquareIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
               </button>
@@ -938,9 +936,7 @@ export const InnerExplorer: React.FC<{
             namespace={selectedNamespace}
             namespaces={namespaces ?? []}
             screen={
-              dialog?.type === 'edit-schema'
-                ? dialog.screen
-                : { kind: 'main' }
+              dialog?.type === 'edit-schema' ? dialog.screen : { kind: 'main' }
             }
             onScreenChange={(s) =>
               setDialog({ type: 'edit-schema', screen: s })

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -939,7 +939,10 @@ export const InnerExplorer: React.FC<{
               dialog?.type === 'edit-schema' ? dialog.screen : { kind: 'main' }
             }
             onScreenChange={(s) =>
-              setDialog({ type: 'edit-schema', screen: s })
+              setDialog(
+                { type: 'edit-schema', screen: s },
+                { history: 'replace' },
+              )
             }
             onClose={(p) => {
               setDialog(null);

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -47,7 +47,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ExplorerDialog, useExplorerProps, useExplorerState } from '.';
+import { useExplorerDialog, useExplorerProps, useExplorerState } from '.';
 import { SearchInput } from './search-input';
 
 import { errorToast, successToast } from '@lib/components/toast';
@@ -256,13 +256,7 @@ export const InnerExplorer: React.FC<{
   const [customPath, setCustomPath] = useState('');
   const [deleteDataConfirmationOpen, setDeleteDataConfirmationOpen] =
     useState(false);
-  const setDialog = (d: ExplorerDialog | null) => {
-    explorerProps.setExplorerState((prev) => ({
-      ...(prev ?? { namespace: '' }),
-      dialog: d,
-    }));
-  };
-  const dialog = currentNav?.dialog ?? null;
+  const { dialog, setDialog } = useExplorerDialog();
   const editNs =
     dialog?.type === 'edit-schema' ? (selectedNamespace ?? null) : null;
   const editableRowId = dialog?.type === 'edit-row' ? dialog.rowId : null;
@@ -903,7 +897,7 @@ export const InnerExplorer: React.FC<{
         ) : null}
       </Dialog>
       <Dialog
-        title="Edit Row"
+        title="Add Row"
         open={addItemDialogOpen}
         onClose={() => setDialog(null)}
       >
@@ -943,6 +937,14 @@ export const InnerExplorer: React.FC<{
             db={db}
             namespace={selectedNamespace}
             namespaces={namespaces ?? []}
+            screen={
+              dialog?.type === 'edit-schema'
+                ? dialog.screen
+                : { kind: 'main' }
+            }
+            onScreenChange={(s) =>
+              setDialog({ type: 'edit-schema', screen: s })
+            }
             onClose={(p) => {
               setDialog(null);
               if (p?.ok) {
@@ -1015,7 +1017,10 @@ export const InnerExplorer: React.FC<{
                 variant="secondary"
                 size="mini"
                 onClick={() => {
-                  setDialog({ type: 'edit-schema' });
+                  setDialog({
+                    type: 'edit-schema',
+                    screen: { kind: 'main' },
+                  });
                 }}
               >
                 Edit Schema

--- a/client/packages/components/src/index.tsx
+++ b/client/packages/components/src/index.tsx
@@ -1,7 +1,11 @@
 import * as ui from './components/ui';
 
 export { Explorer } from './components/explorer/index';
-export type { ExplorerNav } from './components/explorer/index';
+export type {
+  EditSchemaScreen,
+  ExplorerDialog,
+  ExplorerNav,
+} from './components/explorer/index';
 export { StyleMe } from './components/StyleMe';
 
 export { ui };

--- a/client/www/lib/hooks/useExplorerState.ts
+++ b/client/www/lib/hooks/useExplorerState.ts
@@ -1,4 +1,9 @@
-import { Explorer, ExplorerDialog, ExplorerNav } from '@instantdb/components';
+import {
+  EditSchemaScreen,
+  Explorer,
+  ExplorerDialog,
+  ExplorerNav,
+} from '@instantdb/components';
 import { useCallback, useMemo } from 'react';
 import {
   parseAsBoolean,
@@ -10,7 +15,7 @@ import {
 
 type ExplorerState = [
   Parameters<typeof Explorer>[0]['explorerState'],
-  Parameters<typeof Explorer>[0]['setExplorerState'],
+  NonNullable<Parameters<typeof Explorer>[0]['setExplorerState']>,
 ];
 
 type SearchFilterOp = '=' | '$ilike' | '$like' | '$gt' | '$lt' | '$isNull';
@@ -24,6 +29,57 @@ const parseAsFilters = parseAsJson<SearchFilter[]>((v) =>
   Array.isArray(v) ? (v as SearchFilter[]) : null,
 );
 
+function validateEditSchemaScreen(v: unknown): EditSchemaScreen | null {
+  if (!v || typeof v !== 'object') return null;
+  const obj = v as Record<string, unknown>;
+  switch (obj.kind) {
+    case 'main':
+      return { kind: 'main' };
+    case 'rename':
+      return { kind: 'rename' };
+    case 'add-attr':
+      if (obj.attrKind !== 'data' && obj.attrKind !== 'link') return null;
+      return { kind: 'add-attr', attrKind: obj.attrKind };
+    case 'edit-attr':
+      if (typeof obj.attrId !== 'string') return null;
+      if (typeof obj.isForward !== 'boolean') return null;
+      return {
+        kind: 'edit-attr',
+        attrId: obj.attrId,
+        isForward: obj.isForward,
+      };
+    default:
+      return null;
+  }
+}
+
+function validateExplorerDialog(v: unknown): ExplorerDialog | null {
+  if (!v || typeof v !== 'object') return null;
+  const obj = v as Record<string, unknown>;
+  switch (obj.type) {
+    case 'add-row':
+      return { type: 'add-row' };
+    case 'new-namespace':
+      return { type: 'new-namespace' };
+    case 'recently-deleted-ns':
+      return { type: 'recently-deleted-ns' };
+    case 'edit-row':
+      if (typeof obj.rowId !== 'string') return null;
+      return { type: 'edit-row', rowId: obj.rowId };
+    case 'edit-schema': {
+      const screen = validateEditSchemaScreen(obj.screen);
+      if (!screen) return null;
+      return { type: 'edit-schema', screen };
+    }
+    default:
+      return null;
+  }
+}
+
+const parseAsExplorerDialog = parseAsJson<ExplorerDialog>(
+  validateExplorerDialog,
+);
+
 const explorerParsers = {
   ns: parseAsString, // namespace
   where: parseAsWhere,
@@ -32,36 +88,13 @@ const explorerParsers = {
   filters: parseAsFilters,
   limit: parseAsInteger,
   page: parseAsInteger,
-  dialog: parseAsString,
-  dialogRowId: parseAsString,
+  dialog: parseAsExplorerDialog,
 };
 
 const explorerParserOptions = {
   // Use shallow routing to avoid full page re-renders
   shallow: true,
 };
-
-const VALID_DIALOG_TYPES = [
-  'add-row',
-  'edit-row',
-  'edit-schema',
-  'new-namespace',
-  'recently-deleted-ns',
-] as const;
-
-function parseDialog(
-  dialogType: string | null,
-  rowId: string | null,
-): ExplorerDialog | null {
-  if (!dialogType) return null;
-  if (!(VALID_DIALOG_TYPES as readonly string[]).includes(dialogType))
-    return null;
-  if (dialogType === 'edit-row') {
-    if (!rowId) return null;
-    return { type: 'edit-row', rowId };
-  }
-  return { type: dialogType } as ExplorerDialog;
-}
 
 export const useExplorerState = (): ExplorerState => {
   const [state, setState] = useQueryStates(
@@ -70,17 +103,16 @@ export const useExplorerState = (): ExplorerState => {
   );
 
   const explorerState: ExplorerNav | null = useMemo(() => {
-    const dialog = parseDialog(state.dialog, state.dialogRowId);
-    if (!state.ns && !dialog) return null;
+    if (!state.ns) return null;
     return {
-      namespace: state.ns ?? '',
+      namespace: state.ns,
       ...(state.where && { where: state.where }),
       ...(state.sortAttr && { sortAttr: state.sortAttr }),
       ...(state.sortAsc !== null && { sortAsc: state.sortAsc }),
       ...(state.filters && { filters: state.filters }),
       ...(state.limit !== null && { limit: state.limit }),
       ...(state.page !== null && { page: state.page }),
-      ...(dialog && { dialog }),
+      ...(state.dialog && { dialog: state.dialog }),
     };
   }, [state]);
 
@@ -88,20 +120,18 @@ export const useExplorerState = (): ExplorerState => {
     (action: React.SetStateAction<ExplorerNav | null>) => {
       setState(
         (prev) => {
-          const prevDialog = parseDialog(prev.dialog, prev.dialogRowId);
-          const prevNav: ExplorerNav | null =
-            prev.ns || prevDialog
-              ? {
-                  namespace: prev.ns ?? '',
-                  ...(prev.where && { where: prev.where }),
-                  ...(prev.sortAttr && { sortAttr: prev.sortAttr }),
-                  ...(prev.sortAsc !== null && { sortAsc: prev.sortAsc }),
-                  ...(prev.filters && { filters: prev.filters }),
-                  ...(prev.limit !== null && { limit: prev.limit }),
-                  ...(prev.page !== null && { page: prev.page }),
-                  ...(prevDialog && { dialog: prevDialog }),
-                }
-              : null;
+          const prevNav: ExplorerNav | null = prev.ns
+            ? {
+                namespace: prev.ns,
+                ...(prev.where && { where: prev.where }),
+                ...(prev.sortAttr && { sortAttr: prev.sortAttr }),
+                ...(prev.sortAsc !== null && { sortAsc: prev.sortAsc }),
+                ...(prev.filters && { filters: prev.filters }),
+                ...(prev.limit !== null && { limit: prev.limit }),
+                ...(prev.page !== null && { page: prev.page }),
+                ...(prev.dialog && { dialog: prev.dialog }),
+              }
+            : null;
 
           const next = typeof action === 'function' ? action(prevNav) : action;
 
@@ -115,21 +145,18 @@ export const useExplorerState = (): ExplorerState => {
               limit: null,
               page: null,
               dialog: null,
-              dialogRowId: null,
             };
           }
 
           return {
-            ns: next.namespace ? next.namespace : null,
+            ns: next.namespace,
             where: next.where ?? null,
             sortAttr: next.sortAttr ?? null,
             sortAsc: next.sortAsc ?? null,
             filters: next.filters ?? null,
             limit: next.limit ?? null,
             page: next.page ?? null,
-            dialog: next.dialog?.type ?? null,
-            dialogRowId:
-              next.dialog?.type === 'edit-row' ? next.dialog.rowId : null,
+            dialog: next.dialog ?? null,
           };
         },
         { history: 'push' },

--- a/client/www/lib/hooks/useExplorerState.ts
+++ b/client/www/lib/hooks/useExplorerState.ts
@@ -117,7 +117,10 @@ export const useExplorerState = (): ExplorerState => {
   }, [state]);
 
   const setExplorerState = useCallback(
-    (action: React.SetStateAction<ExplorerNav | null>) => {
+    (
+      action: React.SetStateAction<ExplorerNav | null>,
+      options?: { history?: 'push' | 'replace' },
+    ) => {
       setState(
         (prev) => {
           const prevNav: ExplorerNav | null = prev.ns
@@ -159,7 +162,7 @@ export const useExplorerState = (): ExplorerState => {
             dialog: next.dialog ?? null,
           };
         },
-        { history: 'push' },
+        { history: options?.history ?? 'push' },
       );
     },
     [setState],

--- a/client/www/lib/hooks/useExplorerState.ts
+++ b/client/www/lib/hooks/useExplorerState.ts
@@ -1,4 +1,4 @@
-import { Explorer, ExplorerNav } from '@instantdb/components';
+import { Explorer, ExplorerDialog, ExplorerNav } from '@instantdb/components';
 import { useCallback, useMemo } from 'react';
 import {
   parseAsBoolean,
@@ -32,12 +32,36 @@ const explorerParsers = {
   filters: parseAsFilters,
   limit: parseAsInteger,
   page: parseAsInteger,
+  dialog: parseAsString,
+  dialogRowId: parseAsString,
 };
 
 const explorerParserOptions = {
   // Use shallow routing to avoid full page re-renders
   shallow: true,
 };
+
+const VALID_DIALOG_TYPES = [
+  'add-row',
+  'edit-row',
+  'edit-schema',
+  'new-namespace',
+  'recently-deleted-ns',
+] as const;
+
+function parseDialog(
+  dialogType: string | null,
+  rowId: string | null,
+): ExplorerDialog | null {
+  if (!dialogType) return null;
+  if (!(VALID_DIALOG_TYPES as readonly string[]).includes(dialogType))
+    return null;
+  if (dialogType === 'edit-row') {
+    if (!rowId) return null;
+    return { type: 'edit-row', rowId };
+  }
+  return { type: dialogType } as ExplorerDialog;
+}
 
 export const useExplorerState = (): ExplorerState => {
   const [state, setState] = useQueryStates(
@@ -46,15 +70,17 @@ export const useExplorerState = (): ExplorerState => {
   );
 
   const explorerState: ExplorerNav | null = useMemo(() => {
-    if (!state.ns) return null;
+    const dialog = parseDialog(state.dialog, state.dialogRowId);
+    if (!state.ns && !dialog) return null;
     return {
-      namespace: state.ns,
+      namespace: state.ns ?? '',
       ...(state.where && { where: state.where }),
       ...(state.sortAttr && { sortAttr: state.sortAttr }),
       ...(state.sortAsc !== null && { sortAsc: state.sortAsc }),
       ...(state.filters && { filters: state.filters }),
       ...(state.limit !== null && { limit: state.limit }),
       ...(state.page !== null && { page: state.page }),
+      ...(dialog && { dialog }),
     };
   }, [state]);
 
@@ -62,17 +88,20 @@ export const useExplorerState = (): ExplorerState => {
     (action: React.SetStateAction<ExplorerNav | null>) => {
       setState(
         (prev) => {
-          const prevNav: ExplorerNav | null = prev.ns
-            ? {
-                namespace: prev.ns,
-                ...(prev.where && { where: prev.where }),
-                ...(prev.sortAttr && { sortAttr: prev.sortAttr }),
-                ...(prev.sortAsc !== null && { sortAsc: prev.sortAsc }),
-                ...(prev.filters && { filters: prev.filters }),
-                ...(prev.limit !== null && { limit: prev.limit }),
-                ...(prev.page !== null && { page: prev.page }),
-              }
-            : null;
+          const prevDialog = parseDialog(prev.dialog, prev.dialogRowId);
+          const prevNav: ExplorerNav | null =
+            prev.ns || prevDialog
+              ? {
+                  namespace: prev.ns ?? '',
+                  ...(prev.where && { where: prev.where }),
+                  ...(prev.sortAttr && { sortAttr: prev.sortAttr }),
+                  ...(prev.sortAsc !== null && { sortAsc: prev.sortAsc }),
+                  ...(prev.filters && { filters: prev.filters }),
+                  ...(prev.limit !== null && { limit: prev.limit }),
+                  ...(prev.page !== null && { page: prev.page }),
+                  ...(prevDialog && { dialog: prevDialog }),
+                }
+              : null;
 
           const next = typeof action === 'function' ? action(prevNav) : action;
 
@@ -85,17 +114,22 @@ export const useExplorerState = (): ExplorerState => {
               filters: null,
               limit: null,
               page: null,
+              dialog: null,
+              dialogRowId: null,
             };
           }
 
           return {
-            ns: next.namespace,
+            ns: next.namespace ? next.namespace : null,
             where: next.where ?? null,
             sortAttr: next.sortAttr ?? null,
             sortAsc: next.sortAsc ?? null,
             filters: next.filters ?? null,
             limit: next.limit ?? null,
             page: next.page ?? null,
+            dialog: next.dialog?.type ?? null,
+            dialogRowId:
+              next.dialog?.type === 'edit-row' ? next.dialog.rowId : null,
           };
         },
         { history: 'push' },


### PR DESCRIPTION
**Context**

One great thing about the Explorer is that a lot of it's state bubbles up into the URL. 

This is great for sharing deep links, and it's also great for "getting" into different visual states (which is very useful when re-designing) 

**Problem**

Right now our dialog states were controlled within components. There was no way to deep link into editing attrs, adding attrs, undoing table deletions, rows, etc 

**Solution** 

I moved our dialog state into the URL. 

Like the where clauses, I save json in one key. I thought this was better than splatting them into different keys, for (a) keeping track of what keys are available, and (b) making it so invariant states are hard to get into.

**Test plan** 

Load an app

1. Create a row 
2. Edit a row 
3. Add a column (switch between data and link)
4. Edit a column
5. Delete a table, and open recently deleted namespaces

Notice how the URL changes. Refresh each time, and see that you are deep-linked 

@dwwoelfel @nezaj @drew-harris 