### PR TITLE
Move custom email verification to app-level (1/3)

### DIFF
--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -21,6 +21,7 @@ import { errorToast, successToast } from '@/lib/toast';
 import clsx from 'clsx';
 import { useFetchedDash } from '../MainDashLayout';
 import { useDarkMode } from '../DarkModeToggle';
+import { useCustomSenderVerification } from '@/lib/hooks/useCustomSenderVerification';
 
 export type EmailValues = {
   from: string;
@@ -41,58 +42,13 @@ export type SenderVerificationInfo = {
   ReturnPathDomainCNAMEValue: string;
 };
 
-export function getSenderVerification({
-  token,
-  appId,
-}: {
-  token: string;
-  appId: string;
-}): Promise<{
-  senderEmail: string;
-  verification: SenderVerificationInfo | null;
-}> {
-  return jsonFetch(`${config.apiURI}/dash/apps/${appId}/sender-verification`, {
-    method: 'GET',
-    headers: {
-      authorization: `Bearer ${token}`,
-      'content-type': 'application/json',
-    },
-  });
-}
-
 export function Email({ app }: { app: InstantApp }) {
   const dashResponse = useFetchedDash();
   const template = app.magic_code_email_template;
   const token = useContext(TokenContext);
   const [isEditing, setIsEditing] = useState(Boolean(template) ?? false);
-  const [{ isVerifying, verification }, setVerification] = useState<{
-    isVerifying: boolean;
-    verification: SenderVerificationInfo | null;
-  }>({
-    isVerifying: false,
-    verification: null,
-  });
-
+  const verification = useCustomSenderVerification(app);
   const { darkMode } = useDarkMode();
-
-  const checkVerification = async () => {
-    setVerification((prev) => ({ ...prev, isVerifying: true }));
-    try {
-      const response = await getSenderVerification({
-        token,
-        appId: app.id,
-      });
-      setVerification((prev) => ({
-        ...prev,
-        verification: response.verification,
-      }));
-    } catch (error) {
-      console.error('Failed to check verification:', error);
-      errorToast('Failed to check verification status');
-    } finally {
-      setVerification((prev) => ({ ...prev, isVerifying: false }));
-    }
-  };
 
   async function onSubmit(values: EmailValues) {
     return dashResponse
@@ -112,10 +68,13 @@ export function Email({ app }: { app: InstantApp }) {
         ),
       )
       .then(
-        () => {
+        async () => {
           successToast('Email template saved!');
           if (values.senderEmail) {
-            checkVerification();
+            const res = await verification.refetch();
+            if (!res?.instant?.['verified?']) {
+              verification.sendCode();
+            }
           }
         },
         (errorRes) =>
@@ -146,7 +105,7 @@ export function Email({ app }: { app: InstantApp }) {
 
   useEffect(() => {
     if (template?.email) {
-      checkVerification();
+      verification.refetch();
     }
   }, []);
 
@@ -242,16 +201,16 @@ export function Email({ app }: { app: InstantApp }) {
           />
         </div>
 
-        {verification && (
+        {verification.raw.data?.verification && (
           <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
             <div className="flex items-center justify-between">
               <SubsectionHeading>
-                Verify {verification.EmailAddress}
+                Verify {verification.raw.data?.verification?.EmailAddress}
               </SubsectionHeading>
               <Button
                 type="button"
-                onClick={checkVerification}
-                loading={isVerifying}
+                onClick={() => verification.refetch()}
+                loading={verification.loading}
                 variant="primary"
                 size="mini"
               >
@@ -261,13 +220,15 @@ export function Email({ app }: { app: InstantApp }) {
 
             <div className="rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-700/60">
               <div className="mb-2 flex items-center justify-between">
-                <div className="text-sm font-medium">Email Confirmation</div>
+                <div className="text-sm font-medium">
+                  Postmark Email Confirmation
+                </div>
                 <div className="flex items-center gap-2">
                   <StatusCircle
-                    isLoading={isVerifying}
-                    isSuccess={verification.Confirmed}
+                    isLoading={verification.loading}
+                    isSuccess={verification.postmarkVerified}
                   />
-                  {verification.Confirmed ? (
+                  {verification.postmarkVerified ? (
                     <div className="text-xs font-medium text-green-600">
                       Confirmed
                     </div>
@@ -279,10 +240,33 @@ export function Email({ app }: { app: InstantApp }) {
                 </div>
               </div>
               <Content className="text-sm text-gray-600">
-                {verification.Confirmed
-                  ? `Great! You've confirmed ${verification.EmailAddress} and can now send emails from this address.`
-                  : `We've sent a confirmation email to ${verification.EmailAddress}. Please click the link in that email to confirm ownership.`}
+                {verification.postmarkVerified
+                  ? `Great! You've confirmed ${verification.raw.data.verification?.EmailAddress} with Postmark.`
+                  : `We've sent a confirmation email to ${verification.raw.data.verification?.EmailAddress}. Please click the link in that email to confirm ownership.`}
               </Content>
+              <div className="mt-4 flex items-center justify-between">
+                <div className="text-sm font-medium">
+                  Instant Email Confirmation
+                </div>
+                <div className="flex items-center gap-2">
+                  <StatusCircle
+                    isLoading={verification.loading}
+                    isSuccess={verification.instantVerified}
+                  />
+                  {verification.instantVerified ? (
+                    <div className="text-xs font-medium text-green-600">
+                      Confirmed
+                    </div>
+                  ) : (
+                    <div className="text-xs text-gray-500 dark:text-neutral-400">
+                      Pending confirmation
+                    </div>
+                  )}
+                </div>
+              </div>
+              {!verification.instantVerified ? (
+                <SenderOtpVerification verification={verification} />
+              ) : null}
             </div>
 
             {/* Domain Verification */}
@@ -317,7 +301,8 @@ export function Email({ app }: { app: InstantApp }) {
                         Hostname:
                       </div>
                       <code className="block rounded-sm bg-gray-100 px-2 py-1 text-xs break-all select-all dark:bg-neutral-700">
-                        {verification.DKIMPendingHost || verification.DKIMHost}
+                        {verification.raw.data?.verification?.DKIMPendingHost ||
+                          verification.raw.data?.verification?.DKIMHost}
                       </code>
                     </div>
                     <div>
@@ -325,8 +310,9 @@ export function Email({ app }: { app: InstantApp }) {
                         Value:
                       </div>
                       <code className="block rounded-sm bg-gray-100 px-2 py-1 text-xs break-all select-all dark:bg-neutral-700">
-                        {verification.DKIMPendingTextValue ||
-                          verification.DKIMTextValue}
+                        {verification.raw.data?.verification
+                          ?.DKIMPendingTextValue ||
+                          verification.raw.data?.verification?.DKIMTextValue}
                       </code>
                     </div>
                   </div>
@@ -344,7 +330,7 @@ export function Email({ app }: { app: InstantApp }) {
                         Hostname:
                       </div>
                       <code className="block rounded-sm bg-gray-100 px-2 py-1 text-xs break-all select-all dark:bg-neutral-700">
-                        {verification.ReturnPathDomain}
+                        {verification.raw.data?.verification?.ReturnPathDomain}
                       </code>
                     </div>
                     <div>
@@ -352,7 +338,10 @@ export function Email({ app }: { app: InstantApp }) {
                         Value:
                       </div>
                       <code className="block rounded-sm bg-gray-100 px-2 py-1 text-xs break-all select-all dark:bg-neutral-700">
-                        {verification.ReturnPathDomainCNAMEValue}
+                        {
+                          verification.raw.data?.verification
+                            ?.ReturnPathDomainCNAMEValue
+                        }
                       </code>
                     </div>
                   </div>
@@ -391,6 +380,54 @@ export function Email({ app }: { app: InstantApp }) {
       </form>
 
       <MagicCodeExpirationSection app={app} />
+    </div>
+  );
+}
+
+function SenderOtpVerification({
+  verification,
+}: {
+  verification: ReturnType<typeof useCustomSenderVerification>;
+}) {
+  const [code, setCode] = useState('');
+  const address = verification.raw.data?.verification?.EmailAddress;
+
+  return (
+    <div className="mt-2 rounded-sm border bg-gray-50 p-3 dark:border-neutral-600 dark:bg-neutral-800/60">
+      <Content className="mb-3 text-sm text-gray-600 dark:text-neutral-300">
+        {verification.justSentCode
+          ? `We emailed ${address} a six-digit code to verify the email address with this app. Check your inbox for the code.`
+          : `Send a one-time passcode to ${address}, then enter the 6 digits here to confirm you can receive email at this address.`}
+      </Content>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <Button
+          type="button"
+          variant="secondary"
+          loading={verification.verifyCode.isMutating}
+          onClick={() => verification.sendCode()}
+        >
+          {verification.justSentCode ? 'Resend code' : 'Send code'}
+        </Button>
+        <div className="flex flex-1 gap-2">
+          <TextInput
+            label="Verification code"
+            value={code}
+            onChange={(e) => setCode(e)}
+            placeholder="123456"
+            inputMode="numeric"
+          />
+          <Button
+            type="button"
+            variant="primary"
+            loading={verification.verifyCode.isMutating}
+            disabled={code.length !== 6}
+            onClick={() => verification.verifyCode.trigger(code)}
+            className="self-end"
+          >
+            Verify
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -421,7 +421,24 @@ function SenderOtpVerification({
           type="button"
           variant="secondary"
           loading={verification.verifyCode.isMutating}
-          onClick={() => verification.sendCode()}
+          onClick={() =>
+            verification
+              .sendCode()
+              .then(() => {
+                successToast(`Verification code sent to ${address}`);
+              })
+              .catch((error) => {
+                if (error?.body?.message) {
+                  errorToast(
+                    `Failed to send verification code: ${error.body.message}`,
+                  );
+                } else {
+                  errorToast(
+                    `Failed to send verification code: ${error instanceof Error ? error.message : String(error)}`,
+                  );
+                }
+              })
+          }
         >
           {verification.justSentCode ? 'Resend code' : 'Send code'}
         </Button>

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -258,7 +258,7 @@ export function Email({ app }: { app: InstantApp }) {
               </div>
               <Content className="text-sm text-gray-600">
                 {!verification.postmarkVerified &&
-                  `We've sent a confirmation email to ${verification.raw.data.verification?.EmailAddress}. Please click the link in that email to confirm ownership.`}
+                  `Postmark has sent a confirmation email to ${verification.raw.data.verification?.EmailAddress}. Please click the link in that email to confirm ownership.`}
               </Content>
               <div className="mt-4 flex items-center justify-between">
                 <div className="text-sm font-medium">

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -73,7 +73,24 @@ export function Email({ app }: { app: InstantApp }) {
           if (values.senderEmail) {
             const res = await verification.refetch();
             if (!res?.instant?.['verified?']) {
-              verification.sendCode();
+              verification
+                .sendCode()
+                .then(() => {
+                  successToast(
+                    `Verification code sent to ${values.senderEmail}`,
+                  );
+                })
+                .catch((error) => {
+                  if (error?.body?.message) {
+                    errorToast(
+                      `Failed to send verification code: ${error.body.message}`,
+                    );
+                  } else {
+                    errorToast(
+                      `Failed to send verification code: ${error instanceof Error ? error.message : String(error)}`,
+                    );
+                  }
+                });
             }
           }
         },
@@ -240,9 +257,8 @@ export function Email({ app }: { app: InstantApp }) {
                 </div>
               </div>
               <Content className="text-sm text-gray-600">
-                {verification.postmarkVerified
-                  ? `Great! You've confirmed ${verification.raw.data.verification?.EmailAddress} with Postmark.`
-                  : `We've sent a confirmation email to ${verification.raw.data.verification?.EmailAddress}. Please click the link in that email to confirm ownership.`}
+                {!verification.postmarkVerified &&
+                  `We've sent a confirmation email to ${verification.raw.data.verification?.EmailAddress}. Please click the link in that email to confirm ownership.`}
               </Content>
               <div className="mt-4 flex items-center justify-between">
                 <div className="text-sm font-medium">
@@ -412,6 +428,11 @@ function SenderOtpVerification({
         <div className="flex flex-1 gap-2">
           <TextInput
             label="Verification code"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                verification.verifyCode.trigger(normalizedCode);
+              }
+            }}
             value={code}
             onChange={(e) => setCode(e)}
             placeholder="123456"

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -390,6 +390,7 @@ function SenderOtpVerification({
   verification: ReturnType<typeof useCustomSenderVerification>;
 }) {
   const [code, setCode] = useState('');
+  const normalizedCode = code.replace(/\D/g, '');
   const address = verification.raw.data?.verification?.EmailAddress;
 
   return (
@@ -420,8 +421,8 @@ function SenderOtpVerification({
             type="button"
             variant="primary"
             loading={verification.verifyCode.isMutating}
-            disabled={code.length !== 6}
-            onClick={() => verification.verifyCode.trigger(code)}
+            disabled={normalizedCode.length !== 6}
+            onClick={() => verification.verifyCode.trigger(normalizedCode)}
             className="self-end"
           >
             Verify

--- a/client/www/lib/hooks/useCustomSenderVerification.ts
+++ b/client/www/lib/hooks/useCustomSenderVerification.ts
@@ -1,4 +1,4 @@
-// Manages state for verfication of custom sender email addresses for Auth.
+// Manages state for verification of custom sender email addresses for Auth.
 
 import { useContext, useState } from 'react';
 import { InstantApp } from '../types';
@@ -99,8 +99,7 @@ export const useCustomSenderVerification = (app: InstantApp) => {
     async (_key, { arg }: { arg: string }) => {
       const normalizedCode = arg.replace(/\D/g, '').slice(0, 6);
       if (normalizedCode.length !== 6) {
-        errorToast('Enter the 6-digit verification code');
-        return;
+        throw new Error('Enter the 6-digit verification code');
       }
 
       const verified = await verifySenderVerificationCode({

--- a/client/www/lib/hooks/useCustomSenderVerification.ts
+++ b/client/www/lib/hooks/useCustomSenderVerification.ts
@@ -89,9 +89,6 @@ export const useCustomSenderVerification = (app: InstantApp) => {
       throw new Error('Failed to send verification code');
     }
     setJustSentCode(true);
-    successToast(
-      `Verification code sent to ${resp.data?.verification?.EmailAddress}`,
-    );
   };
 
   const verifyCode = useSWRMutation(
@@ -115,7 +112,7 @@ export const useCustomSenderVerification = (app: InstantApp) => {
         resp.mutate();
       },
       onError: (e) => {
-        errorToast('Failed to verify code: ' + e.message);
+        errorToast('Failed to verify code: ' + e.body.message);
       },
     },
   );

--- a/client/www/lib/hooks/useCustomSenderVerification.ts
+++ b/client/www/lib/hooks/useCustomSenderVerification.ts
@@ -1,0 +1,134 @@
+// Manages state for verfication of custom sender email addresses for Auth.
+
+import { useContext, useState } from 'react';
+import { InstantApp } from '../types';
+import useSWR from 'swr';
+import useSWRMutation from 'swr/mutation';
+import { TokenContext } from '../contexts';
+import { errorToast, successToast } from '../toast';
+import { jsonFetch, jsonMutate } from '../fetch';
+import { config } from '../config';
+import { SenderVerificationInfo } from '@/components/dash/auth/Email';
+
+export function getSenderVerification({
+  token,
+  appId,
+}: {
+  token: string;
+  appId: string;
+}): Promise<{
+  verification: SenderVerificationInfo | null;
+  instant?: { 'verified?': boolean };
+}> {
+  return jsonFetch(`${config.apiURI}/dash/apps/${appId}/sender-verification`, {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+  });
+}
+
+function sendSenderVerificationCode({
+  token,
+  appId,
+}: {
+  token: string;
+  appId: string;
+}): Promise<{ sent: boolean }> {
+  return jsonMutate(
+    `${config.apiURI}/dash/apps/${appId}/sender-verification/send-magic-code`,
+    {
+      token,
+    },
+  );
+}
+
+function verifySenderVerificationCode({
+  token,
+  appId,
+  code,
+}: {
+  token: string;
+  appId: string;
+  code: string;
+}): Promise<{ verified: boolean }> {
+  return jsonMutate(
+    `${config.apiURI}/dash/apps/${appId}/sender-verification/verify-magic-code`,
+    {
+      token,
+      body: { code },
+    },
+  );
+}
+
+export const useCustomSenderVerification = (app: InstantApp) => {
+  const template = app.magic_code_email_template;
+  const token = useContext(TokenContext);
+
+  const resp = useSWR(
+    [app.id, template?.id],
+    () =>
+      getSenderVerification({
+        appId: app.id,
+        token: token,
+      }),
+    {
+      onError: (e) => {
+        console.error('Failed to check verification:', e);
+        errorToast('Failed to check verification status');
+      },
+    },
+  );
+
+  const [justSentCode, setJustSentCode] = useState(false);
+
+  const sendCode = async () => {
+    const rep = await sendSenderVerificationCode({ token, appId: app.id });
+    if (!rep.sent) {
+      throw new Error('Failed to send verification code');
+    }
+    setJustSentCode(true);
+    successToast(
+      `Verification code sent to ${resp.data?.verification?.EmailAddress}`,
+    );
+  };
+
+  const verifyCode = useSWRMutation(
+    ['verify-sender-verification-code', app.id],
+    async (_key, { arg }: { arg: string }) => {
+      const normalizedCode = arg.replace(/\D/g, '').slice(0, 6);
+      if (normalizedCode.length !== 6) {
+        errorToast('Enter the 6-digit verification code');
+        return;
+      }
+
+      const verified = await verifySenderVerificationCode({
+        token: token,
+        appId: app.id,
+        code: normalizedCode,
+      });
+      return verified;
+    },
+    {
+      onSuccess: () => {
+        successToast('Sender email verified!');
+        resp.mutate();
+      },
+      onError: (e) => {
+        errorToast('Failed to verify code: ' + e.message);
+      },
+    },
+  );
+
+  return {
+    raw: resp,
+    instantVerified: resp.data?.instant?.['verified?'] ?? false,
+    postmarkVerified: resp.data?.verification?.Confirmed ?? false,
+    loading: resp.isValidating,
+    refetch: resp.mutate,
+    justSentCode,
+    sendCode,
+    verifyCode,
+  };
+};

--- a/server/resources/migrations/111_add_app_email_verification_codes.down.sql
+++ b/server/resources/migrations/111_add_app_email_verification_codes.down.sql
@@ -1,0 +1,1 @@
+DROP table app_email_verification_codes;

--- a/server/resources/migrations/111_add_app_email_verification_codes.up.sql
+++ b/server/resources/migrations/111_add_app_email_verification_codes.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE app_email_verification_codes (
+    id UUID PRIMARY KEY,
+    code text NOT NULL,
+    app_id UUID NOT NULL references apps(id) on delete cascade,
+    verification_id UUID NOT NULL references app_email_verifications(id) on delete cascade,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON app_email_verification_codes (app_id);
+CREATE INDEX ON app_email_verification_codes (verification_id);

--- a/server/resources/migrations/111_add_app_email_verification_codes.up.sql
+++ b/server/resources/migrations/111_add_app_email_verification_codes.up.sql
@@ -3,8 +3,9 @@ CREATE TABLE app_email_verification_codes (
     code text NOT NULL,
     app_id UUID NOT NULL references apps(id) on delete cascade,
     verification_id UUID NOT NULL references app_email_verifications(id) on delete cascade,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX ON app_email_verification_codes (app_id);
+CREATE INDEX ON app_email_verification_codes (created_at);
 CREATE INDEX ON app_email_verification_codes (verification_id);

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1,91 +1,90 @@
 (ns instant.dash.routes
-  (:require
-   [clj-http.client :as clj-http]
-   [clojure.string :as string]
-   [clojure.tools.logging :as log]
-   [clojure.walk :as w]
-   [compojure.core :as compojure :refer [defroutes DELETE GET POST PUT]]
-   [hiccup2.core :as h]
-   [instant.cloudwatch :as cloudwatch]
-   [instant.config :as config]
-   [instant.dash.admin :as dash-admin]
-   [instant.dash.ephemeral-app :as ephemeral-app]
-   [instant.dash.get-a-db :as get-a-db]
-   [instant.db.indexing-jobs :as indexing-jobs]
-   [instant.db.model.attr :as attr-model]
-   [instant.db.transaction :as tx]
-   [instant.discord :as discord]
-   [instant.fixtures :as fixtures]
-   [instant.flags :as flags :refer [admin-email?]]
-   [instant.hard-deletion-sweeper :as sweeper]
-   [instant.intern.metrics :as metrics]
-   [instant.isn :as isn]
-   [instant.jdbc.aurora :as aurora]
-   [instant.lib.ring.websocket :as ws]
-   [instant.machine-summaries :as machine-summaries]
-   [instant.model.app :as app-model]
-   [instant.model.app-admin-token :as app-admin-token-model]
-   [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
-   [instant.model.app-email-sender :as app-email-sender-model]
-   [instant.model.app-email-template :as app-email-template-model]
-   [instant.model.app-email-verification :as verification]
-   [instant.model.app-email-verification-code :as app-email-verification-code]
-   [instant.model.app-file :as app-file-model]
-   [instant.model.app-members :as instant-app-members]
-   [instant.model.app-oauth-client :as app-oauth-client-model]
-   [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
-   [instant.model.app-user-magic-code :as app-user-magic-code-model]
-   [instant.model.instant-cli-login :as instant-cli-login-model]
-   [instant.model.instant-oauth-code :as instant-oauth-code-model]
-   [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
-   [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
-   [instant.model.instant-profile :as instant-profile-model]
-   [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
-   [instant.model.instant-subscription :as instant-subscription-model]
-   [instant.model.instant-user :as instant-user-model]
-   [instant.model.instant-user-magic-code :as instant-user-magic-code-model]
-   [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
-   [instant.model.member-invites :as member-invites-model]
-   [instant.model.oauth-app :as oauth-app-model]
-   [instant.model.org :as org-model]
-   [instant.model.org-members :as instant-org-members]
-   [instant.model.outreach :as outreach-model]
-   [instant.model.rule :as rule-model]
-   [instant.model.schema :as schema-model]
-   [instant.model.shared-oauth-client :refer [assert-shared-credentials-allowed!
-                                              get-shared-credential!]]
-   [instant.model.webhook :as webhook-model]
-   [instant.plans :as plans]
-   [instant.postmark :as postmark]
-   [instant.runtime.magic-code-auth :refer [check-send-rate-limit!
-                                            check-verify-rate-limit!
-                                            check-custom-sender-rate-limit!]]
-   [instant.session-counter :as session-counter]
-   [instant.storage.coordinator :as storage-coordinator]
-   [instant.stripe :as stripe]
-   [instant.superadmin.routes :refer [req->superadmin-app!
-                                      req->superadmin-user!]]
-   [instant.util.async :refer [fut-bg]]
-   [instant.util.crypt :as crypt-util]
-   [instant.util.date :as date]
-   [instant.util.email :as email]
-   [instant.util.exception :as ex]
-   [instant.util.http :as http-util :refer [req->app-and-user! req->auth-user!]]
-   [instant.util.json :as json]
-   [instant.util.number :as number-util]
-   [instant.util.posthog :as posthog]
-   [instant.util.roles :refer [assert-least-privilege!
-                               assert-valid-member-role!]]
-   [instant.util.semver :as semver]
-   [instant.util.string :as string-util]
-   [instant.util.tracer :as tracer]
-   [instant.util.url :as url-util]
-   [instant.util.uuid :as uuid-util]
-   [instant.webhook-processor :as webhook-processor]
-   [medley.core :as medley]
-   [next.jdbc :as next-jdbc]
-   [ring.middleware.cookies :refer [wrap-cookies]]
-   [ring.util.http-response :as response])
+  (:require [clj-http.client :as clj-http]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [clojure.walk :as w]
+            [compojure.core :as compojure :refer [defroutes DELETE GET POST PUT]]
+            [hiccup2.core :as h]
+            [instant.cloudwatch :as cloudwatch]
+            [instant.config :as config]
+            [instant.dash.admin :as dash-admin]
+            [instant.dash.ephemeral-app :as ephemeral-app]
+            [instant.dash.get-a-db :as get-a-db]
+            [instant.db.indexing-jobs :as indexing-jobs]
+            [instant.db.model.attr :as attr-model]
+            [instant.db.transaction :as tx]
+            [instant.discord :as discord]
+            [instant.fixtures :as fixtures]
+            [instant.flags :as flags :refer [admin-email?]]
+            [instant.hard-deletion-sweeper :as sweeper]
+            [instant.intern.metrics :as metrics]
+            [instant.isn :as isn]
+            [instant.jdbc.aurora :as aurora]
+            [instant.lib.ring.websocket :as ws]
+            [instant.machine-summaries :as machine-summaries]
+            [instant.model.app :as app-model]
+            [instant.model.app-admin-token :as app-admin-token-model]
+            [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
+            [instant.model.app-email-sender :as app-email-sender-model]
+            [instant.model.app-email-template :as app-email-template-model]
+            [instant.model.app-email-verification :as app-email-verification]
+            [instant.model.app-email-verification-code :as app-email-verification-code]
+            [instant.model.app-file :as app-file-model]
+            [instant.model.app-members :as instant-app-members]
+            [instant.model.app-oauth-client :as app-oauth-client-model]
+            [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
+            [instant.model.app-user-magic-code :as app-user-magic-code-model]
+            [instant.model.instant-cli-login :as instant-cli-login-model]
+            [instant.model.instant-oauth-code :as instant-oauth-code-model]
+            [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
+            [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
+            [instant.model.instant-profile :as instant-profile-model]
+            [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
+            [instant.model.instant-subscription :as instant-subscription-model]
+            [instant.model.instant-user :as instant-user-model]
+            [instant.model.instant-user-magic-code :as instant-user-magic-code-model]
+            [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
+            [instant.model.member-invites :as member-invites-model]
+            [instant.model.oauth-app :as oauth-app-model]
+            [instant.model.org :as org-model]
+            [instant.model.org-members :as instant-org-members]
+            [instant.model.outreach :as outreach-model]
+            [instant.model.rule :as rule-model]
+            [instant.model.schema :as schema-model]
+            [instant.model.shared-oauth-client :refer [assert-shared-credentials-allowed!
+                                                       get-shared-credential!]]
+            [instant.model.webhook :as webhook-model]
+            [instant.plans :as plans]
+            [instant.postmark :as postmark]
+            [instant.runtime.magic-code-auth :refer [check-send-rate-limit!
+                                                     check-verify-rate-limit!
+                                                     check-custom-sender-rate-limit!]]
+            [instant.session-counter :as session-counter]
+            [instant.storage.coordinator :as storage-coordinator]
+            [instant.stripe :as stripe]
+            [instant.superadmin.routes :refer [req->superadmin-app!
+                                               req->superadmin-user!]]
+            [instant.util.async :refer [fut-bg]]
+            [instant.util.crypt :as crypt-util]
+            [instant.util.date :as date]
+            [instant.util.email :as email]
+            [instant.util.exception :as ex]
+            [instant.util.http :as http-util :refer [req->app-and-user! req->auth-user!]]
+            [instant.util.json :as json]
+            [instant.util.number :as number-util]
+            [instant.util.posthog :as posthog]
+            [instant.util.roles :refer [assert-least-privilege!
+                                        assert-valid-member-role!]]
+            [instant.util.semver :as semver]
+            [instant.util.string :as string-util]
+            [instant.util.tracer :as tracer]
+            [instant.util.url :as url-util]
+            [instant.util.uuid :as uuid-util]
+            [instant.webhook-processor :as webhook-processor]
+            [medley.core :as medley]
+            [next.jdbc :as next-jdbc]
+            [ring.middleware.cookies :refer [wrap-cookies]]
+            [ring.util.http-response :as response])
   (:import
    (com.stripe.model.checkout Session)
    (io.undertow.websockets.core WebSocketChannel)
@@ -1340,10 +1339,10 @@
 
 (defn sender-verification-get [req]
   (let [{{app-id :id} :app} (req->app-and-user! :admin req)
-        {postmark-id :postmark_id verification :verification_verified}
-        (verification/get-by-app-id-and-email-type-with-template
+        {postmark-id :postmark_id instant-verified? :verification_verified}
+        (app-email-verification/get-by-app-id-and-email-type-with-template
          {:app-id app-id :email-type "magic-code"})]
-    (response/ok {:instant {:verified? verification}
+    (response/ok {:instant {:verified? instant-verified?}
                   :verification (when postmark-id
                                   (-> (postmark/get-sender! {:id postmark-id})
                                       :body
@@ -1368,12 +1367,12 @@
         sender-email (email/coerce (get-in req [:body :sender-email])) ;; optional
         custom-sender-name (string-util/coerce-non-blank-str (get-in req [:body :sender-name])) ;; optional
         sender-name (or custom-sender-name (:title app))
-        {sender :sender needs-verify :needs-verify} (when sender-email
-                                                      (app-email-sender-model/sync-sender!
-                                                       {:app-id (:id app)
-                                                        :user-id (:id user)
-                                                        :email sender-email
-                                                        :name sender-name}))
+        {sender :sender needs-verify? :needs-verify} (when sender-email
+                                                       (app-email-sender-model/sync-sender!
+                                                        {:app-id (:id app)
+                                                         :user-id (:id user)
+                                                         :email sender-email
+                                                         :name sender-name}))
         template (app-email-template-model/put!
                   {:app-id (:id app)
                    :email-type email-type
@@ -1381,21 +1380,17 @@
                    :name sender-name
                    :subject subject
                    :body body})]
-    (response/ok {:id (:id template) :needs-verify needs-verify})))
+    (response/ok {:id (:id template) :needs-verify needs-verify?})))
 
 (defn sender-verification-send-magic-code
   "sends the email containing a code to verify a custom sender domain with an app id"
   [req]
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
-        verification-info (verification/get-by-app-id-and-email-type-with-template
+        verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
                            {:app-id app-id :email-type "magic-code"})
-        _ (check-custom-sender-rate-limit! {:email (:email verification-info)})
         verification-id (:verification_id verification-info)
         sender-email (:email verification-info)
-        _ (ex/assert-record! verification-id
-                             :app-email-verification
-                             {:args [{:app-id app-id
-                                      :email-type "magic-code"}]})
+        _ (check-custom-sender-rate-limit! {:email sender-email})
         code (app-user-magic-code-model/rand-code)
         _ (app-email-verification-code/put!
            {:code code
@@ -1409,22 +1404,19 @@
   [req]
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
         submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)
-        verification-info (verification/get-by-app-id-and-email-type-with-template
+        verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
                            {:app-id app-id :email-type "magic-code"})
-        _ (check-custom-sender-rate-limit! {:email (:email verification-info)})
         verification-id (:verification_id verification-info)
-        _ (ex/assert-record! verification-id
-                             :app-email-verification
-                             {:args [{:app-id app-id
-                                      :email-type "magic-code"}]})
-        verified (next-jdbc/with-transaction [tx-conn (aurora/conn-pool :write)]
-                   (when (app-email-verification-code/consume!
-                          tx-conn
-                          {:code submitted-code
-                           :verification-id verification-id
-                           :expiry-minutes (flags/default-magic-code-expiry-minutes)})
-                     (verification/mark-verified! tx-conn {:id verification-id})))]
-    (when-not verified
+        sender-email (:email verification-info)
+        _ (check-custom-sender-rate-limit! {:email sender-email})
+        verified? (next-jdbc/with-transaction [tx-conn (aurora/conn-pool :write)]
+                    (when (app-email-verification-code/consume!
+                           tx-conn
+                           {:code submitted-code
+                            :verification-id verification-id
+                            :expiry-minutes (flags/default-magic-code-expiry-minutes)})
+                      (app-email-verification/mark-verified! tx-conn {:id verification-id})))]
+    (when-not verified?
       (ex/throw-validation-err!
        :code
        submitted-code

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1385,7 +1385,8 @@
 (defn sender-verification-send-magic-code
   "sends the email containing a code to verify a custom sender domain with an app id"
   [req]
-  (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
+  (let [app  (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req))
+        app-id (:id app)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
                            {:app-id app-id :email-type "magic-code"})
         verification-id (:verification_id verification-info)
@@ -1396,7 +1397,7 @@
            {:code code
             :app-id app-id
             :verification-id verification-id})]
-    (postmark/send-structured! (app-email-verification-code/format-email {:code code :sender-email sender-email}))
+    (postmark/send-structured! (app-email-verification-code/format-email {:code code :sender-email sender-email :app-title (:title app)}))
     (response/ok {:sent true})))
 
 (defn sender-verification-verify-magic-code

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1386,7 +1386,7 @@
   "sends the email containing a code to verify a custom sender domain with an app id"
   [req]
   (when-not (flags/use-app-email-verification?)
-    (ex/throw+ {::ex/type ::permission-denied
+    (ex/throw+ {::ex/type ::ex/permission-denied
                 ::ex/message "Permission denied: app-level sender verification not enabled"}))
   (let [app  (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req))
         app-id (:id app)
@@ -1407,7 +1407,7 @@
   "verify the code after receiving the email from sender-verification-send-magic-code"
   [req]
   (when-not (flags/use-app-email-verification?)
-    (ex/throw+ {::ex/type ::permission-denied
+    (ex/throw+ {::ex/type ::ex/permission-denied
                 ::ex/message "Permission denied: app-level sender verification not enabled"}))
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
         submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1386,7 +1386,7 @@
   "sends the email containing a code to verify a custom sender domain with an app id"
   [req]
   (when-not (flags/use-app-email-verification?)
-    (ex/throw+ {::type ::permission-denied
+    (ex/throw+ {::ex/type ::permission-denied
                 ::message "Permission denied: app-level sender verification not enabled"}))
   (let [app  (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req))
         app-id (:id app)
@@ -1407,7 +1407,7 @@
   "verify the code after receiving the email from sender-verification-send-magic-code"
   [req]
   (when-not (flags/use-app-email-verification?)
-    (ex/throw+ {::type ::permission-denied
+    (ex/throw+ {::ex/type ::permission-denied
                 ::message "Permission denied: app-level sender verification not enabled"}))
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
         submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1342,7 +1342,7 @@
         {postmark-id :postmark_id instant-verified? :verification_verified}
         (app-email-verification/get-by-app-id-and-email-type-with-template
          {:app-id app-id :email-type "magic-code"})]
-    (response/ok {:instant {:verified? instant-verified?}
+    (response/ok {:instant {:verified? (if (flags/use-app-email-verification?) instant-verified? true)}
                   :verification (when postmark-id
                                   (-> (postmark/get-sender! {:id postmark-id})
                                       :body
@@ -1367,12 +1367,12 @@
         sender-email (email/coerce (get-in req [:body :sender-email])) ;; optional
         custom-sender-name (string-util/coerce-non-blank-str (get-in req [:body :sender-name])) ;; optional
         sender-name (or custom-sender-name (:title app))
-        {sender :sender needs-verify? :needs-verify} (when sender-email
-                                                       (app-email-sender-model/sync-sender!
-                                                        {:app-id (:id app)
-                                                         :user-id (:id user)
-                                                         :email sender-email
-                                                         :name sender-name}))
+        {sender :sender} (when sender-email
+                           (app-email-sender-model/sync-sender!
+                            {:app-id (:id app)
+                             :user-id (:id user)
+                             :email sender-email
+                             :name sender-name}))
         template (app-email-template-model/put!
                   {:app-id (:id app)
                    :email-type email-type
@@ -1380,11 +1380,14 @@
                    :name sender-name
                    :subject subject
                    :body body})]
-    (response/ok {:id (:id template) :needs-verify needs-verify?})))
+    (response/ok {:id (:id template)})))
 
 (defn sender-verification-send-magic-code
   "sends the email containing a code to verify a custom sender domain with an app id"
   [req]
+  (when-not (flags/use-app-email-verification?)
+    (ex/throw+ {::type ::permission-denied
+                ::message "Permission denied: app-level sender verification not enabled"}))
   (let [app  (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req))
         app-id (:id app)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
@@ -1403,6 +1406,9 @@
 (defn sender-verification-verify-magic-code
   "verify the code after receiving the email from sender-verification-send-magic-code"
   [req]
+  (when-not (flags/use-app-email-verification?)
+    (ex/throw+ {::type ::permission-denied
+                ::message "Permission denied: app-level sender verification not enabled"}))
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
         submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
@@ -1415,8 +1421,9 @@
                            tx-conn
                            {:code submitted-code
                             :verification-id verification-id
-                            :expiry-minutes (flags/default-magic-code-expiry-minutes)})
-                      (app-email-verification/mark-verified! tx-conn {:id verification-id})))]
+                            :expiry-minutes (flags/default-magic-code-expiry-minutes)
+                            :app-id app-id})
+                      (app-email-verification/mark-verified! tx-conn {:id verification-id :app-id app-id})))]
     (when-not verified?
       (ex/throw-validation-err!
        :code

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1,85 +1,91 @@
 (ns instant.dash.routes
-  (:require [clj-http.client :as clj-http]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [clojure.walk :as w]
-            [compojure.core :as compojure :refer [defroutes DELETE GET POST PUT]]
-            [hiccup2.core :as h]
-            [instant.cloudwatch :as cloudwatch]
-            [instant.config :as config]
-            [instant.dash.admin :as dash-admin]
-            [instant.dash.ephemeral-app :as ephemeral-app]
-            [instant.dash.get-a-db :as get-a-db]
-            [instant.db.indexing-jobs :as indexing-jobs]
-            [instant.db.transaction :as tx]
-            [instant.db.model.attr :as attr-model]
-            [instant.discord :as discord]
-            [instant.fixtures :as fixtures]
-            [instant.flags :as flags :refer [admin-email?]]
-            [instant.hard-deletion-sweeper :as sweeper]
-            [instant.intern.metrics :as metrics]
-            [instant.jdbc.aurora :as aurora]
-            [instant.lib.ring.websocket :as ws]
-            [instant.machine-summaries :as machine-summaries]
-            [instant.model.app :as app-model]
-            [instant.model.app-admin-token :as app-admin-token-model]
-            [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
-            [instant.model.app-email-sender :as app-email-sender-model]
-            [instant.model.app-email-template :as app-email-template-model]
-            [instant.model.app-file :as app-file-model]
-            [instant.model.member-invites :as member-invites-model]
-            [instant.model.app-members :as instant-app-members]
-            [instant.model.org-members :as instant-org-members]
-            [instant.model.app-oauth-client :as app-oauth-client-model]
-            [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
-            [instant.model.shared-oauth-client :refer [assert-shared-credentials-allowed!
-                                                       get-shared-credential!]]
-            [instant.model.instant-cli-login :as instant-cli-login-model]
-            [instant.model.instant-oauth-code :as instant-oauth-code-model]
-            [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
-            [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
-            [instant.model.instant-profile :as instant-profile-model]
-            [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
-            [instant.model.instant-subscription :as instant-subscription-model]
-            [instant.model.instant-user :as instant-user-model]
-            [instant.model.instant-user-magic-code :as instant-user-magic-code-model]
-            [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
-            [instant.model.oauth-app :as oauth-app-model]
-            [instant.model.org :as org-model]
-            [instant.model.outreach :as outreach-model]
-            [instant.model.rule :as rule-model]
-            [instant.model.schema :as schema-model]
-            [instant.model.webhook :as webhook-model]
-            [instant.plans :as plans]
-            [instant.postmark :as postmark]
-            [instant.runtime.magic-code-auth :refer [check-send-rate-limit!
-                                                     check-verify-rate-limit!]]
-            [instant.session-counter :as session-counter]
-            [instant.storage.coordinator :as storage-coordinator]
-            [instant.stripe :as stripe]
-            [instant.superadmin.routes :refer [req->superadmin-app! req->superadmin-user!]]
-            [instant.util.async :refer [fut-bg]]
-            [instant.util.crypt :as crypt-util]
-            [instant.util.date :as date]
-            [instant.util.email :as email]
-            [instant.util.exception :as ex]
-            [instant.isn :as isn]
-            [instant.util.http :as http-util :refer [req->app-and-user! req->auth-user!]]
-            [instant.util.json :as json]
-            [instant.util.number :as number-util]
-            [instant.util.roles :refer [assert-least-privilege!
-                                        assert-valid-member-role!]]
-            [instant.util.semver :as semver]
-            [instant.util.string :as string-util]
-            [instant.util.posthog :as posthog]
-            [instant.util.tracer :as tracer]
-            [instant.util.url :as url-util]
-            [instant.util.uuid :as uuid-util]
-            [instant.webhook-processor :as webhook-processor]
-            [medley.core :as medley]
-            [next.jdbc :as next-jdbc]
-            [ring.middleware.cookies :refer [wrap-cookies]]
-            [ring.util.http-response :as response])
+  (:require
+   [clj-http.client :as clj-http]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]
+   [clojure.walk :as w]
+   [compojure.core :as compojure :refer [defroutes DELETE GET POST PUT]]
+   [hiccup2.core :as h]
+   [instant.cloudwatch :as cloudwatch]
+   [instant.config :as config]
+   [instant.dash.admin :as dash-admin]
+   [instant.dash.ephemeral-app :as ephemeral-app]
+   [instant.dash.get-a-db :as get-a-db]
+   [instant.db.indexing-jobs :as indexing-jobs]
+   [instant.db.model.attr :as attr-model]
+   [instant.db.transaction :as tx]
+   [instant.discord :as discord]
+   [instant.fixtures :as fixtures]
+   [instant.flags :as flags :refer [admin-email?]]
+   [instant.hard-deletion-sweeper :as sweeper]
+   [instant.intern.metrics :as metrics]
+   [instant.isn :as isn]
+   [instant.jdbc.aurora :as aurora]
+   [instant.lib.ring.websocket :as ws]
+   [instant.machine-summaries :as machine-summaries]
+   [instant.model.app :as app-model]
+   [instant.model.app-admin-token :as app-admin-token-model]
+   [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
+   [instant.model.app-email-sender :as app-email-sender-model]
+   [instant.model.app-email-template :as app-email-template-model]
+   [instant.model.app-email-verification :as verification]
+   [instant.model.app-email-verification-code :as app-email-verification-code]
+   [instant.model.app-file :as app-file-model]
+   [instant.model.app-members :as instant-app-members]
+   [instant.model.app-oauth-client :as app-oauth-client-model]
+   [instant.model.app-oauth-service-provider :as app-oauth-service-provider-model]
+   [instant.model.app-user-magic-code :as app-user-magic-code-model]
+   [instant.model.instant-cli-login :as instant-cli-login-model]
+   [instant.model.instant-oauth-code :as instant-oauth-code-model]
+   [instant.model.instant-oauth-redirect :as instant-oauth-redirect-model]
+   [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
+   [instant.model.instant-profile :as instant-profile-model]
+   [instant.model.instant-stripe-customer :as instant-stripe-customer-model]
+   [instant.model.instant-subscription :as instant-subscription-model]
+   [instant.model.instant-user :as instant-user-model]
+   [instant.model.instant-user-magic-code :as instant-user-magic-code-model]
+   [instant.model.instant-user-refresh-token :as instant-user-refresh-token-model]
+   [instant.model.member-invites :as member-invites-model]
+   [instant.model.oauth-app :as oauth-app-model]
+   [instant.model.org :as org-model]
+   [instant.model.org-members :as instant-org-members]
+   [instant.model.outreach :as outreach-model]
+   [instant.model.rule :as rule-model]
+   [instant.model.schema :as schema-model]
+   [instant.model.shared-oauth-client :refer [assert-shared-credentials-allowed!
+                                              get-shared-credential!]]
+   [instant.model.webhook :as webhook-model]
+   [instant.plans :as plans]
+   [instant.postmark :as postmark]
+   [instant.runtime.magic-code-auth :refer [check-send-rate-limit!
+                                            check-verify-rate-limit!
+                                            check-custom-sender-rate-limit!]]
+   [instant.session-counter :as session-counter]
+   [instant.storage.coordinator :as storage-coordinator]
+   [instant.stripe :as stripe]
+   [instant.superadmin.routes :refer [req->superadmin-app!
+                                      req->superadmin-user!]]
+   [instant.util.async :refer [fut-bg]]
+   [instant.util.crypt :as crypt-util]
+   [instant.util.date :as date]
+   [instant.util.email :as email]
+   [instant.util.exception :as ex]
+   [instant.util.http :as http-util :refer [req->app-and-user! req->auth-user!]]
+   [instant.util.json :as json]
+   [instant.util.number :as number-util]
+   [instant.util.posthog :as posthog]
+   [instant.util.roles :refer [assert-least-privilege!
+                               assert-valid-member-role!]]
+   [instant.util.semver :as semver]
+   [instant.util.string :as string-util]
+   [instant.util.tracer :as tracer]
+   [instant.util.url :as url-util]
+   [instant.util.uuid :as uuid-util]
+   [instant.webhook-processor :as webhook-processor]
+   [medley.core :as medley]
+   [next.jdbc :as next-jdbc]
+   [ring.middleware.cookies :refer [wrap-cookies]]
+   [ring.util.http-response :as response])
   (:import
    (com.stripe.model.checkout Session)
    (io.undertow.websockets.core WebSocketChannel)
@@ -1334,10 +1340,11 @@
 
 (defn sender-verification-get [req]
   (let [{{app-id :id} :app} (req->app-and-user! :admin req)
-        {postmark-id :postmark_id}
-        (app-email-template-model/get-by-app-id-and-email-type
+        {postmark-id :postmark_id verification :verification_verified}
+        (verification/get-by-app-id-and-email-type-with-template
          {:app-id app-id :email-type "magic-code"})]
-    (response/ok {:verification (when postmark-id
+    (response/ok {:instant {:verified? verification}
+                  :verification (when postmark-id
                                   (-> (postmark/get-sender! {:id postmark-id})
                                       :body
                                       (select-keys [:ID :EmailAddress :Confirmed
@@ -1375,6 +1382,54 @@
                    :subject subject
                    :body body})]
     (response/ok {:id (:id template) :needs-verify needs-verify})))
+
+(defn sender-verification-send-magic-code
+  "sends the email containing a code to verify a custom sender domain with an app id"
+  [req]
+  (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
+        verification-info (verification/get-by-app-id-and-email-type-with-template
+                           {:app-id app-id :email-type "magic-code"})
+        _ (check-custom-sender-rate-limit! {:email (:email verification-info)})
+        verification-id (:verification_id verification-info)
+        sender-email (:email verification-info)
+        _ (ex/assert-record! verification-id
+                             :app-email-verification
+                             {:args [{:app-id app-id
+                                      :email-type "magic-code"}]})
+        code (app-user-magic-code-model/rand-code)
+        _ (app-email-verification-code/put!
+           {:code code
+            :app-id app-id
+            :verification-id verification-id})]
+    (postmark/send-structured! (app-email-verification-code/format-email {:code code :sender-email sender-email}))
+    (response/ok {:sent true})))
+
+(defn sender-verification-verify-magic-code
+  "verify the code after receiving the email from sender-verification-send-magic-code"
+  [req]
+  (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
+        submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)
+        verification-info (verification/get-by-app-id-and-email-type-with-template
+                           {:app-id app-id :email-type "magic-code"})
+        _ (check-custom-sender-rate-limit! {:email (:email verification-info)})
+        verification-id (:verification_id verification-info)
+        _ (ex/assert-record! verification-id
+                             :app-email-verification
+                             {:args [{:app-id app-id
+                                      :email-type "magic-code"}]})
+        verified (next-jdbc/with-transaction [tx-conn (aurora/conn-pool :write)]
+                   (when (app-email-verification-code/consume!
+                          tx-conn
+                          {:code submitted-code
+                           :verification-id verification-id
+                           :expiry-minutes (flags/default-magic-code-expiry-minutes)})
+                     (verification/mark-verified! tx-conn {:id verification-id})))]
+    (when-not verified
+      (ex/throw-validation-err!
+       :code
+       submitted-code
+       [{:message "Invalid verification code."}]))
+    (response/ok {:verified true})))
 
 (comment
   (def any-app (app-model/get-by-id {:id "d8f9e0a9-b6f5-49e9-a186-eabc7fe4ddac"}))
@@ -2226,6 +2281,8 @@
   (POST "/dash/apps/:app_id/members/update" [] team-member-update-post)
 
   (GET "/dash/apps/:app_id/sender-verification" [] sender-verification-get)
+  (POST "/dash/apps/:app_id/sender-verification/send-magic-code" [] sender-verification-send-magic-code)
+  (POST "/dash/apps/:app_id/sender-verification/verify-magic-code" [] sender-verification-verify-magic-code)
   (POST "/dash/apps/:app_id/email_templates" [] email-template-post)
   (DELETE "/dash/apps/:app_id/email_templates/:id" [] email-template-delete)
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1387,7 +1387,7 @@
   [req]
   (when-not (flags/use-app-email-verification?)
     (ex/throw+ {::ex/type ::permission-denied
-                ::message "Permission denied: app-level sender verification not enabled"}))
+                ::ex/message "Permission denied: app-level sender verification not enabled"}))
   (let [app  (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req))
         app-id (:id app)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
@@ -1408,7 +1408,7 @@
   [req]
   (when-not (flags/use-app-email-verification?)
     (ex/throw+ {::ex/type ::permission-denied
-                ::message "Permission denied: app-level sender verification not enabled"}))
+                ::ex/message "Permission denied: app-level sender verification not enabled"}))
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
         submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1361,12 +1361,12 @@
         sender-email (email/coerce (get-in req [:body :sender-email])) ;; optional
         custom-sender-name (string-util/coerce-non-blank-str (get-in req [:body :sender-name])) ;; optional
         sender-name (or custom-sender-name (:title app))
-        sender (when sender-email
-                 (app-email-sender-model/sync-sender!
-                  {:app-id (:id app)
-                   :user-id (:id user)
-                   :email sender-email
-                   :name sender-name}))
+        {sender :sender needs-verify :needs-verify} (when sender-email
+                                                      (app-email-sender-model/sync-sender!
+                                                       {:app-id (:id app)
+                                                        :user-id (:id user)
+                                                        :email sender-email
+                                                        :name sender-name}))
         template (app-email-template-model/put!
                   {:app-id (:id app)
                    :email-type email-type
@@ -1374,7 +1374,7 @@
                    :name sender-name
                    :subject subject
                    :body body})]
-    (response/ok {:id (:id template)})))
+    (response/ok {:id (:id template) :needs-verify needs-verify})))
 
 (comment
   (def any-app (app-model/get-by-id {:id "d8f9e0a9-b6f5-49e9-a186-eabc7fe4ddac"}))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -355,6 +355,9 @@
 (defn use-get-datalog-queries-for-topics-v2? []
   (toggled? :use-get-datalog-queries-for-topics-v2? true))
 
+(defn use-app-email-verification? []
+  (toggled? :use-app-email-verification? false))
+
 (defn enable-wal-entity-log? [app-id]
   (or (toggled? :enable-wal-entity-log-globally)
       (contains? (flag :enable-wal-entity-log-apps) app-id)))

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -3,7 +3,8 @@
             [instant.jdbc.sql :as sql]
             [instant.model.app-email-verification :as verification]
             [instant.postmark :as postmark]
-            [instant.util.exception :as ex])
+            [instant.util.exception :as ex]
+            [instant.flags :as flags])
   (:import (java.util UUID)))
 
 (defn get-by-email
@@ -87,14 +88,20 @@
                       :name name
                       :app-id app-id
                       :user-id user-id
-                      :postmark-id postmark-id})]
-    (verification/put! {:app-id app-id
-                        :sender-id (:id sender)
-                        :verified true})
-    sender))
+                      :postmark-id postmark-id})
+        verification (if (flags/use-app-email-verification?)
+                       (verification/put! {:app-id app-id
+                                           :sender-id (:id sender)
+                                           :verified false})
+                       (verification/put! {:app-id app-id
+                                           :sender-id (:id sender)
+                                           :verified true}))
+        needs-verify (not (:verified verification))]
+    {:sender sender :needs-verify needs-verify}))
 
 (comment
   (postmark/add-sender! {:email "hi@marky.fyi" :name "Marky"})
+  (flags/use-app-email-verification?)
   (ex-data *e)
   (def r (postmark/list-senders! 50 0))
   (def ss (get-in r [:body :SenderSignatures]))

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -89,15 +89,14 @@
                       :app-id app-id
                       :user-id user-id
                       :postmark-id postmark-id})
-        verification (if (flags/use-app-email-verification?)
-                       (verification/put! {:app-id app-id
-                                           :sender-id (:id sender)
-                                           :verified false})
-                       (verification/put! {:app-id app-id
-                                           :sender-id (:id sender)
-                                           :verified true}))
-        needs-verify (not (:verified verification))]
-    {:sender sender :needs-verify needs-verify}))
+        _ (if (flags/use-app-email-verification?)
+            (verification/put! {:app-id app-id
+                                :sender-id (:id sender)
+                                :verified false})
+            (verification/put! {:app-id app-id
+                                :sender-id (:id sender)
+                                :verified true}))]
+    {:sender sender}))
 
 (comment
   (postmark/add-sender! {:email "hi@marky.fyi" :name "Marky"})

--- a/server/src/instant/model/app_email_template.clj
+++ b/server/src/instant/model/app_email_template.clj
@@ -33,6 +33,7 @@
                      t.app_id,
                      t.email_type,
                      t.body,
+                     t.sender_id,
                      t.name,
                      t.subject,
                      s.email,

--- a/server/src/instant/model/app_email_template.clj
+++ b/server/src/instant/model/app_email_template.clj
@@ -37,10 +37,13 @@
                      t.name,
                      t.subject,
                      s.email,
-                     s.postmark_id
+                     s.postmark_id,
+                     v.verified
                     FROM app_email_templates t
                     LEFT JOIN app_email_senders s
                      ON t.sender_id = s.id
+                    LEFT JOIN app_email_verifications v
+                     ON t.sender_id = v.sender_id AND t.app_id = v.app_id
                     WHERE t.app_id = ?::uuid
                     AND t.email_type = ?"
                     app-id email-type])))

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -30,8 +30,8 @@
 (defn verified-by-app-and-sender?
   "returns true if the given app and sender have verified their email"
   [app-id sender-id]
-  (boolean
-   (sql/execute-one! (aurora/conn-pool :read) ["SELECT verified FROM app_email_verifications WHERE app_id = ? AND sender_id = ?" app-id sender-id])))
+  (let [row (sql/execute-one! (aurora/conn-pool :read) ["SELECT verified FROM app_email_verifications WHERE app_id = ? AND sender_id = ?" app-id sender-id])]
+    (boolean (:verified row))))
 
 (defn get-by-app-id-and-email-type-with-template
   ([params] (get-by-app-id-and-email-type-with-template

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -54,7 +54,7 @@
                     LEFT JOIN app_email_senders s
                      ON t.sender_id = s.id
                     LEFT JOIN app_email_verifications v
-                     ON t.sender_id = v.sender_id
+                     ON t.sender_id = v.sender_id AND v.app_id = t.app_id
                     WHERE t.app_id = ?::uuid
                     AND t.email_type = ?"
                     app-id email-type])))

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -6,7 +6,9 @@
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id sender-id verified]}]
-   (sql/execute-one! conn ["INSERT INTO
-     app_email_verifications
-     (id, app_id, sender_id, verified)
-     VALUES (?::uuid, ?, ?, ?) ON CONFLICT DO NOTHING" (random-uuid) app-id sender-id verified])))
+   (sql/execute-one! conn ["INSERT INTO app_email_verifications
+          (id, app_id, sender_id, verified)
+          VALUES (?::uuid, ?, ?, ?)
+          ON CONFLICT (app_id, sender_id) DO UPDATE SET sender_id = EXCLUDED.sender_id
+          RETURNING id, verified"
+                           (random-uuid) app-id sender-id verified])))

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -12,3 +12,49 @@
           ON CONFLICT (app_id, sender_id) DO UPDATE SET sender_id = EXCLUDED.sender_id
           RETURNING id, verified"
                            (random-uuid) app-id sender-id verified])))
+
+(defn get-by-app-and-sender
+  "gets the email verification for the given app and sender"
+  [app-id sender-id]
+  (sql/execute-one! (aurora/conn-pool :read) ["SELECT * FROM app_email_verifications WHERE app_id = ? AND sender_id = ?" app-id sender-id]))
+
+(defn mark-verified!
+  ([params] (mark-verified! (aurora/conn-pool :write) params))
+  ([conn {:keys [id]}]
+   (sql/execute-one! conn ["UPDATE app_email_verifications
+          SET verified = true
+          WHERE id = ?::uuid
+          RETURNING *"
+                           id])))
+
+(defn verified-by-app-and-sender?
+  "returns true if the given app and sender have verified their email"
+  [app-id sender-id]
+  (boolean
+   (sql/execute-one! (aurora/conn-pool :read) ["SELECT verified FROM app_email_verifications WHERE app_id = ? AND sender_id = ?" app-id sender-id])))
+
+(defn get-by-app-id-and-email-type-with-template
+  ([params] (get-by-app-id-and-email-type-with-template
+             (aurora/conn-pool :read) params))
+  ([conn {:keys [app-id email-type]}]
+   (sql/select-one conn
+                   ["SELECT
+                     t.id,
+                     t.app_id,
+                     t.email_type,
+                     t.body,
+                     t.sender_id,
+                     t.name,
+                     t.subject,
+                     s.email,
+                     s.postmark_id,
+                     v.id AS verification_id,
+                     v.verified AS verification_verified
+                    FROM app_email_templates t
+                    LEFT JOIN app_email_senders s
+                     ON t.sender_id = s.id
+                    LEFT JOIN app_email_verifications v
+                     ON t.sender_id = v.sender_id
+                    WHERE t.app_id = ?::uuid
+                    AND t.email_type = ?"
+                    app-id email-type])))

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -25,13 +25,13 @@
 
 (defn mark-verified!
   ([params] (mark-verified! (aurora/conn-pool :write) params))
-  ([conn {:keys [id]}]
+  ([conn {:keys [id app-id]}]
    (sql/execute-one!
     conn ["UPDATE app_email_verifications
           SET verified = true
-          WHERE id = ?::uuid
+          WHERE id = ?::uuid AND app_id = ?
           RETURNING *"
-          id])))
+          id app-id])))
 
 (defn get-by-app-id-and-email-type-with-template
   ([params] (get-by-app-id-and-email-type-with-template

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -1,36 +1,45 @@
 (ns instant.model.app-email-verification
   (:require
    [instant.jdbc.aurora :as aurora]
-   [instant.jdbc.sql :as sql]))
+   [instant.jdbc.sql :as sql]
+   [instant.util.exception :as ex]))
 
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id sender-id verified]}]
-   (sql/execute-one! conn ["INSERT INTO app_email_verifications
-          (id, app_id, sender_id, verified)
-          VALUES (?::uuid, ?, ?, ?)
-          ON CONFLICT (app_id, sender_id) DO UPDATE SET sender_id = EXCLUDED.sender_id
-          RETURNING id, verified"
-                           (random-uuid) app-id sender-id verified])))
+   (sql/execute-one!
+    conn
+    ["INSERT INTO app_email_verifications
+      (id, app_id, sender_id, verified)
+      VALUES (?::uuid, ?, ?, ?)
+      ON CONFLICT (app_id, sender_id) DO UPDATE SET sender_id = EXCLUDED.sender_id
+      RETURNING id, verified"
+     (random-uuid) app-id sender-id verified])))
 
 (defn get-by-app-and-sender
   "gets the email verification for the given app and sender"
   [app-id sender-id]
-  (sql/execute-one! (aurora/conn-pool :read) ["SELECT * FROM app_email_verifications WHERE app_id = ? AND sender_id = ?" app-id sender-id]))
+  (sql/execute-one! (aurora/conn-pool :read)
+                    ["SELECT * FROM app_email_verifications
+                      WHERE app_id = ? AND sender_id = ?" app-id sender-id]))
 
 (defn mark-verified!
   ([params] (mark-verified! (aurora/conn-pool :write) params))
   ([conn {:keys [id]}]
-   (sql/execute-one! conn ["UPDATE app_email_verifications
+   (sql/execute-one!
+    conn ["UPDATE app_email_verifications
           SET verified = true
           WHERE id = ?::uuid
           RETURNING *"
-                           id])))
+          id])))
 
 (defn verified-by-app-and-sender?
   "returns true if the given app and sender have verified their email"
   [app-id sender-id]
-  (let [row (sql/execute-one! (aurora/conn-pool :read) ["SELECT verified FROM app_email_verifications WHERE app_id = ? AND sender_id = ?" app-id sender-id])]
+  (let [row (sql/execute-one!
+             (aurora/conn-pool :read)
+             ["SELECT verified FROM app_email_verifications
+               WHERE app_id = ? AND sender_id = ?" app-id sender-id])]
     (boolean (:verified row))))
 
 (defn get-by-app-id-and-email-type-with-template
@@ -58,3 +67,17 @@
                     WHERE t.app_id = ?::uuid
                     AND t.email_type = ?"
                     app-id email-type])))
+
+(defn get-by-app-id-and-email-type-with-template!
+  ([params] (get-by-app-id-and-email-type-with-template!
+             (aurora/conn-pool :read) params))
+  ([conn {:keys [app-id email-type]}]
+   (let [result (get-by-app-id-and-email-type-with-template
+                 conn
+                 {:app-id app-id :email-type email-type})
+         verification-id (:verification_id result)
+         _ (ex/assert-record! verification-id
+                              :app-email-verification
+                              {:args [{:app-id app-id
+                                       :email-type email-type}]})]
+     result)))

--- a/server/src/instant/model/app_email_verification.clj
+++ b/server/src/instant/model/app_email_verification.clj
@@ -33,15 +33,6 @@
           RETURNING *"
           id])))
 
-(defn verified-by-app-and-sender?
-  "returns true if the given app and sender have verified their email"
-  [app-id sender-id]
-  (let [row (sql/execute-one!
-             (aurora/conn-pool :read)
-             ["SELECT verified FROM app_email_verifications
-               WHERE app_id = ? AND sender_id = ?" app-id sender-id])]
-    (boolean (:verified row))))
-
 (defn get-by-app-id-and-email-type-with-template
   ([params] (get-by-app-id-and-email-type-with-template
              (aurora/conn-pool :read) params))

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -42,7 +42,6 @@
                               AND app_id = ?
                               RETURNING *"
                              code verification-id app-id])]
-     (tool/def-locals)
      (when (and verification-code
                 (expired? expiry-minutes verification-code))
        (ex/throw-expiration-err! :app-email-verification-code {:args [params]}))

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -8,28 +8,23 @@
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [code app-id verification-id]}]
-   (sql/execute-one! conn ["INSERT INTO app_email_verification_codes
+   (sql/execute-one!
+    conn ["INSERT INTO app_email_verification_codes
           (id, code, app_id, verification_id)
           VALUES (?::uuid, ?, ?, ?)
           RETURNING *"
-                           (random-uuid) code app-id verification-id])))
-
-(defn get-all-by-verification-id
-  ([params] (get-all-by-verification-id (aurora/conn-pool :read) params))
-  ([conn {:keys [verification-id]}]
-   (sql/select conn ["SELECT * FROM app_email_verification_codes
-          WHERE verification_id = ?::uuid"
-                     verification-id])))
+          (random-uuid) code app-id verification-id])))
 
 (defn consume!
   ([params] (consume! (aurora/conn-pool :write) params))
   ([conn {:keys [code verification-id expiry-minutes]}]
-   (sql/execute-one! conn ["DELETE FROM app_email_verification_codes
+   (sql/execute-one!
+    conn ["DELETE FROM app_email_verification_codes
           WHERE code = ?
           AND verification_id = ?::uuid
           AND created_at >= NOW() - (? * INTERVAL '1 minute')
           RETURNING *"
-                           code verification-id expiry-minutes])))
+          code verification-id expiry-minutes])))
 
 (defn format-email [{:keys [code sender-email]}]
   (let [{sender-name :name from-email :email} (config/dashboard-email-sender)]
@@ -40,6 +35,6 @@
      :reply-to from-email
      :html
      (email/standard-body
-      "<p>Use this code to verify your Instant sender email address:</p>
+      "<p>Use this code to verify your custom sender email address on Instant:</p>
              <h2 style=\"text-align: center\"><strong>" code "</strong></h2>
              <p>This code can only be used once.</p>")}))

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -3,7 +3,12 @@
    [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
-   [hiccup2.core :as h]))
+   [hiccup2.core :as h]
+   [instant.util.exception :as ex])
+  (:import
+   (java.time Instant)
+   (java.time.temporal ChronoUnit)
+   (java.util Date)))
 
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
@@ -20,17 +25,28 @@
           RETURNING *"
           (random-uuid) code app-id verification-id])))
 
+(defn expired?
+  ([expiry-minutes verification-code]
+   (expired? (Instant/now) expiry-minutes verification-code))
+  ([now expiry-minutes {created-at :created_at}]
+   (> (.between ChronoUnit/MINUTES (Date/.toInstant created-at) now) expiry-minutes)))
+
 (defn consume!
   ([params] (consume! (aurora/conn-pool :write) params))
-  ([conn {:keys [code verification-id expiry-minutes app-id]}]
-   (sql/execute-one!
-    conn ["DELETE FROM app_email_verification_codes
-          WHERE code = ?
-          AND verification_id = ?::uuid
-          AND app_id = ?
-          AND created_at >= NOW() - (? * INTERVAL '1 minute')
-          RETURNING *"
-          code verification-id app-id expiry-minutes])))
+  ([conn {:keys [code verification-id expiry-minutes app-id] :as params}]
+   (let [verification-code (sql/execute-one!
+                            conn
+                            ["DELETE FROM app_email_verification_codes
+                              WHERE code = ?
+                              AND verification_id = ?::uuid
+                              AND app_id = ?
+                              RETURNING *"
+                             code verification-id app-id])]
+     (tool/def-locals)
+     (when (and verification-code
+                (expired? expiry-minutes verification-code))
+       (ex/throw-expiration-err! :app-email-verification-code {:args [params]}))
+     verification-code)))
 
 (defn format-email [{:keys [code sender-email app-title]}]
   (let [{sender-name :name from-email :email} (config/dashboard-email-sender)]

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -3,11 +3,16 @@
    [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
-   [instant.util.email :as email]))
+   [hiccup2.core :as h]))
 
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
   ([conn {:keys [code app-id verification-id]}]
+   (sql/do-execute!
+    conn
+    ["DELETE FROM app_email_verification_codes
+         WHERE verification_id = ?::uuid AND app_id = ?"
+     verification-id app-id])
    (sql/execute-one!
     conn ["INSERT INTO app_email_verification_codes
           (id, code, app_id, verification_id)
@@ -17,14 +22,15 @@
 
 (defn consume!
   ([params] (consume! (aurora/conn-pool :write) params))
-  ([conn {:keys [code verification-id expiry-minutes]}]
+  ([conn {:keys [code verification-id expiry-minutes app-id]}]
    (sql/execute-one!
     conn ["DELETE FROM app_email_verification_codes
           WHERE code = ?
           AND verification_id = ?::uuid
+          AND app_id = ?
           AND created_at >= NOW() - (? * INTERVAL '1 minute')
           RETURNING *"
-          code verification-id expiry-minutes])))
+          code verification-id app-id expiry-minutes])))
 
 (defn format-email [{:keys [code sender-email app-title]}]
   (let [{sender-name :name from-email :email} (config/dashboard-email-sender)]
@@ -33,8 +39,5 @@
      :to [{:email sender-email}]
      :subject (str code " is your Instant sender verification code for app: " app-title)
      :reply-to from-email
-     :html
-     (email/standard-body
-      "<p>Use this code to verify your custom sender email address on Instant for the app: <strong>" app-title "</strong></p>
-             <h2 style=\"text-align: center\"><strong>" code "</strong></h2>
-             <p>This code can only be used once.</p>")}))
+
+     :html (h/html [:p "Use this code to verify your custom sender email address on Instant for the app: " [:strong app-title]] [:h2 {:style "text-align: center"} code] [:p "This code can only be used once."])}))

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -1,0 +1,45 @@
+(ns instant.model.app-email-verification-code
+  (:require
+   [instant.config :as config]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.util.email :as email]))
+
+(defn put!
+  ([params] (put! (aurora/conn-pool :write) params))
+  ([conn {:keys [code app-id verification-id]}]
+   (sql/execute-one! conn ["INSERT INTO app_email_verification_codes
+          (id, code, app_id, verification_id)
+          VALUES (?::uuid, ?, ?, ?)
+          RETURNING *"
+                           (random-uuid) code app-id verification-id])))
+
+(defn get-all-by-verification-id
+  ([params] (get-all-by-verification-id (aurora/conn-pool :read) params))
+  ([conn {:keys [verification-id]}]
+   (sql/select conn ["SELECT * FROM app_email_verification_codes
+          WHERE verification_id = ?::uuid"
+                     verification-id])))
+
+(defn consume!
+  ([params] (consume! (aurora/conn-pool :write) params))
+  ([conn {:keys [code verification-id expiry-minutes]}]
+   (sql/execute-one! conn ["DELETE FROM app_email_verification_codes
+          WHERE code = ?
+          AND verification_id = ?::uuid
+          AND created_at >= NOW() - (? * INTERVAL '1 minute')
+          RETURNING *"
+                           code verification-id expiry-minutes])))
+
+(defn format-email [{:keys [code sender-email]}]
+  (let [{sender-name :name from-email :email} (config/dashboard-email-sender)]
+    {:from {:name sender-name
+            :email from-email}
+     :to [{:email sender-email}]
+     :subject (str code " is your Instant sender verification code")
+     :reply-to from-email
+     :html
+     (email/standard-body
+      "<p>Use this code to verify your Instant sender email address:</p>
+             <h2 style=\"text-align: center\"><strong>" code "</strong></h2>
+             <p>This code can only be used once.</p>")}))

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -40,4 +40,6 @@
      :subject (str code " is your Instant sender verification code for app: " app-title)
      :reply-to from-email
 
-     :html (h/html [:p "Use this code to verify your custom sender email address on Instant for the app: " [:strong app-title]] [:h2 {:style "text-align: center"} code] [:p "This code can only be used once."])}))
+     :html (str (h/html [:p "Use this code to verify your custom sender email address on Instant for the app: "
+                         [:strong app-title]]
+                        [:h2 {:style "text-align: center"} code] [:p "This code can only be used once."]))}))

--- a/server/src/instant/model/app_email_verification_code.clj
+++ b/server/src/instant/model/app_email_verification_code.clj
@@ -26,15 +26,15 @@
           RETURNING *"
           code verification-id expiry-minutes])))
 
-(defn format-email [{:keys [code sender-email]}]
+(defn format-email [{:keys [code sender-email app-title]}]
   (let [{sender-name :name from-email :email} (config/dashboard-email-sender)]
     {:from {:name sender-name
             :email from-email}
      :to [{:email sender-email}]
-     :subject (str code " is your Instant sender verification code")
+     :subject (str code " is your Instant sender verification code for app: " app-title)
      :reply-to from-email
      :html
      (email/standard-body
-      "<p>Use this code to verify your custom sender email address on Instant:</p>
+      "<p>Use this code to verify your custom sender email address on Instant for the app: <strong>" app-title "</strong></p>
              <h2 style=\"text-align: center\"><strong>" code "</strong></h2>
              <p>This code can only be used once.</p>")}))

--- a/server/src/instant/rate_limit.clj
+++ b/server/src/instant/rate_limit.clj
@@ -201,6 +201,14 @@
         ^Bucket bucket (get-bucket key)]
     (.tryConsume bucket 1)))
 
+(defn try-consume-custom-sender
+  "Takes (hz/rate-limit) and email, will return false if the rate-limit is exceeded.
+   Otherwise, will return true and increment the bucket counter."
+  [{:keys [get-bucket]} {:keys [email]}]
+  (let [key (magic-code-key-hash "custom-sender-verify" #uuid "00000000-0000-0000-0000-000000000000" email)
+        ^Bucket bucket (get-bucket key)]
+    (.tryConsume bucket 1)))
+
 (defn parse-duration ^Duration [^String s]
   (let [i (PGInterval. s)]
     (-> Duration/ZERO

--- a/server/src/instant/rate_limit.clj
+++ b/server/src/instant/rate_limit.clj
@@ -201,10 +201,12 @@
         ^Bucket bucket (get-bucket key)]
     (.tryConsume bucket 1)))
 
-(defn try-consume-custom-sender
+(defn try-custom-sender
   "Takes (hz/rate-limit) and email, will return false if the rate-limit is exceeded.
    Otherwise, will return true and increment the bucket counter."
   [{:keys [get-bucket]} {:keys [email]}]
+  ;; use all zeros for the app id since we want to rate limit across emails
+  ;; without the ability to bypass by changing/creating apps
   (let [key (magic-code-key-hash "custom-sender-verify" #uuid "00000000-0000-0000-0000-000000000000" email)
         ^Bucket bucket (get-bucket key)]
     (.tryConsume bucket 1)))

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -6,7 +6,6 @@
    [instant.flags :as flags]
    [instant.model.app :as app-model]
    [instant.model.app-email-template :as app-email-template-model]
-   [instant.model.app-email-verification :as verification]
    [instant.model.app-user :as app-user-model]
    [instant.model.app-user-magic-code :as app-user-magic-code-model]
    [instant.model.app-user-refresh-token :as app-user-refresh-token-model]

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -6,6 +6,7 @@
    [instant.flags :as flags]
    [instant.model.app :as app-model]
    [instant.model.app-email-template :as app-email-template-model]
+   [instant.model.app-email-verification :as verification]
    [instant.model.app-user :as app-user-model]
    [instant.model.app-user-magic-code :as app-user-magic-code-model]
    [instant.model.app-user-refresh-token :as app-user-refresh-token-model]
@@ -61,6 +62,14 @@
       (tracer/record-info! {:name "magic-code/consume-rate-limited"
                             :attributes {:app-id (:app-id params)
                                          :email (:email params)
+                                         :source "bucket4j"}})
+      (ex/throw-record-email-rate-limited!))))
+
+(defn check-custom-sender-rate-limit! [params]
+  (when (flags/toggled? :use-bucket4j true)
+    (when-not (rate-limit/try-consume-custom-sender (eph/get-rate-limit) params)
+      (tracer/record-info! {:name "custom-sender/consume-rate-limited"
+                            :attributes {:email (:email params)
                                          :source "bucket4j"}})
       (ex/throw-record-email-rate-limited!))))
 
@@ -126,10 +135,18 @@
                          :code code
                          :app_title (:title app)
                          :expiration (friendly-expiration app)}
-
         {default-sender-email :email} (config/app-email-sender)
 
-        sender-email    (or (:email template) default-sender-email)
+        custom-email (:email template)
+        custom-email-verified? (and (seq custom-email)
+                                    (verification/verified-by-app-and-sender? app-id (:sender_id template)))
+
+        sender-email (if (flags/use-app-email-verification?)
+                       (if custom-email-verified?
+                         custom-email
+                         default-sender-email)
+                       (or custom-email default-sender-email))
+
         email-params    (if template
                           {:sender-email sender-email
                            :sender-name (or (:name template) (:title app))

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -67,7 +67,7 @@
 
 (defn check-custom-sender-rate-limit! [params]
   (when (flags/toggled? :use-bucket4j true)
-    (when-not (rate-limit/try-consume-custom-sender (eph/get-rate-limit) params)
+    (when-not (rate-limit/try-custom-sender (eph/get-rate-limit) params)
       (tracer/record-info! {:name "custom-sender/consume-rate-limited"
                             :attributes {:email (:email params)
                                          :source "bucket4j"}})
@@ -139,7 +139,7 @@
 
         custom-email (:email template)
         custom-email-verified? (and (seq custom-email)
-                                    (verification/verified-by-app-and-sender? app-id (:sender_id template)))
+                                    (:verified template))
 
         sender-email (if (flags/use-app-email-verification?)
                        (if custom-email-verified?

--- a/server/src/instant/runtime/routes.clj
+++ b/server/src/instant/runtime/routes.clj
@@ -372,19 +372,18 @@
                :else (ucoll/select-keys-no-ns user :app_user_oauth_links))
          :created false)))))
 
-
 (def oauth-callback-testing-landing
   "Helps users test that their redirect is working properly."
   {:status 200
    :headers {"content-type" "text/html"}
    :body (str (h/html (h/raw "<!DOCTYPE html>")
-                [:html {:lang "en"}
-                 [:head
-                  [:meta {:charset "UTF-8"}]
-                  [:meta {:name "viewport"
-                          :content "width=device-width, initial-scale=1.0"}]
-                  [:title "Test redirect"]
-                  [:style "
+                      [:html {:lang "en"}
+                       [:head
+                        [:meta {:charset "UTF-8"}]
+                        [:meta {:name "viewport"
+                                :content "width=device-width, initial-scale=1.0"}]
+                        [:title "Test redirect"]
+                        [:style "
                            body {
                              margin: 0;
                              height: 100vh;

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -1063,7 +1063,7 @@
                                   :throw-exceptions false})]
               (is (= 400 (:status resp)))
               (is (= "admin-token-mismatch"
-                      (-> resp :body <-json (get "hint") (get "reason")))))))))))
+                     (-> resp :body <-json (get "hint") (get "reason")))))))))))
 
 (deftest sender-verification-magic-code-flow
   (with-user
@@ -1086,8 +1086,7 @@
                                                                :sender-name "Custom Sender"
                                                                :subject "{code} is your code"
                                                                :body "Your code is {code}"})})]
-                  (is (= 200 (:status template-resp)))
-                  (is (= true (get-in template-resp [:body :needs-verify]))))
+                  (is (= 200 (:status template-resp))))
 
                 (let [send-resp (http/post (str config/server-origin "/dash/apps/" (:id app) "/sender-verification/send-magic-code")
                                            {:headers {:Authorization (str "Bearer " (:refresh-token user))

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -4,18 +4,22 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [instant.config :as config]
    [instant.fixtures :refer [random-email with-empty-app with-org with-pro-app with-startup-org with-free-org with-user]]
+   [instant.flags :as flags]
    [instant.dash.ephemeral-app :as ephemeral-app]
    [instant.dash.get-a-db :as get-a-db]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
+   [instant.model.app-email-verification :as app-email-verification]
    [instant.model.app-oauth-client :as app-oauth-client-model]
    [instant.model.app-user :as app-user-model]
    [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
    [instant.model.instant-stripe-customer :as stripe-customer-model]
    [instant.model.org-members :as org-members]
+   [instant.postmark :as postmark]
    [instant.model.app-members :as app-members]
+   [instant.runtime.magic-code-auth :as magic-code-auth]
    [instant.stripe :as stripe]
    [instant.util.crypt :as crypt-util]
    [instant.util.http :refer [req->app-and-user!]]
@@ -1059,7 +1063,52 @@
                                   :throw-exceptions false})]
               (is (= 400 (:status resp)))
               (is (= "admin-token-mismatch"
-                     (-> resp :body <-json (get "hint") (get "reason")))))))))))
+                      (-> resp :body <-json (get "hint") (get "reason")))))))))))
+
+(deftest sender-verification-magic-code-flow
+  (with-user
+    (fn [user]
+      (with-empty-app
+        (:id user)
+        (fn [app]
+          (with-redefs [flags/use-app-email-verification? (constantly true)]
+            (let [sender-email (random-email)
+                  letter (atom nil)]
+              (with-redefs [postmark/add-sender! (constantly {:body {:ID 123456}})
+                            postmark/send-structured! #(reset! letter %)
+                            magic-code-auth/check-custom-sender-rate-limit! (constantly nil)]
+                (let [template-resp (http/post (str config/server-origin "/dash/apps/" (:id app) "/email_templates")
+                                               {:headers {:Authorization (str "Bearer " (:refresh-token user))
+                                                          :Content-Type "application/json"}
+                                                :as :json
+                                                :body (->json {:email-type "magic-code"
+                                                               :sender-email sender-email
+                                                               :sender-name "Custom Sender"
+                                                               :subject "{code} is your code"
+                                                               :body "Your code is {code}"})})]
+                  (is (= 200 (:status template-resp)))
+                  (is (= true (get-in template-resp [:body :needs-verify]))))
+
+                (let [send-resp (http/post (str config/server-origin "/dash/apps/" (:id app) "/sender-verification/send-magic-code")
+                                           {:headers {:Authorization (str "Bearer " (:refresh-token user))
+                                                      :Content-Type "application/json"}
+                                            :as :json})
+                      code (re-find #"\d+" (:subject @letter))]
+                  (is (= 200 (:status send-resp)))
+                  (is (= true (get-in send-resp [:body :sent])))
+                  (is (= sender-email (get-in @letter [:to 0 :email])))
+
+                  (let [verify-resp (http/post (str config/server-origin "/dash/apps/" (:id app) "/sender-verification/verify-magic-code")
+                                               {:headers {:Authorization (str "Bearer " (:refresh-token user))
+                                                          :Content-Type "application/json"}
+                                                :as :json
+                                                :body (->json {:code code})})
+                        verification (app-email-verification/get-by-app-id-and-email-type-with-template
+                                      {:app-id (:id app)
+                                       :email-type "magic-code"})]
+                    (is (= 200 (:status verify-resp)))
+                    (is (= true (get-in verify-resp [:body :verified])))
+                    (is (= true (:verification_verified verification)))))))))))))
 
 ;; ---
 ;; get-a-db

--- a/server/test/instant/model/app_email_verification_code_test.clj
+++ b/server/test/instant/model/app_email_verification_code_test.clj
@@ -1,0 +1,70 @@
+(ns instant.model.app-email-verification-code-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.fixtures :refer [random-email with-empty-app with-user]]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.model.app-email-verification :as verification]
+   [instant.model.app-email-verification-code :as verification-code]))
+
+(defn- create-sender! [{:keys [user-id email]}]
+  (sql/execute-one!
+   (aurora/conn-pool :write)
+   ["INSERT INTO app_email_senders
+     (id, user_id, postmark_id, email, name)
+     VALUES (?::uuid, ?::uuid, ?, ?, ?)
+     RETURNING *"
+    (random-uuid) user-id 123456 email "Test Sender"]))
+
+(deftest consume-verification-code-once
+  (with-user
+    (fn [user]
+      (with-empty-app
+        (:id user)
+        (fn [app]
+          (let [sender (create-sender! {:user-id (:id user)
+                                        :email (random-email)})
+                verification (verification/put! {:app-id (:id app)
+                                                 :sender-id (:id sender)
+                                                 :verified false})
+                code (verification-code/put! {:app-id (:id app)
+                                              :verification-id (:id verification)
+                                              :code "123456"})]
+            (testing "matching code is consumed"
+              (is (= (:id code)
+                     (:id (verification-code/consume!
+                           {:verification-id (:id verification)
+                            :code "123456"
+                            :expiry-minutes 10})))))
+
+            (testing "consumed codes cannot be reused"
+              (is (nil? (verification-code/consume!
+                         {:verification-id (:id verification)
+                          :code "123456"
+                          :expiry-minutes 10}))))))))))
+
+(deftest consume-verification-code-rejects-expired-codes
+  (with-user
+    (fn [user]
+      (with-empty-app
+        (:id user)
+        (fn [app]
+          (let [sender (create-sender! {:user-id (:id user)
+                                        :email (random-email)})
+                verification (verification/put! {:app-id (:id app)
+                                                 :sender-id (:id sender)
+                                                 :verified false})]
+            (verification-code/put! {:app-id (:id app)
+                                     :verification-id (:id verification)
+                                     :code "123456"})
+            (sql/execute!
+             (aurora/conn-pool :write)
+             ["UPDATE app_email_verification_codes
+               SET created_at = NOW() - INTERVAL '11 minutes'
+               WHERE verification_id = ?::uuid"
+              (:id verification)])
+
+            (is (nil? (verification-code/consume!
+                       {:verification-id (:id verification)
+                        :code "123456"
+                        :expiry-minutes 10})))))))))

--- a/server/test/instant/model/app_email_verification_code_test.clj
+++ b/server/test/instant/model/app_email_verification_code_test.clj
@@ -2,10 +2,12 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [instant.fixtures :refer [random-email with-empty-app with-user]]
-   [instant.jdbc.aurora :as aurora]
-   [instant.jdbc.sql :as sql]
-   [instant.model.app-email-verification :as verification]
-   [instant.model.app-email-verification-code :as verification-code]))
+    [instant.jdbc.aurora :as aurora]
+    [instant.jdbc.sql :as sql]
+    [instant.model.app-email-verification :as verification]
+    [instant.model.app-email-verification-code :as verification-code]
+    [instant.util.exception :as ex]
+    [instant.util.test :as test-util]))
 
 (defn- create-sender! [{:keys [user-id email]}]
   (sql/execute-one!
@@ -66,8 +68,11 @@
                WHERE verification_id = ?::uuid"
               (:id verification)])
 
-            (is (nil? (verification-code/consume!
+            (is (= ::ex/record-expired
+                   (::ex/type
+                    (test-util/instant-ex-data
+                      (verification-code/consume!
                        {:verification-id (:id verification)
                         :app-id (:id app)
                         :code "123456"
-                        :expiry-minutes 10})))))))))
+                        :expiry-minutes 10})))))))))))

--- a/server/test/instant/model/app_email_verification_code_test.clj
+++ b/server/test/instant/model/app_email_verification_code_test.clj
@@ -34,12 +34,14 @@
               (is (= (:id code)
                      (:id (verification-code/consume!
                            {:verification-id (:id verification)
+                            :app-id (:id app)
                             :code "123456"
                             :expiry-minutes 10})))))
 
             (testing "consumed codes cannot be reused"
               (is (nil? (verification-code/consume!
                          {:verification-id (:id verification)
+                          :app-id (:id app)
                           :code "123456"
                           :expiry-minutes 10}))))))))))
 
@@ -66,5 +68,6 @@
 
             (is (nil? (verification-code/consume!
                        {:verification-id (:id verification)
+                        :app-id (:id app)
                         :code "123456"
                         :expiry-minutes 10})))))))))

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -16,9 +16,9 @@
    [instant.model.app-email-template :as app-email-template-model]
    [instant.model.app-email-verification :as app-email-verification]
    [instant.model.app-oauth-service-provider :as provider-model]
-   [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.model.app-user :as app-user-model]
    [instant.model.rule :as rule-model]
+   [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.postmark :as postmark]
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.store :as rs]
@@ -210,7 +210,8 @@
         (testing "verified custom sender is used"
           (app-email-verification/mark-verified! {:id (:id (app-email-verification/get-by-app-and-sender
                                                             (:id app)
-                                                            (:id sender)))})
+                                                            (:id sender)))
+                                                  :app-id (:id app)})
           (binding [flags/*toggle-overrides* {:use-app-email-verification? true}]
             (let [letter (atom nil)]
               (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
@@ -465,25 +466,25 @@
 (deftest upsert-oauth-link-disambiguates-with-email
   (with-empty-app
     (fn [app]
-      ;; Apple OAuth lets you provide "relay" emails: 
-      ;; these are anonymous emails that forward to the user's real email. 
+      ;; Apple OAuth lets you provide "relay" emails:
+      ;; these are anonymous emails that forward to the user's real email.
 
-      ;; This opens up a potential problem. 
+      ;; This opens up a potential problem.
 
-      ;; Consider the following scenario: 
-      ;; (1) User signs in with magic code: stopa@instantdb.com 
-      ;; (2) User signs in with with Apple, private relay on: foo@privaterelay.appleid.com  
+      ;; Consider the following scenario:
+      ;; (1) User signs in with magic code: stopa@instantdb.com
+      ;; (2) User signs in with with Apple, private relay on: foo@privaterelay.appleid.com
 
-      ;; At this point we'll have _2_ separate users. 
+      ;; At this point we'll have _2_ separate users.
 
-      ;; Now 
-      ;; (3) The user signs in with Apple, private relay off: stopa@instantdb.com. 
+      ;; Now
+      ;; (3) The user signs in with Apple, private relay off: stopa@instantdb.com.
 
-      ;; Which user should we link this 3rd sign up too? It matches _both_ the 
-      ;; existing email user, and the existing Apple Oauth link. 
+      ;; Which user should we link this 3rd sign up too? It matches _both_ the
+      ;; existing email user, and the existing Apple Oauth link.
 
-      ;; Currently, we choose the existing email user. 
-      ;; This means that the user with the private relay email will get stranded. 
+      ;; Currently, we choose the existing email user.
+      ;; This means that the user with the private relay email will get stranded.
       ;; However, in the worst case scenario, they can be recovered manually.
       (let [provider (provider-model/create! {:app-id (:id app)
                                               :provider-name "apple"})

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -1,17 +1,20 @@
 (ns instant.runtime.routes-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [instant.config :as config]
    [instant.core :as core]
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
    [instant.db.model.triple :as triples]
    [instant.db.permissioned-transaction :as permissioned-tx]
-   [instant.fixtures :refer [with-empty-app]]
+   [instant.fixtures :refer [random-email with-empty-app]]
    [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.app-authorized-redirect-origin :as app-authorized-redirect-origin-model]
+   [instant.model.app-email-template :as app-email-template-model]
+   [instant.model.app-email-verification :as app-email-verification]
    [instant.model.app-oauth-service-provider :as provider-model]
    [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.model.app-user :as app-user-model]
@@ -164,6 +167,58 @@
     (is (re-find #"MyApp" body))
     (is (re-find #"123456" body))
     (is (re-find #"10 minutes" body))))
+
+(defn- create-email-sender! [{:keys [user-id email]}]
+  (sql/execute-one!
+   (aurora/conn-pool :write)
+   ["INSERT INTO app_email_senders
+     (id, user_id, postmark_id, email, name)
+     VALUES (?::uuid, ?::uuid, ?, ?, ?)
+     RETURNING *"
+    (random-uuid) user-id 123456 email "Custom Sender"]))
+
+(defn- create-magic-code-template! [{:keys [app-id sender-id]}]
+  (app-email-template-model/put! {:app-id app-id
+                                  :sender-id sender-id
+                                  :email-type "magic-code"
+                                  :name "Custom Sender"
+                                  :subject "{code} is your code"
+                                  :body "Your code is {code}"}))
+
+(deftest magic-code-custom-sender-requires-instant-verification-when-flagged
+  (with-empty-app
+    (fn [app]
+      (let [custom-email (random-email)
+            sender (create-email-sender! {:user-id (:creator_id app)
+                                          :email custom-email})]
+        (create-magic-code-template! {:app-id (:id app)
+                                      :sender-id (:id sender)})
+
+        (testing "unverified custom sender falls back to the default sender"
+          (app-email-verification/put! {:app-id (:id app)
+                                        :sender-id (:id sender)
+                                        :verified false})
+          (binding [flags/*toggle-overrides* {:use-app-email-verification? true}]
+            (let [letter (atom nil)]
+              (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
+                            postmark/send-structured! #(reset! letter %)]
+                (magic-code-auth/send! {:app-id (:id app)
+                                        :email "recipient@example.com"}))
+              (is (= (:email (config/app-email-sender))
+                     (get-in @letter [:from :email]))))))
+
+        (testing "verified custom sender is used"
+          (app-email-verification/mark-verified! {:id (:id (app-email-verification/get-by-app-and-sender
+                                                            (:id app)
+                                                            (:id sender)))})
+          (binding [flags/*toggle-overrides* {:use-app-email-verification? true}]
+            (let [letter (atom nil)]
+              (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
+                            postmark/send-structured! #(reset! letter %)]
+                (magic-code-auth/send! {:app-id (:id app)
+                                        :email "recipient@example.com"}))
+              (is (= custom-email
+                     (get-in @letter [:from :email]))))))))))
 
 (defn update-created-at [app-id code created-at]
   (sql/execute!
@@ -899,4 +954,3 @@
           (is (thrown-with-msg?
                ExceptionInfo #"Unauthorized origin"
                (route/assert-authorized-request-origin! shared-client "https://attacker.com"))))))))
-


### PR DESCRIPTION
This PR migrates the current user-based system for custom oauth email senders to use app ids instead. This adds another on top of the postmark email to verify sender. We will also send a magic code to the user so that they can link the sender's identity with the app. 

This is gated behind the boolean feature flag: `use-app-email-verification?`

Added Routes
POST /dash/apps/:id/sender-verification/send-magic-code
POST /dash/apps/:id/sender-verification/verify-magic-code

I also updated the frontend to include the ui needed for seeing the status of both verification steps and submitting the magic code / resending. It is backwards compatible with the backend feature flag. 

### Important! Includes database migrations which must be run before turning on the feature flag. 

# Deploy Plan
1. merge pr
3. run migrations included in pr
4. deploy backend
5. toggle `use-app-email-verification?` feature flag to true


How to test:
<img width="664" height="405" alt="image" src="https://github.com/user-attachments/assets/4f8742a2-760c-409f-9238-b5de7463adc4" />
Turn on the feature flag. 

Try adding / changing an oauth email template with a custom sender address on the dashboard.


<img width="615" height="315" alt="image" src="https://github.com/user-attachments/assets/652047f3-7dbd-48d8-8a5c-7951a2b3c0b3" />
