### PR TITLE
Fix admin SDK getUser/deleteUser return types to include null

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -668,25 +668,27 @@ class Auth<Schema extends InstantSchemaDef<any, any, any>> {
 
   /**
    * Retrieves an app user by id, email, or refresh token.
+   * Resolves to `null` when no user matches; throws on malformed
+   * input or auth errors.
    *
    * @example
-   *   try {
-   *     const user = await db.auth.getUser({ email })
-   *     console.log("Found user:", user)
-   *   } catch (err) {
-   *     console.error("Failed to retrieve user:", err.message);
+   *   const user = await db.auth.getUser({ email });
+   *   if (!user) {
+   *     console.log("No user found");
+   *     return;
    *   }
+   *   console.log("Found user:", user);
    *
    * @see https://instantdb.com/docs/backend#retrieve-a-user
    */
   getUser = async (
     params: { email: string } | { id: string } | { refresh_token: string },
-  ): Promise<Omit<User, 'refresh_token'>> => {
+  ): Promise<Omit<User, 'refresh_token'> | null> => {
     const qs = Object.entries(params)
       .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
       .join('&');
 
-    const response: { user: User } = await jsonFetch(
+    const response: { user: User | null } = await jsonFetch(
       `${this.config.apiURI}/admin/users?app_id=${this.config.appId}&${qs}`,
       {
         method: 'GET',
@@ -699,25 +701,27 @@ class Auth<Schema extends InstantSchemaDef<any, any, any>> {
 
   /**
    * Deletes an app user by id, email, or refresh token.
+   * Resolves to `null` when no user matches; throws on malformed
+   * input or auth errors.
    *
    * NB: This _only_ deletes the user; it does not delete all user data.
    * You will need to handle this manually.
    *
    * @example
-   *   try {
-   *     const deletedUser = await db.auth.deleteUser({ email })
-   *     console.log("Deleted user:", deletedUser)
-   *   } catch (err) {
-   *     console.error("Failed to delete user:", err.message);
+   *   const deletedUser = await db.auth.deleteUser({ email });
+   *   if (!deletedUser) {
+   *     console.log("No user found to delete");
+   *     return;
    *   }
+   *   console.log("Deleted user:", deletedUser);
    *
    * @see https://instantdb.com/docs/backend#delete-a-user
    */
   deleteUser = async (
     params: { email: string } | { id: string } | { refresh_token: string },
-  ): Promise<User> => {
+  ): Promise<User | null> => {
     const qs = Object.entries(params).map(([k, v]) => `${k}=${v}`);
-    const response: { deleted: User } = await jsonFetch(
+    const response: { deleted: User | null } = await jsonFetch(
       `${this.config.apiURI}/admin/users?app_id=${this.config.appId}&${qs}`,
       {
         method: 'DELETE',

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.35';
+const version = 'v1.0.36';
 
 export { version };


### PR DESCRIPTION
## Summary

Fixes #2682. The admin SDK's `db.auth.getUser` and `db.auth.deleteUser` are typed as returning a non-nullable `User`, but the server actually returns `200 OK` with `{user: null}` / `{deleted: null}` when no match is found. The JSDoc examples show a `try/catch` pattern that does not catch this case, so code following the published types silently treats unknown users as found.

This has been the behavior since the open-source repo's initial commit (server) and since `getUser` was first added in `@instantdb/admin` (client).

## Changes

- `client/packages/admin/src/index.ts`: widen `getUser` to `Promise<Omit<User, 'refresh_token'> | null>`, widen `deleteUser` to `Promise<User | null>`, and fix the inner response casts. JSDoc `@example` blocks now show null-checking instead of the misleading `try/catch`.

No server behavior change. Non-breaking for callers who already null-check (their code becomes well-typed), and surfaces a useful TS error for callers who weren't (their code was silently broken before).

Markdown docs prose updates are handled separately.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean for `client/packages/admin`
- [x] Existing server tests at `server/test/instant/admin/routes_test.clj:439-447` already assert `200 + {user: nil}` on miss, so the server contract this PR matches is intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)