### PR TITLE
[codex-proposal] Dashboard redesign polish

### DIFF
--- a/client/packages/components/src/components/explorer/explorer-layout.tsx
+++ b/client/packages/components/src/components/explorer/explorer-layout.tsx
@@ -92,7 +92,7 @@ export const ExplorerLayout = ({
   return (
     <div
       className={cn(
-        'relative flex w-full flex-1 overflow-hidden border-solid dark:bg-neutral-800',
+        'relative flex w-full flex-1 overflow-hidden border-solid bg-[#fbfaf8] dark:bg-neutral-950',
         props.className,
       )}
     >
@@ -114,13 +114,13 @@ export const ExplorerLayout = ({
       <div
         ref={nsRef}
         className={cn(
-          'absolute top-0 bottom-0 left-0 z-40 flex min-w-[200px] flex-col gap-1 border-r border-solid border-r-gray-200 bg-white p-2 shadow-md md:static md:flex md:shadow-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-white',
+          'absolute top-0 bottom-0 left-0 z-40 flex min-w-[196px] flex-col gap-2 border-r border-solid border-r-gray-200 bg-[#fbfaf8] p-2 shadow-md md:static md:flex md:shadow-none dark:border-neutral-800 dark:bg-neutral-950 dark:text-white',
           {
             hidden: !isNsOpen,
           },
         )}
       >
-        <div className="flex items-center gap-1 text-sm font-semibold dark:text-white">
+        <div className="flex items-center gap-2 px-1 text-xs font-semibold tracking-[0.08em] text-gray-500 uppercase dark:text-neutral-400">
           <ChevronLeftIcon
             height="1rem"
             className="cursor-pointer md:hidden dark:text-white"
@@ -134,6 +134,7 @@ export const ExplorerLayout = ({
               {namespaces.length ? (
                 <ToggleCollection
                   className="text-sm"
+                  buttonClassName="px-2 py-1.5"
                   selectedId={props.explorerState?.namespace}
                   items={namespaces.map((ns) => ({
                     id: ns.id,
@@ -155,12 +156,12 @@ export const ExplorerLayout = ({
             </Button>
             {deletedNamespaces.length ? (
               <Button
-                className="justify-start gap-2 rounded-sm p-2"
+                className="justify-start gap-2 rounded-md px-2 py-1.5"
                 variant="subtle"
                 size="nano"
                 onClick={recentlyDeletedNsDialog.onOpen}
               >
-                <span className="rounded-sm bg-gray-200 px-1 text-gray-700 dark:bg-neutral-700 dark:text-neutral-100">
+                <span className="rounded bg-white px-1.5 text-gray-700 shadow-xs dark:bg-neutral-800 dark:text-neutral-100">
                   {deletedNamespaces.length}
                 </span>
                 <span>Recently Deleted</span>
@@ -178,9 +179,9 @@ export const ExplorerLayout = ({
           </div>
         )}
       </div>
-      <div className="flex flex-col gap-2 border-r border-gray-300 bg-neutral-100 p-1 md:hidden dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="flex flex-col gap-2 border-r border-gray-200 bg-[#fbfaf8] p-1 md:hidden dark:border-neutral-800 dark:bg-neutral-950">
         <button
-          className="flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 select-none hover:bg-neutral-300 dark:hover:bg-neutral-700"
+          className="flex cursor-pointer items-center gap-1 rounded-md px-1 py-0.5 select-none hover:bg-white dark:hover:bg-neutral-800"
           onClick={(e) => {
             e.stopPropagation();
             setIsNsOpen(true);

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -953,10 +953,10 @@ export const InnerExplorer: React.FC<{
           />
         ) : null}
       </Dialog>
-      <div className="flex flex-1 grow flex-col overflow-hidden bg-white dark:bg-neutral-800">
-        <div className="flex items-center overflow-hidden border-b border-b-gray-200 dark:border-neutral-700">
-          <div className="flex min-w-0 flex-1 flex-col justify-between py-2 md:flex-row md:items-center">
-            <div className="flex min-w-0 flex-1 items-center self-stretch overflow-hidden border-b px-2 py-1 pl-4 md:border-b-0 dark:border-neutral-700">
+      <div className="flex flex-1 grow flex-col overflow-hidden bg-white dark:bg-neutral-950">
+        <div className="flex items-center overflow-hidden border-b border-b-gray-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+          <div className="flex min-w-0 flex-1 flex-col justify-between gap-2 px-2 py-2 md:flex-row md:items-center">
+            <div className="flex min-w-0 flex-1 items-center self-stretch overflow-hidden border-b px-1 py-0.5 md:border-b-0 dark:border-neutral-800">
               {showBackButton ? (
                 <ArrowLeftIcon
                   className="mr-4 inline cursor-pointer"
@@ -980,12 +980,14 @@ export const InnerExplorer: React.FC<{
               ) : null}
               <div className="relative min-w-0 flex-1 self-stretch [timeline-scope:--filter-scroll]">
                 <div className="flex h-full items-center overflow-x-auto font-mono text-xs whitespace-nowrap [scroll-timeline:--filter-scroll_inline] dark:text-white">
-                  <strong>{selectedNamespace.name}</strong>{' '}
+                  <strong className="font-semibold text-gray-950 dark:text-white">
+                    {selectedNamespace.name}
+                  </strong>{' '}
                   {currentNav.where ? (
                     <>
                       {' '}
                       where <strong>{currentNav.where[0]}</strong> ={' '}
-                      <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
+                      <em className="rounded border border-gray-200 bg-[#fbfaf8] px-1.5 py-0.5 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
                         {JSON.stringify(currentNav.where[1])}
                       </em>
                     </>
@@ -998,7 +1000,7 @@ export const InnerExplorer: React.FC<{
                     >
                       {currentNav.filters.map(([attr, op, search], i) => (
                         <span key={attr}>
-                          <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
+                          <em className="rounded border border-gray-200 bg-[#fbfaf8] px-1.5 py-0.5 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
                             {attr} {op} {search}
                           </em>
                           {currentNav?.filters?.length &&
@@ -1020,9 +1022,8 @@ export const InnerExplorer: React.FC<{
                 />
               </div>
             </div>
-            <div className="flex justify-between gap-2 px-2 py-1 md:justify-start">
+            <div className="flex justify-between gap-2 md:justify-start">
               <Button
-                className="rounded-sm dark:bg-neutral-700/50"
                 variant="secondary"
                 size="mini"
                 onClick={() => {
@@ -1079,8 +1080,8 @@ export const InnerExplorer: React.FC<{
                   {uploadingFile ? 'Uploading...' : 'Upload file'}
                 </Button>
               </div>
-              <div className="relative flex max-w-[67vw] min-w-0 flex-1 rounded-sm border border-neutral-200 focus-within:ring-2 focus-within:ring-blue-700 dark:border-neutral-700 dark:focus-within:ring-blue-500">
-                <span className="absolute inset-y-0 left-0 flex items-center rounded-l bg-neutral-100 px-3 text-sm text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
+              <div className="relative flex max-w-[67vw] min-w-0 flex-1 rounded-md border border-neutral-200 bg-white shadow-xs focus-within:ring-2 focus-within:ring-[#606AF4] dark:border-neutral-700 dark:bg-neutral-900 dark:focus-within:ring-blue-500">
+                <span className="absolute inset-y-0 left-0 flex items-center rounded-l-md bg-[#fbfaf8] px-3 text-sm text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
                   File Path:
                 </span>
                 <input
@@ -1088,13 +1089,13 @@ export const InnerExplorer: React.FC<{
                   placeholder="Enter a custom path (optional)"
                   value={customPath}
                   onChange={(e) => setCustomPath(e.target.value)}
-                  className="h-9 w-full rounded-sm border-0 bg-transparent py-1 pr-3 pl-24 text-sm ring-0 placeholder:text-neutral-500 focus:outline-none dark:bg-neutral-800 dark:text-white dark:placeholder:text-neutral-400"
+                  className="h-10 w-full rounded-md border-0 bg-transparent py-1 pr-3 pl-24 text-sm ring-0 placeholder:text-neutral-500 focus:outline-none dark:bg-neutral-900 dark:text-white dark:placeholder:text-neutral-400"
                 />
               </div>
             </div>
           </div>
         ) : null}
-        <div className="flex items-center justify-start space-x-2 border-b border-b-gray-200 p-1 text-xs dark:border-neutral-700 dark:text-white">
+        <div className="flex items-center justify-start space-x-2 border-b border-b-gray-200 bg-[#fbfaf8] px-2 py-1.5 text-xs dark:border-neutral-800 dark:bg-neutral-900 dark:text-white">
           {selectedNamespace.name !== '$files' ? (
             <Button
               disabled={readOnlyNs}
@@ -1120,7 +1121,7 @@ export const InnerExplorer: React.FC<{
             )}
           >
             <Select
-              className="rounded-sm text-xs"
+              className="text-xs"
               onChange={(opt) => {
                 if (!opt) return;
 
@@ -1191,10 +1192,10 @@ export const InnerExplorer: React.FC<{
                 <button
                   key={page}
                   className={cn(
-                    'rounded-md px-3 py-1 text-neutral-600 dark:text-neutral-300',
+                    'rounded-md px-2 py-1 font-medium text-neutral-600 transition-colors dark:text-neutral-300',
                     page === currentPage
-                      ? 'bg-neutral-200 dark:bg-neutral-700'
-                      : 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
+                      ? 'bg-white text-gray-950 shadow-xs dark:bg-neutral-800 dark:text-white'
+                      : 'hover:bg-white/70 dark:hover:bg-neutral-800',
                   )}
                   onClick={() => {
                     setOffsets({
@@ -1357,7 +1358,7 @@ export const InnerExplorer: React.FC<{
           onDragEnd={handleDragEnd}
           sensors={sensors}
         >
-          <div className="relative flex-1 overflow-hidden bg-neutral-100 dark:bg-neutral-900/50">
+          <div className="relative flex-1 overflow-hidden bg-[#fbfaf8] dark:bg-neutral-950">
             {!tableSmallerThanViewport && (
               <div
                 className="absolute top-0 right-0 bottom-0 z-50 w-[30px] bg-linear-to-l from-black/20 via-black/5 to-transparent transition-opacity duration-150"
@@ -1384,7 +1385,7 @@ export const InnerExplorer: React.FC<{
                   }}
                   className="z-0 text-left font-mono text-xs text-neutral-500 dark:text-neutral-400"
                 >
-                  <div className="sticky top-0 z-10 border-r border-b border-gray-200 border-r-gray-200 bg-white text-neutral-700 shadow-sm dark:border-r-neutral-700 dark:border-b-neutral-600 dark:bg-[#303030] dark:text-neutral-300">
+                  <div className="sticky top-0 z-10 border-r border-b border-gray-200 border-r-gray-200 bg-[#fbfaf8] text-neutral-700 shadow-sm dark:border-r-neutral-800 dark:border-b-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
                     {table.getHeaderGroups().map((headerGroup) => (
                       <div className={'flex w-full'} key={headerGroup.id}>
                         <SortableContext
@@ -1420,7 +1421,7 @@ export const InnerExplorer: React.FC<{
                   <div>
                     {table.getRowModel().rows.map((row) => (
                       <div
-                        className="group flex border-r border-b border-r-gray-200 border-b-gray-200 bg-white dark:border-neutral-700 dark:border-r-neutral-700 dark:bg-neutral-800"
+                        className="group flex border-r border-b border-r-gray-200 border-b-gray-200 bg-white transition-colors hover:bg-[#fbfaf8] dark:border-neutral-800 dark:border-r-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-900"
                         key={row.id}
                       >
                         {row.getVisibleCells().map((cell) => (

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -114,11 +114,11 @@ export const TableHeader = ({
       )}
       <div className="flex h-full items-stretch justify-between overflow-hidden">
         <div
-          className={`flex shrink items-center gap-1 truncate px-2 py-1 font-semibold th-${header.column.id}`}
+          className={`flex shrink items-center gap-1 truncate px-2.5 py-1.5 font-semibold th-${header.column.id}`}
         >
           {isSortable ? (
             <button
-              className="relative z-50 flex items-center gap-1 py-2 pr-5"
+              className="relative z-50 flex items-center gap-1 py-1.5 pr-5"
               onClick={() => {
                 if (onSort) {
                   let thisAttrName =
@@ -188,7 +188,7 @@ export const TableHeader = ({
             }}
           >
             {headerGroup.headers.length - 1 !== index && (
-              <div className="h-full w-0.5 bg-neutral-200 dark:bg-neutral-700"></div>
+              <div className="h-full w-px bg-neutral-200 dark:bg-neutral-800"></div>
             )}
           </div>
         </div>
@@ -254,7 +254,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
           }}
           style={{
             ...style,
-            padding: disablePadding ? 0 : '0.5rem',
+            padding: disablePadding ? 0 : '0.375rem 0.5rem',
           }}
           className={cn(`cursor-default truncate whitespace-nowrap`)}
           key={cell.id}
@@ -262,7 +262,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
           <span
             className={cn(
               `h-full min-h-full cursor-pointer td-${cell.column.id}`,
-              disablePadding ? '' : 'pr-2',
+              disablePadding ? '' : 'pr-1.5',
             )}
             onClick={() => {
               if (

--- a/client/packages/components/src/components/select.tsx
+++ b/client/packages/components/src/components/select.tsx
@@ -40,14 +40,14 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: 'sm' | 'default';
+  size?: 'sm' | 'default' | 'lg';
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex w-fit items-center justify-between gap-2 rounded-sm border border-gray-300/80 bg-white px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700/50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border border-gray-300 bg-white px-3.5 py-2 text-sm whitespace-nowrap text-gray-900 shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-[#606AF4] focus-visible:ring-2 focus-visible:ring-[#606AF4]/15 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=lg]:h-12 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800 dark:focus-visible:border-[#8f95ff] dark:focus-visible:ring-[#8f95ff]/15 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-sm border bg-gray-100 text-gray-900 shadow-md dark:border-neutral-700 dark:bg-neutral-800 dark:text-white',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-gray-200 bg-white text-gray-900 shadow-md dark:border-neutral-700 dark:bg-neutral-800 dark:text-white',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           darkMode ? 'dark' : '',
@@ -120,7 +120,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none hover:bg-gray-200/50 data-disabled:pointer-events-none data-disabled:opacity-50 dark:text-white dark:hover:bg-neutral-700 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-hidden select-none hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50 dark:text-white dark:hover:bg-neutral-700 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -58,16 +58,31 @@ import { useMonacoJSONSchema } from '@lib/hooks/useMonacoJSONSchema';
 export const Stack = twel('div', 'flex flex-col gap-2');
 export const Group = twel('div', 'flex flex-col gap-2 md:flex-row');
 
-export const Content = twel('div', 'prose dark:text-neutral-400');
-export const ScreenHeading = twel('div', 'text-2xl font-bold');
-export const SectionHeading = twel('div', 'text-xl font-bold');
-export const SubsectionHeading = twel('div', 'text-lg');
-export const BlockHeading = twel('div', 'text-md font-bold');
+export const Content = twel(
+  'div',
+  'prose prose-sm max-w-none leading-relaxed text-gray-600 dark:prose-invert dark:text-neutral-400',
+);
+export const ScreenHeading = twel(
+  'div',
+  'text-4xl font-semibold tracking-normal text-gray-950 dark:text-white',
+);
+export const SectionHeading = twel(
+  'div',
+  'text-xl font-semibold tracking-normal text-gray-950 dark:text-white',
+);
+export const SubsectionHeading = twel(
+  'div',
+  'text-lg font-semibold tracking-normal text-gray-900 dark:text-neutral-100',
+);
+export const BlockHeading = twel(
+  'div',
+  'text-md font-semibold tracking-normal text-gray-900 dark:text-neutral-100',
+);
 
 export const Hint = twel('div', 'text-sm text-gray-400');
 export const Label = twel(
   'div',
-  'text-sm font-bold dark:text-neutral-400 text-gray-700',
+  'text-sm font-semibold text-gray-700 dark:text-neutral-400',
 );
 
 export const LogoIcon = ({
@@ -115,7 +130,7 @@ export function ToggleCollection({
   onChange: (tab: TabButton) => void;
 }) {
   return (
-    <div className={cn('flex w-full flex-col gap-0.5', className)}>
+    <div className={cn('flex w-full flex-col gap-1', className)}>
       {items.map((a) => (
         <button
           key={a.id}
@@ -124,9 +139,10 @@ export function ToggleCollection({
             onChange(a);
           }}
           className={cn(
-            'block cursor-pointer truncate rounded bg-none px-3 py-1 text-left whitespace-nowrap hover:bg-gray-100 disabled:text-gray-400 dark:hover:bg-neutral-700/80',
+            'block cursor-pointer truncate rounded-md bg-none px-3 py-2 text-left text-sm whitespace-nowrap text-gray-600 transition-colors hover:bg-white/70 hover:text-gray-950 disabled:text-gray-400 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-white',
             {
-              'bg-gray-200 dark:bg-neutral-600/50': selectedId === a.id,
+              'bg-white font-semibold text-gray-950 shadow-xs dark:bg-neutral-900 dark:text-white':
+                selectedId === a.id,
             },
             buttonClassName,
           )}
@@ -160,7 +176,7 @@ export function ToggleGroup({
 
         onChange(item);
       }}
-      className="flex gap-1 rounded-sm border border-gray-300 bg-gray-200 p-0.5 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+      className="flex gap-1 rounded-md border border-gray-300 bg-gray-100 p-1 text-sm dark:border-neutral-700 dark:bg-neutral-900"
       type="single"
       defaultValue="center"
       aria-label={ariaLabel}
@@ -169,10 +185,10 @@ export function ToggleGroup({
         <HeadlessToggleGroup.Item
           key={item.id}
           className={cn(
-            'flex-1 rounded-sm p-0.5',
+            'flex-1 rounded px-3 py-1.5 transition-colors',
             selectedId === item.id
-              ? 'bg-white dark:bg-neutral-600/50'
-              : 'bg-gray-200 dark:bg-transparent',
+              ? 'bg-white font-semibold text-gray-950 shadow-xs dark:bg-neutral-700 dark:text-white'
+              : 'text-gray-600 hover:bg-white/60 dark:bg-transparent dark:text-neutral-400 dark:hover:bg-neutral-800',
           )}
           value={item.id}
           aria-label={item.label}
@@ -187,6 +203,7 @@ export function ToggleGroup({
 export function TextInput({
   value,
   type,
+  size = 'normal',
   autoFocus,
   className,
   onChange,
@@ -200,9 +217,11 @@ export function TextInput({
   title,
   required,
   onBlur,
+  ignorePasswordManagers,
 }: {
   value: string;
   type?: 'text' | 'email' | 'sensitive' | 'password';
+  size?: 'normal' | 'large' | 'jumbo';
   className?: string;
   error?: ReactNode;
   onChange: (value: string) => void;
@@ -216,8 +235,11 @@ export function TextInput({
   title?: string | undefined;
   required?: boolean | undefined;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  ignorePasswordManagers?: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const shouldIgnorePasswordManagers =
+    type === 'sensitive' || ignorePasswordManagers;
 
   useEffect(() => {
     if (autoFocus) {
@@ -233,11 +255,11 @@ export function TextInput({
         title={title}
         // Try to prevent password managers (LastPass, 1Password,
         // BitWarden) from attaching to or saving sensitive input.
-        autoComplete={type === 'sensitive' ? 'off' : undefined}
-        data-lpignore={type === 'sensitive' ? 'true' : undefined}
-        data-1p-ignore={type === 'sensitive' ? 'true' : undefined}
-        data-bwignore={type === 'sensitive' ? 'true' : undefined}
-        data-form-type={type === 'sensitive' ? 'other' : undefined}
+        autoComplete={shouldIgnorePasswordManagers ? 'off' : undefined}
+        data-lpignore={shouldIgnorePasswordManagers ? 'true' : undefined}
+        data-1p-ignore={shouldIgnorePasswordManagers ? 'true' : undefined}
+        data-bwignore={shouldIgnorePasswordManagers ? 'true' : undefined}
+        data-form-type={shouldIgnorePasswordManagers ? 'other' : undefined}
         // LastPass attaches its UI to any <input type="password"> even
         // when data-lpignore="true" is set. To opt out we render the
         // field as type="text" and use -webkit-text-security to mask
@@ -260,7 +282,10 @@ export function TextInput({
         placeholder={placeholder}
         value={value ?? ''}
         className={cn(
-          'flex w-full flex-1 rounded-sm border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 disabled:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800 dark:placeholder:text-neutral-500 dark:disabled:text-neutral-700',
+          'flex w-full flex-1 rounded-md border border-gray-300 bg-white text-gray-950 shadow-xs transition-colors outline-none placeholder:text-gray-400 focus:border-[#606AF4] focus:ring-2 focus:ring-[#606AF4]/15 disabled:text-gray-400 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:placeholder:text-neutral-500 dark:focus:border-[#8f95ff] dark:focus:ring-[#8f95ff]/15 dark:disabled:text-neutral-700',
+          size === 'normal' && 'min-h-10 px-3.5 py-2 text-sm',
+          size === 'large' && 'min-h-12 px-4 py-2.5 text-base',
+          size === 'jumbo' && 'min-h-16 border-2 px-5 py-3 text-xl font-medium',
           className,
           {
             'border-red-500': error,
@@ -329,7 +354,7 @@ export function TextArea({
         placeholder={placeholder}
         value={value ?? ''}
         className={cn(
-          'flex w-full flex-1 rounded-sm border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 disabled:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800',
+          'flex w-full flex-1 rounded-md border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-950 shadow-xs transition-colors outline-none placeholder:text-gray-400 focus:border-[#606AF4] focus:ring-2 focus:ring-[#606AF4]/15 disabled:text-gray-400 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:placeholder:text-neutral-500 dark:focus:border-[#8f95ff] dark:focus:ring-[#8f95ff]/15 dark:disabled:text-neutral-700',
           className,
           {
             'border-red-500': error,
@@ -405,6 +430,7 @@ export function Checkbox({
 export function Select<Value extends string | boolean>({
   value,
   options,
+  size = 'default',
   className,
   onChange,
   disabled,
@@ -417,6 +443,7 @@ export function Select<Value extends string | boolean>({
 }: {
   value?: Value;
   options: { label: string | ReactNode; value: Value }[];
+  size?: 'sm' | 'default' | 'lg';
   className?: string;
   onChange: (option?: { label: string | ReactNode; value: Value }) => void;
   disabled?: boolean;
@@ -436,7 +463,12 @@ export function Select<Value extends string | boolean>({
       }}
       value={value?.toString() ?? ''}
     >
-      <SelectTrigger className={className} title={title} tabIndex={tabIndex}>
+      <SelectTrigger
+        className={className}
+        size={size}
+        title={title}
+        tabIndex={tabIndex}
+      >
         <SelectValue placeholder={emptyLabel}>{visibleValue}</SelectValue>
       </SelectTrigger>
       <SelectContent className={contentClassName}>
@@ -469,7 +501,7 @@ export function Button({
   title,
 }: PropsWithChildren<{
   variant?: 'primary' | 'secondary' | 'subtle' | 'destructive' | 'cta';
-  size?: 'mini' | 'normal' | 'large' | 'xl' | 'nano';
+  size?: 'nano' | 'mini' | 'normal' | 'large' | 'xl' | 'jumbo';
   type?: 'link' | 'link-new' | 'button' | 'submit';
   onClick?: MouseEventHandler;
   href?: string;
@@ -490,14 +522,14 @@ export function Button({
   }, []);
 
   const cls = cn(
-    `inline-flex justify-center items-center gap-1 whitespace-nowrap px-8 py-1 font-bold rounded-sm cursor-pointer transition-all disabled:cursor-default`,
+    `inline-flex min-h-10 justify-center items-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-semibold cursor-pointer transition-colors disabled:cursor-default`,
     {
       // primary
-      'bg-[#606AF4] text-white dark:bg-[#606AF4] dark:text-white':
+      'bg-[#ff875b] text-white shadow-xs dark:bg-[#ff875b] dark:text-white':
         variant === 'primary',
-      'hover:text-slate-100 hover:bg-[#4543e9] dark:hover:text-neutral-100 dark:hover:bg-[#4543e9]':
+      'hover:text-white hover:bg-[#ff7448] dark:hover:text-white dark:hover:bg-[#ff7448]':
         variant === 'primary' && isATag,
-      'hover:enabled:text-slate-100 hover:enabled:bg-[#4543e9] disabled:bg-[#9197f3] dark:hover:enabled:text-neutral-100 dark:hover:enabled:bg-[#4543e9] dark:disabled:bg-[#9197f3]':
+      'hover:enabled:text-white hover:enabled:bg-[#ff7448] disabled:bg-[#ffc1aa] disabled:text-white dark:hover:enabled:text-white dark:hover:enabled:bg-[#ff7448] dark:disabled:bg-[#8b4f3c]':
         variant === 'primary' && !isATag,
       // cta
       'bg-orange-600 text-white dark:bg-orange-600 dark:text-white':
@@ -507,30 +539,31 @@ export function Button({
       'hover:enabled:text-slate-100 hover:enabled:bg-orange-500 dark:hover:enabled:text-neutral-100 dark:hover:enabled:bg-orange-500':
         variant === 'cta' && !isATag,
       // secondary
-      'border border-gray-200 text-gray-500 bg-gray-50 shadow-sm dark:border-neutral-600 dark:text-neutral-400 dark:bg-neutral-800':
+      'border border-gray-300 bg-white text-gray-800 shadow-xs dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200':
         variant === 'secondary',
-      'hover:text-gray-600 hover:bg-gray-50/30 dark:hover:text-neutral-300 dark:hover:bg-neutral-700/30':
+      'hover:text-gray-950 hover:bg-gray-50 dark:hover:text-white dark:hover:bg-neutral-800':
         variant === 'secondary' && isATag,
-      'hover:enabled:text-gray-600 hover:enabled:bg-gray-50/30 disabled:text-gray-400 dark:hover:enabled:text-neutral-300 dark:hover:enabled:bg-neutral-700/30 dark:disabled:text-neutral-600':
+      'hover:enabled:text-gray-950 hover:enabled:bg-gray-50 disabled:text-gray-400 dark:hover:enabled:text-white dark:hover:enabled:bg-neutral-800 dark:disabled:text-neutral-600':
         variant === 'secondary' && !isATag,
       // subtle
-      'text-gray-500 bg-white font-normal dark:text-neutral-400 dark:bg-transparent':
+      'bg-transparent text-gray-600 shadow-none dark:text-neutral-400':
         variant === 'subtle',
-      'hover:text-gray-600 hover:bg-gray-200/30 dark:hover:text-neutral-300 dark:hover:bg-neutral-700/30':
+      'hover:text-gray-950 hover:bg-gray-100 dark:hover:text-white dark:hover:bg-neutral-800':
         variant === 'subtle' && isATag,
-      'hover:enabled:text-gray-600 hover:enabled:bg-gray-200/30 dark:hover:enabled:text-neutral-300 dark:hover:enabled:bg-neutral-700/30':
+      'hover:enabled:text-gray-950 hover:enabled:bg-gray-100 dark:hover:enabled:text-white dark:hover:enabled:bg-neutral-800':
         variant === 'subtle' && !isATag,
       // destructive
-      'text-red-500 dark:bg-red-500/10 bg-white border border-red-200 dark:border-red-900/60':
+      'border border-red-200 bg-white text-red-600 shadow-xs dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-400':
         variant === 'destructive',
-      'hover:text-red-600 hover:text-red-600 hover:border-red-300 dark:hover:border-red-800':
+      'hover:text-red-700 hover:border-red-300 hover:bg-red-50 dark:hover:border-red-800 dark:hover:bg-red-950/30':
         variant === 'destructive' && isATag,
-      'hover:enabled:text-red-600 hover:enabled:text-red-600 hover:enabled:border-red-300 disabled:border-red-50 disabled:text-red-300 dark:hover:enabled:text-red-500 dark:hover:enabled:border-red-800 dark:disabled:border-red-950 dark:disabled:text-red-800':
+      'hover:enabled:text-red-700 hover:enabled:border-red-300 hover:enabled:bg-red-50 disabled:border-red-50 disabled:text-red-300 dark:hover:enabled:text-red-300 dark:hover:enabled:border-red-800 dark:hover:enabled:bg-red-950/30 dark:disabled:border-red-950 dark:disabled:text-red-800':
         variant === 'destructive' && !isATag,
-      'text-lg': size === 'large',
-      'text-xl': size === 'xl',
-      'text-sm px-2 py-0.5': size === 'mini',
-      'text-xs px-2 py-0': size === 'nano',
+      'min-h-11 px-5 text-base': size === 'large',
+      'min-h-12 px-6 text-lg': size === 'xl',
+      'min-h-16 px-6 text-xl': size === 'jumbo',
+      'min-h-8 px-3 py-1 text-xs': size === 'mini',
+      'min-h-6 rounded px-2 py-0.5 text-xs': size === 'nano',
       'cursor-not-allowed': disabled,
       'cursor-wait opacity-75': loading, // Apply wait cursor and lower opacity when loading,
       'bg-gray-200 text-gray-400 dark:bg-neutral-700 dark:text-neutral-500':
@@ -782,13 +815,20 @@ export function Dialog({
         }}
         autoFocus={false}
         tabIndex={undefined}
-        className={`w-full max-w-xl overflow-y-auto rounded border-solid bg-white p-3 text-sm shadow dark:bg-neutral-800 dark:text-white ${className}`}
+        className={cn(
+          'w-full max-w-xl overflow-y-auto rounded-lg border border-gray-200 bg-white p-5 text-sm shadow-xl sm:p-6 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white',
+          className,
+        )}
       >
         {!hideCloseButton && (
-          <XMarkIcon
-            className="absolute top-[18px] right-3 h-4 w-4 cursor-pointer"
+          <button
+            type="button"
+            aria-label="Close"
+            className="absolute top-4 right-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-white"
             onClick={onClose}
-          />
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
         )}
         {children}
       </DialogContent>
@@ -933,13 +973,13 @@ export function SmallCopyable({
   return (
     <div
       className={cn(
-        'flex items-center rounded font-mono text-xs opacity-70',
+        'flex min-w-0 items-center rounded-md font-mono text-xs text-gray-500 dark:text-neutral-400',
         {},
       )}
     >
       {label ? (
         <div
-          className="py-1.5 opacity-50"
+          className="shrink-0 py-1.5 text-gray-400 dark:text-neutral-500"
           style={{
             borderTopLeftRadius: 'calc(0.25rem - 1px)',
             borderBottomLeftRadius: 'calc(0.25rem - 1px)',
@@ -951,10 +991,13 @@ export function SmallCopyable({
       <Tooltip open={tooltipOpen}>
         <TooltipTrigger asChild>
           <pre
-            className={clsx('flex-1 cursor-pointer px-2 py-1.5 select-text', {
-              truncate: !multiline,
-              'break-all whitespace-pre-wrap': multiline,
-            })}
+            className={clsx(
+              'min-w-0 flex-1 cursor-pointer px-2 py-1.5 select-text',
+              {
+                truncate: !multiline,
+                'break-all whitespace-pre-wrap': multiline,
+              },
+            )}
             title={hideValue || hidden ? 'Copy to clipboard' : value}
             onClick={(e) => {
               // Only copy if no text is selected
@@ -977,7 +1020,7 @@ export function SmallCopyable({
           <button
             onClick={handleChangeHideValue}
             className={cn(
-              'flex items-center gap-x-1 rounded-sm px-2 py-1 opacity-50 transition-colors hover:bg-gray-50 dark:hover:bg-neutral-700',
+              'flex h-7 w-7 items-center justify-center gap-x-1 rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-neutral-700 dark:hover:text-white',
               { 'text-xs': size === 'normal', 'text-sm': size === 'large' },
             )}
           >
@@ -1021,7 +1064,7 @@ export function Copyable({
   return (
     <div
       className={cn(
-        'flex items-center rounded border bg-white font-mono dark:border-neutral-700 dark:bg-neutral-800',
+        'flex min-w-0 items-stretch overflow-hidden rounded-md border border-gray-200 bg-[#fbfaf8] font-mono shadow-xs dark:border-neutral-700 dark:bg-neutral-900',
         {
           'text-sm': size === 'normal',
           'text-base': size === 'large',
@@ -1030,7 +1073,7 @@ export function Copyable({
     >
       {label ? (
         <div
-          className="border-r bg-gray-50 px-3 py-1.5 dark:border-r-neutral-700 dark:bg-neutral-700"
+          className="flex shrink-0 items-center border-r border-gray-200 bg-white/70 px-3 py-2 text-xs font-semibold text-gray-500 dark:border-r-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
           style={{
             borderTopLeftRadius: 'calc(0.25rem - 1px)',
             borderBottomLeftRadius: 'calc(0.25rem - 1px)',
@@ -1042,10 +1085,13 @@ export function Copyable({
       <Tooltip open={tooltipOpen}>
         <TooltipTrigger asChild>
           <pre
-            className={clsx('flex-1 cursor-pointer px-2 py-1.5 select-text', {
-              truncate: !multiline,
-              'break-all whitespace-pre-wrap': multiline,
-            })}
+            className={clsx(
+              'min-w-0 flex-1 cursor-pointer px-3 py-2 select-text',
+              {
+                truncate: !multiline,
+                'break-all whitespace-pre-wrap': multiline,
+              },
+            )}
             title={hideValue || hidden ? 'Copy to clipboard' : value}
             onClick={(e) => {
               // Only copy if no text is selected
@@ -1063,12 +1109,12 @@ export function Copyable({
         </TooltipTrigger>
         <TooltipContent side="bottom">Copied!</TooltipContent>
       </Tooltip>
-      <div className="flex gap-1 px-1">
+      <div className="flex shrink-0 items-center gap-1 px-1.5">
         {!!handleChangeHideValue && (
           <button
             onClick={handleChangeHideValue}
             className={cn(
-              'flex items-center gap-x-1 rounded-sm bg-white px-2 py-1 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-neutral-600/20 dark:ring-neutral-600 dark:hover:bg-neutral-600',
+              'flex h-8 items-center gap-x-1 rounded-md border border-gray-200 bg-white px-2 text-gray-700 hover:bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700',
               { 'text-xs': size === 'normal', 'text-sm': size === 'large' },
             )}
           >
@@ -1088,7 +1134,7 @@ export function Copyable({
               }, 2500);
             }}
             className={cn(
-              'flex items-center gap-x-1 rounded-sm bg-white px-2 py-1 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-neutral-600/20 dark:ring-neutral-600 dark:hover:bg-neutral-600',
+              'flex h-8 items-center gap-x-1 rounded-md border border-gray-200 bg-white px-2 text-gray-700 hover:bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700',
               { 'text-xs': size === 'normal', 'text-sm': size === 'large' },
             )}
           >
@@ -1433,7 +1479,7 @@ export function CodeEditor(props: {
 }) {
   return (
     <Editor
-      theme={props.darkMode ? 'vs-dark' : 'vs-light'}
+      theme={props.darkMode ? 'instant-dark' : 'instant-light'}
       className={cn(
         props.loading ? 'animate-pulse' : undefined,
         props.className,
@@ -1448,6 +1494,9 @@ export function CodeEditor(props: {
         hideCursorInOverviewRuler: true,
         minimap: { enabled: false },
         automaticLayout: true,
+        fontSize: 13,
+        lineHeight: 20,
+        padding: { top: 12, bottom: 12 },
         tabIndex: props.tabIndex,
         readOnly: props.readOnly,
       }}
@@ -1455,7 +1504,54 @@ export function CodeEditor(props: {
         props.onChange(value || '');
       }}
       onMount={props.onMount}
-      beforeMount={(monaco) => {}}
+      beforeMount={(monaco) => {
+        monaco.editor.defineTheme('instant-light', {
+          base: 'vs',
+          inherit: true,
+          rules: [
+            { token: 'comment', foreground: '737373' },
+            { token: 'keyword', foreground: 'b45309' },
+            { token: 'string', foreground: '047857' },
+            { token: 'number', foreground: '9a3412' },
+            { token: 'type', foreground: '365b9d' },
+            { token: 'delimiter', foreground: '525252' },
+          ],
+          colors: {
+            'editor.background': '#ffffff',
+            'editor.foreground': '#171717',
+            'editorLineNumber.foreground': '#b6b6b6',
+            'editorLineNumber.activeForeground': '#737373',
+            'editor.selectionBackground': '#ffe0d1',
+            'editor.inactiveSelectionBackground': '#fff0e8',
+            'editorCursor.foreground': '#ff875b',
+            'editorIndentGuide.background1': '#eeeeee',
+            'editorIndentGuide.activeBackground1': '#d4d4d4',
+            'editor.lineHighlightBackground': '#fbfaf8',
+          },
+        });
+        monaco.editor.defineTheme('instant-dark', {
+          base: 'vs-dark',
+          inherit: true,
+          rules: [
+            { token: 'comment', foreground: '8a8a8a' },
+            { token: 'keyword', foreground: 'ffb088' },
+            { token: 'string', foreground: '6ee7b7' },
+            { token: 'number', foreground: 'fcd34d' },
+            { token: 'type', foreground: '93c5fd' },
+            { token: 'delimiter', foreground: 'd4d4d4' },
+          ],
+          colors: {
+            'editor.background': '#111111',
+            'editor.foreground': '#f5f5f5',
+            'editorLineNumber.foreground': '#525252',
+            'editorLineNumber.activeForeground': '#a3a3a3',
+            'editor.selectionBackground': '#583424',
+            'editor.inactiveSelectionBackground': '#2f211b',
+            'editorCursor.foreground': '#ffb088',
+            'editor.lineHighlightBackground': '#171717',
+          },
+        });
+      }}
       loading={<FullscreenLoading />}
     />
   );
@@ -1636,7 +1732,22 @@ export function Fence({
               },
               styles: [],
             }
-          : rosePineDawnTheme
+          : {
+              plain: {
+                backgroundColor: '#fffdfa',
+                color: '#171717',
+              },
+              styles: [
+                {
+                  types: ['comment', 'prolog', 'doctype', 'cdata'],
+                  style: { color: '#7a7a7a' },
+                },
+                { types: ['string'], style: { color: '#166534' } },
+                { types: ['number'], style: { color: '#9a3412' } },
+                { types: ['keyword'], style: { color: '#4f46e5' } },
+                { types: ['function'], style: { color: '#0f766e' } },
+              ],
+            }
       }
     >
       {({ className, style, tokens, getTokenProps }) => {
@@ -1702,7 +1813,6 @@ export function Fence({
 }
 
 import * as SwitchPrimitive from '@radix-ui/react-switch';
-import { rosePineDawnTheme } from './rosePineDawnTheme';
 import { useShadowRoot, useShadowDarkMode } from './StyleMe';
 function Switch({
   className,

--- a/client/www/components/components/ui/item.tsx
+++ b/client/www/components/components/ui/item.tsx
@@ -31,13 +31,14 @@ function ItemSeparator({
 }
 
 const itemVariants = cva(
-  'group/item [a]:hover:bg-gray-100/50 focus-visible:border-gray-950 focus-visible:ring-gray-950/50 [a]:transition-colors flex flex-wrap items-center rounded-md border border-gray-200 border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px] dark:[a]:hover:bg-neutral-800/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50 dark:border-neutral-800',
+  'group/item [a]:hover:bg-gray-100/50 focus-visible:border-gray-950 focus-visible:ring-gray-950/50 [a]:transition-colors flex flex-wrap items-center rounded-lg border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px] dark:[a]:hover:bg-neutral-800/50 dark:focus-visible:border-gray-300 dark:focus-visible:ring-gray-300/50',
   {
     variants: {
       variant: {
         default: 'bg-transparent',
-        outline: 'border-gray-200 dark:border-neutral-800',
-        muted: 'bg-gray-100/50 dark:bg-neutral-800/50',
+        outline:
+          'border-gray-200 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-900',
+        muted: 'bg-[#fbfaf8] dark:bg-neutral-800/50',
       },
       size: {
         default: 'gap-4 p-4',

--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -38,21 +38,22 @@ function CodeStep(props: {
 }) {
   return (
     <form
-      className="flex flex-col gap-4"
+      className="flex flex-col gap-5"
       onSubmit={(e) => {
         e.preventDefault();
         props.onVerifyCode();
       }}
     >
-      <ScreenHeading>Enter your code</ScreenHeading>
-      <Content>
+      <ScreenHeading className="text-5xl">Enter your code</ScreenHeading>
+      <Content className="text-2xl leading-9 text-gray-950 dark:text-neutral-200">
         We sent an email to{' '}
         <strong className="dark:text-white">{props.sentEmail}</strong>. Check
         your email, and paste the code you see.
       </Content>
       <TextInput
         autoFocus
-        className="w-full appearance-none rounded-sm outline-hidden"
+        size="jumbo"
+        className="appearance-none outline-hidden"
         placeholder="Your code"
         inputMode="numeric"
         value={props.code}
@@ -60,12 +61,17 @@ function CodeStep(props: {
         error={props.error}
       />
       <Button
+        size="jumbo"
         type="submit"
         disabled={props.disabled || props.code.trim().length === 0}
       >
         Verify Code
       </Button>
-      <Button variant="subtle" onClick={() => props.onBackToLogin()}>
+      <Button
+        size="large"
+        variant="subtle"
+        onClick={() => props.onBackToLogin()}
+      >
         Back to Login
       </Button>
     </form>
@@ -84,22 +90,22 @@ function EmailStep(props: {
   const router = useRouter();
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-8">
       <form
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         onSubmit={(e) => {
           e.preventDefault();
           props.onSendCode();
         }}
       >
-        <ScreenHeading>Let's log you in</ScreenHeading>
-        <Content>
+        <ScreenHeading className="text-5xl">Let's log you in</ScreenHeading>
+        <Content className="text-2xl leading-9 text-gray-950 dark:text-neutral-200">
           Enter your email, and we’ll send you a verification code. We'll create
           an account for you too if you don't already have one :)
         </Content>
         <TextInput
           autoFocus
-          className="w-full rounded-sm"
+          size="jumbo"
           placeholder="Enter your email address"
           type="email"
           value={props.email}
@@ -107,6 +113,7 @@ function EmailStep(props: {
           error={props.error}
         />
         <Button
+          size="jumbo"
           type="submit"
           disabled={props.disabled || props.email.trim().length === 0}
         >
@@ -121,6 +128,7 @@ function EmailStep(props: {
             </span>
           </Divider>
           <Button
+            size="jumbo"
             variant="secondary"
             type="link"
             href={url(config.apiURI, `/dash/oauth/start`, {
@@ -130,7 +138,7 @@ function EmailStep(props: {
             })}
           >
             <span className="flex items-center space-x-2">
-              <Image alt="google icon" src={googleIconSvg} width={16} />
+              <Image alt="google icon" src={googleIconSvg} width={24} />
               <span>Continue with Google</span>
             </span>
           </Button>
@@ -225,13 +233,15 @@ export default function Auth(props: {
     }));
   };
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center p-4 dark:bg-neutral-900">
-      <div className="max-w-sm">
-        <span className="inline-flex items-center space-x-2">
-          <LogoIcon />
-          <span className="font-mono text-sm lowercase">Instant</span>
+    <div className="flex min-h-[100dvh] items-center justify-center bg-[#fbfaf8] p-8 dark:bg-neutral-950">
+      <div className="w-full max-w-[660px]">
+        <span className="mb-8 inline-flex items-center gap-3">
+          <LogoIcon size="normal" className="h-8 w-8" />
+          <span className="text-3xl font-semibold tracking-normal text-gray-950 lowercase dark:text-white">
+            instant
+          </span>
         </span>
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-8">
           {sentEmail ? (
             <CodeStep
               sentEmail={sentEmail}

--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -633,6 +633,7 @@ export function Sandbox({
     <>
       <Dialog title="Save Sandbox" {...saveCurrentDialog}>
         <form
+          className="flex flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
             saveCurrent(newSaveName.trim());
@@ -641,24 +642,26 @@ export function Sandbox({
             setNewSaveName('');
           }}
         >
-          <div className="pb-2">
+          <div className="text-sm text-gray-600 dark:text-neutral-400">
             Enter a name to save the current sandbox as.
           </div>
           <TextInput
             autoFocus
-            className="mt-0"
+            size="large"
             label={<div className="pt-2 pb-0 font-normal">Sandbox Name</div>}
             value={newSaveName}
             onChange={setNewSaveName}
           />
-          <div className="flex justify-end pt-2">
-            <Button type="submit">Save</Button>
+          <div className="flex justify-end border-t border-gray-200 pt-4 dark:border-neutral-800">
+            <Button type="submit" size="large">
+              Save
+            </Button>
           </div>
         </form>
       </Dialog>
-      <div className="flex w-full justify-between border-b bg-white p-2 px-3 dark:border-b-neutral-600 dark:bg-neutral-800">
+      <div className="flex w-full items-center justify-between gap-3 border-b border-gray-200 bg-white px-3 py-2 dark:border-b-neutral-800 dark:bg-neutral-950">
         <PresetManager />
-        <div className="flex items-center gap-8">
+        <div className="flex items-center gap-3">
           <IconButton
             variant="subtle"
             label="Copy link to sandbox"
@@ -685,12 +688,12 @@ export function Sandbox({
         </div>
       </div>
       {dangerouslyCommitTx ? (
-        <div className="border-b border-b-amber-100 bg-amber-50 px-2 py-1 text-xs text-amber-600 dark:border-b-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+        <div className="border-b border-b-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-b-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
           <strong>Use caution!</strong> Successful transactions will update your
           app's DB!
         </div>
       ) : (
-        <div className="border-b border-b-sky-200 bg-sky-50 px-2 py-1 text-xs text-sky-600 dark:border-b-neutral-600 dark:bg-sky-900/80 dark:text-sky-400/90">
+        <div className="border-b border-b-gray-200 bg-[#fbfaf8] px-4 py-2 text-xs text-gray-600 dark:border-b-neutral-800 dark:bg-neutral-900 dark:text-neutral-400">
           <strong>Debug mode.</strong> Transactions will not update your app's
           DB.
         </div>
@@ -699,15 +702,15 @@ export function Sandbox({
         direction="horizontal"
         className="flex h-full flex-1 overflow-y-hidden"
       >
-        <ResizablePanel className="flex min-w-[24em] flex-1 flex-col border-r dark:border-r-neutral-600">
+        <ResizablePanel className="flex min-w-[24em] flex-1 flex-col border-r border-gray-200 bg-white dark:border-r-neutral-800 dark:bg-neutral-950">
           <ResizablePanelGroup direction="vertical">
             <ResizablePanel
               minSize={20}
-              className="flex flex-1 flex-col border-b dark:border-b-neutral-600"
+              className="flex flex-1 flex-col border-b border-gray-200 dark:border-b-neutral-800"
             >
               <div className="flex-1">
                 <Editor
-                  theme={darkMode ? 'vs-dark' : 'light'}
+                  theme={darkMode ? 'instant-dark' : 'instant-light'}
                   height={'100%'}
                   path="sandbox.ts"
                   language="typescript"
@@ -722,7 +725,11 @@ export function Sandbox({
                     minimap: { enabled: false },
                     automaticLayout: true,
                     lineNumbers: 'off',
+                    fontSize: 13,
+                    lineHeight: 20,
+                    padding: { top: 10, bottom: 10 },
                   }}
+                  beforeMount={defineInstantEditorThemes}
                   onMount={async (editor, monaco) => {
                     editor.addCommand(
                       monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
@@ -779,66 +786,64 @@ export function Sandbox({
             <ResizableHandle />
             <ResizablePanel
               minSize={10}
-              className="flex flex-col border-b dark:border-b-neutral-700"
+              className="flex flex-col border-b border-gray-200 bg-white dark:border-b-neutral-800 dark:bg-neutral-950"
             >
-              <div className="flex flex-col gap-1 border-b bg-gray-50 px-2 py-1 text-xs dark:border-b-neutral-700 dark:bg-neutral-800">
+              <div className="border-b border-gray-200 bg-[#fbfaf8] px-3 py-1.5 text-sm font-semibold dark:border-b-neutral-800 dark:bg-neutral-900">
                 Context
               </div>
-              <div className="flex items-center gap-2 px-2 py-1">
-                <Label className="text-xs font-normal">
-                  Set{' '}
-                  <code className="border bg-white px-2 dark:border-neutral-600 dark:bg-neutral-800">
-                    auth.email
-                  </code>
-                </Label>
-                <EmailInput
-                  key={app.id}
-                  db={db}
-                  email={runAsUserEmail || ''}
-                  setEmail={setRunAsUserEmail}
-                  onEnter={execRef.current}
-                />
-              </div>
-              <div className="flex items-center gap-2 px-2 py-1">
-                <Label className="text-xs font-normal">
-                  Set{' '}
-                  <code className="border bg-white px-2 dark:border-neutral-600 dark:bg-neutral-800">
-                    request.ip
-                  </code>
-                </Label>
-                <TextInput
-                  className='dark:text-white" px-2 py-0.5 text-xs dark:border-neutral-600 dark:bg-neutral-800'
-                  value={ipOverride || ''}
-                  onChange={setIpOverride}
-                  onKeyDown={(e) => {
-                    if (e.metaKey && e.key === 'Enter') {
-                      execRef.current();
-                    }
-                  }}
-                />
-              </div>
-
-              <div className="flex items-center gap-2 px-2 py-1">
-                <Label className="text-xs font-normal">
-                  Set{' '}
-                  <code className="border bg-white px-2 dark:border-neutral-600 dark:bg-neutral-800">
-                    request.origin
-                  </code>
-                </Label>
-                <TextInput
-                  className='dark:text-white" px-2 py-0.5 text-xs dark:border-neutral-600 dark:bg-neutral-800'
-                  value={originOverride || ''}
-                  onChange={setOriginOverride}
-                  onKeyDown={(e) => {
-                    if (e.metaKey && e.key === 'Enter') {
-                      execRef.current();
-                    }
-                  }}
-                />
+              <div className="grid grid-cols-1 gap-2 px-3 py-2 xl:grid-cols-3">
+                <div className="min-w-0">
+                  <Label className="mb-1 text-xs">
+                    <code className="rounded border border-gray-200 bg-[#fbfaf8] px-1.5 py-0.5 text-xs dark:border-neutral-700 dark:bg-neutral-800">
+                      auth.email
+                    </code>
+                  </Label>
+                  <EmailInput
+                    key={app.id}
+                    db={db}
+                    email={runAsUserEmail || ''}
+                    setEmail={setRunAsUserEmail}
+                    onEnter={execRef.current}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <Label className="mb-1 text-xs">
+                    <code className="rounded border border-gray-200 bg-[#fbfaf8] px-1.5 py-0.5 text-xs dark:border-neutral-700 dark:bg-neutral-800">
+                      request.ip
+                    </code>
+                  </Label>
+                  <TextInput
+                    className="min-h-8 px-2.5 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
+                    value={ipOverride || ''}
+                    onChange={setIpOverride}
+                    onKeyDown={(e) => {
+                      if (e.metaKey && e.key === 'Enter') {
+                        execRef.current();
+                      }
+                    }}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <Label className="mb-1 text-xs">
+                    <code className="rounded border border-gray-200 bg-[#fbfaf8] px-1.5 py-0.5 text-xs dark:border-neutral-700 dark:bg-neutral-800">
+                      request.origin
+                    </code>
+                  </Label>
+                  <TextInput
+                    className="min-h-8 px-2.5 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
+                    value={originOverride || ''}
+                    onChange={setOriginOverride}
+                    onKeyDown={(e) => {
+                      if (e.metaKey && e.key === 'Enter') {
+                        execRef.current();
+                      }
+                    }}
+                  />
+                </div>
               </div>
 
               <div className="flex flex-1 flex-col">
-                <div className="flex items-center gap-2 border-b bg-gray-50 px-2 py-1 text-xs dark:border-b-neutral-700 dark:bg-neutral-800">
+                <div className="flex items-center gap-3 border-y border-gray-200 bg-[#fbfaf8] px-3 py-1.5 text-sm font-semibold dark:border-y-neutral-800 dark:bg-neutral-900">
                   Permissions
                   <div>
                     <Checkbox
@@ -849,7 +854,7 @@ export function Sandbox({
                   </div>
                 </div>
                 {useAppPerms ? null : (
-                  <div className="border-b border-b-amber-100 bg-amber-50 px-2 py-1 text-xs text-amber-600 dark:border-b-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+                  <div className="border-b border-b-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-b-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
                     <strong>Use caution!</strong> Transactions above will be
                     evaluated with these rules.
                   </div>
@@ -860,7 +865,7 @@ export function Sandbox({
                   >
                     {useAppPerms ? (
                       <Editor
-                        theme={darkMode ? 'vs-dark' : 'light'}
+                        theme={darkMode ? 'instant-dark' : 'instant-light'}
                         key="app"
                         path="app-permissions.json"
                         value={
@@ -872,10 +877,11 @@ export function Sandbox({
                           ...editorOptions,
                           readOnly: true,
                         }}
+                        beforeMount={defineInstantEditorThemes}
                       />
                     ) : (
                       <Editor
-                        theme={darkMode ? 'vs-dark' : 'light'}
+                        theme={darkMode ? 'instant-dark' : 'instant-light'}
                         key="custom"
                         path={rulesEditorPath}
                         value={permsValue}
@@ -883,6 +889,7 @@ export function Sandbox({
                         height={'100%'}
                         language="json"
                         options={editorOptions}
+                        beforeMount={defineInstantEditorThemes}
                         onMount={(editor, monaco) => {
                           editor.addCommand(
                             monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
@@ -916,15 +923,15 @@ export function Sandbox({
           </ResizablePanelGroup>
         </ResizablePanel>
         <ResizableHandle></ResizableHandle>
-        <ResizablePanel className="flex min-w-[24em] flex-1 flex-col overflow-hidden">
-          <div className="flex flex-col gap-1 border-b bg-gray-50 px-2 py-1 text-xs dark:border-b-neutral-700 dark:bg-neutral-800">
-            <div className="flex gap-2">
+        <ResizablePanel className="flex min-w-[24em] flex-1 flex-col overflow-hidden bg-white dark:bg-neutral-950">
+          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-gray-200 bg-[#fbfaf8] px-3 py-2 text-sm dark:border-b-neutral-800 dark:bg-neutral-900">
+            <div className="flex items-center gap-2 font-semibold">
               Output
               <Button size="nano" onClick={() => setOutput([])}>
                 Clear
               </Button>
             </div>
-            <div className="no-scrollbar flex gap-2 overflow-y-auto">
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
               <Checkbox
                 labelClassName="whitespace-nowrap"
                 label="Append results"
@@ -959,8 +966,19 @@ export function Sandbox({
           </div>
           <div
             ref={consoleRef}
-            className="flex w-full flex-1 flex-col gap-4 overflow-x-hidden overflow-y-auto bg-gray-100 p-4 text-xs dark:bg-neutral-800/40"
+            className="flex w-full flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto bg-[#fbfaf8] p-2 text-xs dark:bg-neutral-950"
           >
+            {output.length === 0 ? (
+              <div className="flex min-h-28 flex-col items-center justify-center rounded-md border border-dashed border-gray-300 bg-white px-4 py-6 text-center dark:border-neutral-700 dark:bg-neutral-900">
+                <div className="text-sm font-semibold text-gray-900 dark:text-white">
+                  No output yet
+                </div>
+                <div className="mt-1 max-w-sm text-sm text-gray-500 dark:text-neutral-400">
+                  Run code to inspect logs, queries, transactions, and
+                  permission checks.
+                </div>
+              </div>
+            ) : null}
             {output.map((o, i) =>
               o.type === 'eval' ? (
                 <div
@@ -971,7 +989,7 @@ export function Sandbox({
                 <div
                   key={i}
                   className={clsx(
-                    'rounded-sm border bg-gray-50 shadow-xs transition-all hover:shadow-sm dark:bg-neutral-800',
+                    'rounded-md border bg-white transition-all hover:shadow-xs dark:bg-neutral-900',
                     {
                       'border-sky-200 dark:border-sky-600/50': o.type === 'log',
                       'border-red-200 dark:border-red-600/50':
@@ -1210,7 +1228,7 @@ function EmailInput({
     >
       <ComboboxInput
         size={32}
-        className="px-2 py-0.5 text-xs dark:border-neutral-600 dark:bg-neutral-800 dark:text-white"
+        className="min-h-8 w-full rounded-md border border-gray-300 px-2.5 py-1 text-sm shadow-xs outline-hidden focus:border-[#606AF4] focus:ring-1 focus:ring-[#606AF4] dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
         value={email}
         onChange={(e) => {
           setEmail(e.target.value);
@@ -1226,14 +1244,14 @@ function EmailInput({
       <ComboboxOptions
         anchor="bottom start"
         modal={false}
-        className="z-10 mt-1 w-(--input-width) divide-y overflow-auto border border-gray-300 bg-white shadow-lg dark:divide-neutral-600 dark:border-neutral-600 dark:bg-neutral-700"
+        className="z-10 mt-1 w-(--input-width) divide-y overflow-auto rounded-md border border-gray-200 bg-white shadow-lg dark:divide-neutral-700 dark:border-neutral-700 dark:bg-neutral-800"
       >
         {!email ? (
           <ComboboxOption
             key="none"
             value=""
             className={clsx(
-              'px-2 py-0.5 text-xs data-focus:bg-blue-100 dark:text-white dark:data-focus:bg-neutral-600',
+              'px-3 py-2 text-sm data-focus:bg-blue-50 dark:text-white dark:data-focus:bg-neutral-700',
               {},
             )}
           >
@@ -1246,7 +1264,7 @@ function EmailInput({
             key={user.id}
             value={user.email}
             className={clsx(
-              'px-2 py-0.5 text-xs data-focus:bg-blue-100 dark:text-white dark:data-focus:bg-neutral-600',
+              'px-3 py-2 text-sm data-focus:bg-blue-50 dark:text-white dark:data-focus:bg-neutral-700',
               {},
             )}
           >
@@ -1405,4 +1423,56 @@ const editorOptions = {
   minimap: { enabled: false },
   automaticLayout: true,
   lineNumbers: 'off' as const,
+  fontSize: 13,
+  lineHeight: 20,
+  padding: { top: 10, bottom: 10 },
 };
+
+function defineInstantEditorThemes(monaco: Monaco) {
+  monaco.editor.defineTheme('instant-light', {
+    base: 'vs',
+    inherit: true,
+    rules: [
+      { token: 'comment', foreground: '737373' },
+      { token: 'keyword', foreground: 'b45309' },
+      { token: 'string', foreground: '047857' },
+      { token: 'number', foreground: '9a3412' },
+      { token: 'type', foreground: '365b9d' },
+      { token: 'delimiter', foreground: '525252' },
+    ],
+    colors: {
+      'editor.background': '#ffffff',
+      'editor.foreground': '#171717',
+      'editorLineNumber.foreground': '#b6b6b6',
+      'editorLineNumber.activeForeground': '#737373',
+      'editor.selectionBackground': '#ffe0d1',
+      'editor.inactiveSelectionBackground': '#fff0e8',
+      'editorCursor.foreground': '#ff875b',
+      'editorIndentGuide.background1': '#eeeeee',
+      'editorIndentGuide.activeBackground1': '#d4d4d4',
+      'editor.lineHighlightBackground': '#fbfaf8',
+    },
+  });
+  monaco.editor.defineTheme('instant-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [
+      { token: 'comment', foreground: '8a8a8a' },
+      { token: 'keyword', foreground: 'ffb088' },
+      { token: 'string', foreground: '6ee7b7' },
+      { token: 'number', foreground: 'fcd34d' },
+      { token: 'type', foreground: '93c5fd' },
+      { token: 'delimiter', foreground: 'd4d4d4' },
+    ],
+    colors: {
+      'editor.background': '#111111',
+      'editor.foreground': '#f5f5f5',
+      'editorLineNumber.foreground': '#525252',
+      'editorLineNumber.activeForeground': '#a3a3a3',
+      'editor.selectionBackground': '#583424',
+      'editor.inactiveSelectionBackground': '#2f211b',
+      'editorCursor.foreground': '#ffb088',
+      'editor.lineHighlightBackground': '#171717',
+    },
+  });
+}

--- a/client/www/components/dash/Webhooks.tsx
+++ b/client/www/components/dash/Webhooks.tsx
@@ -1,10 +1,4 @@
-import {
-  Fragment,
-  FormEventHandler,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import { FormEventHandler, useContext, useMemo, useState } from 'react';
 import {
   EllipsisVerticalIcon,
   PencilIcon,
@@ -29,6 +23,7 @@ import {
 import {
   Button,
   Checkbox,
+  cn,
   Content,
   Dialog,
   DropdownMenu,
@@ -96,6 +91,65 @@ export function CopyableText({
       <TooltipContent side="bottom">Copied!</TooltipContent>
     </Tooltip>
   );
+}
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-md border border-gray-200 bg-[#fbfaf8] px-1.5 py-0.5 font-mono text-[11px] text-gray-700 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+      {children}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: InstantWebhook['status'] }) {
+  const disabled = status === 'disabled';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold',
+        disabled
+          ? 'bg-gray-100 text-gray-600 dark:bg-neutral-800 dark:text-neutral-300'
+          : 'bg-green-50 text-green-700 ring-1 ring-green-200 ring-inset dark:bg-green-950/30 dark:text-green-300 dark:ring-green-800',
+      )}
+    >
+      {disabled ? 'Disabled' : 'Active'}
+    </span>
+  );
+}
+
+function Notice({
+  tone = 'neutral',
+  children,
+}: {
+  tone?: 'neutral' | 'warning' | 'danger';
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-3 py-2 text-sm leading-6',
+        tone === 'neutral' &&
+          'border-gray-200 bg-[#fbfaf8] text-gray-700 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-300',
+        tone === 'warning' &&
+          'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200',
+        tone === 'danger' &&
+          'border-red-200 bg-red-50 text-red-800 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200',
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function formatCreatedAt(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
 }
 
 // ---- API ----
@@ -264,12 +318,18 @@ function WebhookForm({
   };
 
   return (
-    <form onSubmit={handle} className="flex flex-col gap-4">
-      <SubsectionHeading>{heading}</SubsectionHeading>
+    <form onSubmit={handle} className="flex flex-col gap-5">
+      <div>
+        <SubsectionHeading>{heading}</SubsectionHeading>
+        <Content className="mt-1 text-sm">
+          Deliver events to one public HTTPS endpoint.
+        </Content>
+      </div>
       <div className="flex flex-col gap-1">
         <Label>Endpoint URL</Label>
         <TextInput
           autoFocus
+          size="large"
           value={url}
           onChange={setUrl}
           placeholder="https://example.com/api/instant-webhook"
@@ -286,7 +346,7 @@ function WebhookForm({
             Define namespaces in your schema to enable webhooks.
           </Content>
         ) : (
-          <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded-sm border bg-gray-50 p-2 dark:border-neutral-700 dark:bg-neutral-800/50">
+          <div className="grid max-h-44 grid-cols-1 gap-2 overflow-y-auto rounded-md border border-gray-200 bg-[#fbfaf8] p-3 sm:grid-cols-2 dark:border-neutral-700 dark:bg-neutral-800/50">
             {allOptions.map((n) => (
               <Checkbox
                 key={n}
@@ -301,7 +361,7 @@ function WebhookForm({
 
       <div className="flex flex-col gap-1">
         <Label>Actions</Label>
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-700 dark:bg-neutral-800/50">
           {ALL_ACTIONS.map((a) => (
             <Checkbox
               key={a}
@@ -313,11 +373,21 @@ function WebhookForm({
         </div>
       </div>
 
-      <div className="flex flex-row gap-2">
-        <Button loading={isLoading} variant="primary" type="submit">
+      <div className="flex flex-row justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+        <Button
+          loading={isLoading}
+          variant="primary"
+          size="large"
+          type="submit"
+        >
           {submitLabel}
         </Button>
-        <Button type="button" variant="secondary" onClick={onCancel}>
+        <Button
+          type="button"
+          variant="secondary"
+          size="large"
+          onClick={onCancel}
+        >
           Cancel
         </Button>
       </div>
@@ -453,19 +523,34 @@ function DisableDialog({
         className="flex flex-col gap-4"
       >
         <SubsectionHeading>Disable webhook</SubsectionHeading>
-        <Content>
+        <Notice tone="warning">
           Disabled webhooks won't deliver events. You can re-enable it at any
           time.
-        </Content>
+        </Notice>
         <div className="flex flex-col gap-1">
           <Label>Reason (optional)</Label>
-          <TextInput autoFocus value={reason} onChange={setReason} />
+          <TextInput
+            autoFocus
+            size="large"
+            value={reason}
+            onChange={setReason}
+          />
         </div>
-        <div className="flex flex-row gap-2">
-          <Button type="submit" loading={isLoading} variant="destructive">
+        <div className="flex flex-row justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button
+            type="submit"
+            loading={isLoading}
+            variant="destructive"
+            size="large"
+          >
             Disable
           </Button>
-          <Button type="button" variant="secondary" onClick={dialog.onClose}>
+          <Button
+            type="button"
+            variant="secondary"
+            size="large"
+            onClick={dialog.onClose}
+          >
             Cancel
           </Button>
         </div>
@@ -504,16 +589,23 @@ function DeleteDialog({
   return (
     <Dialog title="Delete webhook" {...dialog}>
       <div className="flex flex-col gap-3">
-        <SubsectionHeading>{webhook.sink.url}</SubsectionHeading>
-        <Content>
+        <SubsectionHeading className="font-mono text-base break-all">
+          {webhook.sink.url}
+        </SubsectionHeading>
+        <Notice tone="danger">
           Deleting a webhook is permanent. Any pending events for this webhook
           will be discarded.
-        </Content>
-        <div className="flex gap-2">
-          <Button loading={isLoading} variant="destructive" onClick={handle}>
+        </Notice>
+        <div className="flex justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button
+            loading={isLoading}
+            variant="destructive"
+            size="large"
+            onClick={handle}
+          >
             Delete
           </Button>
-          <Button variant="secondary" onClick={dialog.onClose}>
+          <Button variant="secondary" size="large" onClick={dialog.onClose}>
             Cancel
           </Button>
         </div>
@@ -646,42 +738,39 @@ function WebhookRow({
   };
 
   return (
-    <Item
-      variant="outline"
-      className="bg-white dark:border-neutral-700 dark:bg-neutral-800"
-    >
-      <ItemContent>
-        <ItemTitle className="block max-w-full truncate font-mono">
-          <CopyableText value={webhook.sink.url} className="block truncate" />
-        </ItemTitle>
+    <Item variant="outline" size="sm" className="items-start gap-3">
+      <ItemContent className="min-w-0 gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <ItemTitle className="block max-w-full min-w-0 truncate font-mono">
+            <CopyableText value={webhook.sink.url} className="block truncate" />
+          </ItemTitle>
+          <StatusBadge status={webhook.status} />
+        </div>
         {webhook.disabled_reason ? (
           <ItemDescription className="text-red-700 dark:text-red-300">
             {webhook.disabled_reason}
           </ItemDescription>
         ) : null}
-        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
-          <dt className="text-gray-500 dark:text-neutral-500">ID</dt>
-          <dd>
-            <CopyableText value={webhook.id} className="font-mono break-all" />
-          </dd>
-          <dt className="text-gray-500 dark:text-neutral-500">Namespaces</dt>
-          <dd className="font-mono">
-            {(webhook.namespaces ?? []).length === 0
-              ? '(none)'
-              : [...(webhook.namespaces ?? [])].sort().map((e, i, arr) => (
-                  <Fragment key={e}>
-                    <span className="whitespace-nowrap">{e}</span>
-                    {i < arr.length - 1 ? ', ' : ''}
-                  </Fragment>
-                ))}
-          </dd>
-          <dt className="text-gray-500 dark:text-neutral-500">Actions</dt>
-          <dd className="font-mono">
-            {ALL_ACTIONS.filter((a) => webhook.actions.includes(a)).join(', ')}
-          </dd>
-        </dl>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-neutral-500">
+          <CopyableText value={webhook.id} className="font-mono" />
+          <span>Created {formatCreatedAt(webhook.created_at)}</span>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {(webhook.namespaces ?? []).length === 0 ? (
+            <Chip>No namespaces</Chip>
+          ) : (
+            [...(webhook.namespaces ?? [])]
+              .sort()
+              .map((namespace) => <Chip key={namespace}>{namespace}</Chip>)
+          )}
+          {ALL_ACTIONS.filter((a) => webhook.actions.includes(a)).map(
+            (action) => (
+              <Chip key={action}>{action}</Chip>
+            ),
+          )}
+        </div>
       </ItemContent>
-      <ItemActions>
+      <ItemActions className="shrink-0 self-start">
         <Button
           variant="secondary"
           size="mini"
@@ -754,7 +843,7 @@ export function Webhooks({
   const disabledWebhooks = webhooks.filter((w) => w.status === 'disabled');
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 p-5">
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-col gap-1">
           <SectionHeading>Webhooks</SectionHeading>
@@ -763,14 +852,24 @@ export function Webhooks({
             updated, or deleted.
           </Content>
         </div>
-        <Button variant="primary" onClick={createDialog.onOpen}>
+        <Button variant="primary" size="large" onClick={createDialog.onOpen}>
           <PlusIcon height={14} /> New webhook
         </Button>
       </div>
 
       {webhooks.length === 0 ? (
-        <div className="rounded-sm border bg-gray-50 p-8 text-center text-sm text-gray-500 dark:border-neutral-700 dark:bg-neutral-800/50 dark:text-neutral-500">
-          No webhooks yet.
+        <div className="flex min-h-28 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-gray-300 bg-[#fbfaf8] px-4 py-6 text-center dark:border-neutral-700 dark:bg-neutral-950">
+          <div>
+            <div className="font-semibold text-gray-950 dark:text-white">
+              No webhooks yet
+            </div>
+            <div className="mt-1 text-sm text-gray-500 dark:text-neutral-400">
+              Add an endpoint to receive create, update, and delete events.
+            </div>
+          </div>
+          <Button variant="secondary" size="mini" onClick={createDialog.onOpen}>
+            <PlusIcon height={14} /> New webhook
+          </Button>
         </div>
       ) : (
         <>

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -11,7 +11,6 @@ import {
   Content,
   Dialog,
   Label,
-  SectionHeading,
   SubsectionHeading,
   TextInput,
   useDialog,
@@ -152,9 +151,14 @@ export function Email({ app }: { app: InstantApp }) {
 
   if (!isEditing) {
     return (
-      <div className="flex flex-col gap-2">
-        <SectionHeading>Custom Magic Code Email</SectionHeading>
-        <Button onClick={() => setIsEditing(true)}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <SubsectionHeading>Magic code email</SubsectionHeading>
+          <Content className="mt-1 text-sm">
+            Customize the message users receive when they sign in with a code.
+          </Content>
+        </div>
+        <Button size="large" onClick={() => setIsEditing(true)}>
           Customize your magic code email
         </Button>
       </div>
@@ -162,10 +166,17 @@ export function Email({ app }: { app: InstantApp }) {
   }
   return (
     <div>
-      <form {...form.formProps()} className="flex flex-col gap-2">
-        <SectionHeading>Custom Magic Code Email</SectionHeading>
+      <form {...form.formProps()} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <SubsectionHeading>Magic code email</SubsectionHeading>
+            <Content className="mt-1 text-sm">
+              Edit the subject, sender, and body for the magic code email.
+            </Content>
+          </div>
+        </div>
 
-        <div className="flex flex-col gap-1 rounded-sm border bg-gray-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
+        <div className="flex flex-col gap-1 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-700 dark:bg-neutral-800">
           <BlockHeading>Template variables</BlockHeading>
           <Content className="text-sm">
             We provide a few dynamic variables for you to use in your email:
@@ -192,24 +203,31 @@ export function Email({ app }: { app: InstantApp }) {
           </Content>
         </div>
 
-        <TextInput
-          {...form.inputProps('subject')}
-          label="Subject"
-          placeholder="Hey there!  Your code for {app_title} is: {code}"
-        />
+        <div className="grid gap-3 md:grid-cols-2">
+          <TextInput
+            {...form.inputProps('subject')}
+            label="Subject"
+            size="large"
+            placeholder="Hey there! Your code for {app_title} is: {code}"
+          />
 
-        <TextInput
-          {...form.inputProps('from')}
-          label="From"
-          placeholder="YourName from YourCo"
-        />
+          <TextInput
+            {...form.inputProps('from')}
+            label="From"
+            size="large"
+            placeholder="YourName from YourCo"
+          />
+        </div>
 
         <div className="flex flex-col gap-1">
           <Label>Body (HTML or plain-text)</Label>
           <div
-            className={clsx('h-64 rounded-sm border dark:border-neutral-700', {
-              'border-red-500': form.getError('bodyHtml'),
-            })}
+            className={clsx(
+              'h-[360px] overflow-hidden rounded-md border border-gray-200 dark:border-neutral-700',
+              {
+                'border-red-500': form.getError('bodyHtml'),
+              },
+            )}
           >
             <CodeEditor
               darkMode={darkMode}
@@ -225,7 +243,7 @@ export function Email({ app }: { app: InstantApp }) {
           ) : null}
         </div>
 
-        <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
+        <div className="flex flex-col gap-2 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-700 dark:bg-neutral-800">
           <SubsectionHeading>
             Use a custom 'From' address (optional)
           </SubsectionHeading>
@@ -238,12 +256,13 @@ export function Email({ app }: { app: InstantApp }) {
           <TextInput
             {...form.inputProps('senderEmail')}
             label="Sender email address"
+            size="large"
             placeholder="hi@yourdomain.co"
           />
         </div>
 
         {verification && (
-          <div className="flex flex-col gap-2 rounded-sm border bg-gray-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
+          <div className="flex flex-col gap-2 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-700 dark:bg-neutral-800">
             <div className="flex items-center justify-between">
               <SubsectionHeading>
                 Verify {verification.EmailAddress}
@@ -253,13 +272,13 @@ export function Email({ app }: { app: InstantApp }) {
                 onClick={checkVerification}
                 loading={isVerifying}
                 variant="primary"
-                size="mini"
+                size="large"
               >
                 Refresh Status
               </Button>
             </div>
 
-            <div className="rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-700/60">
+            <div className="rounded-md border border-gray-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-700/60">
               <div className="mb-2 flex items-center justify-between">
                 <div className="text-sm font-medium">Email Confirmation</div>
                 <div className="flex items-center gap-2">
@@ -286,7 +305,7 @@ export function Email({ app }: { app: InstantApp }) {
             </div>
 
             {/* Domain Verification */}
-            <div className="rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-700/60">
+            <div className="rounded-md border border-gray-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-700/60">
               <div className="mb-2 flex items-center justify-between">
                 <div className="text-sm font-medium">
                   Bonus: Domain Verification
@@ -362,9 +381,8 @@ export function Email({ app }: { app: InstantApp }) {
           </div>
         )}
 
-        <Button {...form.submitButtonProps()} />
-
-        <>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button size="large" {...form.submitButtonProps()} />
           <ActionButton
             variant="destructive"
             label="Delete template"
@@ -387,7 +405,7 @@ export function Email({ app }: { app: InstantApp }) {
               setIsEditing(false);
             }}
           />
-        </>
+        </div>
       </form>
 
       <MagicCodeExpirationSection app={app} />
@@ -446,7 +464,7 @@ function MagicCodeExpirationSection({ app }: { app: InstantApp }) {
           <Content className="text-sm">
             Choose how long magic codes remain valid.
           </Content>
-          <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
             <strong>Recommended: 10 minutes.</strong> Shorter lifetimes reduce
             the window for code interception.
           </div>
@@ -454,7 +472,7 @@ function MagicCodeExpirationSection({ app }: { app: InstantApp }) {
             {EXPIRY_OPTIONS.map((option) => (
               <label
                 key={option.value}
-                className="flex cursor-pointer items-center gap-2 rounded border p-3 dark:border-neutral-700"
+                className="flex cursor-pointer items-center gap-2 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 text-sm dark:border-neutral-700 dark:bg-neutral-800/50"
               >
                 <input
                   type="radio"
@@ -467,11 +485,17 @@ function MagicCodeExpirationSection({ app }: { app: InstantApp }) {
             ))}
           </div>
           <div className="flex justify-end gap-2">
-            <Button type="button" onClick={dialog.onClose} variant="subtle">
+            <Button
+              type="button"
+              size="large"
+              onClick={dialog.onClose}
+              variant="secondary"
+            >
               Cancel
             </Button>
             <Button
               type="button"
+              size="large"
               onClick={handleSave}
               loading={isSaving}
               variant="primary"

--- a/client/www/components/dash/explorer/QueryInspector.tsx
+++ b/client/www/components/dash/explorer/QueryInspector.tsx
@@ -209,65 +209,72 @@ export function QueryInspector({
   };
 
   return (
-    <div className={cn('flex flex-1', className)}>
-      <div className="flex max-w-lg flex-1 flex-col dark:bg-neutral-800">
-        <h2 className="mt-4 mb-1 px-3 text-sm font-semibold">InstaQL query</h2>
-
-        <div className="relative h-64 overflow-hidden rounded-sm border-y dark:border-y-neutral-800">
-          <CodeEditor
-            darkMode={darkMode}
-            language="json"
-            value={draft}
-            onChange={(code) => setQueryDraft(code)}
-            onMount={(editor, monaco) => {
-              // cmd+S/cmd+Enter bindings to run query
-              editor.addCommand(
-                monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
-                () => run(editor.getValue()),
-              );
-              editor.addCommand(
-                monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-                () => run(editor.getValue()),
-              );
-            }}
-          />
-          <div className="absolute bottom-0 flex w-full items-center justify-between gap-4 px-3 py-2">
+    <div
+      className={cn(
+        'flex min-h-0 flex-1 bg-[#fbfaf8] text-gray-950 dark:bg-neutral-950 dark:text-white',
+        className,
+      )}
+    >
+      <div className="flex w-full max-w-[520px] shrink-0 flex-col gap-4 border-r border-gray-200 p-4 dark:border-neutral-800">
+        <section className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex items-start justify-between gap-4 border-b border-gray-200 px-4 py-3 dark:border-neutral-800">
+            <div>
+              <h2 className="text-sm font-semibold">InstaQL query</h2>
+              <p className="mt-1 text-xs text-gray-500 dark:text-neutral-400">
+                Write JSON, then run it against the active app.
+              </p>
+            </div>
             <Button
               className="group"
               variant="secondary"
               size="mini"
               onClick={handleSaveQuery}
             >
-              <StarIcon className="mr-0.5 h-4 w-4 transition-colors group-hover:text-amber-500" />
+              <StarIcon className="h-4 w-4 transition-colors group-hover:text-amber-500" />
               Save
             </Button>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="secondary"
-                size="mini"
-                onClick={handleClearQuery}
-              >
-                Clear
-              </Button>
-              <Button variant="primary" size="mini" onClick={handleRunQuery}>
-                Run
-              </Button>
-            </div>
           </div>
-        </div>
 
-        <div className="">
-          <h2 className="mt-4 mb-1 px-3 text-sm font-semibold">
-            Saved queries
-          </h2>
+          <div className="relative h-72 overflow-hidden border-b border-gray-200 dark:border-neutral-800">
+            <CodeEditor
+              darkMode={darkMode}
+              language="json"
+              value={draft}
+              onChange={(code) => setQueryDraft(code)}
+              onMount={(editor, monaco) => {
+                editor.addCommand(
+                  monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
+                  () => run(editor.getValue()),
+                );
+                editor.addCommand(
+                  monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+                  () => run(editor.getValue()),
+                );
+              }}
+            />
+          </div>
+          <div className="flex items-center justify-end gap-2 px-4 py-3">
+            <Button variant="secondary" size="mini" onClick={handleClearQuery}>
+              Clear
+            </Button>
+            <Button variant="primary" size="mini" onClick={handleRunQuery}>
+              Run
+            </Button>
+          </div>
+        </section>
 
-          <div className="px-3 text-sm">
+        <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="border-b border-gray-200 px-4 py-3 dark:border-neutral-800">
+            <h2 className="text-sm font-semibold">Saved queries</h2>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2 text-sm">
             {saved.length > 0 ? (
               saved.map((item) => {
                 return (
                   <div
                     key={item.ts}
-                    className="group mb-1 flex items-center justify-between gap-2 text-gray-700 dark:text-neutral-200"
+                    className="group flex items-center justify-between gap-2 rounded-md border border-transparent px-2 py-2 text-gray-700 transition-colors hover:border-gray-200 hover:bg-[#fbfaf8] dark:text-neutral-200 dark:hover:border-neutral-700 dark:hover:bg-neutral-800"
                   >
                     <Tooltip.Provider>
                       <Tooltip.Root delayDuration={200}>
@@ -292,7 +299,7 @@ export function QueryInspector({
                     </Tooltip.Provider>
                     <div className="flex items-center gap-1">
                       <Button
-                        className="px-1 opacity-0 transition-opacity group-hover:opacity-100"
+                        className="px-1 opacity-50 transition-opacity group-hover:opacity-100"
                         variant="destructive"
                         size="mini"
                         onClick={() => handleRemoveFromSaved(item.ts)}
@@ -300,7 +307,7 @@ export function QueryInspector({
                         <TrashIcon className="h-4 w-4" />
                       </Button>
                       <Button
-                        className="px-1 opacity-0 transition-opacity group-hover:opacity-100"
+                        className="px-1 opacity-50 transition-opacity group-hover:opacity-100"
                         variant="primary"
                         size="mini"
                         onClick={() => run(item.query)}
@@ -312,21 +319,21 @@ export function QueryInspector({
                 );
               })
             ) : (
-              <div className="py-1 text-gray-400">Nothing here yet!</div>
+              <div className="px-2 py-2 text-gray-400">Nothing here yet.</div>
             )}
           </div>
-        </div>
 
-        <div className="mt-4 border-t py-4 dark:border-t-neutral-700">
-          <h2 className="mb-1 px-3 text-sm font-semibold">Query history</h2>
+          <div className="border-t border-gray-200 px-4 py-3 dark:border-neutral-800">
+            <h2 className="text-sm font-semibold">Query history</h2>
+          </div>
 
-          <div className="px-3 text-sm">
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2 text-sm">
             {history.length > 0 ? (
               history.slice(0, 20).map((item) => {
                 return (
                   <div
                     key={item.ts}
-                    className="group mb-1 flex items-center justify-between gap-2 text-gray-700 dark:text-neutral-300"
+                    className="group flex items-center justify-between gap-2 rounded-md border border-transparent px-2 py-2 text-gray-700 transition-colors hover:border-gray-200 hover:bg-[#fbfaf8] dark:text-neutral-300 dark:hover:border-neutral-700 dark:hover:bg-neutral-800"
                   >
                     <Tooltip.Provider>
                       <Tooltip.Root delayDuration={200}>
@@ -351,7 +358,7 @@ export function QueryInspector({
                     </Tooltip.Provider>
                     <div className="flex items-center gap-1">
                       <Button
-                        className="px-1 opacity-0 transition-opacity group-hover:opacity-100"
+                        className="px-1 opacity-50 transition-opacity group-hover:opacity-100"
                         variant="destructive"
                         size="mini"
                         onClick={() => handleRemoveFromHistory(item.ts)}
@@ -359,7 +366,7 @@ export function QueryInspector({
                         <TrashIcon className="h-4 w-4" />
                       </Button>
                       <Button
-                        className="px-1 opacity-0 transition-opacity group-hover:opacity-100"
+                        className="px-1 opacity-50 transition-opacity group-hover:opacity-100"
                         variant="primary"
                         size="mini"
                         onClick={() => run(item.query)}
@@ -371,22 +378,26 @@ export function QueryInspector({
                 );
               })
             ) : (
-              <div className="py-1 text-gray-400">Nothing here yet!</div>
+              <div className="px-2 py-2 text-gray-400">Nothing here yet.</div>
             )}
           </div>
-        </div>
+        </section>
       </div>
-      <div className="flex max-h-full flex-1 flex-col overflow-scroll border-l dark:border-l-neutral-700 dark:bg-neutral-800">
-        <h2 className="mt-4 mb-1 px-3 text-sm font-semibold">Query results</h2>
-        <div className="flex-1 overflow-hidden rounded-sm border-y dark:border-y-neutral-700">
-          <CodeEditor
-            darkMode={darkMode}
-            loading={isLoading}
-            language={'json'}
-            value={JSON.stringify(data || error || {}, null, 2)}
-            onChange={() => {}}
-          />
-        </div>
+      <div className="flex min-w-0 flex-1 flex-col p-4">
+        <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="border-b border-gray-200 px-4 py-3 dark:border-neutral-800">
+            <h2 className="text-sm font-semibold">Query results</h2>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <CodeEditor
+              darkMode={darkMode}
+              loading={isLoading}
+              language={'json'}
+              value={JSON.stringify(data || error || {}, null, 2)}
+              onChange={() => {}}
+            />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/client/www/components/select.tsx
+++ b/client/www/components/select.tsx
@@ -39,14 +39,14 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: 'sm' | 'default';
+  size?: 'sm' | 'default' | 'lg';
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex w-fit items-center justify-between gap-2 rounded-xs border border-gray-300/80 bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-2xs outline-hidden transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 data-[slot=select-value]:*:line-clamp-1 data-[slot=select-value]:*:flex data-[slot=select-value]:*:items-center data-[slot=select-value]:*:gap-2 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700/50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border border-gray-300 bg-white px-3.5 py-2 text-sm whitespace-nowrap text-gray-900 shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-[#606AF4] focus-visible:ring-2 focus-visible:ring-[#606AF4]/15 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=lg]:h-12 data-[size=sm]:h-8 data-[slot=select-value]:*:line-clamp-1 data-[slot=select-value]:*:flex data-[slot=select-value]:*:items-center data-[slot=select-value]:*:gap-2 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800 dark:focus-visible:border-[#8f95ff] dark:focus-visible:ring-[#8f95ff]/15 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -70,7 +70,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xs border bg-gray-100 shadow-md dark:border-neutral-700 dark:bg-neutral-800 dark:text-white',
+          'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-gray-200 bg-white text-gray-900 shadow-md dark:border-neutral-700 dark:bg-neutral-800 dark:text-white',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,
@@ -116,7 +116,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-xs py-1.5 pr-8 pl-2 text-sm outline-hidden select-none hover:bg-gray-200/50 data-disabled:pointer-events-none data-disabled:opacity-50 dark:text-white dark:hover:bg-neutral-700 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 last:[span]:*:flex last:[span]:*:items-center last:[span]:*:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-hidden select-none hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50 dark:text-white dark:hover:bg-neutral-700 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 last:[span]:*:flex last:[span]:*:items-center last:[span]:*:gap-2",
         className,
       )}
       {...props}

--- a/client/www/components/ui.tsx
+++ b/client/www/components/ui.tsx
@@ -97,7 +97,7 @@ export function NavTabBar({
   return (
     <div
       className={clsx(
-        'no-scrollbar flex flex-row gap-4 overflow-x-auto border-b py-1',
+        'no-scrollbar flex flex-row gap-1 overflow-x-auto rounded-md border border-gray-200 bg-white p-1 text-sm shadow-xs dark:border-neutral-700 dark:bg-neutral-900',
         className,
       )}
     >
@@ -108,9 +108,10 @@ export function NavTabBar({
             {...t.link}
             rel="noopener noreferrer"
             className={clsx(
-              'flex cursor-pointer rounded bg-none p-2 py-0.5 whitespace-nowrap disabled:text-gray-400',
+              'flex cursor-pointer rounded px-3 py-1.5 whitespace-nowrap text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-950 disabled:text-gray-400 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-white',
               {
-                'bg-gray-200': selectedId === t.id && !disabled,
+                'bg-gray-100 font-semibold text-gray-950 dark:bg-neutral-800 dark:text-white':
+                  selectedId === t.id && !disabled,
               },
             )}
           >
@@ -122,9 +123,9 @@ export function NavTabBar({
             disabled={disabled}
             onClick={() => onSelect(t)}
             className={clsx(
-              'flex cursor-pointer rounded bg-none whitespace-nowrap decoration-gray-400 transition-colors hover:underline disabled:text-gray-400',
+              'flex cursor-pointer rounded px-3 py-1.5 whitespace-nowrap text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-950 disabled:text-gray-400 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-white',
               {
-                'underline decoration-[#606AF4]! decoration-2':
+                'bg-gray-100 font-semibold text-gray-950 dark:bg-neutral-800 dark:text-white':
                   selectedId === t.id && !disabled,
               },
             )}
@@ -153,7 +154,7 @@ export function TabBar({
   return (
     <div
       className={clsx(
-        'no-scrollbar flex flex-row gap-0.5 overflow-x-auto border-b px-2 py-1 dark:border-b-neutral-700',
+        'no-scrollbar flex flex-row gap-1 overflow-x-auto border-b border-gray-200 px-3 py-2 text-sm dark:border-b-neutral-700',
         className,
       )}
     >
@@ -164,9 +165,9 @@ export function TabBar({
             {...t.link}
             rel=""
             className={clsx(
-              'flex cursor-pointer rounded bg-none px-4 py-0.5 whitespace-nowrap hover:bg-gray-100 disabled:text-gray-400 dark:hover:bg-neutral-600',
+              'flex cursor-pointer rounded-md px-3 py-1.5 whitespace-nowrap text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-950 disabled:text-gray-400 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-white',
               {
-                'bg-gray-200 dark:bg-neutral-700':
+                'bg-gray-100 font-semibold text-gray-950 dark:bg-neutral-700 dark:text-white':
                   selectedId === t.id && !disabled,
               },
             )}
@@ -179,9 +180,9 @@ export function TabBar({
             disabled={disabled}
             onClick={() => onSelect(t)}
             className={clsx(
-              'flex cursor-pointer rounded bg-none px-4 py-0.5 whitespace-nowrap hover:bg-gray-100 disabled:text-gray-400 dark:hover:bg-neutral-600',
+              'flex cursor-pointer rounded-md px-3 py-1.5 whitespace-nowrap text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-950 disabled:text-gray-400 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-white',
               {
-                'bg-gray-200 dark:bg-neutral-700':
+                'bg-gray-100 font-semibold text-gray-950 dark:bg-neutral-700 dark:text-white':
                   selectedId === t.id && !disabled,
               },
             )}

--- a/client/www/pages/dash-redesign/CLAUDE.md
+++ b/client/www/pages/dash-redesign/CLAUDE.md
@@ -33,7 +33,3 @@ When asked to add a new page to the redesign viewer:
 
 - This file is a **viewer**, not the real app. Don't add real navigation, real mutations, or analytics here.
 - Once `index.tsx` gets unwieldy (~1000+ lines), suggest splitting views into separate files. Next.js pages router treats `_`-prefixed files/folders as non-routes, so something like `pages/dash-redesign/_views/HomeView.tsx` would work — or move the components to `components/dash-redesign/` and import them.
-
-## Reference: design system
-
-See `./design_system/dashboard-patterns.md` and `./design_system/README.md` (inside this folder) for the broader brand and dashboard conventions (colors, typography, layout patterns, dark mode mapping, destructive flows, etc.). When redesigning, those are the source of truth.

--- a/client/www/pages/dash-redesign/_views/Admin/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Admin/Current.tsx
@@ -1,13 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import {
   ActionForm,
   Button,
   Checkbox,
   Content,
-  Copyable,
   Dialog,
-  Divider,
   Label,
   SectionHeading,
   Select,
@@ -16,6 +14,12 @@ import {
 } from '@/components/ui';
 import {
   DashShell,
+  DashPage,
+  DashPanel,
+  DashPanelHeader,
+  DashRow,
+  DashNotice,
+  DashSecretField,
   EphemeralError,
   EphemeralLoading,
   useEphemeralInstantApp,
@@ -34,10 +38,12 @@ function DocsCard({
   return (
     <a
       href={href}
-      className="block cursor-pointer justify-start space-y-2 rounded-sm border bg-white p-4 shadow-xs transition-colors hover:bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700/50"
+      className="block cursor-pointer justify-start rounded-md border border-gray-200 bg-[#fbfaf8] p-3 transition-colors hover:border-gray-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
     >
       <div>
-        <div className="font-bold">{title}</div>
+        <div className="font-semibold text-gray-950 dark:text-white">
+          {title}
+        </div>
         <div className="text-sm text-gray-500 dark:text-neutral-400">
           {children}
         </div>
@@ -53,7 +59,6 @@ function AdminBody({
   adminToken: string;
   appTitle: string;
 }) {
-  const [hideAdminToken, setHideAdminToken] = useState(true);
   const [appName, setAppName] = useState(appTitle);
 
   const members = [
@@ -66,109 +71,121 @@ function AdminBody({
   ];
 
   return (
-    <div className="flex h-full max-w-2xl flex-col gap-4 p-4">
-      <SectionHeading className="pt-4">Admin SDK</SectionHeading>
-      <DocsCard href="/docs/backend" title="Instant and your backend">
-        Learn how to use the Admin SDK to integrate Instant with your backend.
-      </DocsCard>
-      <Content>
-        Use the admin token below to authenticate with your backend. Keep this
-        token a secret. If need be, you can regenerate it by{' '}
-        <a className="hover:cursor-pointer dark:text-white" href="#">
-          clicking here
-        </a>
-        .
-      </Content>
-      <Copyable
-        onChangeHideValue={() => setHideAdminToken(!hideAdminToken)}
-        hideValue={hideAdminToken}
-        label="Secret"
-        value={adminToken}
-      />
-      <Divider />
+    <DashPage size="wide">
+      <div>
+        <SectionHeading>Admin</SectionHeading>
+        <Content className="mt-1">
+          Manage backend access, app ownership, and destructive operations for
+          this app.
+        </Content>
+      </div>
 
-      <form
-        className="flex flex-col gap-2"
-        onSubmit={(e) => e.preventDefault()}
-      >
-        <TextInput
-          label="App name"
-          placeholder="My awesome app"
-          value={appName}
-          onChange={setAppName}
-        />
-        <Button variant="secondary">Update app name</Button>
-      </form>
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)]">
+        <div className="flex flex-col gap-4">
+          <DashPanel>
+            <DashPanelHeader
+              title="Admin SDK"
+              description="Use this token from trusted backend environments only."
+            />
+            <div className="space-y-4">
+              <DocsCard href="/docs/backend" title="Instant and your backend">
+                Learn how to integrate Instant with your backend.
+              </DocsCard>
+              <Content>
+                Regenerate the token if it has been exposed or needs to be
+                rotated.
+              </Content>
+              <DashSecretField
+                label="Secret"
+                value={adminToken}
+                description="Admin token"
+              />
+            </div>
+          </DashPanel>
 
-      <div className="flex flex-col gap-1">
-        <SectionHeading>Team Members</SectionHeading>
-        <SubsectionHeading>Members</SubsectionHeading>
-        {members.length ? (
-          <div className="flex flex-col gap-1">
-            {members.map((member) => (
-              <div
-                key={member.id}
-                className="flex items-center justify-between gap-3"
-              >
-                <div className="flex flex-1 justify-between">
-                  <div>{member.email}</div>
-                  <div className="text-gray-400 dark:text-neutral-400">
-                    {member.role[0].toUpperCase() + member.role.slice(1)}
-                  </div>
-                </div>
-                <div className="flex w-28">
-                  <Button className="w-full" variant="secondary">
-                    Edit
-                  </Button>
+          <DashPanel>
+            <DashPanelHeader
+              title="Danger zone"
+              description="These actions permanently remove app data."
+            />
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Button variant="destructive">
+                <TrashIcon height="1rem" /> Clear app
+              </Button>
+              <Button variant="destructive">
+                <TrashIcon height="1rem" /> Delete app
+              </Button>
+            </div>
+          </DashPanel>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <DashPanel>
+            <DashPanelHeader title="App settings" />
+            <form
+              className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end"
+              onSubmit={(e) => e.preventDefault()}
+            >
+              <TextInput
+                label="App name"
+                size="large"
+                placeholder="My awesome app"
+                value={appName}
+                onChange={setAppName}
+              />
+              <Button variant="secondary" size="large">
+                Save name
+              </Button>
+            </form>
+          </DashPanel>
+
+          <DashPanel>
+            <DashPanelHeader
+              title="Team members"
+              description="Admins can manage app settings and team access."
+              action={<Button variant="secondary">Invite member</Button>}
+            />
+            {members.length ? (
+              <div>
+                {members.map((member) => (
+                  <DashRow
+                    key={member.id}
+                    label={member.email}
+                    value={member.role[0].toUpperCase() + member.role.slice(1)}
+                    action={
+                      <Button size="mini" variant="secondary">
+                        Edit
+                      </Button>
+                    }
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-gray-500 dark:text-neutral-400">
+                No team members
+              </div>
+            )}
+          </DashPanel>
+
+          <DashPanel>
+            <DashPanelHeader
+              title="Transfer app"
+              description="Move this app to another organization."
+            />
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+              <div className="flex flex-col gap-1">
+                <Label>Destination organization</Label>
+                <div className="flex min-h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3.5 py-2 text-sm shadow-xs dark:border-neutral-700 dark:bg-neutral-900">
+                  <span>my-new-org</span>
+                  <span className="text-gray-400">▾</span>
                 </div>
               </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-gray-400 dark:text-neutral-400">
-            No team members
-          </div>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <Button variant="secondary">Invite a team member</Button>
-      </div>
-
-      <div>
-        <SectionHeading className="pt-4">Transfer App</SectionHeading>
-        <div className="flex flex-col gap-2">
-          <div className="flex flex-col gap-1 pt-2">
-            <Label className="font-normal opacity-70">
-              Destination Organization
-            </Label>
-            <div className="flex w-full items-center justify-between rounded-xs border border-gray-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-700/40">
-              <span>my-new-org</span>
-              <span className="text-gray-400">▾</span>
+              <Button variant="secondary">Transfer</Button>
             </div>
-          </div>
-          <div>
-            <Button variant="secondary">Transfer app</Button>
-          </div>
+          </DashPanel>
         </div>
       </div>
-
-      <div className="mt-auto space-y-2 pb-4">
-        <SectionHeading className="pt-4">Danger zone</SectionHeading>
-        <Content>
-          These are destructive actions and will irreversibly delete associated
-          data.
-        </Content>
-        <div className="flex flex-col space-y-6">
-          <Button variant="destructive">
-            <TrashIcon height="1rem" /> Clear app
-          </Button>
-          <Button variant="destructive">
-            <TrashIcon height="1rem" /> Delete app
-          </Button>
-        </div>
-      </div>
-    </div>
+    </DashPage>
   );
 }
 
@@ -183,13 +200,36 @@ function EditMemberDialog({
   return (
     <Dialog title="Edit Member" open={open} onClose={onClose}>
       <div className="flex flex-col gap-4">
-        <h5 className="flex items-center text-lg font-bold">
-          Edit team member
-        </h5>
-        <Button variant="primary">Promote to admin</Button>
-        <Button className="w-full" variant="destructive">
-          Remove from team
-        </Button>
+        <div>
+          <SubsectionHeading>Edit team member</SubsectionHeading>
+          <Content className="mt-1">
+            collab@example.com currently has collaborator access.
+          </Content>
+        </div>
+        <div className="rounded-md border border-gray-200 dark:border-neutral-800">
+          <div className="flex items-center justify-between gap-4 border-b border-gray-100 p-3 dark:border-neutral-800">
+            <div>
+              <div className="text-sm font-semibold text-gray-950 dark:text-white">
+                Role
+              </div>
+              <Content className="text-sm">
+                Allow app and schema changes.
+              </Content>
+            </div>
+            <Button variant="primary">Promote</Button>
+          </div>
+          <div className="flex items-center justify-between gap-4 p-3">
+            <div>
+              <div className="text-sm font-semibold text-red-700 dark:text-red-300">
+                Remove access
+              </div>
+              <Content className="text-sm">
+                Remove this member from the app.
+              </Content>
+            </div>
+            <Button variant="destructive">Remove</Button>
+          </div>
+        </div>
       </div>
     </Dialog>
   );
@@ -207,18 +247,18 @@ function InviteMemberDialog({
   return (
     <Dialog title="Invite Members" open={open} onClose={onClose}>
       <ActionForm className="flex flex-col gap-4">
-        <h5 className="flex items-center text-lg font-bold">
-          Invite a team member
-        </h5>
+        <SubsectionHeading>Invite a team member</SubsectionHeading>
         <TextInput
           label="Email"
           type="email"
+          size="large"
           value={email}
           onChange={setEmail}
         />
         <div className="flex flex-col gap-1">
           <Label>Role</Label>
           <Select
+            size="lg"
             value={role}
             onChange={(o) => o && setRole(o.value as 'admin' | 'collaborator')}
             options={[
@@ -227,9 +267,24 @@ function InviteMemberDialog({
             ]}
           />
         </div>
-        <Button type="submit" variant="primary" disabled={!email}>
-          Invite
-        </Button>
+        <div className="flex justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button
+            type="button"
+            variant="secondary"
+            size="large"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            size="large"
+            disabled={!email}
+          >
+            Invite
+          </Button>
+        </div>
       </ActionForm>
     </Dialog>
   );
@@ -245,11 +300,11 @@ function ClearAppDialog({
   const [ok, setOk] = useState(false);
   return (
     <Dialog title="Clear App" open={open} onClose={onClose}>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <SubsectionHeading className="text-red-600">
           Clear app
         </SubsectionHeading>
-        <Content className="space-y-2">
+        <DashNotice tone="danger">
           <p>
             Clearing an app will irreversibly delete all namespaces, triples,
             and permissions.
@@ -262,15 +317,20 @@ function ClearAppDialog({
             This is equivalent to deleting all your namespaces in the explorer
             and clearing your permissions.
           </p>
-        </Content>
+        </DashNotice>
         <Checkbox
           checked={ok}
           onChange={(c) => setOk(c)}
           label="I understand and want to clear this app."
         />
-        <Button variant="destructive" disabled={!ok}>
-          Clear data
-        </Button>
+        <div className="flex justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button variant="secondary" size="large" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="destructive" size="large" disabled={!ok}>
+            Clear data
+          </Button>
+        </div>
       </div>
     </Dialog>
   );
@@ -286,21 +346,26 @@ function DeleteAppDialog({
   const [ok, setOk] = useState(false);
   return (
     <Dialog title="Delete App" open={open} onClose={onClose}>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <SubsectionHeading className="text-red-600">
           Delete app
         </SubsectionHeading>
-        <Content>
+        <DashNotice tone="danger">
           Deleting an app will irreversibly delete all associated data.
-        </Content>
+        </DashNotice>
         <Checkbox
           checked={ok}
           onChange={(c) => setOk(c)}
           label="I understand and want to delete this app."
         />
-        <Button variant="destructive" disabled={!ok}>
-          Delete
-        </Button>
+        <div className="flex justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button variant="secondary" size="large" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="destructive" size="large" disabled={!ok}>
+            Delete
+          </Button>
+        </div>
       </div>
     </Dialog>
   );
@@ -309,11 +374,9 @@ function DeleteAppDialog({
 export function Current({ sub = 'default' }: { sub?: AdminSubState }) {
   const ephemeral = useEphemeralInstantApp();
   const [openSub, setOpenSub] = useState<AdminSubState>(sub);
-  // sync external sub → internal open state on prop change
-  if (sub !== openSub && sub !== 'default') {
-    // pin to the sub the sidebar requested
-    setOpenSub(sub);
-  }
+  useEffect(() => {
+    if (sub !== 'default') setOpenSub(sub);
+  }, [sub]);
   if (ephemeral.status === 'loading') return <EphemeralLoading />;
   if (ephemeral.status === 'error') {
     return <EphemeralError error={ephemeral.error} reset={ephemeral.reset} />;

--- a/client/www/pages/dash-redesign/_views/AdminRams/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/AdminRams/Current.tsx
@@ -1,0 +1,577 @@
+import { ReactNode, useEffect, useState } from 'react';
+import {
+  ActionForm,
+  Button,
+  Checkbox,
+  Content,
+  Dialog,
+  Label,
+  Select,
+  TextInput,
+  cn,
+} from '@/components/ui';
+import {
+  DashShell,
+  EphemeralError,
+  EphemeralLoading,
+  useEphemeralInstantApp,
+} from '../_shared';
+import { AdminRamsSubState } from './index';
+
+type Role = 'owner' | 'admin' | 'collaborator';
+type Member = { id: string; email: string; role: Role };
+
+const MEMBERS: Member[] = [
+  { id: 'me', email: 'sto.pa@instantdb.com', role: 'owner' },
+  { id: '2', email: 'admin@example.com', role: 'admin' },
+  { id: '1', email: 'collab@example.com', role: 'collaborator' },
+];
+
+const PENDING = [{ id: 'i1', email: 'pending@example.com', role: 'collaborator' }];
+
+const roleLabel: Record<Role, string> = {
+  owner: 'Owner',
+  admin: 'Admin',
+  collaborator: 'Collaborator',
+};
+
+type Actions = {
+  invite: () => void;
+  edit: () => void;
+  clear: () => void;
+  remove: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Controls — the functional pieces, no chrome
+// ---------------------------------------------------------------------------
+
+function TextButton({
+  onClick,
+  children,
+  className,
+}: {
+  onClick?: () => void;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'text-[13px] text-neutral-500 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white',
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TokenControl({ token }: { token: string }) {
+  const [hidden, setHidden] = useState(true);
+  const [copied, setCopied] = useState(false);
+  const shown = hidden ? token.replace(/[^-]/g, '•') : token;
+  return (
+    <div className="max-w-xl">
+      <div className="flex items-stretch overflow-hidden rounded-md border border-neutral-300 bg-white dark:border-neutral-700 dark:bg-neutral-900">
+        <code className="min-w-0 flex-1 truncate px-3 py-2.5 font-mono text-[13px] text-neutral-800 dark:text-neutral-200">
+          {shown}
+        </code>
+        <button
+          type="button"
+          onClick={() => setHidden((v) => !v)}
+          className="border-l border-neutral-200 px-3 text-[13px] text-neutral-600 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+        >
+          {hidden ? 'Reveal' : 'Hide'}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            window.navigator.clipboard.writeText(token);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+          className="border-l border-neutral-200 px-3 text-[13px] text-neutral-600 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <TextButton className="mt-2">Regenerate token</TextButton>
+    </div>
+  );
+}
+
+function NameControl({ title }: { title: string }) {
+  const [name, setName] = useState(title);
+  return (
+    <form
+      className="flex max-w-xl flex-col gap-3 sm:flex-row sm:items-end"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <div className="flex-1">
+        <TextInput value={name} onChange={setName} placeholder="My app" />
+      </div>
+      <Button variant="secondary">Save</Button>
+    </form>
+  );
+}
+
+function MembersControl({
+  table,
+  actions,
+}: {
+  table?: boolean;
+  actions: Actions;
+}) {
+  if (table) {
+    return (
+      <div className="max-w-2xl">
+        <table className="w-full text-[13px]">
+          <thead>
+            <tr className="border-b border-neutral-200 text-left text-neutral-500 dark:border-neutral-700">
+              <th className="py-2 font-normal">Email</th>
+              <th className="py-2 font-normal">Role</th>
+              <th className="py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {MEMBERS.map((m) => (
+              <tr
+                key={m.id}
+                className="border-b border-neutral-100 dark:border-neutral-800"
+              >
+                <td className="py-2.5 text-neutral-900 dark:text-neutral-100">
+                  {m.email}
+                </td>
+                <td className="py-2.5 text-neutral-500 dark:text-neutral-400">
+                  {roleLabel[m.role]}
+                </td>
+                <td className="py-2.5 text-right">
+                  {m.role !== 'owner' ? (
+                    <TextButton onClick={actions.edit}>Edit</TextButton>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+            {PENDING.map((i) => (
+              <tr
+                key={i.id}
+                className="border-b border-neutral-100 dark:border-neutral-800"
+              >
+                <td className="py-2.5 text-neutral-500 dark:text-neutral-400">
+                  {i.email}
+                </td>
+                <td className="py-2.5 text-neutral-400">Pending</td>
+                <td className="py-2.5 text-right">
+                  <TextButton>Revoke</TextButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mt-3">
+          <Button variant="secondary" size="mini" onClick={actions.invite}>
+            Invite
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-xl">
+      <div>
+        {MEMBERS.map((m) => (
+          <div
+            key={m.id}
+            className="flex items-center justify-between gap-4 border-t border-neutral-100 py-2.5 first:border-t-0 dark:border-neutral-800"
+          >
+            <div className="min-w-0 truncate text-sm text-neutral-900 dark:text-neutral-100">
+              {m.email}
+            </div>
+            <div className="flex items-center gap-4">
+              <span className="text-[13px] text-neutral-500 dark:text-neutral-400">
+                {roleLabel[m.role]}
+              </span>
+              {m.role !== 'owner' ? (
+                <Button variant="secondary" size="mini" onClick={actions.edit}>
+                  Edit
+                </Button>
+              ) : (
+                <span className="w-[42px]" />
+              )}
+            </div>
+          </div>
+        ))}
+        {PENDING.map((i) => (
+          <div
+            key={i.id}
+            className="flex items-center justify-between gap-4 border-t border-neutral-100 py-2.5 dark:border-neutral-800"
+          >
+            <div className="min-w-0 truncate text-sm text-neutral-500 dark:text-neutral-400">
+              {i.email}
+            </div>
+            <div className="flex items-center gap-4">
+              <span className="text-[13px] text-neutral-400">Pending</span>
+              <Button variant="secondary" size="mini">
+                Revoke
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4">
+        <Button variant="secondary" onClick={actions.invite}>
+          Invite
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function TransferControl() {
+  const [org, setOrg] = useState('my-new-org');
+  return (
+    <div className="flex max-w-xl flex-col gap-3 sm:flex-row sm:items-end">
+      <div className="flex flex-1 flex-col gap-1">
+        <Label>Destination organization</Label>
+        <Select
+          value={org}
+          onChange={(o) => o && setOrg(o.value)}
+          options={[
+            { value: 'my-new-org', label: 'my-new-org' },
+            { value: 'side-projects', label: 'side-projects' },
+          ]}
+        />
+      </div>
+      <Button variant="secondary">Transfer</Button>
+    </div>
+  );
+}
+
+function DangerControl({ actions }: { actions: Actions }) {
+  return (
+    <div className="max-w-xl divide-y divide-neutral-100 dark:divide-neutral-800">
+      <div className="flex items-center justify-between gap-6 py-3 first:pt-0">
+        <div className="min-w-0">
+          <div className="text-sm text-neutral-900 dark:text-neutral-100">
+            Clear app
+          </div>
+          <div className="text-[13px] leading-5 text-neutral-500 dark:text-neutral-400">
+            Deletes all data. Keeps the app, keys, and members.
+          </div>
+        </div>
+        <Button variant="secondary" onClick={actions.clear}>
+          Clear
+        </Button>
+      </div>
+      <div className="flex items-center justify-between gap-6 py-3">
+        <div className="min-w-0">
+          <div className="text-sm text-neutral-900 dark:text-neutral-100">
+            Delete app
+          </div>
+          <div className="text-[13px] leading-5 text-neutral-500 dark:text-neutral-400">
+            Permanently deletes this app and all its data.
+          </div>
+        </div>
+        <Button variant="destructive" onClick={actions.remove}>
+          Delete
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sections — shared definition, rendered differently per layout
+// ---------------------------------------------------------------------------
+
+type SectionDef = {
+  id: string;
+  label: string;
+  hint?: string;
+  content: ReactNode;
+};
+
+function buildSections(
+  app: { admin_token: string; title: string },
+  actions: Actions,
+  table?: boolean,
+): SectionDef[] {
+  return [
+    {
+      id: 'token',
+      label: 'Admin token',
+      hint: 'Use only on the server.',
+      content: <TokenControl token={app.admin_token} />,
+    },
+    { id: 'name', label: 'Name', content: <NameControl title={app.title} /> },
+    {
+      id: 'members',
+      label: 'Members',
+      hint: 'People with access to this app.',
+      content: <MembersControl table={table} actions={actions} />,
+    },
+    {
+      id: 'transfer',
+      label: 'Transfer',
+      hint: 'Move this app to another organization.',
+      content: <TransferControl />,
+    },
+    {
+      id: 'danger',
+      label: 'Danger zone',
+      content: <DangerControl actions={actions} />,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Layouts
+// ---------------------------------------------------------------------------
+
+function ListLayout({ sections }: { sections: SectionDef[] }) {
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-10 md:px-10">
+      {sections.map((s) => (
+        <section
+          key={s.id}
+          className="grid gap-x-10 gap-y-3 border-neutral-200 py-9 first:pt-0 md:grid-cols-[11rem_minmax(0,1fr)] dark:border-neutral-800 [&:not(:first-child)]:border-t"
+        >
+          <div className="md:pt-0.5">
+            <h3 className="text-sm font-medium text-neutral-900 dark:text-white">
+              {s.label}
+            </h3>
+            {s.hint ? (
+              <p className="mt-1 text-[13px] leading-5 text-neutral-500 dark:text-neutral-400">
+                {s.hint}
+              </p>
+            ) : null}
+          </div>
+          <div>{s.content}</div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function SplitLayout({ sections }: { sections: SectionDef[] }) {
+  const [active, setActive] = useState(sections[0].id);
+  const current = sections.find((s) => s.id === active) ?? sections[0];
+  return (
+    <div className="mx-auto flex w-full max-w-4xl">
+      <nav className="w-48 shrink-0 border-r border-neutral-200 px-3 py-8 dark:border-neutral-800">
+        {sections.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            onClick={() => setActive(s.id)}
+            className={cn(
+              'block w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
+              active === s.id
+                ? 'bg-white font-medium text-neutral-900 shadow-xs dark:bg-neutral-900 dark:text-white'
+                : 'text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white',
+            )}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+      <div className="min-w-0 flex-1 px-8 py-9">
+        <h3 className="text-sm font-medium text-neutral-900 dark:text-white">
+          {current.label}
+        </h3>
+        {current.hint ? (
+          <p className="mt-1 text-[13px] leading-5 text-neutral-500 dark:text-neutral-400">
+            {current.hint}
+          </p>
+        ) : null}
+        <div className="mt-5">{current.content}</div>
+      </div>
+    </div>
+  );
+}
+
+function TableLayout({ sections }: { sections: SectionDef[] }) {
+  return (
+    <div className="mx-auto w-full max-w-2xl px-6 py-8 md:px-8">
+      {sections.map((s) => (
+        <section
+          key={s.id}
+          className="border-neutral-200 py-6 first:pt-0 dark:border-neutral-800 [&:not(:first-child)]:border-t"
+        >
+          <div className="mb-3 flex items-baseline justify-between gap-3">
+            <h3 className="text-sm font-semibold text-neutral-900 dark:text-white">
+              {s.label}
+            </h3>
+            {s.hint ? (
+              <span className="text-[13px] text-neutral-400">{s.hint}</span>
+            ) : null}
+          </div>
+          {s.content}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dialogs
+// ---------------------------------------------------------------------------
+
+function EditMemberDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog title="Edit member" open={open} onClose={onClose}>
+      <div className="flex flex-col gap-4">
+        <div className="text-sm text-neutral-600 dark:text-neutral-300">
+          collab@example.com · Collaborator
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button variant="secondary" className="flex-1">
+            Promote to admin
+          </Button>
+          <Button variant="destructive" className="flex-1">
+            Remove
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function InviteMemberDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<'admin' | 'collaborator'>('collaborator');
+  return (
+    <Dialog title="Invite member" open={open} onClose={onClose}>
+      <ActionForm className="flex flex-col gap-4">
+        <TextInput
+          label="Email"
+          type="email"
+          size="large"
+          value={email}
+          onChange={setEmail}
+        />
+        <div className="flex flex-col gap-1">
+          <Label>Role</Label>
+          <Select
+            size="lg"
+            value={role}
+            onChange={(o) => o && setRole(o.value as 'admin' | 'collaborator')}
+            options={[
+              { value: 'admin', label: 'Admin' },
+              { value: 'collaborator', label: 'Collaborator' },
+            ]}
+          />
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="secondary" size="large" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="large" disabled={!email}>
+            Invite
+          </Button>
+        </div>
+      </ActionForm>
+    </Dialog>
+  );
+}
+
+function ConfirmDialog({
+  open,
+  onClose,
+  title,
+  cta,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  cta: string;
+  children: ReactNode;
+}) {
+  const [ok, setOk] = useState(false);
+  useEffect(() => {
+    if (!open) setOk(false);
+  }, [open]);
+  return (
+    <Dialog title={title} open={open} onClose={onClose}>
+      <div className="flex flex-col gap-4">
+        <Content className="text-sm">{children}</Content>
+        <Checkbox checked={ok} onChange={setOk} label="I understand this can't be undone." />
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="secondary" size="large" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="destructive" size="large" disabled={!ok}>
+            {cta}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+export function Current({ sub = 'list' }: { sub?: AdminRamsSubState }) {
+  const ephemeral = useEphemeralInstantApp();
+  const [dialog, setDialog] = useState<
+    null | 'invite' | 'edit' | 'clear' | 'delete'
+  >(null);
+
+  if (ephemeral.status === 'loading') return <EphemeralLoading />;
+  if (ephemeral.status === 'error') {
+    return <EphemeralError error={ephemeral.error} reset={ephemeral.reset} />;
+  }
+  const app = ephemeral.app;
+  const close = () => setDialog(null);
+  const actions: Actions = {
+    invite: () => setDialog('invite'),
+    edit: () => setDialog('edit'),
+    clear: () => setDialog('clear'),
+    remove: () => setDialog('delete'),
+  };
+
+  return (
+    <DashShell active="admin" app={app}>
+      <AdminRamsContent sub={sub} app={app} actions={actions} />
+      <EditMemberDialog open={dialog === 'edit'} onClose={close} />
+      <InviteMemberDialog open={dialog === 'invite'} onClose={close} />
+      <ConfirmDialog
+        open={dialog === 'clear'}
+        onClose={close}
+        title="Clear app"
+        cta="Clear data"
+      >
+        Deletes all namespaces, triples, and permissions. The app id, admin
+        token, users, billing, and members stay.
+      </ConfirmDialog>
+      <ConfirmDialog
+        open={dialog === 'delete'}
+        onClose={close}
+        title="Delete app"
+        cta="Delete"
+      >
+        Permanently deletes this app and everything in it.
+      </ConfirmDialog>
+    </DashShell>
+  );
+}
+
+function AdminRamsContent({
+  sub,
+  app,
+  actions,
+}: {
+  sub: AdminRamsSubState;
+  app: { admin_token: string; title: string };
+  actions: Actions;
+}) {
+  const sections = buildSections(app, actions, sub === 'table');
+  if (sub === 'split') return <SplitLayout sections={sections} />;
+  if (sub === 'table') return <TableLayout sections={sections} />;
+  return <ListLayout sections={sections} />;
+}

--- a/client/www/pages/dash-redesign/_views/AdminRams/index.tsx
+++ b/client/www/pages/dash-redesign/_views/AdminRams/index.tsx
@@ -1,0 +1,12 @@
+export { Current as AdminRamsView } from './Current';
+
+export type AdminRamsSubState = 'list' | 'split' | 'table';
+
+export const ADMIN_RAMS_SUB_STATES: {
+  key: AdminRamsSubState;
+  label: string;
+}[] = [
+  { key: 'list', label: 'List' },
+  { key: 'split', label: 'Split' },
+  { key: 'table', label: 'Table' },
+];

--- a/client/www/pages/dash-redesign/_views/Auth/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Auth/Current.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { PlusIcon } from '@heroicons/react/24/solid';
 
-import { Button, Content, Divider, SectionHeading } from '@/components/ui';
+import { Button, Content, SectionHeading } from '@/components/ui';
 import config from '@/lib/config';
 import { useAuthedFetch } from '@/lib/auth';
 import { TokenContext } from '@/lib/contexts';
@@ -51,7 +51,15 @@ import linkedinIconSvg from '../../../../public/img/linkedin.svg';
 import clerkLogoSvg from '../../../../public/img/clerk_logo_black.svg';
 import firebaseLogoSvg from '../../../../public/img/firebase_auth.svg';
 
-import { DashShell, useFetchedDash } from '../_shared';
+import {
+  DashPanel,
+  DashPanelHeader,
+  DashPage,
+  DashEmptyState,
+  DashNotice,
+  DashShell,
+  useFetchedDash,
+} from '../_shared';
 import { AuthSubState } from './index';
 
 // -------------- mock data --------------
@@ -122,11 +130,10 @@ function planForSubState(real: AppsAuthResponse, sub: AuthSubState): Plan {
       return {
         ...base,
         data: { ...real, oauth_clients: [] },
-        scrollTo: 'auth-clients',
       };
 
     case 'clients-overview':
-      return { ...base, scrollTo: 'auth-clients' };
+      return base;
 
     case 'picker':
       return {
@@ -287,7 +294,7 @@ function ProviderPickerButton({
   return (
     <button
       onClick={onClick}
-      className="flex cursor-pointer flex-col items-center gap-2 rounded border p-4 transition-colors hover:bg-gray-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+      className="flex cursor-pointer flex-col items-center gap-2 rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 hover:bg-[#fbfaf8] dark:border-neutral-800 dark:bg-neutral-950 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
     >
       <Image
         alt={`${cfg.label} icon`}
@@ -309,9 +316,12 @@ function ProviderPicker({
   onCancel: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-4 rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
-      <SectionHeading>Select auth provider</SectionHeading>
-      <div className="grid grid-cols-3 gap-2">
+    <div className="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-4 shadow-xs dark:border-neutral-800 dark:bg-neutral-900">
+      <DashPanelHeader
+        title="Select auth provider"
+        description="Choose a provider to configure for sign in."
+      />
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
         {PROVIDER_ORDER.map((providerType) => (
           <ProviderPickerButton
             key={providerType}
@@ -564,47 +574,40 @@ function ClientItem({
 
 function EmptyState({ onAddClient }: { onAddClient: () => void }) {
   return (
-    <div className="flex flex-col items-center gap-4 rounded-sm border border-dashed bg-white p-8 text-center dark:border-neutral-700 dark:bg-neutral-800">
-      <div className="flex gap-2">
-        {PROVIDER_ORDER.slice(0, 4).map((providerType) => (
-          <Image
-            key={providerType}
-            alt={`${PROVIDER_CONFIG[providerType].label} icon`}
-            src={PROVIDER_CONFIG[providerType].icon}
-            width={20}
-            height={20}
-            className={
-              PROVIDER_CONFIG[providerType].darkInvert
-                ? 'opacity-40 dark:opacity-80 dark:invert'
-                : 'opacity-40 dark:opacity-80'
-            }
-          />
-        ))}
-      </div>
-      <div className="flex flex-col gap-1">
-        <div className="dark:text-white">
-          <strong>No OAuth clients configured</strong>
+    <DashEmptyState
+      title="No OAuth clients configured"
+      description="Add an auth client to enable social login or third-party authentication for your app."
+      action={
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex gap-2">
+            {PROVIDER_ORDER.slice(0, 4).map((providerType) => (
+              <Image
+                key={providerType}
+                alt={`${PROVIDER_CONFIG[providerType].label} icon`}
+                src={PROVIDER_CONFIG[providerType].icon}
+                width={20}
+                height={20}
+                className={
+                  PROVIDER_CONFIG[providerType].darkInvert
+                    ? 'opacity-40 dark:opacity-80 dark:invert'
+                    : 'opacity-40 dark:opacity-80'
+                }
+              />
+            ))}
+          </div>
+          <Button onClick={onAddClient} variant="secondary">
+            <PlusIcon height={14} /> Add client
+          </Button>
         </div>
-        <Content>
-          Add an auth client to enable social login or third-party
-          authentication for your app.
-        </Content>
-      </div>
-      <Button onClick={onAddClient} variant="secondary">
-        <PlusIcon height={14} /> Add client
-      </Button>
-    </div>
+      }
+    />
   );
 }
 
 // -------------- body --------------
 
 function SubStateBanner({ message }: { message: string }) {
-  return (
-    <div className="mb-3 rounded-sm border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-200">
-      {message}
-    </div>
-  );
+  return <DashNotice tone="warning">{message}</DashNotice>;
 }
 
 function AuthBody({
@@ -728,84 +731,94 @@ function AuthBody({
   const expandedClientId = plan.defaultOpenClientId ?? lastCreatedClientId;
 
   return (
-    <div className="flex max-w-xl flex-col gap-6 p-4">
+    <DashPage size="wide">
+      <div>
+        <SectionHeading>Auth</SectionHeading>
+        <Content className="mt-1">
+          Configure OAuth clients, redirect origins, test users, and magic code
+          email for this app.
+        </Content>
+      </div>
       {plan.banner && <SubStateBanner message={plan.banner} />}
 
-      <div ref={clientsRef} className="flex flex-col gap-4">
-        <SectionHeading>Auth Clients</SectionHeading>
-
-        {!hasClients && !showAddFlow && (
-          <EmptyState onAddClient={() => setShowAddFlow(true)} />
-        )}
-
-        {hasClients && (
-          <div className="flex flex-col gap-2">
-            {clients.map((client) => {
-              const provider = providersById[client.provider_id];
-              const providerName = provider?.provider_name || 'unknown';
-              const open = client.id === expandedClientId;
-              return (
-                <ClientItem
-                  key={open ? `${client.id}-open` : client.id}
-                  app={app}
-                  client={client}
-                  providerName={providerName}
-                  onUpdateClient={handleUpdateClient}
-                  onDeleteClient={handleDeleteClient}
-                  defaultOpen={open}
-                />
-              );
-            })}
-          </div>
-        )}
-
-        {(hasClients || showAddFlow) && (
-          <AddClientFlow
-            key={
-              showAddFlow
-                ? `adding-${plan.initialFlowState.step}-${
-                    plan.initialFlowState.step === 'configuring'
-                      ? plan.initialFlowState.providerType
-                      : ''
-                  }`
-                : 'idle'
-            }
-            app={app}
-            providers={providersByName}
-            usedClientNames={usedClientNames}
-            onAddProvider={handleAddProvider}
-            onAddClient={handleAddClient}
-            onCancel={() => setShowAddFlow(false)}
-            initialFlowState={
-              showAddFlow ? plan.initialFlowState : { step: 'idle' }
-            }
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.8fr)]">
+        <DashPanel ref={clientsRef} className="min-w-0">
+          <DashPanelHeader
+            title="Auth clients"
+            description="Enable social login or third-party authentication."
           />
-        )}
+
+          {!hasClients && !showAddFlow && (
+            <EmptyState onAddClient={() => setShowAddFlow(true)} />
+          )}
+
+          {hasClients && (
+            <div className="flex flex-col gap-3">
+              {clients.map((client) => {
+                const provider = providersById[client.provider_id];
+                const providerName = provider?.provider_name || 'unknown';
+                const open = client.id === expandedClientId;
+                return (
+                  <ClientItem
+                    key={open ? `${client.id}-open` : client.id}
+                    app={app}
+                    client={client}
+                    providerName={providerName}
+                    onUpdateClient={handleUpdateClient}
+                    onDeleteClient={handleDeleteClient}
+                    defaultOpen={open}
+                  />
+                );
+              })}
+            </div>
+          )}
+
+          {(hasClients || showAddFlow) && (
+            <div className="mt-4">
+              <AddClientFlow
+                key={
+                  showAddFlow
+                    ? `adding-${plan.initialFlowState.step}-${
+                        plan.initialFlowState.step === 'configuring'
+                          ? plan.initialFlowState.providerType
+                          : ''
+                      }`
+                    : 'idle'
+                }
+                app={app}
+                providers={providersByName}
+                usedClientNames={usedClientNames}
+                onAddProvider={handleAddProvider}
+                onAddClient={handleAddClient}
+                onCancel={() => setShowAddFlow(false)}
+                initialFlowState={
+                  showAddFlow ? plan.initialFlowState : { step: 'idle' }
+                }
+              />
+            </div>
+          )}
+        </DashPanel>
+
+        <div className="flex min-w-0 flex-col gap-4">
+          <DashPanel ref={originsRef}>
+            <AuthorizedOrigins
+              app={app}
+              origins={data.authorized_redirect_origins || []}
+              onAddOrigin={handleAddOrigin}
+              onRemoveOrigin={handleRemoveOrigin}
+            />
+          </DashPanel>
+
+          <DashPanel ref={testUsersRef}>
+            <TestUsers app={app} />
+          </DashPanel>
+        </div>
       </div>
 
-      <Divider />
-
-      <div ref={originsRef}>
-        <AuthorizedOrigins
-          app={app}
-          origins={data.authorized_redirect_origins || []}
-          onAddOrigin={handleAddOrigin}
-          onRemoveOrigin={handleRemoveOrigin}
-        />
-      </div>
-
-      <Divider />
-
-      <div ref={testUsersRef}>
-        <TestUsers app={app} />
-      </div>
-
-      <Divider />
-
-      <div ref={emailRef}>
+      <DashPanel ref={emailRef} className="min-w-0">
         <Email app={app} />
-      </div>
-    </div>
+      </DashPanel>
+    </DashPage>
   );
 }
 

--- a/client/www/pages/dash-redesign/_views/Auth/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Auth/Current.tsx
@@ -1,8 +1,15 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { ReactNode, useContext, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
-import { PlusIcon } from '@heroicons/react/24/solid';
+import { PlusIcon, TrashIcon } from '@heroicons/react/24/solid';
 
-import { Button, Content, SectionHeading } from '@/components/ui';
+import {
+  BlockHeading,
+  Button,
+  cn,
+  Content,
+  SectionHeading,
+  TextInput,
+} from '@/components/ui';
 import config from '@/lib/config';
 import { useAuthedFetch } from '@/lib/auth';
 import { TokenContext } from '@/lib/contexts';
@@ -37,7 +44,11 @@ import {
   LinkedInClient,
   AddLinkedInClientForm,
 } from '@/components/dash/auth/LinkedIn';
-import { AuthorizedOrigins } from '@/components/dash/auth/Origins';
+import {
+  AuthorizedOrigins,
+  AuthorizedOriginRow,
+  AuthorizedOriginsForm,
+} from '@/components/dash/auth/Origins';
 import {
   FirebaseClient,
   AddFirebaseClientForm,
@@ -61,6 +72,7 @@ import {
   useFetchedDash,
 } from '../_shared';
 import { AuthSubState } from './index';
+import { AuthFlows, FlowIdea } from './Flows';
 
 // -------------- mock data --------------
 
@@ -126,6 +138,14 @@ function planForSubState(real: AppsAuthResponse, sub: AuthSubState): Plan {
   };
 
   switch (sub) {
+    case 'redesign-quiet-panels':
+    case 'redesign-quiet-rows':
+    case 'redesign-quiet-column':
+    case 'redesign-tracks':
+    case 'redesign-columns':
+    case 'redesign-focused':
+      return { ...base, data: populatedDemo(real) };
+
     case 'clients-empty':
       return {
         ...base,
@@ -235,6 +255,10 @@ function planForSubState(real: AppsAuthResponse, sub: AuthSubState): Plan {
 
     case 'magic-email':
       return { ...base, scrollTo: 'magic-email' };
+
+    // flow-* states are routed before this loader and never reach here.
+    default:
+      return base;
   }
 }
 
@@ -244,6 +268,22 @@ function ensureGoogleProvider(real: AppsAuthResponse): AppsAuthResponse {
   return {
     ...real,
     oauth_service_providers: [MOCK_GOOGLE_PROVIDER, ...providers],
+  };
+}
+
+// The redesign reads best with a populated app, so the two-method hierarchy is
+// legible. Inject a sample client + origins only when the real app has none.
+function populatedDemo(real: AppsAuthResponse): AppsAuthResponse {
+  const withClient =
+    (real.oauth_clients?.length ?? 0) > 0
+      ? real
+      : injectGoogleClient(real, MOCK_GOOGLE_CLIENT_CUSTOM);
+  return {
+    ...withClient,
+    authorized_redirect_origins:
+      (real.authorized_redirect_origins?.length ?? 0) > 0
+        ? real.authorized_redirect_origins
+        : MOCK_ORIGINS,
   };
 }
 
@@ -822,6 +862,890 @@ function AuthBody({
   );
 }
 
+// ============================================================
+// Redesign: auth organized by the two ways people sign in.
+//
+// Instead of four equal cards, the page groups around two "methods",
+// each owning its dependency:
+//   Social login → auth clients + redirect origins
+//   Magic codes  → magic-code email + test users (static codes)
+//
+// Variants share the same content (the *Inner components) and only
+// differ in chrome: three quiet/functional layouts and three bolder
+// "control panel" ones.
+// ============================================================
+
+type RedesignVariant =
+  | 'tracks'
+  | 'columns'
+  | 'focused'
+  | 'quiet-panels'
+  | 'quiet-rows'
+  | 'quiet-column';
+
+function expiryLabel(minutes?: number | null) {
+  switch (minutes ?? 10) {
+    case 60:
+      return '1 hour';
+    case 1440:
+      return '24 hours';
+    default:
+      return `${minutes ?? 10} minutes`;
+  }
+}
+
+// ---- shared content (the substance, free of any section chrome) ----
+// Each "inner" renders just the functional body; the bold and quiet variants
+// wrap them differently, so the layout exploration never duplicates logic.
+
+function ClientsInner({
+  app,
+  clients,
+  providersById,
+  providersByName,
+  usedClientNames,
+  onAddProvider,
+  onAddClient,
+  onUpdateClient,
+  onDeleteClient,
+}: {
+  app: InstantApp;
+  clients: OAuthClient[];
+  providersById: Record<string, OAuthServiceProvider>;
+  providersByName: Record<string, OAuthServiceProvider>;
+  usedClientNames: Set<string>;
+  onAddProvider: (provider: OAuthServiceProvider) => void;
+  onAddClient: (client: OAuthClient) => void;
+  onUpdateClient: (client: OAuthClient) => void;
+  onDeleteClient: (client: OAuthClient) => void;
+}) {
+  const [showAddFlow, setShowAddFlow] = useState(false);
+  const [lastCreatedClientId, setLastCreatedClientId] = useState<string | null>(
+    null,
+  );
+  const hasClients = clients.length > 0;
+  const handleAdd = (client: OAuthClient) => {
+    setLastCreatedClientId(client.id);
+    setShowAddFlow(false);
+    onAddClient(client);
+  };
+  return (
+    <>
+      {!hasClients && !showAddFlow && (
+        <EmptyState onAddClient={() => setShowAddFlow(true)} />
+      )}
+      {hasClients && (
+        <div className="flex flex-col gap-3">
+          {clients.map((client) => {
+            const provider = providersById[client.provider_id];
+            const providerName = provider?.provider_name || 'unknown';
+            const open = client.id === lastCreatedClientId;
+            return (
+              <ClientItem
+                key={open ? `${client.id}-open` : client.id}
+                app={app}
+                client={client}
+                providerName={providerName}
+                onUpdateClient={onUpdateClient}
+                onDeleteClient={onDeleteClient}
+                defaultOpen={open}
+              />
+            );
+          })}
+        </div>
+      )}
+      {(hasClients || showAddFlow) && (
+        <div className="mt-4">
+          <AddClientFlow
+            key={showAddFlow ? 'adding' : 'idle'}
+            app={app}
+            providers={providersByName}
+            usedClientNames={usedClientNames}
+            onAddProvider={onAddProvider}
+            onAddClient={handleAdd}
+            onCancel={() => setShowAddFlow(false)}
+            initialFlowState={showAddFlow ? { step: 'picking' } : { step: 'idle' }}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+function OriginsInner({
+  app,
+  origins,
+  onAdd,
+  onRemove,
+}: {
+  app: InstantApp;
+  origins: AuthorizedOrigin[];
+  onAdd: (origin: AuthorizedOrigin) => void;
+  onRemove: (origin: AuthorizedOrigin) => void;
+}) {
+  const [showForm, setShowForm] = useState(origins.length === 0);
+  return (
+    <div className="flex flex-col gap-2">
+      {origins.map((o) => (
+        <AuthorizedOriginRow
+          key={o.id}
+          app={app}
+          origin={o}
+          onRemoveOrigin={onRemove}
+        />
+      ))}
+      {showForm ? (
+        <AuthorizedOriginsForm
+          app={app}
+          onAddOrigin={(o) => {
+            setShowForm(false);
+            onAdd(o);
+          }}
+          onCancel={() => setShowForm(false)}
+        />
+      ) : (
+        <Button variant="secondary" onClick={() => setShowForm(true)}>
+          <PlusIcon height={14} /> Add an origin
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function EmailInner({ app }: { app: InstantApp }) {
+  const subject =
+    app.magic_code_email_template?.subject ||
+    '{code} is your code for {app_title}';
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-xs text-gray-400 dark:text-neutral-500">
+          Subject
+        </div>
+        <div className="mt-0.5 truncate font-mono text-sm text-gray-700 dark:text-neutral-300">
+          {subject}
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm text-gray-500 dark:text-neutral-400">
+          Expires after {expiryLabel(app.magic_code_expiry_minutes)}.
+        </span>
+        <Button variant="secondary">Customize</Button>
+      </div>
+    </div>
+  );
+}
+
+// Local-only test users (the viewer keeps state but makes no network calls).
+type LocalTestUser = { id: string; email: string; code: string };
+
+function TestUsersInner() {
+  const [users, setUsers] = useState<LocalTestUser[]>([
+    { id: 'seed', email: 'reviewer@example.com', code: '424242' },
+  ]);
+  const [showForm, setShowForm] = useState(false);
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('424242');
+
+  const valid = email.trim().length > 0 && /^\d{6}$/.test(code);
+  const add = () => {
+    if (!valid) return;
+    setUsers((u) => [
+      { id: crypto.randomUUID(), email: email.trim().toLowerCase(), code },
+      ...u,
+    ]);
+    setEmail('');
+    setCode('424242');
+    setShowForm(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {users.map((user) => (
+        <div
+          key={user.id}
+          className="flex items-center justify-between rounded-md border border-gray-200 bg-[#fbfaf8] px-3 py-2.5 dark:border-neutral-800 dark:bg-neutral-950"
+        >
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium text-gray-900 dark:text-white">
+              {user.email}
+            </span>
+            <span className="font-mono text-xs text-gray-500 dark:text-neutral-400">
+              code {user.code}
+            </span>
+          </div>
+          <button
+            type="button"
+            aria-label="Remove test user"
+            className="cursor-pointer text-gray-400 hover:text-red-500 dark:text-neutral-500 dark:hover:text-red-400"
+            onClick={() => setUsers((u) => u.filter((x) => x.id !== user.id))}
+          >
+            <TrashIcon height="1rem" />
+          </button>
+        </div>
+      ))}
+      {showForm ? (
+        <div className="flex items-start gap-2 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-800 dark:bg-neutral-950">
+          <div className="flex-1">
+            <TextInput
+              label="Email"
+              placeholder="test@example.com"
+              value={email}
+              onChange={setEmail}
+              autoFocus
+            />
+          </div>
+          <div className="w-32">
+            <TextInput
+              label="Code"
+              placeholder="123456"
+              value={code}
+              onChange={setCode}
+              error={
+                code && !/^\d{6}$/.test(code) ? 'Must be 6 digits' : undefined
+              }
+            />
+          </div>
+          <div className="pt-6">
+            <Button variant="primary" onClick={add} disabled={!valid}>
+              Add
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button variant="secondary" onClick={() => setShowForm(true)}>
+          <PlusIcon height={14} /> Add a test user
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ---- bold ("control panel") chrome ----
+
+// Small mono telemetry pill: a dot + uppercase label, like a status readout.
+function StatusPill({ on, children }: { on: boolean; children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 font-mono text-[11px] tracking-wider text-gray-500 uppercase dark:text-neutral-400">
+      <span
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          on ? 'bg-orange-500' : 'bg-gray-300 dark:bg-neutral-700',
+        )}
+      />
+      {children}
+    </span>
+  );
+}
+
+// The dominant hierarchy level: a big mono index, a Switzer title, a blurb,
+// and a live status line, all over a hairline rule.
+function MethodHeader({
+  index,
+  title,
+  blurb,
+  status,
+  compact,
+}: {
+  index: string;
+  title: string;
+  blurb: string;
+  status: ReactNode;
+  compact?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2 border-b border-gray-200 pb-3 sm:flex-row sm:items-start sm:justify-between dark:border-neutral-800">
+      <div className="flex items-baseline gap-3">
+        <span className="font-mono text-2xl leading-none font-bold tabular-nums text-orange-500">
+          {index}
+        </span>
+        <div>
+          <h3
+            className={cn(
+              'font-semibold tracking-tight text-gray-950 dark:text-white',
+              compact ? 'text-base' : 'text-xl',
+            )}
+          >
+            {title}
+          </h3>
+          <p className="mt-0.5 text-sm text-gray-600 dark:text-neutral-400">
+            {blurb}
+          </p>
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 sm:justify-end sm:pt-1">
+        {status}
+      </div>
+    </div>
+  );
+}
+
+// A block is the secondary level: hairline card, small label.
+function MethodBlock({
+  children,
+  nested,
+  className,
+}: {
+  children: ReactNode;
+  nested?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-gray-200 bg-white p-4 shadow-xs dark:border-neutral-800 dark:bg-neutral-900',
+        nested && 'border-l-2 border-l-orange-500/40',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function BlockLabel({
+  title,
+  hint,
+  badge,
+}: {
+  title: ReactNode;
+  hint?: ReactNode;
+  badge?: ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-start justify-between gap-3">
+      <div>
+        <BlockHeading>{title}</BlockHeading>
+        {hint ? <Content className="mt-0.5 text-sm">{hint}</Content> : null}
+      </div>
+      {badge ? <div className="shrink-0">{badge}</div> : null}
+    </div>
+  );
+}
+
+// Mono "dependency" note that ties a nested block to its parent method.
+function DependencyNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="mb-3 font-mono text-[11px] tracking-wider text-orange-500/80 uppercase">
+      ↳ {children}
+    </div>
+  );
+}
+
+// ---- quiet ("Dieter Rams") chrome: hierarchy from type + space, no decoration ----
+
+function QuietMethodTitle({
+  title,
+  meta,
+}: {
+  title: string;
+  meta?: ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <h3 className="text-lg font-semibold tracking-tight text-gray-950 dark:text-white">
+        {title}
+      </h3>
+      {meta ? (
+        <span className="text-sm text-gray-400 dark:text-neutral-500">
+          {meta}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function QuietItem({
+  title,
+  helper,
+  children,
+  className,
+}: {
+  title: ReactNode;
+  helper?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('py-5', className)}>
+      <div className="text-sm font-semibold text-gray-900 dark:text-white">
+        {title}
+      </div>
+      {helper ? (
+        <p className="mt-0.5 text-sm text-gray-500 dark:text-neutral-400">
+          {helper}
+        </p>
+      ) : null}
+      <div className="mt-3">{children}</div>
+    </div>
+  );
+}
+
+function FocusedSwitch({
+  value,
+  onChange,
+}: {
+  value: 'social' | 'magic';
+  onChange: (v: 'social' | 'magic') => void;
+}) {
+  const options: { id: 'magic' | 'social'; label: string }[] = [
+    { id: 'magic', label: '02 · Magic codes' },
+    { id: 'social', label: '01 · Social login' },
+  ];
+  return (
+    <div className="inline-flex rounded-md border border-gray-200 bg-white p-1 shadow-xs dark:border-neutral-800 dark:bg-neutral-900">
+      {options.map((o) => {
+        const active = o.id === value;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => onChange(o.id)}
+            className={cn(
+              'rounded-sm px-3 py-1.5 font-mono text-xs tracking-wider uppercase transition-colors',
+              active
+                ? 'bg-orange-500 text-white'
+                : 'text-gray-500 hover:text-gray-900 dark:text-neutral-400 dark:hover:text-white',
+            )}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function AuthRedesign({
+  app,
+  initialData,
+  variant,
+}: {
+  app: InstantApp;
+  initialData: AppsAuthResponse;
+  variant: RedesignVariant;
+}) {
+  const [data, setData] = useState<AppsAuthResponse>(initialData);
+  const [focusedMethod, setFocusedMethod] = useState<'social' | 'magic'>(
+    'magic',
+  );
+
+  const handleAddOrigin = (origin: AuthorizedOrigin) =>
+    setData((d) => ({
+      ...d,
+      authorized_redirect_origins: [
+        origin,
+        ...(d.authorized_redirect_origins || []),
+      ],
+    }));
+
+  const handleRemoveOrigin = (origin: AuthorizedOrigin) =>
+    setData((d) => ({
+      ...d,
+      authorized_redirect_origins: d.authorized_redirect_origins?.filter(
+        (o) => o.id !== origin.id,
+      ),
+    }));
+
+  const handleAddProvider = (provider: OAuthServiceProvider) =>
+    setData((d) => ({
+      ...d,
+      oauth_service_providers: [provider, ...(d.oauth_service_providers || [])],
+    }));
+
+  const handleAddClient = (client: OAuthClient) =>
+    setData((d) => ({
+      ...d,
+      oauth_clients: [client, ...(d.oauth_clients || [])],
+    }));
+
+  const handleDeleteClient = (client: OAuthClient) =>
+    setData((d) => ({
+      ...d,
+      oauth_clients: (d.oauth_clients || []).filter((c) => c.id !== client.id),
+    }));
+
+  const handleUpdateClient = (client: OAuthClient) =>
+    setData((d) => ({
+      ...d,
+      oauth_clients: (d.oauth_clients || []).map((c) =>
+        c.id !== client.id ? c : client,
+      ),
+    }));
+
+  const providersByName: Record<string, OAuthServiceProvider> =
+    data.oauth_service_providers?.reduce(
+      (acc: Record<string, OAuthServiceProvider>, p) => {
+        acc[p.provider_name] = p;
+        return acc;
+      },
+      {},
+    ) || {};
+
+  const providersById: Record<string, OAuthServiceProvider> =
+    data.oauth_service_providers?.reduce(
+      (acc: Record<string, OAuthServiceProvider>, p) => {
+        acc[p.id] = p;
+        return acc;
+      },
+      {},
+    ) || {};
+
+  const usedClientNames = new Set<string>();
+  for (const client of data.oauth_clients || []) {
+    usedClientNames.add(client.client_name);
+  }
+
+  const clients = data.oauth_clients || [];
+  const origins = data.authorized_redirect_origins || [];
+  const hasClients = clients.length > 0;
+  const hasCustomEmail = Boolean(app.magic_code_email_template);
+
+  // Shared content, wrapped differently by each variant.
+  const clientsInner = (
+    <ClientsInner
+      app={app}
+      clients={clients}
+      providersById={providersById}
+      providersByName={providersByName}
+      usedClientNames={usedClientNames}
+      onAddProvider={handleAddProvider}
+      onAddClient={handleAddClient}
+      onUpdateClient={handleUpdateClient}
+      onDeleteClient={handleDeleteClient}
+    />
+  );
+  const originsInner = (
+    <OriginsInner
+      app={app}
+      origins={origins}
+      onAdd={handleAddOrigin}
+      onRemove={handleRemoveOrigin}
+    />
+  );
+  const emailInner = <EmailInner app={app} />;
+  const testUsersInner = <TestUsersInner />;
+
+  // Plain, factual state lines for the quiet variants.
+  const socialMeta =
+    hasClients || origins.length > 0
+      ? `${clients.length} client${clients.length === 1 ? '' : 's'}, ${
+          origins.length
+        } origin${origins.length === 1 ? '' : 's'}`
+      : 'Not set up';
+  const magicMeta = hasCustomEmail ? 'Custom email' : 'Default email';
+
+  // ---- quiet · two panels (methods side by side, hairline-divided items) ----
+  if (variant === 'quiet-panels') {
+    return (
+      <DashPage size="wide">
+        <div className="grid gap-5 duration-500 animate-in fade-in lg:grid-cols-2">
+          <div className="rounded-lg border border-gray-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="border-b border-gray-100 px-5 py-4 dark:border-neutral-800">
+              <QuietMethodTitle title="Social login" meta={socialMeta} />
+            </div>
+            <div className="divide-y divide-gray-100 px-5 dark:divide-neutral-800">
+              <QuietItem title="Auth clients">{clientsInner}</QuietItem>
+              <QuietItem
+                title="Redirect origins"
+                helper="Allowed URLs for the OAuth redirect flow."
+              >
+                {originsInner}
+              </QuietItem>
+            </div>
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="border-b border-gray-100 px-5 py-4 dark:border-neutral-800">
+              <QuietMethodTitle title="Magic codes" meta={magicMeta} />
+            </div>
+            <div className="divide-y divide-gray-100 px-5 dark:divide-neutral-800">
+              <QuietItem title="Magic code email">{emailInner}</QuietItem>
+              <QuietItem
+                title="Test users"
+                helper="Codes that never expire."
+              >
+                {testUsersInner}
+              </QuietItem>
+            </div>
+          </div>
+        </div>
+      </DashPage>
+    );
+  }
+
+  // ---- quiet · settings rows (grouped containers, stacked) ----
+  if (variant === 'quiet-rows') {
+    return (
+      <DashPage size="narrow">
+        <div className="flex flex-col gap-8 duration-500 animate-in fade-in">
+          <section>
+            <QuietMethodTitle title="Social login" meta={socialMeta} />
+            <div className="mt-3 divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white px-5 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-900">
+              <QuietItem title="Auth clients">{clientsInner}</QuietItem>
+              <QuietItem
+                title="Redirect origins"
+                helper="Allowed URLs for the OAuth redirect flow."
+              >
+                {originsInner}
+              </QuietItem>
+            </div>
+          </section>
+          <section>
+            <QuietMethodTitle title="Magic codes" meta={magicMeta} />
+            <div className="mt-3 divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white px-5 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-900">
+              <QuietItem title="Magic code email">{emailInner}</QuietItem>
+              <QuietItem
+                title="Test users"
+                helper="Codes that never expire."
+              >
+                {testUsersInner}
+              </QuietItem>
+            </div>
+          </section>
+        </div>
+      </DashPage>
+    );
+  }
+
+  // ---- quiet · one column (no card chrome, space + a single rule) ----
+  if (variant === 'quiet-column') {
+    return (
+      <DashPage size="narrow">
+        <div className="duration-500 animate-in fade-in">
+          <section className="pb-10">
+            <QuietMethodTitle title="Social login" meta={socialMeta} />
+            <div className="mt-2">
+              <QuietItem title="Auth clients">{clientsInner}</QuietItem>
+              <QuietItem
+                title="Redirect origins"
+                helper="Allowed URLs for the OAuth redirect flow."
+              >
+                {originsInner}
+              </QuietItem>
+            </div>
+          </section>
+          <div className="border-t border-gray-200 dark:border-neutral-800" />
+          <section className="pt-10">
+            <QuietMethodTitle title="Magic codes" meta={magicMeta} />
+            <div className="mt-2">
+              <QuietItem title="Magic code email">{emailInner}</QuietItem>
+              <QuietItem
+                title="Test users"
+                helper="Codes that never expire."
+              >
+                {testUsersInner}
+              </QuietItem>
+            </div>
+          </section>
+        </div>
+      </DashPage>
+    );
+  }
+
+  // ---- bold variants (the "control panel" direction) ----
+  const clientsBlock = (
+    <MethodBlock>
+      <BlockLabel
+        title="Auth clients"
+        hint="Sign in with Google, Apple, GitHub, and more."
+      />
+      {clientsInner}
+    </MethodBlock>
+  );
+
+  const emailBlock = (
+    <MethodBlock>
+      <BlockLabel
+        title="Magic code email"
+        hint="The email people get when they sign in with a code."
+        badge={
+          <StatusPill on={hasCustomEmail}>
+            {hasCustomEmail ? 'Custom' : 'Default'}
+          </StatusPill>
+        }
+      />
+      {emailInner}
+    </MethodBlock>
+  );
+
+  const originsBlockBold = (nested: boolean) => (
+    <MethodBlock nested={nested}>
+      {nested ? (
+        <DependencyNote>Required for the OAuth redirect flow</DependencyNote>
+      ) : null}
+      <BlockLabel
+        title="Redirect origins"
+        hint="Allow OAuth sign-in to start from your site's URLs."
+      />
+      {originsInner}
+    </MethodBlock>
+  );
+
+  const testUsersBlockBold = (nested: boolean) => (
+    <MethodBlock nested={nested}>
+      {nested ? (
+        <DependencyNote>A magic code that never expires</DependencyNote>
+      ) : null}
+      <BlockLabel
+        title="Test users"
+        hint="Static codes for development, CI, and app-store review."
+      />
+      {testUsersInner}
+    </MethodBlock>
+  );
+
+  const socialStatus = (
+    <>
+      <StatusPill on={hasClients}>
+        {clients.length} client{clients.length === 1 ? '' : 's'}
+      </StatusPill>
+      <StatusPill on={origins.length > 0}>
+        {origins.length} origin{origins.length === 1 ? '' : 's'}
+      </StatusPill>
+    </>
+  );
+
+  const magicStatus = (
+    <>
+      <StatusPill on>Always on</StatusPill>
+      <StatusPill on={hasCustomEmail}>
+        {hasCustomEmail ? 'Custom email' : 'Default email'}
+      </StatusPill>
+    </>
+  );
+
+  const header = (
+    <div>
+      <div className="font-mono text-[11px] tracking-[0.2em] text-orange-500 uppercase">
+        Authentication
+      </div>
+      <h2 className="mt-1 text-2xl font-semibold tracking-tight text-gray-950 dark:text-white">
+        Two ways people sign in
+      </h2>
+      <Content className="mt-1">
+        Configure how users authenticate with {app.title}. Social login and
+        magic codes are independent — set up either or both.
+      </Content>
+    </div>
+  );
+
+  // ---- tracks: stacked methods, dependencies nested + indented ----
+  if (variant === 'tracks') {
+    return (
+      <DashPage size="wide">
+        {header}
+        <section className="flex flex-col gap-4 duration-500 animate-in fade-in slide-in-from-bottom-2">
+          <MethodHeader
+            index="01"
+            title="Social login"
+            blurb="Let people sign in with an existing account. Opt-in."
+            status={socialStatus}
+          />
+          {clientsBlock}
+          <div className="pl-4 sm:pl-8">{originsBlockBold(true)}</div>
+        </section>
+        <section
+          className="flex flex-col gap-4 duration-500 animate-in fade-in slide-in-from-bottom-2"
+          style={{ animationDelay: '120ms' }}
+        >
+          <MethodHeader
+            index="02"
+            title="Magic codes"
+            blurb="Email a one-time code. On by default for every app."
+            status={magicStatus}
+          />
+          {emailBlock}
+          <div className="pl-4 sm:pl-8">{testUsersBlockBold(true)}</div>
+        </section>
+      </DashPage>
+    );
+  }
+
+  // ---- columns: methods side by side, dependencies as peers ----
+  if (variant === 'columns') {
+    return (
+      <DashPage size="wide">
+        {header}
+        <div className="flex flex-col gap-1 rounded-md border border-gray-200 bg-white px-4 py-3 font-mono text-xs shadow-xs sm:flex-row sm:items-center sm:gap-8 dark:border-neutral-800 dark:bg-neutral-900">
+          <span className="flex items-center gap-2">
+            <span className="text-orange-500">SOCIAL ▸</span>
+            <span className="text-gray-500 dark:text-neutral-400">
+              {clients.length} client{clients.length === 1 ? '' : 's'} ·{' '}
+              {origins.length} origin{origins.length === 1 ? '' : 's'}
+            </span>
+          </span>
+          <span className="flex items-center gap-2">
+            <span className="text-orange-500">MAGIC ▸</span>
+            <span className="text-gray-500 dark:text-neutral-400">
+              {hasCustomEmail ? 'custom' : 'default'} email · always on
+            </span>
+          </span>
+        </div>
+        <div className="grid gap-6 duration-500 animate-in fade-in slide-in-from-bottom-2 lg:grid-cols-2">
+          <section className="flex flex-col gap-4">
+            <MethodHeader
+              index="01"
+              title="Social login"
+              blurb="Sign in with an existing account."
+              status={socialStatus}
+              compact
+            />
+            {clientsBlock}
+            {originsBlockBold(false)}
+          </section>
+          <section className="flex flex-col gap-4">
+            <MethodHeader
+              index="02"
+              title="Magic codes"
+              blurb="Email a one-time code."
+              status={magicStatus}
+              compact
+            />
+            {emailBlock}
+            {testUsersBlockBold(false)}
+          </section>
+        </div>
+      </DashPage>
+    );
+  }
+
+  // ---- focused: one method at a time via a segmented switch ----
+  return (
+    <DashPage size="wide">
+      {header}
+      <FocusedSwitch value={focusedMethod} onChange={setFocusedMethod} />
+      <section
+        key={focusedMethod}
+        className="flex flex-col gap-4 duration-300 animate-in fade-in slide-in-from-bottom-1"
+      >
+        {focusedMethod === 'social' ? (
+          <>
+            <MethodHeader
+              index="01"
+              title="Social login"
+              blurb="Let people sign in with an existing account. Opt-in."
+              status={socialStatus}
+            />
+            {clientsBlock}
+            {originsBlockBold(true)}
+          </>
+        ) : (
+          <>
+            <MethodHeader
+              index="02"
+              title="Magic codes"
+              blurb="Email a one-time code. On by default for every app."
+              status={magicStatus}
+            />
+            {emailBlock}
+            {testUsersBlockBold(true)}
+          </>
+        )}
+      </section>
+    </DashPage>
+  );
+}
+
 // -------------- outer view --------------
 
 function AuthDataLoader({ app, sub }: { app: InstantApp; sub: AuthSubState }) {
@@ -856,6 +1780,18 @@ function AuthDataLoader({ app, sub }: { app: InstantApp; sub: AuthSubState }) {
 
   const plan = planForSubState(authResponse.data, sub);
 
+  if (sub.startsWith('redesign-')) {
+    const variant = sub.slice('redesign-'.length) as RedesignVariant;
+    return (
+      <AuthRedesign
+        key={sub}
+        app={app}
+        initialData={plan.data}
+        variant={variant}
+      />
+    );
+  }
+
   return <AuthBody key={sub} app={app} initialData={plan.data} plan={plan} />;
 }
 
@@ -882,9 +1818,17 @@ export function Current({ sub }: { sub: AuthSubState }) {
     );
   }
 
+  const flowIdea = sub.startsWith('flow-')
+    ? (sub.slice('flow-'.length) as FlowIdea)
+    : null;
+
   return (
-    <DashShell active="auth" app={app}>
-      <AuthDataLoader app={app} sub={sub} />
+    <DashShell active="auth" app={app} hideNav={flowIdea === 'merged'}>
+      {flowIdea ? (
+        <AuthFlows key={sub} idea={flowIdea} appTitle={app.title} />
+      ) : (
+        <AuthDataLoader app={app} sub={sub} />
+      )}
     </DashShell>
   );
 }

--- a/client/www/pages/dash-redesign/_views/Auth/Flows.tsx
+++ b/client/www/pages/dash-redesign/_views/Auth/Flows.tsx
@@ -1,0 +1,1608 @@
+// ============================================================
+// Auth disclosure flows — fully interactive, mock, side-effect-free.
+//
+// The point of these is to *experience* the whole lifecycle (empty →
+// add → edit → delete) for each disclosure model, and to feel how the
+// heavy leaves (an OAuth client's config + code snippets, the magic-code
+// email editor) behave when you go deep:
+//
+//   drill   — overview is a calm index; heavy leaves open a focused page
+//   master  — two-pane: list rail + detail pane
+//   sheet   — overview stays put; heavy leaves slide over from the right
+//
+// Everything is local state. No network, no real clients created.
+// ============================================================
+
+import { ReactNode, useState } from 'react';
+import Image from 'next/image';
+import {
+  BeakerIcon,
+  BoltIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CodeBracketIcon,
+  CreditCardIcon,
+  CubeIcon,
+  EnvelopeIcon,
+  FunnelIcon,
+  GlobeAltIcon,
+  HomeIcon,
+  IdentificationIcon,
+  LockClosedIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+  ShieldCheckIcon,
+  TrashIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+
+import { Button, TextInput, cn } from '@/components/ui';
+import { DashPage } from '../_shared';
+
+import googleIconSvg from '../../../../public/img/google_g.svg';
+import appleLogoSvg from '../../../../public/img/apple_logo_black.svg';
+import githubIconSvg from '../../../../public/img/github.svg';
+import linkedinIconSvg from '../../../../public/img/linkedin.svg';
+import clerkLogoSvg from '../../../../public/img/clerk_logo_black.svg';
+import firebaseLogoSvg from '../../../../public/img/firebase_auth.svg';
+
+export type FlowIdea = 'drill' | 'master' | 'sheet' | 'merged';
+
+// -------------------- providers --------------------
+
+type ProviderId =
+  | 'google'
+  | 'apple'
+  | 'github'
+  | 'linkedin'
+  | 'clerk'
+  | 'firebase';
+
+const PROVIDERS: {
+  id: ProviderId;
+  label: string;
+  icon: any;
+  invert?: boolean;
+  hasDevKeys?: boolean;
+}[] = [
+  { id: 'google', label: 'Google', icon: googleIconSvg, hasDevKeys: true },
+  { id: 'apple', label: 'Apple', icon: appleLogoSvg, invert: true },
+  { id: 'github', label: 'GitHub', icon: githubIconSvg, invert: true },
+  { id: 'linkedin', label: 'LinkedIn', icon: linkedinIconSvg },
+  { id: 'clerk', label: 'Clerk', icon: clerkLogoSvg, invert: true },
+  { id: 'firebase', label: 'Firebase', icon: firebaseLogoSvg },
+];
+
+const providerCfg = (id: ProviderId) =>
+  PROVIDERS.find((p) => p.id === id) ?? PROVIDERS[0];
+
+const REDIRECT_URI = 'https://api.instantdb.com/runtime/oauth/callback';
+
+// -------------------- mock model --------------------
+
+type ClientMode = 'dev' | 'custom';
+type MockClient = {
+  id: string;
+  provider: ProviderId;
+  name: string;
+  mode: ClientMode;
+  clientId?: string;
+};
+type OriginKind = 'website' | 'vercel' | 'netlify' | 'scheme';
+type MockOrigin = { id: string; kind: OriginKind; value: string };
+type MockTestUser = { id: string; email: string; code: string };
+type MockEmail = {
+  customized: boolean;
+  subject: string;
+  from: string;
+  body: string;
+  senderEmail: string;
+};
+
+type AuthModel = {
+  clients: MockClient[];
+  origins: MockOrigin[];
+  testUsers: MockTestUser[];
+  email: MockEmail;
+};
+
+const defaultBody = `<div style="font-family: Helvetica, Arial, sans-serif">
+  <p>Welcome,</p>
+  <p>Your verification code is:</p>
+  <h2>{code}</h2>
+  <p>This code expires in 10 minutes.</p>
+</div>`;
+
+function freshEmail(): MockEmail {
+  return {
+    customized: false,
+    subject: '{code} is your code for {app_title}',
+    from: '',
+    body: defaultBody,
+    senderEmail: '',
+  };
+}
+
+function useAuthModel() {
+  const [model, setModel] = useState<AuthModel>({
+    clients: [],
+    origins: [],
+    testUsers: [],
+    email: freshEmail(),
+  });
+
+  const actions = {
+    addClient(c: Omit<MockClient, 'id'>) {
+      const id = crypto.randomUUID();
+      setModel((m) => ({ ...m, clients: [...m.clients, { ...c, id }] }));
+      return id;
+    },
+    updateClient(id: string, patch: Partial<MockClient>) {
+      setModel((m) => ({
+        ...m,
+        clients: m.clients.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+      }));
+    },
+    deleteClient(id: string) {
+      setModel((m) => ({
+        ...m,
+        clients: m.clients.filter((c) => c.id !== id),
+      }));
+    },
+    addOrigin(o: Omit<MockOrigin, 'id'>) {
+      setModel((m) => ({
+        ...m,
+        origins: [...m.origins, { ...o, id: crypto.randomUUID() }],
+      }));
+    },
+    removeOrigin(id: string) {
+      setModel((m) => ({
+        ...m,
+        origins: m.origins.filter((o) => o.id !== id),
+      }));
+    },
+    addTestUser(u: Omit<MockTestUser, 'id'>) {
+      setModel((m) => ({
+        ...m,
+        testUsers: [{ ...u, id: crypto.randomUUID() }, ...m.testUsers],
+      }));
+    },
+    removeTestUser(id: string) {
+      setModel((m) => ({
+        ...m,
+        testUsers: m.testUsers.filter((u) => u.id !== id),
+      }));
+    },
+    saveEmail(patch: Partial<MockEmail>) {
+      setModel((m) => ({
+        ...m,
+        email: { ...m.email, ...patch, customized: true },
+      }));
+    },
+    resetEmail() {
+      setModel((m) => ({ ...m, email: freshEmail() }));
+    },
+  };
+
+  return { model, actions };
+}
+
+type Actions = ReturnType<typeof useAuthModel>['actions'];
+
+// -------------------- small shared atoms --------------------
+
+function Field({
+  label,
+  children,
+}: {
+  label: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium text-gray-500 dark:text-neutral-400">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CopyField({
+  label,
+  value,
+  mono = true,
+}: {
+  label?: ReactNode;
+  value: string;
+  mono?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  const inner = (
+    <div className="flex items-center justify-between gap-3 rounded-md border border-gray-200 bg-[#fbfaf8] px-3 py-2 dark:border-neutral-800 dark:bg-neutral-950">
+      <span
+        className={cn(
+          'truncate text-sm text-gray-800 dark:text-neutral-200',
+          mono && 'font-mono',
+        )}
+      >
+        {value}
+      </span>
+      <button
+        type="button"
+        className="shrink-0 text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-neutral-400 dark:hover:text-white"
+        onClick={() => {
+          navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        }}
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+  return label ? <Field label={label}>{inner}</Field> : inner;
+}
+
+function CodeBlock({ title, code }: { title: string; code: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="overflow-hidden rounded-md border border-gray-200 dark:border-neutral-800">
+      <div className="flex items-center justify-between border-b border-gray-100 bg-[#fbfaf8] px-3 py-1.5 dark:border-neutral-800 dark:bg-neutral-950">
+        <span className="font-mono text-[11px] tracking-wider text-gray-400 uppercase dark:text-neutral-500">
+          {title}
+        </span>
+        <button
+          type="button"
+          className="text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-neutral-400 dark:hover:text-white"
+          onClick={() => {
+            navigator.clipboard.writeText(code);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="overflow-auto bg-white px-3 py-3 font-mono text-xs leading-5 text-gray-700 dark:bg-neutral-900 dark:text-neutral-300">
+        {code}
+      </pre>
+    </div>
+  );
+}
+
+function InfoBox({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-md border border-gray-200 bg-[#fbfaf8] p-3 text-sm text-gray-600 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-400">
+      {children}
+    </div>
+  );
+}
+
+function Pill({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500 dark:border-neutral-700 dark:text-neutral-400">
+      {children}
+    </span>
+  );
+}
+
+function MethodHeading({ title, meta }: { title: string; meta: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <h3 className="text-lg font-semibold tracking-tight text-gray-950 dark:text-white">
+        {title}
+      </h3>
+      <span className="text-sm text-gray-400 dark:text-neutral-500">{meta}</span>
+    </div>
+  );
+}
+
+function SubLabel({ title, helper }: { title: string; helper?: string }) {
+  return (
+    <div className="mb-3">
+      <div className="text-sm font-semibold text-gray-900 dark:text-white">
+        {title}
+      </div>
+      {helper ? (
+        <p className="mt-0.5 text-sm text-gray-500 dark:text-neutral-400">
+          {helper}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ProviderIcon({ id, size = 20 }: { id: ProviderId; size?: number }) {
+  const cfg = providerCfg(id);
+  return (
+    <Image
+      alt={cfg.label}
+      src={cfg.icon}
+      width={size}
+      height={size}
+      className={cfg.invert ? 'dark:invert' : ''}
+    />
+  );
+}
+
+// -------------------- leaf editors (the deep content) --------------------
+
+function AddClientWizard({
+  onAdd,
+  onCancel,
+}: {
+  onAdd: (c: Omit<MockClient, 'id'>) => void;
+  onCancel: () => void;
+}) {
+  const [provider, setProvider] = useState<ProviderId | null>(null);
+  const [name, setName] = useState('');
+  const [mode, setMode] = useState<ClientMode>('dev');
+  const [clientId, setClientId] = useState('');
+  const [secret, setSecret] = useState('');
+
+  if (!provider) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="text-sm text-gray-500 dark:text-neutral-400">
+          Choose a provider to configure.
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {PROVIDERS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => {
+                setProvider(p.id);
+                setName(`${p.id}-web`);
+                setMode(p.hasDevKeys ? 'dev' : 'custom');
+              }}
+              className="flex flex-col items-center gap-2 rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 hover:bg-[#fbfaf8] dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+            >
+              <ProviderIcon id={p.id} size={24} />
+              <span className="text-sm">{p.label}</span>
+            </button>
+          ))}
+        </div>
+        <div>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const cfg = providerCfg(provider);
+  const showCustomFields = mode === 'custom';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <ProviderIcon id={provider} />
+        <span className="text-sm font-medium">{cfg.label}</span>
+      </div>
+
+      <Field label="Client name">
+        <TextInput value={name} onChange={setName} placeholder="my-web-client" />
+      </Field>
+
+      {cfg.hasDevKeys ? (
+        <div className="inline-flex w-fit rounded-md border border-gray-200 bg-white p-1 dark:border-neutral-800 dark:bg-neutral-900">
+          {(['dev', 'custom'] as ClientMode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={cn(
+                'rounded-sm px-3 py-1.5 text-sm transition-colors',
+                mode === m
+                  ? 'bg-orange-500 text-white'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-neutral-400 dark:hover:text-white',
+              )}
+            >
+              {m === 'dev' ? 'Use Instant dev keys' : 'Use my own'}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {mode === 'dev' ? (
+        <InfoBox>
+          Instant's shared development keys let you try sign-in immediately. Add
+          your own credentials before launch.
+        </InfoBox>
+      ) : (
+        <>
+          <Field label={`Client ID from the ${cfg.label} console`}>
+            <TextInput
+              value={clientId}
+              onChange={setClientId}
+              placeholder="1234567890-abc.apps..."
+            />
+          </Field>
+          <Field label="Client secret">
+            <TextInput
+              value={secret}
+              onChange={setSecret}
+              placeholder="••••••••••••••••"
+            />
+          </Field>
+          <Field label='Add this to "Authorized redirect URIs"'>
+            <CopyField value={REDIRECT_URI} />
+          </Field>
+        </>
+      )}
+
+      <div className="flex gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+        <Button
+          variant="primary"
+          disabled={!name || (showCustomFields && !clientId)}
+          onClick={() =>
+            onAdd({
+              provider,
+              name,
+              mode,
+              clientId: showCustomFields ? clientId : undefined,
+            })
+          }
+        >
+          Add client
+        </Button>
+        <Button variant="secondary" onClick={() => setProvider(null)}>
+          Back
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ClientConfigPanel({
+  client,
+  onUpdate,
+  onDelete,
+}: {
+  client: MockClient;
+  onUpdate: (patch: Partial<MockClient>) => void;
+  onDelete: () => void;
+}) {
+  const cfg = providerCfg(client.provider);
+  const [editing, setEditing] = useState(false);
+  const [clientId, setClientId] = useState(client.clientId ?? '');
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const code = `const url = db.auth.createAuthorizationURL({
+  clientName: "${client.name}",
+  redirectURL: window.location.href,
+});
+
+// <a href={url}>Log in with ${cfg.label}</a>`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <ProviderIcon id={client.provider} size={24} />
+        <span className="text-sm font-medium">{client.name}</span>
+        <Pill>
+          {client.mode === 'dev' ? 'Instant dev keys' : 'Custom credentials'}
+        </Pill>
+      </div>
+
+      <CopyField label="Client name" value={client.name} mono={false} />
+
+      {client.mode === 'dev' ? (
+        <InfoBox>
+          Using Instant's shared development keys. Great for prototyping; switch
+          to your own credentials before launch.
+        </InfoBox>
+      ) : editing ? (
+        <Field label="Client ID">
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <TextInput value={clientId} onChange={setClientId} />
+            </div>
+            <Button
+              variant="primary"
+              onClick={() => {
+                onUpdate({ clientId });
+                setEditing(false);
+              }}
+            >
+              Save
+            </Button>
+            <Button variant="secondary" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+          </div>
+        </Field>
+      ) : (
+        <CopyField label="Client ID" value={client.clientId || ''} />
+      )}
+
+      <Field label='Redirect URI — add this to the provider console'>
+        <CopyField value={REDIRECT_URI} />
+      </Field>
+
+      <Field label="Sign in from your app">
+        <CodeBlock title="example" code={code} />
+      </Field>
+
+      <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-neutral-800">
+        {client.mode === 'custom' && !editing ? (
+          <Button variant="secondary" onClick={() => setEditing(true)}>
+            Update credentials
+          </Button>
+        ) : (
+          <span />
+        )}
+        {confirmDelete ? (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-500">Remove this client?</span>
+            <Button variant="destructive" onClick={onDelete}>
+              Delete
+            </Button>
+            <Button variant="secondary" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
+            Delete
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DnsRow({
+  record,
+  type,
+  host,
+  value,
+}: {
+  record: string;
+  type: string;
+  host: string;
+  value: string;
+}) {
+  return (
+    <div className="grid grid-cols-[1fr_70px_2fr] gap-2 border-b border-gray-100 px-3 py-3 text-sm last:border-b-0 dark:border-neutral-800">
+      <div className="font-medium">{record}</div>
+      <div className="text-gray-500 dark:text-neutral-400">{type}</div>
+      <div className="flex flex-col gap-1">
+        <code className="block truncate rounded-sm bg-gray-100 px-2 py-1 text-xs dark:bg-neutral-800">
+          {host}
+        </code>
+        <code className="block truncate rounded-sm bg-gray-100 px-2 py-1 text-xs dark:bg-neutral-800">
+          {value}
+        </code>
+      </div>
+    </div>
+  );
+}
+
+function EmailEditor({
+  appTitle,
+  email,
+  onSave,
+  onDelete,
+}: {
+  appTitle: string;
+  email: MockEmail;
+  onSave: (patch: Partial<MockEmail>) => void;
+  onDelete: () => void;
+}) {
+  const [subject, setSubject] = useState(email.subject);
+  const [from, setFrom] = useState(email.from);
+  const [body, setBody] = useState(email.body);
+  const [senderEmail, setSenderEmail] = useState(email.senderEmail);
+  const [showExpiry, setShowExpiry] = useState(false);
+  const [expiry, setExpiry] = useState(10);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <InfoBox>
+        <div className="font-semibold text-gray-700 dark:text-neutral-200">
+          Template variables
+        </div>
+        <p className="mt-1">
+          Use <code className="font-mono">{'{code}'}</code>,{' '}
+          <code className="font-mono">{'{app_title}'}</code> (
+          {appTitle || 'your app'}), and{' '}
+          <code className="font-mono">{'{user_email}'}</code> in the subject and
+          body. <code className="font-mono">{'{code}'}</code> is required.
+        </p>
+      </InfoBox>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Field label="Subject">
+          <TextInput value={subject} onChange={setSubject} />
+        </Field>
+        <Field label="From">
+          <TextInput
+            value={from}
+            onChange={setFrom}
+            placeholder="YourName from YourCo"
+          />
+        </Field>
+      </div>
+
+      <Field label="Body (HTML or plain text)">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          spellCheck={false}
+          className="h-60 w-full rounded-md border border-gray-200 bg-white p-3 font-mono text-xs leading-5 text-gray-700 focus:outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300"
+        />
+      </Field>
+
+      <div className="rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-800 dark:bg-neutral-950">
+        <div className="text-sm font-semibold text-gray-900 dark:text-white">
+          Use a custom "From" address (optional)
+        </div>
+        <p className="mt-1 text-sm text-gray-500 dark:text-neutral-400">
+          Send from your own domain to build trust with recipients.
+        </p>
+        <div className="mt-2">
+          <TextInput
+            value={senderEmail}
+            onChange={setSenderEmail}
+            placeholder="hi@yourdomain.co"
+          />
+        </div>
+      </div>
+
+      {senderEmail ? (
+        <div className="rounded-md border border-gray-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2 dark:border-neutral-800">
+            <span className="text-sm font-medium">Verify {senderEmail}</span>
+            <span className="text-xs text-gray-400">Pending confirmation</span>
+          </div>
+          <DnsRow
+            record="DKIM"
+            type="TXT"
+            host="instant._domainkey.yourdomain.co"
+            value="k=rsa; p=MIGfMA0GCSq…"
+          />
+          <DnsRow
+            record="Return-Path"
+            type="CNAME"
+            host="pm-bounces.yourdomain.co"
+            value="pm.mtasv.net"
+          />
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-neutral-800">
+        <Button
+          variant="primary"
+          onClick={() => onSave({ subject, from, body, senderEmail })}
+        >
+          Save template
+        </Button>
+        {email.customized ? (
+          <Button variant="destructive" onClick={onDelete}>
+            Delete template
+          </Button>
+        ) : null}
+      </div>
+
+      <button
+        type="button"
+        className="self-start text-sm text-gray-400 underline hover:text-gray-600 dark:text-neutral-500 dark:hover:text-neutral-300"
+        onClick={() => setShowExpiry((s) => !s)}
+      >
+        Change magic code expiration
+      </button>
+      {showExpiry ? (
+        <div className="flex flex-col gap-2">
+          {[
+            { label: '10 minutes', value: 10 },
+            { label: '1 hour', value: 60 },
+            { label: '24 hours', value: 1440 },
+          ].map((o) => (
+            <label
+              key={o.value}
+              className="flex cursor-pointer items-center gap-2 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 text-sm dark:border-neutral-800 dark:bg-neutral-950"
+            >
+              <input
+                type="radio"
+                name="expiry"
+                checked={expiry === o.value}
+                onChange={() => setExpiry(o.value)}
+              />
+              {o.label}
+            </label>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const ORIGIN_KINDS: { value: OriginKind; label: string; placeholder: string }[] =
+  [
+    { value: 'website', label: 'Website', placeholder: 'example.com' },
+    { value: 'vercel', label: 'Vercel previews', placeholder: 'my-project' },
+    { value: 'netlify', label: 'Netlify previews', placeholder: 'my-site' },
+    { value: 'scheme', label: 'App scheme', placeholder: 'myapp://' },
+  ];
+
+function OriginsEditor({
+  model,
+  actions,
+}: {
+  model: AuthModel;
+  actions: Actions;
+}) {
+  const [showForm, setShowForm] = useState(model.origins.length === 0);
+  const [kind, setKind] = useState<OriginKind>('website');
+  const [value, setValue] = useState('');
+  const placeholder =
+    ORIGIN_KINDS.find((k) => k.value === kind)?.placeholder ?? '';
+
+  return (
+    <div className="flex flex-col gap-2">
+      {model.origins.map((o) => (
+        <div
+          key={o.id}
+          className="flex items-center justify-between rounded-md border border-gray-200 bg-[#fbfaf8] px-3 py-2.5 dark:border-neutral-800 dark:bg-neutral-950"
+        >
+          <div className="flex items-center gap-3">
+            <GlobeAltIcon className="h-4 w-4 text-gray-400" />
+            <div className="flex flex-col">
+              <span className="text-xs text-gray-400 dark:text-neutral-500">
+                {ORIGIN_KINDS.find((k) => k.value === o.kind)?.label}
+              </span>
+              <span className="text-sm font-medium">{o.value}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Remove origin"
+            className="text-gray-400 hover:text-red-500"
+            onClick={() => actions.removeOrigin(o.id)}
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+
+      {showForm ? (
+        <div className="flex flex-col gap-3 rounded-md border border-gray-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex gap-2">
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value as OriginKind)}
+              className="rounded-md border border-gray-200 bg-white px-2 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-900"
+            >
+              {ORIGIN_KINDS.map((k) => (
+                <option key={k.value} value={k.value}>
+                  {k.label}
+                </option>
+              ))}
+            </select>
+            <div className="flex-1">
+              <TextInput
+                value={value}
+                onChange={setValue}
+                placeholder={placeholder}
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="primary"
+              disabled={!value}
+              onClick={() => {
+                actions.addOrigin({ kind, value });
+                setValue('');
+                setShowForm(false);
+              }}
+            >
+              Add
+            </Button>
+            <Button variant="secondary" onClick={() => setShowForm(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button variant="secondary" onClick={() => setShowForm(true)}>
+          <PlusIcon className="h-3.5 w-3.5" /> Add an origin
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function TestUsersEditor({
+  model,
+  actions,
+}: {
+  model: AuthModel;
+  actions: Actions;
+}) {
+  const [showForm, setShowForm] = useState(false);
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('424242');
+  const valid = email.trim().length > 0 && /^\d{6}$/.test(code);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {model.testUsers.map((u) => (
+        <div
+          key={u.id}
+          className="flex items-center justify-between rounded-md border border-gray-200 bg-[#fbfaf8] px-3 py-2.5 dark:border-neutral-800 dark:bg-neutral-950"
+        >
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">{u.email}</span>
+            <span className="font-mono text-xs text-gray-500 dark:text-neutral-400">
+              code {u.code}
+            </span>
+          </div>
+          <button
+            type="button"
+            aria-label="Remove test user"
+            className="text-gray-400 hover:text-red-500"
+            onClick={() => actions.removeTestUser(u.id)}
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+
+      {showForm ? (
+        <div className="flex items-start gap-2 rounded-md border border-gray-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex-1">
+            <TextInput
+              label="Email"
+              placeholder="test@example.com"
+              value={email}
+              onChange={setEmail}
+              autoFocus
+            />
+          </div>
+          <div className="w-32">
+            <TextInput
+              label="Code"
+              placeholder="123456"
+              value={code}
+              onChange={setCode}
+              error={code && !/^\d{6}$/.test(code) ? '6 digits' : undefined}
+            />
+          </div>
+          <div className="pt-6">
+            <Button
+              variant="primary"
+              disabled={!valid}
+              onClick={() => {
+                actions.addTestUser({ email: email.trim().toLowerCase(), code });
+                setEmail('');
+                setCode('424242');
+                setShowForm(false);
+              }}
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button variant="secondary" onClick={() => setShowForm(true)}>
+          <PlusIcon className="h-3.5 w-3.5" /> Add a test user
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// -------------------- targets + shared renderers --------------------
+
+// social / magic select a method's management pane; the rest are leaf editors.
+type Target =
+  | { kind: 'social' }
+  | { kind: 'magic' }
+  | { kind: 'add-client' }
+  | { kind: 'client'; id: string }
+  | { kind: 'email' };
+
+function targetTitle(t: Target, model: AuthModel): string {
+  switch (t.kind) {
+    case 'social':
+      return 'Social login';
+    case 'magic':
+      return 'Magic codes';
+    case 'add-client':
+      return 'Add a client';
+    case 'client': {
+      const c = model.clients.find((x) => x.id === t.id);
+      return c ? `${providerCfg(c.provider).label} client` : 'Client';
+    }
+    case 'email':
+      return 'Magic code email';
+  }
+}
+
+function LeafDetail({
+  target,
+  appTitle,
+  model,
+  actions,
+  onClose,
+}: {
+  target: Target;
+  appTitle: string;
+  model: AuthModel;
+  actions: Actions;
+  onClose: () => void;
+}) {
+  switch (target.kind) {
+    case 'social':
+    case 'magic':
+      return null; // section panes are rendered by the shells, not here
+    case 'add-client':
+      return (
+        <AddClientWizard
+          onCancel={onClose}
+          onAdd={(c) => {
+            actions.addClient(c);
+            onClose();
+          }}
+        />
+      );
+    case 'client': {
+      const c = model.clients.find((x) => x.id === target.id);
+      if (!c) return null;
+      return (
+        <ClientConfigPanel
+          client={c}
+          onUpdate={(patch) => actions.updateClient(c.id, patch)}
+          onDelete={() => {
+            actions.deleteClient(c.id);
+            onClose();
+          }}
+        />
+      );
+    }
+    case 'email':
+      return (
+        <EmailEditor
+          appTitle={appTitle}
+          email={model.email}
+          onSave={(patch) => {
+            actions.saveEmail(patch);
+            onClose();
+          }}
+          onDelete={() => {
+            actions.resetEmail();
+            onClose();
+          }}
+        />
+      );
+  }
+}
+
+function socialMeta(model: AuthModel): string {
+  if (model.clients.length === 0 && model.origins.length === 0)
+    return 'Not set up';
+  return `${model.clients.length} client${
+    model.clients.length === 1 ? '' : 's'
+  }, ${model.origins.length} origin${model.origins.length === 1 ? '' : 's'}`;
+}
+function magicMeta(model: AuthModel): string {
+  return model.email.customized ? 'Custom email' : 'Default email';
+}
+
+function ClientRow({
+  client,
+  onOpen,
+}: {
+  client: MockClient;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-center justify-between gap-3 rounded-md border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-gray-300 hover:bg-[#fbfaf8] dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+    >
+      <div className="flex items-center gap-3">
+        <ProviderIcon id={client.provider} />
+        <div className="flex flex-col">
+          <span className="text-sm font-medium">{client.name}</span>
+          <span className="text-xs text-gray-500 dark:text-neutral-400">
+            {client.mode === 'dev' ? 'Instant dev keys' : client.clientId}
+          </span>
+        </div>
+      </div>
+      <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+    </button>
+  );
+}
+
+function EmptyClients({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-gray-300 bg-[#fbfaf8] px-4 py-6 text-center dark:border-neutral-700 dark:bg-neutral-950">
+      <div className="text-sm font-semibold text-gray-900 dark:text-white">
+        No social logins yet
+      </div>
+      <div className="flex gap-2 opacity-60">
+        {PROVIDERS.slice(0, 4).map((p) => (
+          <ProviderIcon key={p.id} id={p.id} />
+        ))}
+      </div>
+      <Button variant="secondary" onClick={onAdd}>
+        <PlusIcon className="h-3.5 w-3.5" /> Add client
+      </Button>
+    </div>
+  );
+}
+
+// Overview shared by drill + sheet: light leaves inline, heavy leaves trigger onOpen.
+// One method's management surface. Light leaves (origins, test users) are
+// inline; heavy leaves (a client, the email editor) call onOpen to drill in.
+function SocialSection({
+  model,
+  actions,
+  onOpen,
+}: {
+  model: AuthModel;
+  actions: Actions;
+  onOpen: (t: Target) => void;
+}) {
+  return (
+    <section>
+      <MethodHeading title="Social login" meta={socialMeta(model)} />
+      <div className="mt-3 flex flex-col gap-2">
+        {model.clients.length === 0 ? (
+          <EmptyClients onAdd={() => onOpen({ kind: 'add-client' })} />
+        ) : (
+          <>
+            {model.clients.map((c) => (
+              <ClientRow
+                key={c.id}
+                client={c}
+                onOpen={() => onOpen({ kind: 'client', id: c.id })}
+              />
+            ))}
+            <Button
+              variant="secondary"
+              onClick={() => onOpen({ kind: 'add-client' })}
+            >
+              <PlusIcon className="h-3.5 w-3.5" /> Add client
+            </Button>
+          </>
+        )}
+      </div>
+      <div className="mt-6">
+        <SubLabel
+          title="Redirect origins"
+          helper="Allowed URLs for the OAuth redirect flow."
+        />
+        <OriginsEditor model={model} actions={actions} />
+      </div>
+    </section>
+  );
+}
+
+function MagicSection({
+  model,
+  actions,
+  onOpen,
+}: {
+  model: AuthModel;
+  actions: Actions;
+  onOpen: (t: Target) => void;
+}) {
+  return (
+    <section>
+      <MethodHeading title="Magic codes" meta={magicMeta(model)} />
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => onOpen({ kind: 'email' })}
+          className="flex w-full items-center justify-between gap-3 rounded-md border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-gray-300 hover:bg-[#fbfaf8] dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+        >
+          <div className="flex flex-col">
+            <span className="text-sm font-medium">Magic code email</span>
+            <span className="truncate font-mono text-xs text-gray-500 dark:text-neutral-400">
+              {model.email.subject}
+            </span>
+          </div>
+          <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+        </button>
+      </div>
+      <div className="mt-6">
+        <SubLabel title="Test users" helper="Codes that never expire." />
+        <TestUsersEditor model={model} actions={actions} />
+      </div>
+    </section>
+  );
+}
+
+// drill-in / sheet show both methods at once.
+function OverviewBody({
+  model,
+  actions,
+  onOpen,
+}: {
+  model: AuthModel;
+  actions: Actions;
+  onOpen: (t: Target) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-10">
+      <SocialSection model={model} actions={actions} onOpen={onOpen} />
+      <div className="border-t border-gray-200 dark:border-neutral-800" />
+      <MagicSection model={model} actions={actions} onOpen={onOpen} />
+    </div>
+  );
+}
+
+function BackLink({
+  onClick,
+  label,
+}: {
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-900 dark:text-neutral-400 dark:hover:text-white"
+    >
+      <ChevronLeftIcon className="h-4 w-4" /> {label}
+    </button>
+  );
+}
+
+// -------------------- shell: drill-in --------------------
+
+function DrillInShell({
+  appTitle,
+  model,
+  actions,
+}: {
+  appTitle: string;
+  model: AuthModel;
+  actions: Actions;
+}) {
+  const [route, setRoute] = useState<Target | null>(null);
+
+  if (route) {
+    return (
+      <DashPage size="default">
+        <BackLink onClick={() => setRoute(null)} label="Authentication" />
+        <h2 className="text-2xl font-semibold tracking-tight text-gray-950 dark:text-white">
+          {targetTitle(route, model)}
+        </h2>
+        <div
+          key={`${route.kind}-${'id' in route ? route.id : ''}`}
+          className="duration-300 animate-in fade-in slide-in-from-bottom-1"
+        >
+          <LeafDetail
+            target={route}
+            appTitle={appTitle}
+            model={model}
+            actions={actions}
+            onClose={() => setRoute(null)}
+          />
+        </div>
+      </DashPage>
+    );
+  }
+
+  return (
+    <DashPage size="default">
+      <OverviewBody model={model} actions={actions} onOpen={setRoute} />
+    </DashPage>
+  );
+}
+
+// -------------------- shell: sheet --------------------
+
+function Sheet({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 z-40">
+      <div
+        className="absolute inset-0 bg-black/20 duration-200 animate-in fade-in"
+        onClick={onClose}
+      />
+      <div className="absolute top-0 right-0 flex h-full w-full max-w-[640px] flex-col bg-[#fbfaf8] shadow-2xl duration-300 animate-in slide-in-from-right-4 dark:bg-neutral-950">
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4 dark:border-neutral-800">
+          <h3 className="text-lg font-semibold tracking-tight text-gray-950 dark:text-white">
+            {title}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-700 dark:hover:text-neutral-200"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-auto p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function SheetShell({
+  appTitle,
+  model,
+  actions,
+}: {
+  appTitle: string;
+  model: AuthModel;
+  actions: Actions;
+}) {
+  const [target, setTarget] = useState<Target | null>(null);
+  return (
+    <>
+      <DashPage size="default">
+        <OverviewBody model={model} actions={actions} onOpen={setTarget} />
+      </DashPage>
+      {target ? (
+        <Sheet
+          title={targetTitle(target, model)}
+          onClose={() => setTarget(null)}
+        >
+          <LeafDetail
+            target={target}
+            appTitle={appTitle}
+            model={model}
+            actions={actions}
+            onClose={() => setTarget(null)}
+          />
+        </Sheet>
+      ) : null}
+    </>
+  );
+}
+
+// -------------------- shell: master-detail --------------------
+
+function parentSection(t: Target): Target {
+  return t.kind === 'email' ? { kind: 'magic' } : { kind: 'social' };
+}
+
+function sameTarget(a: Target, b: Target | null): boolean {
+  if (!b) return false;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'client' && b.kind === 'client') return a.id === b.id;
+  return true;
+}
+
+// The detail pane for the rail shells: a method's management surface, or a leaf
+// editor with a back link up to its parent method.
+function MethodPane({
+  selected,
+  onSelect,
+  model,
+  actions,
+  appTitle,
+}: {
+  selected: Target;
+  onSelect: (t: Target) => void;
+  model: AuthModel;
+  actions: Actions;
+  appTitle: string;
+}) {
+  if (selected.kind === 'social') {
+    return <SocialSection model={model} actions={actions} onOpen={onSelect} />;
+  }
+  if (selected.kind === 'magic') {
+    return <MagicSection model={model} actions={actions} onOpen={onSelect} />;
+  }
+  const parent = parentSection(selected);
+  return (
+    <div className="flex flex-col gap-4">
+      <BackLink
+        label={targetTitle(parent, model)}
+        onClick={() => onSelect(parent)}
+      />
+      <h2 className="text-lg font-semibold tracking-tight text-gray-950 dark:text-white">
+        {targetTitle(selected, model)}
+      </h2>
+      <LeafDetail
+        target={selected}
+        appTitle={appTitle}
+        model={model}
+        actions={actions}
+        onClose={() => onSelect(parent)}
+      />
+    </div>
+  );
+}
+
+function railSectionCls(active: boolean) {
+  return cn(
+    'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors',
+    active
+      ? 'bg-gray-200/70 font-semibold text-gray-950 dark:bg-neutral-800 dark:text-white'
+      : 'font-medium text-gray-700 hover:bg-gray-200/40 dark:text-neutral-300 dark:hover:bg-neutral-900',
+  );
+}
+
+function railSubCls(active: boolean) {
+  return cn(
+    'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors',
+    active
+      ? 'bg-gray-200/70 font-medium text-gray-950 dark:bg-neutral-800 dark:text-white'
+      : 'text-gray-500 hover:text-gray-900 dark:text-neutral-400 dark:hover:text-white',
+  );
+}
+
+// Shared rail body: the two methods, with clients nested under social.
+function AuthRailItems({
+  selected,
+  onSelect,
+  model,
+}: {
+  selected: Target;
+  onSelect: (t: Target) => void;
+  model: AuthModel;
+}) {
+  const socialActive =
+    selected.kind === 'social' ||
+    selected.kind === 'add-client' ||
+    selected.kind === 'client';
+  const magicActive = selected.kind === 'magic' || selected.kind === 'email';
+  return (
+    <div className="flex flex-col gap-0.5">
+      <button
+        type="button"
+        className={railSectionCls(socialActive)}
+        onClick={() => onSelect({ kind: 'social' })}
+      >
+        <IdentificationIcon className="h-4 w-4" />
+        <span className="truncate">Social login</span>
+      </button>
+      <div className="mb-1 ml-[1.4rem] flex flex-col gap-0.5 border-l border-gray-200 pl-1.5 dark:border-neutral-800">
+        {model.clients.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            className={railSubCls(
+              sameTarget({ kind: 'client', id: c.id }, selected),
+            )}
+            onClick={() => onSelect({ kind: 'client', id: c.id })}
+          >
+            <span className="flex h-4 w-4 items-center justify-center">
+              <ProviderIcon id={c.provider} size={14} />
+            </span>
+            <span className="truncate">{c.name}</span>
+          </button>
+        ))}
+        <button
+          type="button"
+          className={railSubCls(selected.kind === 'add-client')}
+          onClick={() => onSelect({ kind: 'add-client' })}
+        >
+          <span className="flex h-4 w-4 items-center justify-center">
+            <PlusIcon className="h-3.5 w-3.5" />
+          </span>
+          <span>Add client</span>
+        </button>
+      </div>
+      <button
+        type="button"
+        className={railSectionCls(magicActive)}
+        onClick={() => onSelect({ kind: 'magic' })}
+      >
+        <EnvelopeIcon className="h-4 w-4" />
+        <span className="truncate">Magic codes</span>
+      </button>
+    </div>
+  );
+}
+
+function MasterDetailShell({
+  appTitle,
+  model,
+  actions,
+}: {
+  appTitle: string;
+  model: AuthModel;
+  actions: Actions;
+}) {
+  const [selected, setSelected] = useState<Target>({ kind: 'social' });
+  return (
+    <div className="flex min-h-full">
+      <aside className="sticky top-0 max-h-screen w-60 shrink-0 self-start overflow-auto border-r border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-800 dark:bg-neutral-950">
+        <AuthRailItems
+          selected={selected}
+          onSelect={setSelected}
+          model={model}
+        />
+      </aside>
+      <main className="min-w-0 flex-1 px-6 py-6 md:px-8">
+        <div className="mx-auto max-w-2xl">
+          <div
+            key={`${selected.kind}-${'id' in selected ? selected.id : ''}`}
+            className="duration-200 animate-in fade-in"
+          >
+            <MethodPane
+              selected={selected}
+              onSelect={setSelected}
+              model={model}
+              actions={actions}
+              appTitle={appTitle}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+// -------------------- shell: merged nav --------------------
+// The auth sub-tree lives inside the global left nav (Auth expanded), so there
+// is a single rail instead of nav-rail + master-rail. The content area is the
+// detail pane. Reuses the same overview/leaf content as master-detail.
+
+const GLOBAL_TABS: { id: string; label: string; icon: ReactNode }[] = [
+  { id: 'home', label: 'Home', icon: <HomeIcon className="h-3.5 w-3.5" /> },
+  {
+    id: 'explorer',
+    label: 'Explorer',
+    icon: <FunnelIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'schema',
+    label: 'Schema',
+    icon: <CodeBracketIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'perms',
+    label: 'Permissions',
+    icon: <LockClosedIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'auth',
+    label: 'Auth',
+    icon: <IdentificationIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'repl',
+    label: 'Query Inspector',
+    icon: <MagnifyingGlassIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'webhooks',
+    label: 'Webhooks',
+    icon: <BoltIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'sandbox',
+    label: 'Sandbox',
+    icon: <BeakerIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'admin',
+    label: 'Admin',
+    icon: <ShieldCheckIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'billing',
+    label: 'Billing',
+    icon: <CreditCardIcon className="h-3.5 w-3.5" />,
+  },
+  {
+    id: 'oauth-apps',
+    label: 'OAuth Apps',
+    icon: <CubeIcon className="h-3.5 w-3.5" />,
+  },
+];
+
+function MergedNav({
+  model,
+  selected,
+  onSelect,
+}: {
+  model: AuthModel;
+  selected: Target;
+  onSelect: (t: Target) => void;
+}) {
+  return (
+    <nav className="sticky top-0 max-h-screen w-56 shrink-0 self-start overflow-auto border-r border-gray-200 bg-[#fbfaf8] p-2 dark:border-neutral-800 dark:bg-neutral-950">
+      {GLOBAL_TABS.map((tab) => {
+        if (tab.id !== 'auth') {
+          return (
+            <div
+              key={tab.id}
+              className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-gray-500 dark:text-neutral-400"
+            >
+              {tab.icon}
+              <span>{tab.label}</span>
+            </div>
+          );
+        }
+        return (
+          <div key="auth" className="my-0.5">
+            <div className="flex items-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-950 shadow-xs dark:bg-neutral-900 dark:text-white">
+              {tab.icon}
+              <span>Auth</span>
+            </div>
+            <div className="mt-1 mb-1 ml-[1.4rem] border-l border-gray-200 pl-1.5 dark:border-neutral-800">
+              <AuthRailItems
+                selected={selected}
+                onSelect={onSelect}
+                model={model}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}
+
+function MergedNavShell({
+  appTitle,
+  model,
+  actions,
+}: {
+  appTitle: string;
+  model: AuthModel;
+  actions: Actions;
+}) {
+  const [selected, setSelected] = useState<Target>({ kind: 'social' });
+  return (
+    <div className="flex min-h-full">
+      <MergedNav model={model} selected={selected} onSelect={setSelected} />
+      <main className="min-w-0 flex-1 px-6 py-6 md:px-8">
+        <div className="mx-auto max-w-2xl">
+          <div
+            key={`${selected.kind}-${'id' in selected ? selected.id : ''}`}
+            className="duration-200 animate-in fade-in"
+          >
+            <MethodPane
+              selected={selected}
+              onSelect={setSelected}
+              model={model}
+              actions={actions}
+              appTitle={appTitle}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+// -------------------- entry --------------------
+
+export function AuthFlows({
+  idea,
+  appTitle,
+}: {
+  idea: FlowIdea;
+  appTitle: string;
+}) {
+  const { model, actions } = useAuthModel();
+  if (idea === 'merged') {
+    return (
+      <MergedNavShell appTitle={appTitle} model={model} actions={actions} />
+    );
+  }
+  if (idea === 'master') {
+    return (
+      <MasterDetailShell appTitle={appTitle} model={model} actions={actions} />
+    );
+  }
+  if (idea === 'sheet') {
+    return <SheetShell appTitle={appTitle} model={model} actions={actions} />;
+  }
+  return <DrillInShell appTitle={appTitle} model={model} actions={actions} />;
+}

--- a/client/www/pages/dash-redesign/_views/Auth/index.tsx
+++ b/client/www/pages/dash-redesign/_views/Auth/index.tsx
@@ -1,6 +1,16 @@
 export { Current as AuthView } from './Current';
 
 export type AuthSubState =
+  | 'flow-drill'
+  | 'flow-master'
+  | 'flow-merged'
+  | 'flow-sheet'
+  | 'redesign-quiet-panels'
+  | 'redesign-quiet-rows'
+  | 'redesign-quiet-column'
+  | 'redesign-tracks'
+  | 'redesign-columns'
+  | 'redesign-focused'
   | 'clients-empty'
   | 'clients-overview'
   | 'picker'
@@ -16,6 +26,16 @@ export type AuthSubState =
   | 'magic-email';
 
 export const AUTH_SUB_STATES: { key: AuthSubState; label: string }[] = [
+  { key: 'flow-drill', label: 'Flow · drill-in' },
+  { key: 'flow-master', label: 'Flow · master-detail' },
+  { key: 'flow-merged', label: 'Flow · merged nav' },
+  { key: 'flow-sheet', label: 'Flow · sheet' },
+  { key: 'redesign-quiet-panels', label: 'Quiet · two panels' },
+  { key: 'redesign-quiet-rows', label: 'Quiet · settings rows' },
+  { key: 'redesign-quiet-column', label: 'Quiet · one column' },
+  { key: 'redesign-tracks', label: 'Bold · stacked tracks' },
+  { key: 'redesign-columns', label: 'Bold · two columns' },
+  { key: 'redesign-focused', label: 'Bold · focused method' },
   { key: 'clients-overview', label: 'Clients · overview' },
   { key: 'clients-empty', label: 'Clients · empty' },
   { key: 'picker', label: 'Add client · picker' },

--- a/client/www/pages/dash-redesign/_views/Billing/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Billing/Current.tsx
@@ -1,5 +1,9 @@
 import { Button, Content, SectionHeading } from '@/components/ui';
 import {
+  DashPage,
+  DashNotice,
+  DashPanel,
+  DashPanelHeader,
   DashShell,
   EphemeralError,
   EphemeralLoading,
@@ -35,41 +39,55 @@ function BillingBody() {
   };
 
   return (
-    <div className="flex max-w-md flex-col gap-4 p-4">
-      <SectionHeading>Billing</SectionHeading>
-      <div className="flex items-center gap-2">
-        <h1 className="font-bold">Current plan</h1>
-        <div className="rounded-sm border px-2 py-1 font-bold dark:border-neutral-600">
-          {subscriptionName}
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-1 rounded-sm border bg-white px-2 pt-1 pb-3 dark:border-neutral-700 dark:bg-neutral-800">
-        <h2 className="flex justify-between gap-2 p-2">
-          <span className="font-bold">Usage</span>{' '}
-          <span className="font-mono text-sm">
-            {friendly(totalUsageBytes)} / {friendly(limitBytes)}
-          </span>
-        </h2>
-        <ProgressBar width={progress} />
-        <div className="flex justify-start gap-4 pt-3 pl-2 text-sm">
-          <span className="font-mono text-sm text-gray-500 dark:text-neutral-400">
-            DB ({friendly(totalAppBytes)})
-          </span>
-          <span className="font-mono text-sm text-gray-500 dark:text-neutral-400">
-            Storage ({friendly(totalStorageBytes)})
-          </span>
-        </div>
-      </div>
-
-      <div className="flex flex-col space-y-4">
-        <Button variant="primary">Upgrade to Pro</Button>
-        <Content className="rounded-sm border border-purple-400 bg-purple-100 px-2 py-1 text-sm text-purple-800 italic dark:border-purple-500/50 dark:bg-purple-500/20 dark:text-white">
-          Pro offers 10GB of storage, backups, multiple team members for apps,
-          and priority support.
+    <DashPage size="default">
+      <div>
+        <SectionHeading>Billing</SectionHeading>
+        <Content className="mt-1">
+          Review usage and upgrade when you need more room.
         </Content>
       </div>
-    </div>
+
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_320px]">
+        <DashPanel>
+          <DashPanelHeader
+            title="Usage"
+            description={`${friendly(totalUsageBytes)} of ${friendly(
+              limitBytes,
+            )} used`}
+          />
+          <ProgressBar width={progress} />
+          <div className="flex justify-start gap-4 pt-4 text-sm">
+            <span className="font-mono text-sm text-gray-500 dark:text-neutral-400">
+              DB ({friendly(totalAppBytes)})
+            </span>
+            <span className="font-mono text-sm text-gray-500 dark:text-neutral-400">
+              Storage ({friendly(totalStorageBytes)})
+            </span>
+          </div>
+        </DashPanel>
+
+        <DashPanel>
+          <DashPanelHeader
+            title="Current plan"
+            description="Free plan"
+            action={
+              <div className="rounded-md border border-gray-200 bg-[#fbfaf8] px-3 py-1.5 text-sm font-semibold dark:border-neutral-700 dark:bg-neutral-800">
+                {subscriptionName}
+              </div>
+            }
+          />
+          <div className="flex flex-col gap-3">
+            <Button variant="primary" size="large">
+              Upgrade to Pro
+            </Button>
+            <DashNotice tone="neutral">
+              Pro includes 10GB of storage, backups, multiple team members, and
+              priority support.
+            </DashNotice>
+          </div>
+        </DashPanel>
+      </div>
+    </DashPage>
   );
 }
 

--- a/client/www/pages/dash-redesign/_views/EnterCode/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/EnterCode/Current.tsx
@@ -8,28 +8,28 @@ export function Current() {
   return (
     <AuthShell>
       <form
-        className="flex flex-col gap-5"
+        className="flex flex-col gap-4"
         onSubmit={(e) => e.preventDefault()}
       >
-        <ScreenHeading className="text-5xl">Enter your code</ScreenHeading>
-        <Content className="text-2xl leading-9 text-gray-950 dark:text-neutral-200">
+        <ScreenHeading className="text-3xl">Enter your code</ScreenHeading>
+        <Content className="text-base leading-6 text-gray-600 dark:text-neutral-400">
           We sent an email to{' '}
           <strong className="dark:text-white">{sentEmail}</strong>. Check your
           email, and paste the code you see.
         </Content>
         <TextInput
           autoFocus
-          size="jumbo"
+          size="large"
           className="appearance-none outline-hidden"
           placeholder="Your code"
           inputMode="numeric"
           value={code}
           onChange={(v) => setCode(v)}
         />
-        <Button size="jumbo" type="submit" disabled={code.trim().length === 0}>
+        <Button size="large" type="submit" disabled={code.trim().length === 0}>
           Verify code
         </Button>
-        <Button size="large" variant="subtle" onClick={() => {}}>
+        <Button variant="subtle" onClick={() => {}}>
           Back to login
         </Button>
       </form>

--- a/client/www/pages/dash-redesign/_views/EnterCode/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/EnterCode/Current.tsx
@@ -8,27 +8,29 @@ export function Current() {
   return (
     <AuthShell>
       <form
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         onSubmit={(e) => e.preventDefault()}
       >
-        <ScreenHeading>Enter your code</ScreenHeading>
-        <Content>
+        <ScreenHeading className="text-5xl">Enter your code</ScreenHeading>
+        <Content className="text-2xl leading-9 text-gray-950 dark:text-neutral-200">
           We sent an email to{' '}
           <strong className="dark:text-white">{sentEmail}</strong>. Check your
           email, and paste the code you see.
         </Content>
         <TextInput
-          className="w-full appearance-none rounded-sm outline-hidden"
+          autoFocus
+          size="jumbo"
+          className="appearance-none outline-hidden"
           placeholder="Your code"
           inputMode="numeric"
           value={code}
           onChange={(v) => setCode(v)}
         />
-        <Button type="submit" disabled={code.trim().length === 0}>
-          Verify Code
+        <Button size="jumbo" type="submit" disabled={code.trim().length === 0}>
+          Verify code
         </Button>
-        <Button variant="subtle" onClick={() => {}}>
-          Back to Login
+        <Button size="large" variant="subtle" onClick={() => {}}>
+          Back to login
         </Button>
       </form>
     </AuthShell>

--- a/client/www/pages/dash-redesign/_views/Home/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Home/Current.tsx
@@ -1,10 +1,11 @@
 import { useContext, useEffect, useState } from 'react';
-import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import {
-  Button,
+  ArrowTopRightOnSquareIcon,
+  CheckIcon,
+  ClipboardDocumentIcon,
+} from '@heroicons/react/24/outline';
+import {
   Content,
-  Copyable,
-  ScreenHeading,
   SectionHeading,
   Select,
   SubsectionHeading,
@@ -14,7 +15,14 @@ import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
 import config from '@/lib/config';
 import AnimatedCounter from '@/components/AnimatedCounter';
-import { DashShell, toDirectoryName, useFetchedDash } from '../_shared';
+import {
+  DashPage,
+  DashPanel,
+  DashPanelHeader,
+  DashShell,
+  toDirectoryName,
+  useFetchedDash,
+} from '../_shared';
 
 type AppStatsResponse = {
   count: number;
@@ -73,9 +81,9 @@ function AppStatsSection({ app }: { app: InstantApp }) {
     : [];
 
   return (
-    <div className="mt-10">
-      <SectionHeading>Your App Statistics</SectionHeading>
-      <div className="mt-4 space-y-2 rounded-sm border bg-white p-4 shadow-xs transition-colors dark:border-neutral-700 dark:bg-neutral-800">
+    <DashPanel>
+      <DashPanelHeader title="Live sessions" />
+      <div className="space-y-2">
         <div className="flex items-center justify-between">
           <div className="mt-1">
             {isLoading ? (
@@ -92,7 +100,7 @@ function AppStatsSection({ app }: { app: InstantApp }) {
         </div>
 
         {!isLoading && !error && sortedOrigins.length > 0 && (
-          <div className="mt-4 border-gray-200 pt-4 dark:border-neutral-600">
+          <div className="mt-4 border-t border-gray-200 pt-4 dark:border-neutral-800">
             <div className="mb-2 text-sm font-medium text-gray-500 dark:text-neutral-400">
               Per Origin
             </div>
@@ -130,7 +138,7 @@ function AppStatsSection({ app }: { app: InstantApp }) {
           </div>
         )}
       </div>
-    </div>
+    </DashPanel>
   );
 }
 
@@ -190,10 +198,12 @@ function HomeCard({
   return (
     <a
       href={href}
-      className="block cursor-pointer justify-start space-y-2 rounded-sm border bg-white p-4 shadow-xs transition-colors hover:bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700/50"
+      className="block cursor-pointer justify-start rounded-md border border-gray-200 bg-white p-4 shadow-xs transition-colors hover:border-gray-300 hover:bg-[#fbfaf8] dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
     >
       <div>
-        <div className="font-bold">{title}</div>
+        <div className="font-semibold text-gray-950 dark:text-white">
+          {title}
+        </div>
         <div className="text-sm text-gray-500 dark:text-neutral-400">
           {description}
         </div>
@@ -202,138 +212,144 @@ function HomeCard({
   );
 }
 
+function CommandSnippet({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div className="flex min-w-0 items-center overflow-hidden rounded-md border border-gray-200 bg-gray-950 text-sm text-gray-100 shadow-xs dark:border-neutral-700 dark:bg-neutral-950">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center border-r border-white/10 font-mono text-gray-500">
+        $
+      </div>
+      <code className="min-w-0 flex-1 overflow-x-auto px-3 font-mono text-[13px] whitespace-nowrap">
+        {value}
+      </code>
+      <button
+        type="button"
+        className="mr-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-white/10 hover:text-white"
+        title="Copy command"
+        onClick={() => {
+          window.navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+      >
+        {copied ? (
+          <CheckIcon className="h-4 w-4" />
+        ) : (
+          <ClipboardDocumentIcon className="h-4 w-4" />
+        )}
+      </button>
+    </div>
+  );
+}
+
 function HomeBody({ app }: { app: InstantApp }) {
   const [framework, setFramework] = useState<Framework>('nextjs');
-  const [hideAppId, setHideAppId] = useState(false);
   const dirName = toDirectoryName(app.title);
   const steps = getHomeSteps(framework, dirName, app.id, app.admin_token);
 
   return (
-    <div className="max-w-2xl p-4 text-sm md:text-base">
-      <div className="pb-10">
-        <SectionHeading>Getting Started</SectionHeading>
-        <div className="flex flex-wrap items-center gap-1 pt-1">
-          <span>Run these commands to create a new</span>
-          <Select
-            value={framework}
-            options={[
-              { label: 'web app', value: 'nextjs' },
-              { label: 'mobile app', value: 'expo' },
-            ]}
-            onChange={(option) =>
-              option && setFramework(option.value as Framework)
+    <DashPage size="wide">
+      <div>
+        <SectionHeading>Home</SectionHeading>
+        <Content className="mt-1">
+          Start a new app with the credentials already wired in.
+        </Content>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.25fr)_340px]">
+        <DashPanel className="min-w-0">
+          <DashPanelHeader
+            title="Getting started"
+            description="Choose a target and run the commands in order."
+            action={
+              <Select
+                value={framework}
+                options={[
+                  { label: 'Web app', value: 'nextjs' },
+                  { label: 'Mobile app', value: 'expo' },
+                ]}
+                onChange={(option) =>
+                  option && setFramework(option.value as Framework)
+                }
+              />
             }
           />
-          <span>with your credentials.</span>
-        </div>
 
-        <div className="mt-6">
-          {steps.map((step, index) => (
-            <div key={index} className="flex gap-4">
-              <div className="flex flex-col items-center">
-                <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-neutral-400/20 bg-gray-200 text-sm font-medium text-gray-700 dark:bg-neutral-700 dark:text-neutral-300">
-                  {index + 1}
+          <div>
+            {steps.map((step, index) => (
+              <div key={index} className="flex gap-4">
+                <div className="flex flex-col items-center">
+                  <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-gray-200 bg-[#fbfaf8] text-sm font-semibold text-gray-700 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+                    {index + 1}
+                  </div>
+                  {index < steps.length - 1 && (
+                    <div className="h-full w-px bg-gray-200 dark:bg-neutral-800" />
+                  )}
                 </div>
-                {index < steps.length - 1 && (
-                  <div className="h-full w-px bg-gray-200 dark:bg-neutral-700" />
-                )}
+                <div className="min-w-0 flex-1 pb-4">
+                  <SubsectionHeading>{step.title}</SubsectionHeading>
+                  <Content>
+                    <p className="mt-1 text-sm">{step.description}</p>
+                  </Content>
+                  {step.command && (
+                    <div className="mt-3 mb-4">
+                      <CommandSnippet value={step.command} />
+                    </div>
+                  )}
+                  {step.link && (
+                    <div className="mt-3 mb-4">
+                      <a
+                        href={step.link}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                      >
+                        {step.link}
+                        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                      </a>
+                    </div>
+                  )}
+                </div>
               </div>
-              <div className="min-w-0 flex-1 pb-2">
-                <SubsectionHeading>{step.title}</SubsectionHeading>
-                <Content>
-                  <p className="mt-1 text-sm">{step.description}</p>
-                </Content>
-                {step.command && (
-                  <div className="mt-3 mb-4">
-                    <Copyable value={step.command} label="$" />
-                  </div>
-                )}
-                {step.link && (
-                  <div className="mt-3 mb-4">
-                    <a
-                      href={step.link}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                    >
-                      {step.link}
-                      <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-                    </a>
-                  </div>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-2 border-t pt-6 dark:border-neutral-700">
-          <div className="flex gap-4">
-            <div className="flex flex-col items-center">
-              <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-green-600/30 bg-green-100 text-sm dark:bg-green-900/30">
-                <span className="text-green-600 dark:text-green-400">✓</span>
-              </div>
-            </div>
-            <div className="flex-1">
-              <SubsectionHeading>Got it working?</SubsectionHeading>
-              <Content>
-                <p className="mt-1 text-sm">Give yourself a pat on the back!</p>
-              </Content>
-              <Button variant="secondary" className="mt-3" size="normal">
-                Heck yeah!
-              </Button>
-            </div>
+            ))}
           </div>
+
+          <div className="mt-1 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-800 dark:bg-neutral-950">
+            <SubsectionHeading>Verify the connection</SubsectionHeading>
+            <Content>
+              <p className="mt-1 text-sm">
+                Once your app connects, the live session count updates in the
+                app health panel. Then use Explorer or Sandbox to inspect data.
+              </p>
+            </Content>
+          </div>
+        </DashPanel>
+
+        <div className="flex min-w-0 flex-col gap-4">
+          <AppStatsSection app={app} />
+
+          <DashPanel>
+            <DashPanelHeader
+              title="Next steps"
+              description="Helpful links once the app is running."
+            />
+            <div className="grid gap-2">
+              <HomeCard
+                href="/docs"
+                title="Read the docs"
+                description="Start learning how to use Instant."
+              />
+              <HomeCard
+                href="https://discord.com/invite/VU53p7uQcE"
+                title="Join the community"
+                description="Meet other builders and share feedback."
+              />
+            </div>
+          </DashPanel>
         </div>
       </div>
-
-      <SectionHeading>Next Steps</SectionHeading>
-      <div className="pt-1">
-        Now that you have your app running, here's some helpful links on what to
-        do next!
-      </div>
-
-      <div className="flex flex-col gap-4 pt-4 md:flex-row md:flex-wrap md:justify-center">
-        <div className="md:w-[calc(50%-0.5rem)]">
-          <HomeCard
-            href="/docs"
-            title="Read the Docs"
-            description="Jump into our docs to start learning how to use Instant."
-          />
-        </div>
-        <div className="md:w-[calc(50%-0.5rem)]">
-          <HomeCard
-            href="https://discord.com/invite/VU53p7uQcE"
-            title="Join the community"
-            description="Join our Discord to meet like-minded hackers, and to give us feedback too!"
-          />
-        </div>
-      </div>
-
-      <div className="mt-10">
-        <SectionHeading>Your Public App ID</SectionHeading>
-        <div className="pt-1">
-          Use this App ID to connect to your database{' '}
-          <a
-            className="underline hover:cursor-pointer dark:text-white"
-            href="/docs/init"
-            target="_blank"
-          >
-            via init
-          </a>
-          . This ID is safe to use in public-facing applications.
-        </div>
-        <div className="mt-4">
-          <Copyable
-            value={app.id}
-            size="large"
-            hideValue={hideAppId}
-            onChangeHideValue={() => setHideAppId(!hideAppId)}
-          />
-        </div>
-      </div>
-
-      <AppStatsSection app={app} />
-    </div>
+    </DashPage>
   );
 }
 

--- a/client/www/pages/dash-redesign/_views/Login/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Login/Current.tsx
@@ -15,33 +15,36 @@ export function Current() {
   return (
     <AuthShell>
       <form
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         onSubmit={(e) => e.preventDefault()}
       >
-        <ScreenHeading>Let's log you in</ScreenHeading>
-        <Content>
+        <ScreenHeading className="text-5xl">Let's log you in</ScreenHeading>
+        <Content className="text-2xl leading-9 text-gray-950 dark:text-neutral-200">
           Enter your email, and we’ll send you a verification code. We'll create
           an account for you too if you don't already have one :)
         </Content>
         <TextInput
-          className="w-full rounded-sm"
-          placeholder="Enter your email address"
+          autoFocus
+          size="jumbo"
+          className="pr-14"
+          placeholder="Enter your email"
           type="email"
+          ignorePasswordManagers
           value={email}
           onChange={(v) => setEmail(v)}
         />
-        <Button type="submit" disabled={email.trim().length === 0}>
-          Send Code
+        <Button size="jumbo" type="submit" disabled={email.trim().length === 0}>
+          Send code
         </Button>
       </form>
       <Divider>
-        <span className="mx-4 text-xs text-gray-900 dark:text-neutral-400">
-          OR
+        <span className="mx-4 text-base text-gray-500 dark:text-neutral-400">
+          or
         </span>
       </Divider>
-      <Button variant="secondary" type="link" href="#">
-        <span className="flex items-center space-x-2">
-          <Image alt="google icon" src={googleIconSvg} width={16} />
+      <Button size="jumbo" variant="secondary" type="link" href="#">
+        <span className="flex items-center gap-4">
+          <Image alt="google icon" src={googleIconSvg} width={28} />
           <span>Continue with Google</span>
         </span>
       </Button>

--- a/client/www/pages/dash-redesign/_views/Login/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Login/Current.tsx
@@ -15,36 +15,35 @@ export function Current() {
   return (
     <AuthShell>
       <form
-        className="flex flex-col gap-5"
+        className="flex flex-col gap-4"
         onSubmit={(e) => e.preventDefault()}
       >
-        <ScreenHeading className="text-5xl">Let's log you in</ScreenHeading>
-        <Content className="text-2xl leading-9 text-gray-950 dark:text-neutral-200">
+        <ScreenHeading className="text-3xl">Let's log you in</ScreenHeading>
+        <Content className="text-base leading-6 text-gray-600 dark:text-neutral-400">
           Enter your email, and we’ll send you a verification code. We'll create
           an account for you too if you don't already have one :)
         </Content>
         <TextInput
           autoFocus
-          size="jumbo"
-          className="pr-14"
+          size="large"
           placeholder="Enter your email"
           type="email"
           ignorePasswordManagers
           value={email}
           onChange={(v) => setEmail(v)}
         />
-        <Button size="jumbo" type="submit" disabled={email.trim().length === 0}>
+        <Button size="large" type="submit" disabled={email.trim().length === 0}>
           Send code
         </Button>
       </form>
       <Divider>
-        <span className="mx-4 text-base text-gray-500 dark:text-neutral-400">
+        <span className="mx-4 text-sm text-gray-500 dark:text-neutral-400">
           or
         </span>
       </Divider>
-      <Button size="jumbo" variant="secondary" type="link" href="#">
-        <span className="flex items-center gap-4">
-          <Image alt="google icon" src={googleIconSvg} width={28} />
+      <Button size="large" variant="secondary" type="link" href="#">
+        <span className="flex items-center gap-2.5">
+          <Image alt="google icon" src={googleIconSvg} width={20} />
           <span>Continue with Google</span>
         </span>
       </Button>

--- a/client/www/pages/dash-redesign/_views/OAuthApps/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/OAuthApps/Current.tsx
@@ -4,14 +4,17 @@ import {
   ActionForm,
   Button,
   Content,
-  Copyable,
-  Divider,
-  Label,
   SectionHeading,
   SubsectionHeading,
   TextInput,
 } from '@/components/ui';
 import {
+  DashPage,
+  DashNotice,
+  DashPanel,
+  DashPanelHeader,
+  DashRow,
+  DashSecretField,
   DashShell,
   EphemeralError,
   EphemeralLoading,
@@ -62,7 +65,7 @@ const MOCK_CLIENT_SECRET =
 
 function MockLogo() {
   return (
-    <div className="flex h-12 w-12 place-content-center items-center rounded-lg border-2 border-dashed border-gray-400 bg-gray-100 dark:border-neutral-600 dark:bg-neutral-700">
+    <div className="flex h-12 w-12 place-content-center items-center rounded-lg border border-dashed border-gray-300 bg-[#fbfaf8] text-gray-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
       <ArrowUpTrayIcon height="1em" className="m-auto" />
     </div>
   );
@@ -73,11 +76,13 @@ function Crumbs({ focusedAppName }: { focusedAppName?: string }) {
     return <SectionHeading>OAuth Apps</SectionHeading>;
   }
   return (
-    <div className="flex flex-row gap-1">
-      <a href="#" className="underline">
-        <SectionHeading>OAuth Apps</SectionHeading>
+    <div>
+      <a
+        href="#"
+        className="text-sm font-medium text-gray-500 hover:text-gray-950 dark:text-neutral-400 dark:hover:text-white"
+      >
+        OAuth Apps
       </a>
-      <SectionHeading>/</SectionHeading>
       <SectionHeading>{focusedAppName}</SectionHeading>
     </div>
   );
@@ -87,23 +92,34 @@ function ListSubView() {
   return (
     <>
       <Crumbs />
-      <div className="flex max-w-md flex-col gap-6">
-        {MOCK_APPS.map((a) => (
-          <div key={a.id} className="flex flex-col gap-4">
+      <DashPanel>
+        <DashPanelHeader
+          title="Registered apps"
+          description="OAuth apps let third-party clients request access through Instant."
+          action={
+            <Button variant="secondary">
+              <PlusIcon height={14} /> Create app
+            </Button>
+          }
+        />
+        <div className="grid gap-3 md:grid-cols-2">
+          {MOCK_APPS.map((a) => (
             <a
+              key={a.id}
               href="#"
-              className="flex w-full cursor-pointer flex-row items-center gap-4 p-2 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-neutral-700"
+              className="flex w-full cursor-pointer flex-row items-center gap-4 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 transition-colors duration-200 hover:border-gray-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
             >
               <MockLogo />
-              <SectionHeading>{a.appName}</SectionHeading>
+              <div className="min-w-0">
+                <SubsectionHeading>{a.appName}</SubsectionHeading>
+                <div className="truncate text-sm text-gray-500 dark:text-neutral-400">
+                  {a.homepageUrl}
+                </div>
+              </div>
             </a>
-            <Divider />
-          </div>
-        ))}
-      </div>
-      <Button variant="secondary">
-        <PlusIcon height={14} /> Create OAuth App
-      </Button>
+          ))}
+        </div>
+      </DashPanel>
     </>
   );
 }
@@ -117,61 +133,61 @@ function CreateAppSubView() {
   return (
     <>
       <Crumbs />
-      <ActionForm className="flex max-w-md flex-col gap-4">
-        <SubsectionHeading>Create a new OAuth App</SubsectionHeading>
-        <div className="flex items-center gap-3">
-          <MockLogo />
-          <Content className="text-sm">Upload a logo (optional).</Content>
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label>Unique name</Label>
+      <DashPanel>
+        <DashPanelHeader
+          title="Create OAuth app"
+          description="Add app details shown during authorization."
+        />
+        <ActionForm className="grid gap-4 md:grid-cols-2">
+          <div className="flex items-center gap-3 md:col-span-2">
+            <MockLogo />
+            <Content className="text-sm">Upload a logo (optional).</Content>
+          </div>
           <TextInput
+            label="Unique name"
+            size="large"
             value={appName}
             onChange={setAppName}
             placeholder="Acme CLI"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label>Homepage URL</Label>
           <TextInput
+            label="Homepage URL"
+            size="large"
             value={homepageUrl}
             onChange={setHomepageUrl}
             placeholder="https://acme.example.com"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label>Privacy policy URL</Label>
           <TextInput
+            label="Privacy policy URL"
+            size="large"
             value={privacyPolicy}
             onChange={setPrivacyPolicy}
             placeholder="https://acme.example.com/privacy"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label>Terms of service URL</Label>
           <TextInput
+            label="Terms of service URL"
+            size="large"
             value={tos}
             onChange={setTos}
             placeholder="https://acme.example.com/tos"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label>Support email</Label>
           <TextInput
+            label="Support email"
+            size="large"
             value={supportEmail}
             onChange={setSupportEmail}
             placeholder="support@acme.example.com"
           />
-        </div>
-        <div className="flex justify-end gap-2">
-          <Button variant="secondary" type="button">
-            Cancel
-          </Button>
-          <Button variant="primary" type="submit">
-            Create app
-          </Button>
-        </div>
-      </ActionForm>
+          <div className="flex items-end justify-end gap-2">
+            <Button variant="secondary" size="large" type="button">
+              Cancel
+            </Button>
+            <Button variant="primary" size="large" type="submit">
+              Create app
+            </Button>
+          </div>
+        </ActionForm>
+      </DashPanel>
     </>
   );
 }
@@ -181,77 +197,74 @@ function AppDetailSubView() {
   return (
     <>
       <Crumbs focusedAppName={app.appName} />
-      <div className="flex max-w-2xl flex-col gap-6">
-        <div className="flex items-center gap-4">
-          <MockLogo />
-          <div className="flex flex-col">
-            <SubsectionHeading>{app.appName}</SubsectionHeading>
-            <a
-              href={app.homepageUrl}
-              className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-            >
-              {app.homepageUrl}
-            </a>
-          </div>
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="flex flex-col gap-4">
+          <DashPanel>
+            <div className="flex items-center gap-4">
+              <MockLogo />
+              <div className="min-w-0">
+                <SubsectionHeading>{app.appName}</SubsectionHeading>
+                <a
+                  href={app.homepageUrl}
+                  className="truncate text-sm text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {app.homepageUrl}
+                </a>
+              </div>
+            </div>
+          </DashPanel>
+
+          <DashPanel>
+            <DashPanelHeader
+              title="Clients"
+              action={
+                <Button variant="secondary" size="mini">
+                  <PlusIcon height={12} /> New client
+                </Button>
+              }
+            />
+            <div>
+              {app.clients.map((c) => (
+                <DashRow
+                  key={c.id}
+                  label={c.clientName}
+                  value={c.authorizedRedirectUrls[0]}
+                  action={
+                    <div className="font-mono text-xs text-gray-500 dark:text-neutral-400">
+                      {c.clientId}
+                    </div>
+                  }
+                />
+              ))}
+            </div>
+          </DashPanel>
         </div>
 
-        <div className="flex flex-col gap-3 rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <div className="grid grid-cols-2 gap-3 text-sm">
+        <div className="flex flex-col gap-4">
+          <DashPanel>
+            <DashPanelHeader title="App details" />
             <div>
-              <Label>Privacy policy</Label>
-              <div className="truncate">{app.appPrivacyPolicyLink}</div>
+              <DashRow
+                label="Privacy policy"
+                value={app.appPrivacyPolicyLink}
+              />
+              <DashRow label="Terms of service" value={app.appTosLink} />
+              <DashRow label="Support email" value={app.supportEmail} />
             </div>
-            <div>
-              <Label>Terms of service</Label>
-              <div className="truncate">{app.appTosLink}</div>
-            </div>
-            <div>
-              <Label>Support email</Label>
-              <div>{app.supportEmail}</div>
-            </div>
-          </div>
-          <div>
-            <Button variant="secondary" size="mini">
+            <Button className="mt-3" variant="secondary" size="mini">
               Edit details
             </Button>
-          </div>
-        </div>
+          </DashPanel>
 
-        <div className="flex items-center justify-between">
-          <SubsectionHeading>Clients</SubsectionHeading>
-          <Button variant="secondary" size="mini">
-            <PlusIcon height={12} /> New client
-          </Button>
-        </div>
-        <div className="divide-y rounded-sm border bg-white dark:divide-neutral-700 dark:border-neutral-700 dark:bg-neutral-800">
-          {app.clients.map((c) => (
-            <div key={c.id} className="flex flex-col gap-1 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="font-medium">{c.clientName}</div>
-                <div className="font-mono text-xs text-gray-500 dark:text-neutral-400">
-                  {c.clientId}
-                </div>
-              </div>
-              <div className="text-xs text-gray-500 dark:text-neutral-400">
-                {c.authorizedRedirectUrls[0]}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div>
-          <SubsectionHeading>Delete {app.appName}</SubsectionHeading>
-          <Content className="dark:text-neutral-400">
-            <p>
-              Deleting this OAuth app will revoke all client access. This cannot
-              be undone.
-            </p>
-          </Content>
-          <div className="mt-3">
+          <DashPanel>
+            <DashPanelHeader
+              title={`Delete ${app.appName}`}
+              description="Revoke all client access for this OAuth app."
+            />
             <Button variant="destructive" size="mini">
               Delete app
             </Button>
-          </div>
+          </DashPanel>
         </div>
       </div>
     </>
@@ -265,33 +278,33 @@ function CreateClientSubView() {
   return (
     <>
       <Crumbs focusedAppName={app.appName} />
-      <ActionForm className="flex max-w-md flex-col gap-4">
-        <SubsectionHeading>Create a new Client</SubsectionHeading>
-        <div className="flex flex-col gap-1">
-          <Label>Client name</Label>
+      <DashPanel className="max-w-2xl">
+        <DashPanelHeader title="Create client" />
+        <ActionForm className="grid gap-4">
           <TextInput
+            label="Client name"
+            size="large"
             value={clientName}
             onChange={setClientName}
             placeholder="Production"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label>Authorized redirect URL</Label>
           <TextInput
+            label="Authorized redirect URL"
+            size="large"
             value={redirectUrl}
             onChange={setRedirectUrl}
             placeholder="https://acme.example.com/oauth/callback"
           />
-        </div>
-        <div className="flex justify-end gap-2">
-          <Button variant="secondary" type="button">
-            Cancel
-          </Button>
-          <Button variant="primary" type="submit">
-            Create client
-          </Button>
-        </div>
-      </ActionForm>
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" size="large" type="button">
+              Cancel
+            </Button>
+            <Button variant="primary" size="large" type="submit">
+              Create client
+            </Button>
+          </div>
+        </ActionForm>
+      </DashPanel>
     </>
   );
 }
@@ -300,37 +313,38 @@ function ClientSecretSubView() {
   return (
     <>
       <Crumbs focusedAppName={MOCK_FOCUSED_APP.appName} />
-      <div className="flex max-w-md flex-col gap-3 rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
-        <SubsectionHeading>Copy your client secret</SubsectionHeading>
-        <Content>
-          <p>
-            Copy and save your client secret somewhere safe. Instant does not
-            keep a copy of the secret. You will have to generate a new one if
-            this is lost.
-          </p>
-        </Content>
-        <Copyable
-          value={MOCK_CLIENT_SECRET}
+      <DashPanel className="max-w-2xl">
+        <DashPanelHeader title="Copy your client secret" />
+        <DashNotice tone="warning">
+          Copy and save your client secret somewhere safe. Instant does not keep
+          a copy of the secret. You will have to generate a new one if this is
+          lost.
+        </DashNotice>
+        <DashSecretField
+          className="mt-4"
           label="Client secret"
-          defaultHidden={true}
+          value={MOCK_CLIENT_SECRET}
+          description="Shown once"
         />
-        <div className="flex justify-end">
-          <Button variant="primary">Done</Button>
+        <div className="mt-4 flex justify-end">
+          <Button variant="primary" size="large">
+            Done
+          </Button>
         </div>
-      </div>
+      </DashPanel>
     </>
   );
 }
 
 function OAuthAppsBody({ sub }: { sub: OAuthAppsSubState }) {
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <DashPage size="wide">
       {sub === 'list' && <ListSubView />}
       {sub === 'create-app' && <CreateAppSubView />}
       {sub === 'app-detail' && <AppDetailSubView />}
       {sub === 'create-client' && <CreateClientSubView />}
       {sub === 'client-secret' && <ClientSecretSubView />}
-    </div>
+    </DashPage>
   );
 }
 

--- a/client/www/pages/dash-redesign/_views/Onboarding/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Onboarding/Current.tsx
@@ -46,7 +46,7 @@ function WelcomeStage() {
       <div className="flex max-w-2xl flex-col gap-5">
         <span className="inline-flex items-center gap-2.5">
           <LogoIcon size="normal" />
-          <span className="text-2xl font-semibold tracking-normal text-gray-950 lowercase dark:text-white">
+          <span className="font-mono text-[20px] font-bold text-gray-950 lowercase dark:text-white">
             instant
           </span>
         </span>

--- a/client/www/pages/dash-redesign/_views/Onboarding/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Onboarding/Current.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
-import { Button, Content, ScreenHeading, TextInput } from '@/components/ui';
+import {
+  Button,
+  Content,
+  LogoIcon,
+  ScreenHeading,
+  SubsectionHeading,
+  TextInput,
+} from '@/components/ui';
 import { OnboardingShell } from '../_shared';
 import { OnboardingStage } from './index';
 
@@ -28,15 +35,53 @@ const experienceOptions: {
 ];
 
 function WelcomeStage() {
+  const setupItems = [
+    ['Profile', 'Tell us how you build.'],
+    ['App', 'Name the first project.'],
+    ['Dashboard', 'Land in a configured workspace.'],
+  ];
+
   return (
-    <div className="flex w-full max-w-sm flex-col gap-4 p-4">
-      <div className="flex justify-center text-4xl">🎉️</div>
-      <ScreenHeading className="text-center">Welcome to Instant</ScreenHeading>
-      <Content>
-        We're excited to have you! Before we get started, we need to do two
-        things.
-      </Content>
-      <Button onClick={() => {}}>Let's go!</Button>
+    <div className="grid w-full max-w-5xl gap-8 p-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-center">
+      <div className="flex max-w-2xl flex-col gap-5">
+        <span className="inline-flex items-center gap-2.5">
+          <LogoIcon size="normal" />
+          <span className="text-2xl font-semibold tracking-normal text-gray-950 lowercase dark:text-white">
+            instant
+          </span>
+        </span>
+        <div className="space-y-3">
+          <ScreenHeading>Welcome to Instant</ScreenHeading>
+          <Content className="text-xl leading-8 text-gray-950 dark:text-neutral-200">
+            Set up your profile, name an app, and land in a workspace with auth,
+            schema, explorer, and sandbox ready.
+          </Content>
+        </div>
+        <Button className="w-fit" size="xl" onClick={() => {}}>
+          Start setup
+        </Button>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-xs dark:border-neutral-800 dark:bg-neutral-900">
+        <SubsectionHeading>Setup path</SubsectionHeading>
+        <div className="mt-4 flex flex-col gap-3">
+          {setupItems.map(([title, description], index) => (
+            <div key={title} className="flex gap-3">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-[#fbfaf8] text-xs font-semibold text-gray-700 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+                {index + 1}
+              </div>
+              <div>
+                <div className="text-sm font-semibold text-gray-950 dark:text-white">
+                  {title}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-neutral-400">
+                  {description}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -47,13 +92,13 @@ function ProfileStage() {
   return (
     <form
       onSubmit={(e) => e.preventDefault()}
-      className="flex w-full max-w-md flex-col gap-6 p-4"
+      className="flex w-full max-w-[560px] flex-col gap-6 p-6"
     >
-      <div className="flex justify-center text-4xl">👋</div>
       <ScreenHeading className="text-center">
         Tell us about yourself
       </ScreenHeading>
       <TextInput
+        size="large"
         label="How did you hear about us?"
         placeholder="Twitter, Bookface, Hacker News, etc?"
         value={heard}
@@ -71,8 +116,8 @@ function ProfileStage() {
               onClick={() => setExperience(option.value)}
               className={`flex flex-col gap-1 rounded-md border p-3 text-left transition-colors hover:cursor-pointer ${
                 experience === option.value
-                  ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20'
-                  : 'border-gray-200 hover:border-gray-400 hover:bg-gray-50 dark:border-neutral-700 dark:hover:border-neutral-500 dark:hover:bg-neutral-800'
+                  ? 'border-[#606AF4] bg-[#606AF4]/5 dark:border-[#8f95ff] dark:bg-[#8f95ff]/10'
+                  : 'border-gray-200 bg-white hover:border-gray-300 hover:bg-[#fbfaf8] dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-500 dark:hover:bg-neutral-800'
               }`}
             >
               <span className="font-medium">{option.label}</span>
@@ -83,7 +128,11 @@ function ProfileStage() {
           ))}
         </div>
       </div>
-      <Button type="submit" disabled={heard.trim().length === 0 || !experience}>
+      <Button
+        size="large"
+        type="submit"
+        disabled={heard.trim().length === 0 || !experience}
+      >
         Onwards!
       </Button>
     </form>
@@ -93,23 +142,27 @@ function ProfileStage() {
 function CreateAppStage() {
   const [appName, setAppName] = useState('');
   return (
-    <div className="w-full max-w-sm p-4">
+    <div className="w-full max-w-[660px] p-6">
       <form
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         onSubmit={(e) => e.preventDefault()}
       >
-        <h1 className="flex justify-center text-4xl">🔥</h1>
         <ScreenHeading className="text-center">Name your app</ScreenHeading>
-        <Content>
+        <Content className="text-center text-lg leading-7">
           You're in! Time to build your first app. What would you like to call
           it?
         </Content>
         <TextInput
+          size="jumbo"
           placeholder="Name your app"
           value={appName}
           onChange={(v) => setAppName(v)}
         />
-        <Button type="submit" disabled={appName.trim().length === 0}>
+        <Button
+          size="jumbo"
+          type="submit"
+          disabled={appName.trim().length === 0}
+        >
           Let's build!
         </Button>
       </form>

--- a/client/www/pages/dash-redesign/_views/Org/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Org/Current.tsx
@@ -5,16 +5,21 @@ import {
   Badge,
   Button,
   Content,
-  Label,
   NavTabBar,
   ScreenHeading,
-  SectionHeading,
   SmallCopyable,
-  SubsectionHeading,
   TabItem,
   TextInput,
 } from '@/components/ui';
-import { BackToAppsLink, MockTopBar } from '../_shared';
+import {
+  BackToAppsLink,
+  DashEmptyState,
+  DashPage,
+  DashPanel,
+  DashPanelHeader,
+  DashRow,
+  MockTopBar,
+} from '../_shared';
 import { OrgSubState } from './index';
 
 const MOCK_ORG = {
@@ -31,13 +36,13 @@ const TABS: TabItem[] = [
 
 function OrgHeader() {
   return (
-    <div className="bg-gray-50 dark:bg-neutral-800">
-      <div className="flex flex-col justify-between border-b border-b-gray-300 px-3 py-2 md:flex-row md:gap-4 dark:border-b-neutral-800">
+    <div className="bg-white dark:bg-neutral-950">
+      <div className="flex flex-col justify-between border-b border-gray-200 px-4 py-3 md:flex-row md:items-center md:gap-4 dark:border-neutral-800">
         <div className="flex items-center gap-2">
-          <h2 className="font-mono font-bold md:text-xl">
+          <h2 className="font-semibold md:text-xl">
             <div className="flex items-center gap-4">
               <BuildingOffice2Icon className="opacity-40" width={20} />
-              <div className="text-lg font-bold">{MOCK_ORG.title}</div>
+              <div className="text-xl font-semibold">{MOCK_ORG.title}</div>
             </div>
           </h2>
           <Badge>{MOCK_ORG.plan} Plan</Badge>
@@ -57,86 +62,80 @@ function OrgHeader() {
 function MembersTab() {
   const myEmail = 'sto.pa@instantdb.com';
   return (
-    <div>
-      <div className="flex items-end justify-between py-2">
-        <SubsectionHeading>Current Members</SubsectionHeading>
-        <Button size="mini">Invite</Button>
-      </div>
-      <div className="divide-y rounded-xs border bg-white dark:divide-neutral-700 dark:border-neutral-700 dark:bg-neutral-800">
-        <div className="flex w-full items-center justify-between gap-2 rounded-xs p-2">
-          <div className="flex items-center gap-3">
-            {myEmail}
-            <Badge>Me</Badge>
-          </div>
-          <div className="text-sm">Owner</div>
-        </div>
-        <div className="flex w-full items-center justify-between gap-2 rounded-xs p-2">
-          <div className="flex items-center gap-3">teammate@example.com</div>
-          <div className="text-sm">Admin</div>
-        </div>
-      </div>
-      <div className="mt-6">
-        <SubsectionHeading>Pending Invites</SubsectionHeading>
-        <div className="w-full py-8 text-center text-sm opacity-50">
-          No pending invites
-        </div>
-      </div>
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <DashPanel>
+        <DashPanelHeader
+          title="Current members"
+          action={<Button size="mini">Invite</Button>}
+        />
+        <DashRow
+          label={
+            <span className="flex items-center gap-2">
+              {myEmail}
+              <Badge>Me</Badge>
+            </span>
+          }
+          value="Owner"
+        />
+        <DashRow label="teammate@example.com" value="Admin" />
+      </DashPanel>
+      <DashPanel>
+        <DashPanelHeader title="Pending invites" />
+        <DashEmptyState
+          title="No pending invites"
+          description="Invited teammates will appear here until they accept."
+        />
+      </DashPanel>
     </div>
   );
 }
 
 function BillingTab() {
   return (
-    <div>
-      <SectionHeading className="pt-8 pb-2">Billing</SectionHeading>
-      <Content className="dark:text-neutral-400">
-        <p>You're on the {MOCK_ORG.plan} Plan.</p>
-      </Content>
-      <div className="mt-4 rounded-sm border bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
-        <div className="text-sm text-gray-500 dark:text-neutral-400">
-          Usage and billing details will appear here.
-        </div>
-      </div>
-    </div>
+    <DashPanel>
+      <DashPanelHeader
+        title="Billing"
+        description={`You're on the ${MOCK_ORG.plan} plan.`}
+        action={<Badge>{MOCK_ORG.plan}</Badge>}
+      />
+      <DashEmptyState
+        title="Usage will appear here"
+        description="Storage, bandwidth, and invoices are grouped here for organization billing."
+      />
+    </DashPanel>
   );
 }
 
 function ManageTab() {
   return (
-    <div className="flex flex-col gap-8 pt-6">
-      <div>
-        <SubsectionHeading>Rename organization</SubsectionHeading>
-        <Content className="dark:text-neutral-400">
-          <p>Update the display name shown in the top bar and member views.</p>
-        </Content>
-        <div className="mt-3 flex max-w-md flex-col gap-2">
-          <Label>Name</Label>
+    <div className="grid gap-4 lg:grid-cols-2">
+      <DashPanel>
+        <DashPanelHeader
+          title="Rename organization"
+          description="Update the display name shown in the top bar and member views."
+        />
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
           <TextInput
+            label="Name"
+            size="large"
             value={MOCK_ORG.title}
             onChange={() => {}}
             placeholder="Organization name"
           />
-          <div>
-            <Button variant="primary" size="mini">
-              Save
-            </Button>
-          </div>
-        </div>
-      </div>
-      <div>
-        <SubsectionHeading>Delete organization</SubsectionHeading>
-        <Content className="dark:text-neutral-400">
-          <p>
-            Deleting this org will permanently remove all of its apps, members,
-            and billing history. This cannot be undone.
-          </p>
-        </Content>
-        <div className="mt-3">
-          <Button variant="destructive" size="mini">
-            Delete organization
+          <Button variant="primary" size="large">
+            Save
           </Button>
         </div>
-      </div>
+      </DashPanel>
+      <DashPanel>
+        <DashPanelHeader
+          title="Delete organization"
+          description="Permanently remove all apps, members, and billing history."
+        />
+        <Button variant="destructive" size="mini">
+          Delete organization
+        </Button>
+      </DashPanel>
     </div>
   );
 }
@@ -144,9 +143,8 @@ function ManageTab() {
 function EmptyOrgNewApp() {
   const [name, setName] = useState('');
   return (
-    <div className="my-auto grid h-full w-full place-items-center">
-      <ActionForm className="flex max-w-md flex-col gap-4">
-        <div className="mb-2 flex justify-center text-4xl">🔥</div>
+    <div className="my-auto grid h-full w-full place-items-center p-6">
+      <ActionForm className="flex w-full max-w-[660px] flex-col gap-5">
         <ScreenHeading className="text-center">
           Time for a new app?
         </ScreenHeading>
@@ -157,14 +155,15 @@ function EmptyOrgNewApp() {
         </Content>
         <Content>What would you like to call it?</Content>
         <TextInput
+          size="jumbo"
           placeholder="Name your app"
           value={name}
           onChange={(n) => setName(n)}
         />
-        <Button type="submit" disabled={name.trim().length === 0}>
+        <Button size="jumbo" type="submit" disabled={name.trim().length === 0}>
           Let's go!
         </Button>
-        <Button type="button" variant="secondary">
+        <Button type="button" variant="secondary" size="large">
           Nevermind
         </Button>
       </ActionForm>
@@ -175,7 +174,7 @@ function EmptyOrgNewApp() {
 export function Current({ sub }: { sub: OrgSubState }) {
   if (sub === 'empty') {
     return (
-      <div className="flex min-h-screen flex-col bg-white dark:bg-neutral-900 dark:text-white">
+      <div className="flex min-h-screen flex-col bg-[#fbfaf8] dark:bg-neutral-950 dark:text-white">
         <MockTopBar account={{ kind: 'org', title: MOCK_ORG.title }} />
         <div className="flex flex-1">
           <EmptyOrgNewApp />
@@ -184,13 +183,13 @@ export function Current({ sub }: { sub: OrgSubState }) {
     );
   }
   return (
-    <div className="flex min-h-screen flex-col bg-gray-100 dark:bg-neutral-900 dark:text-white">
+    <div className="flex min-h-screen flex-col bg-[#fbfaf8] dark:bg-neutral-950 dark:text-white">
       <MockTopBar
         account={{ kind: 'org', title: MOCK_ORG.title }}
         leftExtra={<BackToAppsLink />}
       />
       <OrgHeader />
-      <div className="mx-auto w-full max-w-[680px] overflow-scroll px-4 pt-6 lg:px-12">
+      <DashPage size="default">
         <NavTabBar
           className="border-transparent"
           tabs={TABS}
@@ -202,7 +201,7 @@ export function Current({ sub }: { sub: OrgSubState }) {
         {sub === 'members' && <MembersTab />}
         {sub === 'billing' && <BillingTab />}
         {sub === 'manage' && <ManageTab />}
-      </div>
+      </DashPage>
     </div>
   );
 }

--- a/client/www/pages/dash-redesign/_views/Perms/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Perms/Current.tsx
@@ -54,10 +54,12 @@ function DocsCard({
   return (
     <a
       href={href}
-      className="block cursor-pointer justify-start space-y-2 rounded-sm border bg-white p-4 shadow-xs transition-colors hover:bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700/50"
+      className="block cursor-pointer justify-start rounded-md border border-gray-200 bg-[#fbfaf8] p-4 shadow-xs transition-colors hover:border-gray-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
     >
       <div>
-        <div className="font-bold">{title}</div>
+        <div className="font-semibold text-gray-950 dark:text-white">
+          {title}
+        </div>
         <div className="text-sm text-gray-500 dark:text-neutral-400">
           {children}
         </div>
@@ -271,7 +273,7 @@ function PermsContent({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-      <div className="flex min-h-0 min-w-[260px] flex-col gap-4 border-r p-4 text-sm md:basis-96 md:text-base dark:border-r-neutral-700">
+      <div className="flex min-h-0 min-w-[260px] flex-col gap-4 border-r border-gray-200 bg-white p-5 text-sm md:basis-80 dark:border-r-neutral-800 dark:bg-neutral-950">
         <SectionHeading>Permissions</SectionHeading>
         <Content className="dark:text-neutral-300">
           <p>
@@ -288,7 +290,7 @@ function PermsContent({
           Learn how to use CEL expressions to secure your app
         </DocsCard>
       </div>
-      <div className="flex w-full flex-1 flex-col justify-start dark:bg-neutral-800">
+      <div className="flex w-full flex-1 flex-col justify-start dark:bg-neutral-900">
         {errorRes && (
           <div className="bg-red-100 p-4 text-sm">
             <div className="max-w-sm">
@@ -338,8 +340,8 @@ function PermsContent({
             }
           />
         ) : historyUnavailable ? (
-          <div className="flex h-full min-h-0 flex-col bg-gray-50 dark:bg-[#252525]">
-            <div className="flex items-center justify-between gap-4 border-b px-4 py-2 dark:border-b-neutral-700">
+          <div className="flex h-full min-h-0 flex-col bg-white dark:bg-neutral-950">
+            <div className="flex items-center justify-between gap-4 border-b border-gray-200 px-4 py-2 dark:border-b-neutral-800">
               <div className="font-mono">{editorLabel}</div>
               <Button
                 variant="secondary"

--- a/client/www/pages/dash-redesign/_views/Schema/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Schema/Current.tsx
@@ -47,7 +47,7 @@ function SchemaContent({ attrs }: { attrs: Record<string, DBAttr> | null }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-      <div className="flex min-h-0 flex-col gap-4 border-r p-4 text-sm md:text-base lg:basis-96 dark:border-r-neutral-600">
+      <div className="flex min-h-0 flex-col gap-4 border-r border-gray-200 bg-white p-5 text-sm lg:basis-96 dark:border-r-neutral-800 dark:bg-neutral-950">
         <SectionHeading>Schema</SectionHeading>
         <p>This is the schema for your app in code form.</p>
         <p>
@@ -55,17 +55,16 @@ function SchemaContent({ attrs }: { attrs: Record<string, DBAttr> | null }) {
           <code className="tracking-tight">instant-cli</code> to push and pull
           changes to your schema:
         </p>
-        <p>
-          <div className="overflow-auto rounded-sm border bg-white text-sm dark:border-neutral-600 dark:bg-neutral-800">
-            <Fence
-              darkMode={darkMode}
-              copyable
-              className="border-none!"
-              code={`npx instant-cli@latest pull`}
-              language="bash"
-            />
-          </div>
-        </p>
+        <div className="overflow-auto rounded-md border border-gray-200 bg-[#fbfaf8] text-sm dark:border-neutral-800 dark:bg-neutral-900">
+          <Fence
+            darkMode={darkMode}
+            copyable
+            className="border-none!"
+            code={`npx instant-cli@latest pull`}
+            language="bash"
+            style={{ paddingRight: 96 }}
+          />
+        </div>
         <p>
           <a
             className="flex items-baseline gap-1 underline"
@@ -78,7 +77,7 @@ function SchemaContent({ attrs }: { attrs: Record<string, DBAttr> | null }) {
         </p>
       </div>
       <div className="flex w-full flex-1 flex-col justify-start">
-        <div className="flex items-center justify-between gap-4 border-b bg-gray-50 px-4 py-2 dark:border-b-neutral-600 dark:bg-neutral-800">
+        <div className="flex items-center justify-between gap-4 border-b border-gray-200 bg-white px-4 py-2 dark:border-b-neutral-800 dark:bg-neutral-950">
           <div className="font-mono text-sm">instant.schema.ts</div>
           <div className="flex items-center gap-2">
             <Label>Package</Label>

--- a/client/www/pages/dash-redesign/_views/UserSettings/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/UserSettings/Current.tsx
@@ -1,18 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import {
-  ActionForm,
   Button,
   Content,
-  Copyable,
   Dialog,
-  Label,
   NavTabBar,
   SectionHeading,
   SubsectionHeading,
   TabItem,
 } from '@/components/ui';
-import { BackToAppsLink, MockTopBar } from '../_shared';
+import {
+  BackToAppsLink,
+  DashEmptyState,
+  DashNotice,
+  DashPage,
+  DashPanel,
+  DashPanelHeader,
+  DashSecretField,
+  MockTopBar,
+} from '../_shared';
 import { UserSettingsSubState } from './index';
 
 const MOCK_EMAIL = 'sto.pa@instantdb.com';
@@ -26,9 +32,9 @@ const TABS: TabItem[] = [
 
 function UserSettingsShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col bg-gray-100 dark:bg-neutral-900 dark:text-white">
+    <div className="flex min-h-screen flex-col bg-[#fbfaf8] dark:bg-neutral-950 dark:text-white">
       <MockTopBar leftExtra={<BackToAppsLink />} />
-      <div className="mx-auto w-full max-w-4xl px-8 pt-8">{children}</div>
+      {children}
     </div>
   );
 }
@@ -42,10 +48,10 @@ function UserSettingsHeader({
 }) {
   return (
     <>
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col items-baseline pb-4 md:flex-row md:gap-4">
-          <div className="text-lg font-semibold">User Settings</div>
-          <div className="text-gray-600 dark:text-neutral-400">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <SectionHeading>User Settings</SectionHeading>
+          <div className="mt-1 text-sm text-gray-600 dark:text-neutral-400">
             {MOCK_EMAIL}
           </div>
         </div>
@@ -63,72 +69,64 @@ function UserSettingsHeader({
 
 function TokensTab() {
   return (
-    <div className="mx-auto mt-2 flex flex-1 flex-col">
-      <div className="flex flex-row items-center justify-between">
-        <div className="pt-1 pb-4">
-          <div className="prose dark:text-neutral-300">
-            <SectionHeading className="font-bold">
-              Personal Access Tokens <sup className="text-sm">[BETA]</sup>
-            </SectionHeading>
-            <p>
-              Welcome to the Platform Beta! You can create{' '}
-              <code className="dark:bg-neutral-800 dark:text-white">
-                Personal Access Tokens
-              </code>{' '}
-              here. <br />
-              <a className="dark:text-white" href="/labs/platform_demo">
-                Take a look at this guide
-              </a>{' '}
-              to see how to use the platform API, and create apps on demand!
-            </p>
-          </div>
-        </div>
-      </div>
-      <div className="space-y-2">
-        <Button variant="primary" size="mini">
-          <PlusIcon className="mr-1 h-4 w-4" />
-          New access token
-        </Button>
-        <div className="flex flex-col items-center justify-center py-8 text-gray-500 dark:text-neutral-400">
-          <p className="text-sm">No personal access tokens created yet.</p>
-        </div>
-      </div>
-    </div>
+    <DashPanel>
+      <DashPanelHeader
+        title={
+          <>
+            Personal Access Tokens <sup className="text-xs">Beta</sup>
+          </>
+        }
+        description={
+          <>
+            Create tokens for the platform API.{' '}
+            <a className="underline dark:text-white" href="/labs/platform_demo">
+              Read the guide
+            </a>
+            .
+          </>
+        }
+        action={
+          <Button variant="primary" size="mini">
+            <PlusIcon className="mr-1 h-4 w-4" />
+            New token
+          </Button>
+        }
+      />
+      <DashEmptyState
+        title="No tokens yet"
+        description="Create a token when a local tool, script, or service needs Platform API access."
+      />
+    </DashPanel>
   );
 }
 
 function OAuthTab() {
   return (
-    <div className="mt-2 flex max-w-2xl flex-1 flex-col p-4">
-      <div className="flex flex-row items-center gap-4 pb-4">
-        <SectionHeading className="font-bold">
-          Authorized OAuth Apps
-        </SectionHeading>
-      </div>
-      <Content className="dark:text-neutral-400">
-        <p>
-          Below are any OAuth apps that you have granted access to your Instant
-          Account.
-        </p>
-      </Content>
-      <div className="mt-6 text-sm text-gray-500 italic dark:text-neutral-400">
-        You haven't authorized any OAuth apps yet.
-      </div>
-    </div>
+    <DashPanel>
+      <DashPanelHeader
+        title="Authorized OAuth Apps"
+        description="Apps that can access your Instant account."
+      />
+      <DashEmptyState
+        title="No authorized OAuth apps"
+        description="Apps you authorize to access your Instant account will appear here."
+      />
+    </DashPanel>
   );
 }
 
 function InvitesTab() {
   return (
-    <div className="mt-2 flex w-full max-w-2xl flex-col gap-4 px-4 py-8">
-      <div className="mb-2 flex text-4xl">📫</div>
-      <SectionHeading>Team Invites</SectionHeading>
-      <div className="flex flex-1 flex-col gap-4">
-        <Content className="dark:text-netural-400 text-gray-400 italic">
-          You have no pending invites.
-        </Content>
-      </div>
-    </div>
+    <DashPanel>
+      <DashPanelHeader
+        title="Team invites"
+        description="Organization invitations sent to this account."
+      />
+      <DashEmptyState
+        title="No pending invites"
+        description="Organization invitations sent to this account will appear here."
+      />
+    </DashPanel>
   );
 }
 
@@ -140,18 +138,32 @@ function CopyTokenDialog({
   onClose: () => void;
 }) {
   return (
-    <Dialog title="Copy Token" open={open} onClose={onClose}>
-      <SubsectionHeading>Copy your token</SubsectionHeading>
-      <div className="mt-2 flex min-w-0 flex-col gap-2">
-        <Content>
-          <p>
-            Copy and save your token somewhere safe. Instant does not keep a
-            copy of the token. You will have to generate a new token if this one
-            is lost.
-          </p>
-        </Content>
-        <div className="w-full max-w-full min-w-0 overflow-x-auto">
-          <Copyable value={MOCK_TOKEN} label="Token" defaultHidden={true} />
+    <Dialog
+      title="Copy Token"
+      open={open}
+      onClose={onClose}
+      className="max-w-2xl"
+    >
+      <div className="flex min-w-0 flex-col gap-4">
+        <div>
+          <SubsectionHeading>Copy your token</SubsectionHeading>
+          <Content className="mt-1">
+            This token is only shown once. Store it before closing this dialog.
+          </Content>
+        </div>
+        <DashNotice tone="warning">
+          Instant does not keep a copy of the token. You will have to generate a
+          new token if this one is lost.
+        </DashNotice>
+        <DashSecretField
+          label="Personal access token"
+          value={MOCK_TOKEN}
+          description="Shown once"
+        />
+        <div className="flex flex-wrap justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Done
+          </Button>
         </div>
       </div>
     </Dialog>
@@ -164,24 +176,29 @@ export function Current({ sub }: { sub: UserSettingsSubState }) {
   const showCopyDialog = sub === 'token-created';
   // Local state for dialog so closing it doesn't require a sidebar nav
   const [dialogOpen, setDialogOpen] = useState(true);
+  useEffect(() => {
+    if (showCopyDialog) setDialogOpen(true);
+  }, [showCopyDialog]);
 
   return (
     <UserSettingsShell>
-      <UserSettingsHeader
-        activeTab={activeTab}
-        onSelectTab={() => {
-          /* sidebar drives the active tab */
-        }}
-      />
-      {activeTab === 'tokens' && <TokensTab />}
-      {activeTab === 'oauth' && <OAuthTab />}
-      {activeTab === 'invites' && <InvitesTab />}
-      {showCopyDialog && (
-        <CopyTokenDialog
-          open={dialogOpen}
-          onClose={() => setDialogOpen(false)}
+      <DashPage size="default">
+        <UserSettingsHeader
+          activeTab={activeTab}
+          onSelectTab={() => {
+            /* sidebar drives the active tab */
+          }}
         />
-      )}
+        {activeTab === 'tokens' && <TokensTab />}
+        {activeTab === 'oauth' && <OAuthTab />}
+        {activeTab === 'invites' && <InvitesTab />}
+        {showCopyDialog && (
+          <CopyTokenDialog
+            open={dialogOpen}
+            onClose={() => setDialogOpen(false)}
+          />
+        )}
+      </DashPage>
     </UserSettingsShell>
   );
 }

--- a/client/www/pages/dash-redesign/_views/Webhooks/Current.tsx
+++ b/client/www/pages/dash-redesign/_views/Webhooks/Current.tsx
@@ -27,7 +27,7 @@ import { useSchemaQuery } from '@/lib/hooks/explorer';
 import { useReadyRouter } from '@/components/clientOnlyPage';
 import { Webhooks } from '@/components/dash/Webhooks';
 
-import { DashShell } from '../_shared';
+import { DashNotice, DashShell } from '../_shared';
 import { useEphemeralApp } from '../_ephemeral';
 import { WebhooksSubState } from './index';
 
@@ -166,15 +166,25 @@ function WebhookForm({
   };
 
   return (
-    <form onSubmit={handle} className="flex flex-col gap-4">
+    <form onSubmit={handle} className="flex flex-col gap-5">
+      <div>
+        <SubsectionHeading>Webhook endpoint</SubsectionHeading>
+        <Content className="mt-1 text-sm">
+          Deliver events to one public HTTPS endpoint.
+        </Content>
+      </div>
       <div className="flex flex-col gap-1">
-        <Label>URL</Label>
+        <Label>Endpoint URL</Label>
         <TextInput
           autoFocus
+          size="large"
           value={url}
           onChange={setUrl}
-          placeholder="https://example.com/webhook"
+          placeholder="https://example.com/api/instant-webhook"
         />
+        <Content className="text-xs text-gray-500 dark:text-neutral-500">
+          Must be an https URL. Localhost is not allowed.
+        </Content>
       </div>
       <div className="flex flex-col gap-1">
         <Label>Namespaces</Label>
@@ -183,38 +193,46 @@ function WebhookForm({
             No namespaces yet. Create one in the Explorer first.
           </Content>
         ) : (
-          <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded-sm border bg-gray-50 p-2 dark:border-neutral-700 dark:bg-neutral-800/50">
+          <div className="grid max-h-44 grid-cols-1 gap-2 overflow-y-auto rounded-md border border-gray-200 bg-[#fbfaf8] p-3 sm:grid-cols-2 dark:border-neutral-700 dark:bg-neutral-800/50">
             {allOptions.map((ns) => (
-              <label key={ns} className="flex items-center gap-2 text-sm">
-                <Checkbox
-                  checked={selectedNamespaces.has(ns)}
-                  onChange={() => setSelectedNamespaces((s) => toggle(s, ns))}
-                />
-                <span className="font-mono">{ns}</span>
-              </label>
+              <Checkbox
+                key={ns}
+                checked={selectedNamespaces.has(ns)}
+                onChange={() => setSelectedNamespaces((s) => toggle(s, ns))}
+                label={ns}
+              />
             ))}
           </div>
         )}
       </div>
       <div className="flex flex-col gap-1">
         <Label>Actions</Label>
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3 rounded-md border border-gray-200 bg-[#fbfaf8] p-3 dark:border-neutral-700 dark:bg-neutral-800/50">
           {ALL_ACTIONS.map((a) => (
-            <label key={a} className="flex items-center gap-2 text-sm">
-              <Checkbox
-                checked={actions.has(a)}
-                onChange={() => setActions((s) => toggle(s, a))}
-              />
-              <span>{a}</span>
-            </label>
+            <Checkbox
+              key={a}
+              checked={actions.has(a)}
+              onChange={() => setActions((s) => toggle(s, a))}
+              label={a}
+            />
           ))}
         </div>
       </div>
-      <div className="flex flex-row gap-2">
-        <Button type="submit" loading={isLoading} variant="primary">
+      <div className="flex flex-row justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+        <Button
+          type="submit"
+          loading={isLoading}
+          variant="primary"
+          size="large"
+        >
           {submitLabel}
         </Button>
-        <Button type="button" variant="secondary" onClick={onCancel}>
+        <Button
+          type="button"
+          variant="secondary"
+          size="large"
+          onClick={onCancel}
+        >
           Cancel
         </Button>
       </div>
@@ -348,19 +366,34 @@ function DisableDialog({
         className="flex flex-col gap-4"
       >
         <SubsectionHeading>Disable webhook</SubsectionHeading>
-        <Content>
+        <DashNotice tone="warning">
           Disabled webhooks won't deliver events. You can re-enable it at any
           time.
-        </Content>
+        </DashNotice>
         <div className="flex flex-col gap-1">
           <Label>Reason (optional)</Label>
-          <TextInput autoFocus value={reason} onChange={setReason} />
+          <TextInput
+            autoFocus
+            size="large"
+            value={reason}
+            onChange={setReason}
+          />
         </div>
-        <div className="flex flex-row gap-2">
-          <Button type="submit" loading={isLoading} variant="destructive">
+        <div className="flex flex-row justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button
+            type="submit"
+            loading={isLoading}
+            variant="destructive"
+            size="large"
+          >
             Disable
           </Button>
-          <Button type="button" variant="secondary" onClick={dialog.onClose}>
+          <Button
+            type="button"
+            variant="secondary"
+            size="large"
+            onClick={dialog.onClose}
+          >
             Cancel
           </Button>
         </div>
@@ -399,16 +432,23 @@ function DeleteDialog({
   return (
     <Dialog title="Delete webhook" {...dialog}>
       <div className="flex flex-col gap-3">
-        <SubsectionHeading>{webhook.sink.url}</SubsectionHeading>
-        <Content>
+        <SubsectionHeading className="font-mono text-base break-all">
+          {webhook.sink.url}
+        </SubsectionHeading>
+        <DashNotice tone="danger">
           Deleting a webhook is permanent. Any pending events for this webhook
           will be discarded.
-        </Content>
-        <div className="flex gap-2">
-          <Button loading={isLoading} variant="destructive" onClick={handle}>
+        </DashNotice>
+        <div className="flex justify-end gap-2 border-t border-gray-200 pt-4 dark:border-neutral-800">
+          <Button
+            loading={isLoading}
+            variant="destructive"
+            size="large"
+            onClick={handle}
+          >
             Delete
           </Button>
-          <Button variant="secondary" onClick={dialog.onClose}>
+          <Button variant="secondary" size="large" onClick={dialog.onClose}>
             Cancel
           </Button>
         </div>
@@ -420,7 +460,6 @@ function DeleteDialog({
 // ---- Seeding ----
 
 async function seedWebhooks(token: string, appId: string) {
-  console.log('[dash-redesign] seeding webhooks for sandbox app', appId);
   await createWebhook(token, appId, {
     url: 'https://example.com/todo-events',
     namespaces: ['todos'],

--- a/client/www/pages/dash-redesign/_views/_ephemeral.ts
+++ b/client/www/pages/dash-redesign/_views/_ephemeral.ts
@@ -53,7 +53,6 @@ async function fetchSchemaBlobs(
     headers: adminHeaders(appId, adminToken),
   });
   if (!schemaRes.ok) {
-    console.warn('[dash-redesign] schema fetch failed', await schemaRes.text());
     return null;
   }
   const schemaJson = (await schemaRes.json()) as {
@@ -80,7 +79,7 @@ async function transactDeleteAttrs(
     },
   );
   if (!delRes.ok) {
-    console.warn('[dash-redesign] delete-attr failed', await delRes.text());
+    return;
   }
 }
 
@@ -88,12 +87,8 @@ async function softDeletePriorityAttr(appId: string, adminToken: string) {
   const blobs = await fetchSchemaBlobs(appId, adminToken);
   const attrId = blobs?.todos?.priority?.id;
   if (!attrId) {
-    console.warn(
-      '[dash-redesign] could not find todos.priority attr; skipping',
-    );
     return;
   }
-  console.log('[dash-redesign] soft-deleting todos.priority attr', attrId);
   await transactDeleteAttrs(appId, adminToken, [attrId]);
 }
 
@@ -112,9 +107,6 @@ async function seedAndDeleteNotesNamespace(appId: string, adminToken: string) {
   const blobs = await fetchSchemaBlobs(appId, adminToken);
   const nsAttrs = blobs?.notes;
   if (!nsAttrs) {
-    console.warn(
-      '[dash-redesign] could not find notes namespace; skipping namespace delete',
-    );
     return;
   }
   const attrIds: string[] = [];
@@ -124,21 +116,15 @@ async function seedAndDeleteNotesNamespace(appId: string, adminToken: string) {
     }
   }
   if (attrIds.length === 0) {
-    console.warn('[dash-redesign] no attrs in notes namespace; skipping');
     return;
   }
-  console.log(
-    `[dash-redesign] soft-deleting notes namespace (${attrIds.length} attrs)`,
-  );
   await transactDeleteAttrs(appId, adminToken, attrIds);
 }
 
 async function provisionAndSeed(): Promise<Cached> {
-  console.log('[dash-redesign] provisioning ephemeral app...');
   const { app } = await provisionApp({ title: 'Dash Redesign Sandbox' });
   const appId = app.id;
   const adminToken = app['admin-token'];
-  console.log('[dash-redesign] provisioned, seeding todos...', { appId });
   const db = init({ apiURI: config.apiURI, appId, adminToken });
   const firstTodoId = id();
   await db.transact([
@@ -178,13 +164,6 @@ async function provisionAndSeed(): Promise<Cached> {
       ([name, val]) => name !== 'id' && val?.id,
     )?.[1]?.id ||
     '';
-  if (!firstTodoAttrId) {
-    console.warn(
-      '[dash-redesign] could not find any editable attr on todos',
-      todosBlobs,
-    );
-  }
-  console.log('[dash-redesign] seed complete', { firstTodoAttrId });
   return {
     id: appId,
     adminToken,

--- a/client/www/pages/dash-redesign/_views/_shared.tsx
+++ b/client/www/pages/dash-redesign/_views/_shared.tsx
@@ -150,15 +150,15 @@ export function DashDataProvider({ children }: { children: ReactNode }) {
 
 export function AuthShell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center bg-[#fbfaf8] p-8 dark:bg-neutral-950">
-      <div className="w-full max-w-[660px]">
-        <span className="mb-8 inline-flex items-center gap-3">
-          <LogoIcon size="normal" className="h-8 w-8" />
-          <span className="text-3xl font-semibold tracking-normal text-gray-950 lowercase dark:text-white">
+    <div className="flex min-h-[100dvh] items-center justify-center bg-[#fbfaf8] p-6 dark:bg-neutral-950">
+      <div className="w-full max-w-[440px]">
+        <span className="mb-6 inline-flex items-center gap-2.5">
+          <LogoIcon size="normal" className="h-7 w-7" />
+          <span className="font-mono text-[20px] font-bold text-gray-950 lowercase dark:text-white">
             instant
           </span>
         </span>
-        <div className="flex flex-col gap-8">{children}</div>
+        <div className="flex flex-col gap-6">{children}</div>
       </div>
     </div>
   );

--- a/client/www/pages/dash-redesign/_views/_shared.tsx
+++ b/client/www/pages/dash-redesign/_views/_shared.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { forwardRef, ReactNode, useState } from 'react';
 import {
+  ClipboardDocumentIcon,
   ArrowTopRightOnSquareIcon,
   ArrowUturnLeftIcon,
   BeakerIcon,
@@ -8,6 +9,8 @@ import {
   CodeBracketIcon,
   CreditCardIcon,
   CubeIcon,
+  EyeIcon,
+  EyeSlashIcon,
   FunnelIcon,
   HomeIcon,
   IdentificationIcon,
@@ -19,6 +22,7 @@ import {
 import { ChevronDownIcon, MoonIcon, PlusIcon } from '@heroicons/react/24/solid';
 import {
   Button,
+  cn,
   FullscreenLoading,
   LogoIcon,
   SmallCopyable,
@@ -109,7 +113,7 @@ export function toDirectoryName(title: string): string {
   return dirName || 'instant-app';
 }
 
-export function DashDataProvider({ children }: { children: React.ReactNode }) {
+export function DashDataProvider({ children }: { children: ReactNode }) {
   const token = useAuthToken();
 
   if (!token) {
@@ -144,15 +148,17 @@ export function DashDataProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function AuthShell({ children }: { children: React.ReactNode }) {
+export function AuthShell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center p-4 dark:bg-neutral-900">
-      <div className="max-w-sm">
-        <span className="inline-flex items-center space-x-2">
-          <LogoIcon />
-          <span className="font-mono text-sm lowercase">Instant</span>
+    <div className="flex min-h-[100dvh] items-center justify-center bg-[#fbfaf8] p-8 dark:bg-neutral-950">
+      <div className="w-full max-w-[660px]">
+        <span className="mb-8 inline-flex items-center gap-3">
+          <LogoIcon size="normal" className="h-8 w-8" />
+          <span className="text-3xl font-semibold tracking-normal text-gray-950 lowercase dark:text-white">
+            instant
+          </span>
         </span>
-        <div className="flex flex-col gap-4">{children}</div>
+        <div className="flex flex-col gap-8">{children}</div>
       </div>
     </div>
   );
@@ -181,7 +187,7 @@ export function MockTopBar({
 }: {
   appTitle?: string;
   account?: TopBarAccount;
-  leftExtra?: React.ReactNode;
+  leftExtra?: ReactNode;
 }) {
   const accountIcon =
     account.kind === 'user' ? (
@@ -191,10 +197,10 @@ export function MockTopBar({
     );
   const accountLabel = account.kind === 'user' ? account.email : account.title;
   return (
-    <div className="relative flex flex-col gap-2 border-b border-b-gray-300 px-2 py-2 md:px-4 dark:border-b-neutral-700 dark:bg-neutral-800 dark:text-white">
+    <div className="relative flex flex-col gap-2 border-b border-gray-200 bg-white px-3 py-2 md:px-5 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-row items-center gap-2">
-          <div className="flex items-center justify-between gap-9 rounded-xs border border-gray-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-700/40">
+          <div className="flex min-h-10 min-w-[220px] items-center justify-between gap-4 rounded-md border border-gray-300 bg-white px-3.5 text-sm shadow-xs dark:border-neutral-700 dark:bg-neutral-900">
             <div className="flex items-center gap-2">
               {accountIcon}
               <div>{accountLabel}</div>
@@ -202,14 +208,14 @@ export function MockTopBar({
             <ChevronDownIcon width={15} />
           </div>
           {appTitle && (
-            <div className="flex items-center justify-between gap-9 truncate rounded-xs border border-gray-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-700/40">
+            <div className="flex min-h-10 min-w-[180px] items-center justify-between gap-4 truncate rounded-md border border-gray-300 bg-white px-3.5 text-sm shadow-xs dark:border-neutral-700 dark:bg-neutral-900">
               <div>{appTitle}</div>
               <ChevronDownIcon width={15} />
             </div>
           )}
           {leftExtra}
         </div>
-        <div className="flex items-center gap-4 md:gap-6">
+        <div className="flex items-center gap-3 md:gap-4">
           <a
             className="flex items-center gap-1 text-sm opacity-50 hover:underline"
             href="#"
@@ -229,9 +235,9 @@ export function MockTopBar({
   );
 }
 
-export function OnboardingShell({ children }: { children: React.ReactNode }) {
+export function OnboardingShell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-screen flex-col dark:bg-neutral-900">
+    <div className="flex h-screen flex-col bg-[#fbfaf8] dark:bg-neutral-950">
       <MockTopBar />
       <div className="flex flex-1 items-center justify-center">{children}</div>
     </div>
@@ -251,7 +257,7 @@ export type DashTabId =
   | 'oauth-apps'
   | 'webhooks';
 
-const DASH_TABS: { id: DashTabId; title: string; icon: React.ReactNode }[] = [
+const DASH_TABS: { id: DashTabId; title: string; icon: ReactNode }[] = [
   { id: 'home', title: 'Home', icon: <HomeIcon width={14} /> },
   { id: 'explorer', title: 'Explorer', icon: <FunnelIcon width={14} /> },
   { id: 'schema', title: 'Schema', icon: <CodeBracketIcon width={14} /> },
@@ -271,18 +277,18 @@ const DASH_TABS: { id: DashTabId; title: string; icon: React.ReactNode }[] = [
 
 function LeftNav({ active }: { active: DashTabId }) {
   return (
-    <div className="flex flex-col gap-2 border-b border-gray-300 bg-gray-50 md:w-48 md:gap-0 md:border-r md:border-b-0 dark:border-neutral-700/80 dark:bg-neutral-800/40">
-      <div className="hidden h-full flex-row overflow-auto bg-gray-50 md:visible md:static md:flex md:flex-col dark:bg-neutral-800/40">
+    <div className="flex flex-col gap-2 border-b border-gray-200 bg-[#fbfaf8] md:w-52 md:gap-0 md:border-r md:border-b-0 dark:border-neutral-800 dark:bg-neutral-950">
+      <div className="hidden h-full flex-row overflow-auto p-2 md:visible md:static md:flex md:flex-col">
         {DASH_TABS.map((t) => {
           const isActive = t.id === active;
           return (
             <button
               key={t.id}
               type="button"
-              className={`flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+              className={`flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors ${
                 isActive
-                  ? 'bg-white dark:bg-neutral-800 dark:text-white'
-                  : 'hover:bg-gray-100 dark:hover:bg-neutral-800/80'
+                  ? 'bg-white font-semibold text-gray-950 shadow-xs dark:bg-neutral-900 dark:text-white'
+                  : 'text-gray-600 hover:bg-white/70 hover:text-gray-950 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-white'
               }`}
             >
               {t.icon}
@@ -298,14 +304,16 @@ function LeftNav({ active }: { active: DashTabId }) {
 function AppHeader({ app }: { app: InstantApp }) {
   const [hideAppId, setHideAppId] = useState(false);
   return (
-    <div className="bg-gray-50 dark:bg-neutral-800/90">
-      <div className="flex flex-col justify-between border-b border-b-gray-300 px-3 py-2 md:flex-row md:gap-4 dark:border-b-neutral-700">
+    <div className="bg-white dark:bg-neutral-950">
+      <div className="flex flex-col justify-between border-b border-gray-200 px-4 py-3 md:flex-row md:items-center md:gap-4 dark:border-neutral-800">
         <div className="flex items-center gap-2">
-          <h2 className="font-semibold md:text-xl">{app.title}</h2>
+          <h2 className="text-xl font-semibold tracking-normal text-gray-950 dark:text-white">
+            {app.title}
+          </h2>
         </div>
         <SmallCopyable
           size="normal"
-          label="Public App ID"
+          label="App ID"
           value={app.id}
           hideValue={hideAppId}
           onChangeHideValue={() => setHideAppId(!hideAppId)}
@@ -322,18 +330,251 @@ export function DashShell({
 }: {
   active: DashTabId;
   app: InstantApp;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
-    <div className="flex h-screen flex-col dark:bg-neutral-900">
+    <div className="flex h-screen flex-col bg-[#fbfaf8] text-gray-950 dark:bg-neutral-950 dark:text-white">
       <MockTopBar appTitle={app.title} />
       <AppHeader app={app} />
       <div className="flex w-full grow flex-col overflow-hidden md:flex-row">
         <LeftNav active={active} />
-        <div className="flex w-full flex-1 flex-col overflow-auto">
+        <div className="flex w-full flex-1 flex-col overflow-auto bg-[#fbfaf8] dark:bg-neutral-950">
           {children}
         </div>
       </div>
+    </div>
+  );
+}
+
+export function DashPage({
+  children,
+  className,
+  size = 'default',
+}: {
+  children: ReactNode;
+  className?: string;
+  size?: 'narrow' | 'default' | 'wide' | 'full';
+}) {
+  return (
+    <div
+      className={cn(
+        'mx-auto flex w-full flex-1 flex-col gap-6 px-5 py-5 md:px-7 md:py-6',
+        size === 'narrow' && 'max-w-2xl',
+        size === 'default' && 'max-w-4xl',
+        size === 'wide' && 'max-w-6xl',
+        size === 'full' && 'max-w-none',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const DashPanel = forwardRef<
+  HTMLDivElement,
+  { children: ReactNode; className?: string }
+>(({ children, className }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'rounded-lg border border-gray-200 bg-white p-4 shadow-xs dark:border-neutral-800 dark:bg-neutral-900',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+});
+DashPanel.displayName = 'DashPanel';
+
+export function DashEmptyState({
+  title,
+  description,
+  action,
+  className,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-28 flex-col items-center justify-center rounded-md border border-dashed border-gray-300 bg-[#fbfaf8] px-4 py-6 text-center dark:border-neutral-700 dark:bg-neutral-950',
+        className,
+      )}
+    >
+      <div className="text-sm font-semibold text-gray-900 dark:text-white">
+        {title}
+      </div>
+      {description ? (
+        <div className="mt-1 max-w-sm text-sm text-gray-500 dark:text-neutral-400">
+          {description}
+        </div>
+      ) : null}
+      {action ? <div className="mt-4">{action}</div> : null}
+    </div>
+  );
+}
+
+export function DashNotice({
+  tone = 'neutral',
+  children,
+  className,
+}: {
+  tone?: 'neutral' | 'warning' | 'danger';
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-3 py-2 text-sm leading-6',
+        tone === 'neutral' &&
+          'border-gray-200 bg-[#fbfaf8] text-gray-700 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-300',
+        tone === 'warning' &&
+          'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200',
+        tone === 'danger' &&
+          'border-red-200 bg-red-50 text-red-800 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function maskSecret(value: string) {
+  return value.replace(/[^_\-\s]/g, '*');
+}
+
+export function DashSecretField({
+  label,
+  value,
+  defaultHidden = true,
+  description,
+  className,
+}: {
+  label: ReactNode;
+  value: string;
+  defaultHidden?: boolean;
+  description?: ReactNode;
+  className?: string;
+}) {
+  const [hidden, setHidden] = useState(defaultHidden);
+  const [copied, setCopied] = useState(false);
+  const displayValue = hidden ? maskSecret(value) : value;
+
+  return (
+    <div
+      className={cn(
+        'min-w-0 overflow-hidden rounded-md border border-gray-200 bg-gray-950 shadow-xs dark:border-neutral-700',
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-white/10 px-3 py-2">
+        <div className="min-w-0">
+          <div className="truncate text-xs font-semibold text-gray-300">
+            {label}
+          </div>
+          {description ? (
+            <div className="mt-0.5 truncate text-xs text-gray-500">
+              {description}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs font-semibold text-gray-300 transition-colors hover:bg-white/10 hover:text-white"
+            onClick={() => setHidden((v) => !v)}
+          >
+            {hidden ? (
+              <EyeIcon className="h-4 w-4" />
+            ) : (
+              <EyeSlashIcon className="h-4 w-4" />
+            )}
+            {hidden ? 'Show' : 'Hide'}
+          </button>
+          <button
+            type="button"
+            className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs font-semibold text-gray-300 transition-colors hover:bg-white/10 hover:text-white"
+            onClick={() => {
+              window.navigator.clipboard.writeText(value);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            }}
+          >
+            <ClipboardDocumentIcon className="h-4 w-4" />
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+      <pre className="max-h-44 min-w-0 overflow-auto px-3 py-3 font-mono text-sm leading-6 whitespace-pre-wrap text-gray-100">
+        {displayValue}
+      </pre>
+    </div>
+  );
+}
+
+export function DashPanelHeader({
+  title,
+  description,
+  action,
+  className,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'mb-4 flex flex-col justify-between gap-3 sm:flex-row sm:items-start',
+        className,
+      )}
+    >
+      <div className="min-w-0">
+        <div className="text-lg font-semibold tracking-normal text-gray-950 dark:text-white">
+          {title}
+        </div>
+        {description ? (
+          <div className="mt-1 text-sm leading-6 text-gray-600 dark:text-neutral-400">
+            {description}
+          </div>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}
+
+export function DashRow({
+  label,
+  value,
+  action,
+}: {
+  label: ReactNode;
+  value?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-t border-gray-100 py-3 first:border-t-0 dark:border-neutral-800">
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium text-gray-950 dark:text-white">
+          {label}
+        </div>
+        {value ? (
+          <div className="mt-0.5 truncate text-sm text-gray-500 dark:text-neutral-400">
+            {value}
+          </div>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
     </div>
   );
 }

--- a/client/www/pages/dash-redesign/_views/_shared.tsx
+++ b/client/www/pages/dash-redesign/_views/_shared.tsx
@@ -327,17 +327,21 @@ export function DashShell({
   active,
   app,
   children,
+  hideNav,
 }: {
   active: DashTabId;
   app: InstantApp;
   children: ReactNode;
+  // When a view provides its own merged nav (e.g. the merged-nav auth flow),
+  // suppress the standard left nav so we don't end up with two rails.
+  hideNav?: boolean;
 }) {
   return (
     <div className="flex h-screen flex-col bg-[#fbfaf8] text-gray-950 dark:bg-neutral-950 dark:text-white">
       <MockTopBar appTitle={app.title} />
       <AppHeader app={app} />
       <div className="flex w-full grow flex-col overflow-hidden md:flex-row">
-        <LeftNav active={active} />
+        {hideNav ? null : <LeftNav active={active} />}
         <div className="flex w-full flex-1 flex-col overflow-auto bg-[#fbfaf8] dark:bg-neutral-950">
           {children}
         </div>

--- a/client/www/pages/dash-redesign/index.tsx
+++ b/client/www/pages/dash-redesign/index.tsx
@@ -30,6 +30,11 @@ import {
 } from './_views/UserSettings';
 import { OrgSubState, ORG_SUB_STATES, OrgView } from './_views/Org';
 import { AdminSubState, ADMIN_SUB_STATES, AdminView } from './_views/Admin';
+import {
+  AdminRamsSubState,
+  ADMIN_RAMS_SUB_STATES,
+  AdminRamsView,
+} from './_views/AdminRams';
 import { BillingView } from './_views/Billing';
 import {
   OAuthAppsSubState,
@@ -53,6 +58,7 @@ type ViewKey =
   | 'user-settings'
   | 'org'
   | 'admin'
+  | 'admin-rams'
   | 'billing'
   | 'oauth-apps';
 
@@ -81,6 +87,11 @@ const NAV: NavItem[] = [
   },
   { view: 'org', label: 'Org', stages: ORG_SUB_STATES },
   { view: 'admin', label: 'Admin', stages: ADMIN_SUB_STATES },
+  {
+    view: 'admin-rams',
+    label: 'Admin (Rams)',
+    stages: ADMIN_RAMS_SUB_STATES,
+  },
   { view: 'billing', label: 'Billing' },
   {
     view: 'oauth-apps',
@@ -102,6 +113,7 @@ type FlatItem =
         | 'org'
         | 'oauth-apps'
         | 'admin'
+        | 'admin-rams'
       >;
     }
   | { kind: 'stage'; view: 'onboarding'; stage: OnboardingStage }
@@ -111,7 +123,8 @@ type FlatItem =
   | { kind: 'stage'; view: 'user-settings'; stage: UserSettingsSubState }
   | { kind: 'stage'; view: 'org'; stage: OrgSubState }
   | { kind: 'stage'; view: 'oauth-apps'; stage: OAuthAppsSubState }
-  | { kind: 'stage'; view: 'admin'; stage: AdminSubState };
+  | { kind: 'stage'; view: 'admin'; stage: AdminSubState }
+  | { kind: 'stage'; view: 'admin-rams'; stage: AdminRamsSubState };
 
 const FLAT_NAV: FlatItem[] = [
   { kind: 'view', view: 'login' },
@@ -146,6 +159,9 @@ const FLAT_NAV: FlatItem[] = [
   ...ADMIN_SUB_STATES.map(
     (s): FlatItem => ({ kind: 'stage', view: 'admin', stage: s.key }),
   ),
+  ...ADMIN_RAMS_SUB_STATES.map(
+    (s): FlatItem => ({ kind: 'stage', view: 'admin-rams', stage: s.key }),
+  ),
   { kind: 'view', view: 'billing' },
   ...OAUTH_APPS_SUB_STATES.map(
     (s): FlatItem => ({ kind: 'stage', view: 'oauth-apps', stage: s.key }),
@@ -164,6 +180,7 @@ function ViewerSidebar({
   orgSub,
   oauthAppsSub,
   adminSub,
+  adminRamsSub,
   onSelectView,
   onSelectStage,
   buttonRefs,
@@ -177,6 +194,7 @@ function ViewerSidebar({
   orgSub: OrgSubState;
   oauthAppsSub: OAuthAppsSubState;
   adminSub: AdminSubState;
+  adminRamsSub: AdminRamsSubState;
   onSelectView: (v: ViewKey) => void;
   onSelectStage: (view: ViewKey, stageKey: string) => void;
   buttonRefs: React.MutableRefObject<Map<string, HTMLButtonElement | null>>;
@@ -191,6 +209,7 @@ function ViewerSidebar({
     if (itemView === 'org') return orgSub === key;
     if (itemView === 'oauth-apps') return oauthAppsSub === key;
     if (itemView === 'admin') return adminSub === key;
+    if (itemView === 'admin-rams') return adminRamsSub === key;
     return false;
   };
 
@@ -261,6 +280,7 @@ function flatIndex(
   orgSub: OrgSubState,
   oauthAppsSub: OAuthAppsSubState,
   adminSub: AdminSubState,
+  adminRamsSub: AdminRamsSubState,
 ): number {
   if (view === 'onboarding') {
     return FLAT_NAV.findIndex(
@@ -313,6 +333,14 @@ function flatIndex(
       (i) => i.kind === 'stage' && i.view === 'admin' && i.stage === adminSub,
     );
   }
+  if (view === 'admin-rams') {
+    return FLAT_NAV.findIndex(
+      (i) =>
+        i.kind === 'stage' &&
+        i.view === 'admin-rams' &&
+        i.stage === adminRamsSub,
+    );
+  }
   return FLAT_NAV.findIndex((i) => i.kind === 'view' && i.view === view);
 }
 
@@ -328,6 +356,7 @@ export default function DashRedesignViewer() {
   const [orgSub, setOrgSub] = useState<OrgSubState>('members');
   const [oauthAppsSub, setOauthAppsSub] = useState<OAuthAppsSubState>('list');
   const [adminSub, setAdminSub] = useState<AdminSubState>('default');
+  const [adminRamsSub, setAdminRamsSub] = useState<AdminRamsSubState>('list');
 
   const buttonRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map());
   const isFirstRender = useRef(true);
@@ -350,6 +379,8 @@ export default function DashRedesignViewer() {
         return `stage:oauth-apps:${oauthAppsSub}`;
       case 'admin':
         return `stage:admin:${adminSub}`;
+      case 'admin-rams':
+        return `stage:admin-rams:${adminRamsSub}`;
       default:
         return `view:${view}`;
     }
@@ -363,6 +394,7 @@ export default function DashRedesignViewer() {
     orgSub,
     oauthAppsSub,
     adminSub,
+    adminRamsSub,
   ]);
 
   // Park focus on the active sidebar button after a view/stage change.
@@ -415,6 +447,7 @@ export default function DashRedesignViewer() {
         orgSub,
         oauthAppsSub,
         adminSub,
+        adminRamsSub,
       );
       const next = FLAT_NAV[(idx + delta + FLAT_NAV.length) % FLAT_NAV.length];
       setView(next.view);
@@ -442,6 +475,9 @@ export default function DashRedesignViewer() {
       if (next.kind === 'stage' && next.view === 'admin') {
         setAdminSub(next.stage);
       }
+      if (next.kind === 'stage' && next.view === 'admin-rams') {
+        setAdminRamsSub(next.stage);
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -455,6 +491,7 @@ export default function DashRedesignViewer() {
     orgSub,
     oauthAppsSub,
     adminSub,
+    adminRamsSub,
   ]);
 
   const onSelectStage = (targetView: ViewKey, stageKey: string) => {
@@ -483,6 +520,9 @@ export default function DashRedesignViewer() {
     if (targetView === 'admin') {
       setAdminSub(stageKey as AdminSubState);
     }
+    if (targetView === 'admin-rams') {
+      setAdminRamsSub(stageKey as AdminRamsSubState);
+    }
   };
 
   return (
@@ -501,6 +541,7 @@ export default function DashRedesignViewer() {
           orgSub={orgSub}
           oauthAppsSub={oauthAppsSub}
           adminSub={adminSub}
+          adminRamsSub={adminRamsSub}
           onSelectView={setView}
           onSelectStage={onSelectStage}
           buttonRefs={buttonRefs}
@@ -542,6 +583,7 @@ export default function DashRedesignViewer() {
           )}
           {view === 'org' && <OrgView sub={orgSub} />}
           {view === 'admin' && <AdminView sub={adminSub} />}
+          {view === 'admin-rams' && <AdminRamsView sub={adminRamsSub} />}
           {view === 'billing' && <BillingView />}
           {view === 'oauth-apps' && <OAuthAppsView sub={oauthAppsSub} />}
         </main>

--- a/client/www/pages/dash-redesign/index.tsx
+++ b/client/www/pages/dash-redesign/index.tsx
@@ -16,11 +16,7 @@ import {
 } from './_views/Explorer';
 import { SchemaView } from './_views/Schema';
 import { PermsView } from './_views/Perms';
-import {
-  AuthSubState,
-  AUTH_SUB_STATES,
-  AuthView,
-} from './_views/Auth';
+import { AuthSubState, AUTH_SUB_STATES, AuthView } from './_views/Auth';
 import { QueryInspectorView } from './_views/QueryInspector';
 import {
   WebhooksSubState,
@@ -156,7 +152,7 @@ const FLAT_NAV: FlatItem[] = [
   ),
 ];
 
-const SIDEBAR_WIDTH = 'w-56';
+const SIDEBAR_WIDTH = 'w-60';
 
 function ViewerSidebar({
   view,
@@ -200,12 +196,12 @@ function ViewerSidebar({
 
   return (
     <aside
-      className={`sticky top-0 h-screen ${SIDEBAR_WIDTH} shrink-0 overflow-y-auto border-r border-gray-200 bg-gray-50 dark:border-neutral-700 dark:bg-neutral-900`}
+      className={`sticky top-0 h-screen ${SIDEBAR_WIDTH} shrink-0 overflow-y-auto border-r border-gray-200 bg-[#fbfaf8] dark:border-neutral-800 dark:bg-neutral-950`}
     >
-      <div className="px-3 py-3 font-mono text-[10px] tracking-wider text-gray-500 uppercase dark:text-neutral-500">
+      <div className="px-3 py-3 text-[11px] font-semibold tracking-wide text-gray-500 uppercase dark:text-neutral-500">
         Dash redesign
       </div>
-      <nav className="flex flex-col pb-4 text-sm">
+      <nav className="flex flex-col gap-0.5 px-2 pb-4 text-sm">
         {NAV.map((item) => {
           const isActiveView = view === item.view;
           return (
@@ -216,10 +212,10 @@ function ViewerSidebar({
                   buttonRefs.current.set(`view:${item.view}`, el);
                 }}
                 onClick={() => onSelectView(item.view)}
-                className={`flex w-full items-center px-3 py-1.5 text-left transition-colors ${
+                className={`flex w-full items-center rounded-md px-3 py-2 text-left transition-colors ${
                   isActiveView
-                    ? 'bg-white font-medium text-gray-900 dark:bg-neutral-800 dark:text-white'
-                    : 'text-gray-600 hover:bg-gray-100 dark:text-neutral-400 dark:hover:bg-neutral-800/60'
+                    ? 'bg-white font-semibold text-gray-950 shadow-xs dark:bg-neutral-900 dark:text-white'
+                    : 'text-gray-600 hover:bg-white/70 hover:text-gray-950 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-white'
                 }`}
               >
                 {item.label}
@@ -234,10 +230,10 @@ function ViewerSidebar({
                       buttonRefs.current.set(`stage:${item.view}:${s.key}`, el);
                     }}
                     onClick={() => onSelectStage(item.view, s.key)}
-                    className={`flex w-full items-center py-1 pr-3 pl-7 text-left text-xs transition-colors ${
+                    className={`flex w-full items-center rounded-md py-1.5 pr-3 pl-7 text-left text-xs transition-colors ${
                       active
-                        ? 'bg-white font-medium text-gray-900 dark:bg-neutral-800 dark:text-white'
-                        : 'text-gray-500 hover:bg-gray-100 dark:text-neutral-500 dark:hover:bg-neutral-800/60'
+                        ? 'bg-white font-semibold text-gray-950 shadow-xs dark:bg-neutral-900 dark:text-white'
+                        : 'text-gray-500 hover:bg-white/70 hover:text-gray-900 dark:text-neutral-500 dark:hover:bg-neutral-900 dark:hover:text-white'
                     }`}
                   >
                     <span className="mr-2 text-gray-400 dark:text-neutral-600">
@@ -494,7 +490,7 @@ export default function DashRedesignViewer() {
       <Head>
         <title>Dash redesign viewer</title>
       </Head>
-      <div className="flex min-h-screen">
+      <div className="flex min-h-screen bg-[#fbfaf8] dark:bg-neutral-950">
         <ViewerSidebar
           view={view}
           onboardingStage={onboardingStage}


### PR DESCRIPTION
## Summary
- modernize the dash redesign viewer with shared dashboard primitives for empty states, notices, secrets, inputs, and dialogs
- tighten dense dashboard layouts across auth, admin, sandbox, webhooks, OAuth apps, user settings, billing, org, and onboarding states
- update code/editor styling and fix login/code input sizing so controls match the new design language

## Verification
- pnpm exec prettier --write on touched files
- git diff --check
- pnpm exec tsc --noEmit --pretty false (fails only on existing .next/types/validator.ts page-config errors for dash-redesign/_views helper modules)
- full in-app browser sweep of 61 dash-redesign states