### PR TITLE
Use URLSearchParams for admin SDK getUser/deleteUser query strings

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -684,9 +684,7 @@ class Auth<Schema extends InstantSchemaDef<any, any, any>> {
   getUser = async (
     params: { email: string } | { id: string } | { refresh_token: string },
   ): Promise<Omit<User, 'refresh_token'> | null> => {
-    const qs = Object.entries(params)
-      .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
-      .join('&');
+    const qs = new URLSearchParams(Object.entries(params)).toString();
 
     const response: { user: User | null } = await jsonFetch(
       `${this.config.apiURI}/admin/users?app_id=${this.config.appId}&${qs}`,
@@ -720,7 +718,7 @@ class Auth<Schema extends InstantSchemaDef<any, any, any>> {
   deleteUser = async (
     params: { email: string } | { id: string } | { refresh_token: string },
   ): Promise<User | null> => {
-    const qs = Object.entries(params).map(([k, v]) => `${k}=${v}`);
+    const qs = new URLSearchParams(Object.entries(params)).toString();
     const response: { deleted: User | null } = await jsonFetch(
       `${this.config.apiURI}/admin/users?app_id=${this.config.appId}&${qs}`,
       {

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.36';
+const version = 'v1.0.37';
 
 export { version };


### PR DESCRIPTION
## Summary

`deleteUser` built its query string with raw template interpolation, missing two things `getUser` already did:

```ts
const qs = Object.entries(params).map(([k, v]) => `${k}=${v}`);
```

- **No URI encoding.** An email like `alyssa+test@example.com` is sent as `email=alyssa+test@example.com`, where the server parses `+` as a space, so the lookup misses the intended user.
- **No `.join('&')`.** `map` returns an array; the outer template literal joins it with commas, not `&`. Harmless today because `deleteUser` is always called with exactly one key, but still wrong.

Rather than copy `getUser`'s hand-rolled `encodeURIComponent + join('&')` into `deleteUser`, this PR switches both to `URLSearchParams`:

```ts
const qs = new URLSearchParams(Object.entries(params)).toString();
```

Encoding and joining are now handled by the platform. Caught by CodeRabbit and @drew-harris on the original PR thread.

### Note on encoding behavior

`URLSearchParams` encodes spaces as `+` (form-urlencoded) where `encodeURIComponent` uses `%20`. Both are valid in query strings and Ring decodes them identically, so no server-side change. In practice none of the values passed here (emails, UUIDs) can contain spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)