### PR TITLE
Faster in-room? check

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -392,7 +392,9 @@
 (defn in-room?
   "Returns whether a session is part of a room."
   [app-id room-id sess-id]
-  (contains? (get-room-data app-id room-id) sess-id))
+  (let [room-key (hazelcast/room-key app-id room-id)]
+    (contains? (get-in @room-maps [:rooms room-key :session-ids])
+               sess-id)))
 
 (defn join-room! [app-id sess-id current-user room-id data]
   (register-session! app-id room-id sess-id)


### PR DESCRIPTION
Small change to help with the thundering herd in hazelcast rooms.

Before we would fetch the full value of the map to check if you're in the room, which would require hazelcast to deserialize the full value and possibly transfer it to the machine. Now we just look at our local room-maps atom.

Part of a larger change to fix the thundering herd problem. Putting this in its own PR so that we can roll back to this low-risk change if the larger hazelcast changes cause errors (those will be in the next couple of PRs).