### PR TITLE
Scroll the filter line if it gets too long

### DIFF
--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -945,7 +945,7 @@ export const InnerExplorer: React.FC<{
       <div className="flex flex-1 grow flex-col overflow-hidden bg-white dark:bg-neutral-800">
         <div className="flex items-center overflow-hidden border-b border-b-gray-200 dark:border-neutral-700">
           <div className="flex min-w-0 flex-1 flex-col justify-between py-2 md:flex-row md:items-center">
-            <div className="flex min-w-0 flex-1 items-center overflow-hidden border-b px-2 py-1 pl-4 md:border-b-0 dark:border-neutral-700">
+            <div className="flex min-w-0 flex-1 items-center self-stretch overflow-hidden border-b px-2 py-1 pl-4 md:border-b-0 dark:border-neutral-700">
               {showBackButton ? (
                 <ArrowLeftIcon
                   className="mr-4 inline cursor-pointer"
@@ -967,36 +967,46 @@ export const InnerExplorer: React.FC<{
                   }}
                 />
               ) : null}
-              <div className="min-w-0 flex-1 overflow-x-auto font-mono text-xs whitespace-nowrap dark:text-white">
-                <strong>{selectedNamespace.name}</strong>{' '}
-                {currentNav.where ? (
-                  <>
-                    {' '}
-                    where <strong>{currentNav.where[0]}</strong> ={' '}
-                    <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
-                      {JSON.stringify(currentNav.where[1])}
-                    </em>
-                  </>
-                ) : null}
-                {currentNav?.filters?.length ? (
-                  <span
-                    title={currentNav.filters
-                      .map(([attr, op, search]) => `${attr} ${op} ${search}`)
-                      .join(' || ')}
-                  >
-                    {currentNav.filters.map(([attr, op, search], i) => (
-                      <span key={attr}>
-                        <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
-                          {attr} {op} {search}
-                        </em>
-                        {currentNav?.filters?.length &&
-                        i < currentNav.filters.length - 1
-                          ? ' || '
-                          : null}
-                      </span>
-                    ))}
-                  </span>
-                ) : null}
+              <div className="relative min-w-0 flex-1 self-stretch [timeline-scope:--filter-scroll]">
+                <div className="flex h-full items-center overflow-x-auto font-mono text-xs whitespace-nowrap [scroll-timeline:--filter-scroll_inline] dark:text-white">
+                  <strong>{selectedNamespace.name}</strong>{' '}
+                  {currentNav.where ? (
+                    <>
+                      {' '}
+                      where <strong>{currentNav.where[0]}</strong> ={' '}
+                      <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
+                        {JSON.stringify(currentNav.where[1])}
+                      </em>
+                    </>
+                  ) : null}
+                  {currentNav?.filters?.length ? (
+                    <span
+                      title={currentNav.filters
+                        .map(([attr, op, search]) => `${attr} ${op} ${search}`)
+                        .join(' || ')}
+                    >
+                      {currentNav.filters.map(([attr, op, search], i) => (
+                        <span key={attr}>
+                          <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
+                            {attr} {op} {search}
+                          </em>
+                          {currentNav?.filters?.length &&
+                          i < currentNav.filters.length - 1
+                            ? ' || '
+                            : null}
+                        </span>
+                      ))}
+                    </span>
+                  ) : null}
+                </div>
+                <div
+                  aria-hidden="true"
+                  className="filter-shadow-l pointer-events-none absolute top-0 bottom-0 left-0 w-[30px] bg-linear-to-r from-black/10 via-black/0 to-transparent"
+                />
+                <div
+                  aria-hidden="true"
+                  className="filter-shadow-r pointer-events-none absolute top-0 right-0 bottom-0 w-[30px] bg-linear-to-l from-black/20 via-black/5 to-transparent"
+                />
               </div>
             </div>
             <div className="flex justify-between gap-2 px-2 py-1 md:justify-start">

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -944,8 +944,8 @@ export const InnerExplorer: React.FC<{
       </Dialog>
       <div className="flex flex-1 grow flex-col overflow-hidden bg-white dark:bg-neutral-800">
         <div className="flex items-center overflow-hidden border-b border-b-gray-200 dark:border-neutral-700">
-          <div className="flex flex-1 flex-col justify-between py-2 md:flex-row md:items-center">
-            <div className="flex items-center overflow-hidden border-b px-2 py-1 pl-4 md:border-b-0 dark:border-neutral-700">
+          <div className="flex min-w-0 flex-1 flex-col justify-between py-2 md:flex-row md:items-center">
+            <div className="flex min-w-0 flex-1 items-center overflow-hidden border-b px-2 py-1 pl-4 md:border-b-0 dark:border-neutral-700">
               {showBackButton ? (
                 <ArrowLeftIcon
                   className="mr-4 inline cursor-pointer"
@@ -967,7 +967,7 @@ export const InnerExplorer: React.FC<{
                   }}
                 />
               ) : null}
-              <div className="text-ellipses shrink truncate overflow-hidden font-mono text-xs whitespace-nowrap dark:text-white">
+              <div className="min-w-0 flex-1 overflow-x-auto font-mono text-xs whitespace-nowrap dark:text-white">
                 <strong>{selectedNamespace.name}</strong>{' '}
                 {currentNav.where ? (
                   <>

--- a/client/packages/components/src/style.css
+++ b/client/packages/components/src/style.css
@@ -74,3 +74,35 @@
 html {
   --default-mono-font-family: 'Berk Mono', var(--font-berk-mono), 'monospace';
 }
+
+@keyframes filter-shadow-r-fade {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes filter-shadow-l-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@utility filter-shadow-r {
+  opacity: 0;
+  animation: filter-shadow-r-fade linear backwards;
+  animation-timeline: --filter-scroll;
+  animation-range: calc(100% - 16px) 100%;
+}
+
+@utility filter-shadow-l {
+  opacity: 0;
+  animation: filter-shadow-l-fade linear forwards;
+  animation-timeline: --filter-scroll;
+  animation-range: 0% 16px;
+}

--- a/client/packages/components/src/style.css
+++ b/client/packages/components/src/style.css
@@ -75,6 +75,7 @@ html {
   --default-mono-font-family: 'Berk Mono', var(--font-berk-mono), 'monospace';
 }
 
+/* Mirrored in www/styles/globals.css for the dashboard's non-shadow-DOM mount. */
 @keyframes filter-shadow-r-fade {
   from {
     opacity: 1;

--- a/client/packages/components/src/style.css
+++ b/client/packages/components/src/style.css
@@ -95,15 +95,26 @@ html {
 }
 
 @utility filter-shadow-r {
-  opacity: 0;
-  animation: filter-shadow-r-fade linear backwards;
-  animation-timeline: --filter-scroll;
-  animation-range: calc(100% - 16px) 100%;
+  opacity: 1;
+
+  @supports (animation-timeline: scroll()) {
+    @media (prefers-reduced-motion: no-preference) {
+      opacity: 0;
+      animation: filter-shadow-r-fade linear backwards;
+      animation-timeline: --filter-scroll;
+      animation-range: calc(100% - 16px) 100%;
+    }
+  }
 }
 
 @utility filter-shadow-l {
   opacity: 0;
-  animation: filter-shadow-l-fade linear forwards;
-  animation-timeline: --filter-scroll;
-  animation-range: 0% 16px;
+
+  @supports (animation-timeline: scroll()) {
+    @media (prefers-reduced-motion: no-preference) {
+      animation: filter-shadow-l-fade linear forwards;
+      animation-timeline: --filter-scroll;
+      animation-range: 0% 16px;
+    }
+  }
 }

--- a/client/www/styles/globals.css
+++ b/client/www/styles/globals.css
@@ -1,8 +1,9 @@
 @import 'tailwindcss';
 
 @theme {
-  --default-mono-font-family: 'Berkeley Mono', ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --default-mono-font-family:
+    'Berkeley Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
   --font-mono: var(--default-mono-font-family);
 }
 
@@ -33,8 +34,9 @@
   *,
   html {
     --default-font-family: 'Switzer', 'IBM Plex Sans', sans-serif;
-    --default-mono-font-family: 'Berkeley Mono', ui-monospace, SFMono-Regular,
-      Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    --default-mono-font-family:
+      'Berkeley Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
   }
   ::cue {
     font-family: var(--default-font-family);
@@ -58,14 +60,45 @@
   /* Firefox */
 }
 
+@keyframes filter-shadow-r-fade {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes filter-shadow-l-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@utility filter-shadow-r {
+  opacity: 0;
+  animation: filter-shadow-r-fade linear backwards;
+  animation-timeline: --filter-scroll;
+  animation-range: calc(100% - 16px) 100%;
+}
+
+@utility filter-shadow-l {
+  opacity: 0;
+  animation: filter-shadow-l-fade linear forwards;
+  animation-timeline: --filter-scroll;
+  animation-range: 0% 16px;
+}
+
 @layer base {
   @font-face {
     font-family: 'Berkeley Mono';
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
-    src: url('/fonts/BerkeleyMono-Regular.woff2')
-      format('woff2');
+    src: url('/fonts/BerkeleyMono-Regular.woff2') format('woff2');
     font-display: block;
   }
 
@@ -74,8 +107,7 @@
     font-weight: normal;
     font-style: italic;
     font-stretch: normal;
-    src: url('/fonts/BerkeleyMono-Italic.woff2')
-      format('woff2');
+    src: url('/fonts/BerkeleyMono-Italic.woff2') format('woff2');
     font-display: block;
   }
 
@@ -84,8 +116,7 @@
     font-weight: bold;
     font-style: normal;
     font-stretch: normal;
-    src: url('/fonts/BerkeleyMono-Bold.woff2')
-      format('woff2');
+    src: url('/fonts/BerkeleyMono-Bold.woff2') format('woff2');
     font-display: block;
   }
 
@@ -94,8 +125,7 @@
     font-weight: bold;
     font-style: italic;
     font-stretch: normal;
-    src: url('/fonts/BerkeleyMono-BoldItalic.woff2')
-      format('woff2');
+    src: url('/fonts/BerkeleyMono-BoldItalic.woff2') format('woff2');
     font-display: block;
   }
 
@@ -142,9 +172,10 @@
 
 html {
   height: 100%;
-  background-color: #FBF9F6;
-  --default-mono-font-family: 'Berkeley Mono', ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  background-color: #fbf9f6;
+  --default-mono-font-family:
+    'Berkeley Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
 body {

--- a/client/www/styles/globals.css
+++ b/client/www/styles/globals.css
@@ -80,17 +80,28 @@
 }
 
 @utility filter-shadow-r {
-  opacity: 0;
-  animation: filter-shadow-r-fade linear backwards;
-  animation-timeline: --filter-scroll;
-  animation-range: calc(100% - 16px) 100%;
+  opacity: 1;
+
+  @supports (animation-timeline: scroll()) {
+    @media (prefers-reduced-motion: no-preference) {
+      opacity: 0;
+      animation: filter-shadow-r-fade linear backwards;
+      animation-timeline: --filter-scroll;
+      animation-range: calc(100% - 16px) 100%;
+    }
+  }
 }
 
 @utility filter-shadow-l {
   opacity: 0;
-  animation: filter-shadow-l-fade linear forwards;
-  animation-timeline: --filter-scroll;
-  animation-range: 0% 16px;
+
+  @supports (animation-timeline: scroll()) {
+    @media (prefers-reduced-motion: no-preference) {
+      animation: filter-shadow-l-fade linear forwards;
+      animation-timeline: --filter-scroll;
+      animation-range: 0% 16px;
+    }
+  }
 }
 
 @layer base {

--- a/client/www/styles/globals.css
+++ b/client/www/styles/globals.css
@@ -60,6 +60,7 @@
   /* Firefox */
 }
 
+/* Mirrored in packages/components/src/style.css for the shadow-DOM path. */
 @keyframes filter-shadow-r-fade {
   from {
     opacity: 1;


### PR DESCRIPTION
Fixes a bug where the filter input would push the input out of view. Now we'll scroll the input:

Before:
<img width="839" height="60" alt="Screenshot 2026-05-15 at 1 31 10 PM" src="https://github.com/user-attachments/assets/d088d160-39f4-4e3e-a1e0-cf2247843004" />


After:
<img width="839" height="60" alt="Screenshot 2026-05-15 at 2 30 56 PM" src="https://github.com/user-attachments/assets/496f7326-f48f-419e-b7d6-303b326e2b92" />
