### PR TITLE
Remove noisy console log in reactor

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -956,7 +956,7 @@ export default class Reactor {
   }
 
   _handleReceiveError(msg) {
-    console.log('error', msg);
+    this._log.info('error', msg);
     const eventId = msg['client-event-id'];
     // This might not be a mutation, but it can't hurt to delete it
     this._inFlightMutationEventIds.delete(eventId);

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.37';
+const version = 'v1.0.38';
 
 export { version };


### PR DESCRIPTION
Replace it with a this._log instead.

Fixes https://github.com/instantdb/instant/issues/2674