### PR TITLE
Set explicit max-entity-size for undertow

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -214,6 +214,7 @@
   (let [config (merge
                 {:host "0.0.0.0"
                  :port (config/get-server-port)
+                 :max-entity-size -1
                  :configurator (fn [^Undertow$Builder builder]
                                  (.setServerOption builder UndertowOptions/ENABLE_STATISTICS true))}
                 (when (.exists (io/file "dev-resources/certs/dev.jks"))

--- a/server/src/instant/lib/ring/undertow.clj
+++ b/server/src/instant/lib/ring/undertow.clj
@@ -95,6 +95,7 @@
   [^Undertow$Builder builder {:keys [io-threads worker-threads buffer-size direct-buffers? max-entity-size]}]
   (cond-> builder
     max-entity-size (.setServerOption UndertowOptions/MAX_ENTITY_SIZE (long max-entity-size))
+    max-entity-size (.setServerOption UndertowOptions/MULTIPART_MAX_ENTITY_SIZE (long max-entity-size))
     io-threads (.setIoThreads io-threads)
     worker-threads (.setWorkerThreads worker-threads)
     buffer-size (.setBufferSize buffer-size)


### PR DESCRIPTION
 Bumping `io.undertow/undertow-core` from 2.3.18 to 2.3.23 in #2668 silently introduced a 2 MiB cap on request bodies. This meant things like uploads above the cap would fail.

Setting this config explicitly now to restore previous behavior
