### PR TITLE
Pick migrate binary by arch in self-hosted Dockerfile

### DIFF
--- a/server/Dockerfile.self-hosted
+++ b/server/Dockerfile.self-hosted
@@ -27,7 +27,15 @@ WORKDIR /app
 
 # Install dependencies and golang-migrate
 RUN yum -y install tar gzip && \
-    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+      ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+      ARCH="arm64"; \
+    else \
+      echo "Unsupported architecture: $ARCH"; exit 1; \
+    fi && \
+    curl -L "https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-$ARCH.tar.gz" | tar xvz && \
     mv migrate /usr/local/bin/migrate && \
     yum clean all
 


### PR DESCRIPTION
## Summary

The arm64 variant of `ghcr.io/instantdb/server:latest` was being built with the amd64 `migrate` binary baked into an otherwise-arm64 image. This was causing self host to fail on arm-based machines

The fix is for the Dockerfile to pick the arm variant of migrate. This updates to match the pattern we already used in `Dockerfile-dev`.

Tested this on my local machine and got it working!

🤖 Generated with [Claude Code](https://claude.com/claude-code)