### PR TITLE
Proposal: investigate stuck-query (add-query-exists) hang

### DIFF
--- a/client/packages/core/__tests__/src/stuckQuery.e2e.test.ts
+++ b/client/packages/core/__tests__/src/stuckQuery.e2e.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, vi } from 'vitest';
+import { i, id } from '../../src';
+import { makeE2ETest } from './utils/e2e';
+
+// -----------------------------------------------------------------------------
+// Stuck-query bug
+//
+// Symptom (from prod):
+//   `db.useQuery(...)` returns `{ isLoading: true, data: undefined, error: undefined }`
+//   forever. Reported by Mirando on Edge/Windows when many search cards
+//   subscribe to per-card queries while scrolling.
+//
+// Client-side bug:
+//   `Reactor.js:657` — the `add-query-exists` handler only wakes
+//   `queryOnce` deferreds via `notifyOneQueryOnce`. Regular `subscribeQuery`
+//   callbacks are not notified. If the server ever responds with
+//   `add-query-exists` to a fresh subscriber that has no cached result, the
+//   subscriber hangs.
+//
+// Server-side trigger (the race I found):
+//   The grouped-queue routes `:add-query` and `:remove-query` for query `q`
+//   to `[:query sess-id q]`, but `:refresh` goes to `[:refresh sess-id]`.
+//   Those are *different groups* — they run concurrently.
+//
+//   1. Client subscribes Q. Server adds Q to `session-instaql-queries`
+//      via `bump-instaql-version!`.
+//   2. Some other transaction touches Q's topic. The invalidator marks Q
+//      stale and enqueues a `:refresh` event.
+//   3. The refresh worker reads `get-stale-instaql-queries` (Q is in the
+//      snapshot) and pmap-dispatches `recompute-instaql-query!` tasks.
+//   4. Concurrently, the client unsubscribes Q. The remove-query worker
+//      retracts the Q entity from the store via `remove-query!`.
+//   5. The refresh's recompute for Q now calls `bump-instaql-version!`.
+//      `bump-instaql-version-tx-data` (store.clj:525) has an *else branch*
+//      that CREATES the entity if it's missing. So Q is silently re-added
+//      to the session.
+//   6. Client re-subscribes Q. Server sees Q in session-instaql-queries
+//      → replies `add-query-exists` → subscriber hangs (client bug).
+//
+// IDB caveat that hides the bug locally:
+//   The reactor persists query results to IndexedDB. Once a query has
+//   landed in IDB, the next subscribe loads from cache and notifies the
+//   subscriber *before* the server's `add-query-exists` arrives — masking
+//   the hang. The bug only manifests when IDB doesn't have the data for q,
+//   which in prod is "this card I haven't viewed in a while was GC'd from
+//   IDB" or "first visit to this search."
+//
+// The `add-query-exists hangs ...` test below uses a 2s sleep to let the
+// throttled persistence write *delete* the just-unloaded key (PersistedObject
+// keysToDelete branch), which is what reproduces the empty-cache prod state.
+//
+// Both bug-repro tests require an nREPL patch on the running server. With
+// patches off they pass (bug doesn't trigger); with patches on they fail
+// (bug triggers).
+// -----------------------------------------------------------------------------
+
+const test = makeE2ETest({
+  schema: i.schema({
+    entities: {
+      pro_searches: i.entity({ title: i.string() }),
+      properties: i.entity({ propertyId: i.number().indexed() }),
+      pro_search_properties: i.entity({}),
+    },
+    links: {
+      pspToSearch: {
+        forward: {
+          on: 'pro_search_properties',
+          has: 'one',
+          label: 'pro_searches',
+        },
+        reverse: {
+          on: 'pro_searches',
+          has: 'many',
+          label: 'pro_search_properties',
+        },
+      },
+    },
+  }),
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('stuck query repro', () => {
+  // Baseline: the user's pattern (sub → data → unsub → re-sub) hammered 50×.
+  // Passes with server in its normal state.
+  test('rapid sub → unsub → sub does not hang (50 cycles)', async ({ db }) => {
+    const searchId = id();
+    await db.transact([
+      db.tx.pro_searches[searchId].update({ title: 'baseline' }),
+    ]);
+    const q = {
+      pro_search_properties: {
+        $: { where: { 'pro_searches.id': searchId } },
+        pro_searches: {},
+      },
+    };
+    for (let i = 0; i < 50; i++) {
+      let r1: any = null;
+      const u1 = db.subscribeQuery(q, (r) => (r1 = r));
+      await vi.waitFor(() => expect(r1?.data).toBeDefined(), {
+        timeout: 5000,
+      });
+      u1();
+
+      let r2: any = null;
+      const u2 = db.subscribeQuery(q, (r) => (r2 = r));
+      await vi.waitFor(() => expect(r2?.data).toBeDefined(), {
+        timeout: 5000,
+      });
+      u2();
+    }
+  });
+
+  // Bug repro — root cause path (refresh race).
+  //
+  //   Apply this server patch first (widens the race window so the test
+  //   triggers deterministically):
+  //
+  //     cd server && ./scripts/nrepl-eval "(in-ns 'instant.reactive.session) \
+  //       (def orig-recompute recompute-instaql-query!) \
+  //       (alter-var-root #'recompute-instaql-query! \
+  //         (constantly (fn [opts q] (Thread/sleep 300) (orig-recompute opts q)))) \
+  //       :patched"
+  //
+  //   Restore: `(require 'instant.reactive.session :reload)`.
+  test.skip('refresh race re-adds removed query → next sub hangs', async ({
+    db,
+  }) => {
+    const searchId = id();
+    await db.transact([
+      db.tx.pro_searches[searchId].update({ title: 'race-test' }),
+    ]);
+    const q = {
+      pro_search_properties: {
+        $: { where: { 'pro_searches.id': searchId } },
+        pro_searches: {},
+      },
+    };
+
+    let r1: any = null;
+    const u1 = db.subscribeQuery(q, (r) => (r1 = r));
+    await vi.waitFor(() => expect(r1?.data).toBeDefined(), { timeout: 5000 });
+
+    // Trigger refresh: invalidator marks q stale, queues `:refresh` event.
+    db.transact([
+      db.tx.pro_search_properties[id()]
+        .update({})
+        .link({ pro_searches: searchId }),
+    ]);
+
+    await sleep(20);
+    u1(); // remove-query races the refresh worker
+
+    // Wait for the patched 300ms recompute to finish — by which time the
+    // refresh's bump-instaql-version! has re-created q in the session.
+    await sleep(2000);
+
+    let r2: any = null;
+    const u2 = db.subscribeQuery(q, (r) => (r2 = r));
+    try {
+      await vi.waitFor(() => expect(r2?.data).toBeDefined(), {
+        timeout: 5000,
+      });
+    } finally {
+      u2();
+    }
+  });
+
+  // Bug repro — symptom isolation.
+  //
+  //   Apply this server patch first (makes remove-query a no-op, simulating
+  //   ANY way the server's session retains q):
+  //
+  //     cd server && ./scripts/nrepl-eval \
+  //       "(alter-var-root #'instant.reactive.store/remove-query! \
+  //          (constantly (fn [& _] nil))) :patched"
+  //
+  //   Restore: `(require 'instant.reactive.store :reload)`.
+  test.skip('add-query-exists hangs a regular subscriber', async ({ db }) => {
+    const searchId = id();
+    await db.transact([
+      db.tx.pro_searches[searchId].update({ title: 'noop-repro' }),
+    ]);
+    const q = {
+      pro_search_properties: {
+        $: { where: { 'pro_searches.id': searchId } },
+        pro_searches: {},
+      },
+    };
+
+    let r1: any = null;
+    const u1 = db.subscribeQuery(q, (r) => (r1 = r));
+    await vi.waitFor(() => expect(r1?.data).toBeDefined(), { timeout: 5000 });
+
+    u1();
+    // Long sleep so the throttled querySubs persist runs *after* unloadKey
+    // and deletes the cached result from IDB (PersistedObject's keysToDelete
+    // branch). This mirrors prod where IDB has no entry for the card.
+    await sleep(2000);
+
+    let r2: any = null;
+    const u2 = db.subscribeQuery(q, (r) => (r2 = r));
+    try {
+      await vi.waitFor(() => expect(r2?.data).toBeDefined(), {
+        timeout: 5000,
+      });
+    } finally {
+      u2();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Investigation + e2e repro for the stuck-query bug Mirando reported on Discord (Edge/Windows, `useProSearchManagedProperty: still loading after 5s`). This PR proposes a root cause, demonstrates it 100% with two server-side nREPL patches, and includes a test file (`client/packages/core/__tests__/src/stuckQuery.e2e.test.ts`) with the full analysis as a comment block.

**Not proposing a fix in this PR** — draft for review of the diagnosis and fix direction.

## Symptom

`db.useQuery(...)` returns `{ isLoading: true, data: undefined, error: undefined }` forever. No errors surface to the user. Reproduced in batches when many cards on a search page subscribe to per-card queries.

## Client-side bug

`Reactor.js:657` — the `add-query-exists` handler only wakes `queryOnce` deferreds via `notifyOneQueryOnce`. Regular `subscribeQuery` callbacks in `queryCbs` are not notified.

```js
case 'add-query-exists': {
  this.notifyOneQueryOnce(weakHash(msg.q));
  break;
}
```

```mermaid
flowchart TD
    A[Server sends add-query-exists] --> B[_handleReceive]
    B --> C{op = add-query-exists}
    C --> D[notifyOneQueryOnce hash]
    D --> E{queryOnceDfds hash}
    E -->|has dfds| F[Resolve queryOnce promises]
    E -->|no dfds<br/>regular subscribers waiting| G[no-op — subscribers hang]
    style G fill:#f88
```

## Server-side trigger — the race

The grouped-queue routes `:add-query` and `:remove-query` for query `q` to `[:query sess-id q]`, but `:refresh` goes to `[:refresh sess-id]`. **Different groups → they run concurrently.**

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant Q as [:query sess-id q]<br/>worker
    participant R as [:refresh sess-id]<br/>worker
    participant S as session-instaql-queries<br/>(datomic)

    C->>Q: add-query q
    Q->>S: bump-instaql-version! → CREATE q
    Q-->>C: add-query-ok

    Note over C: another tx touches q's topic →<br/>invalidator marks q stale →<br/>enqueues :refresh

    par concurrent (different groups)
        R->>S: get-stale-instaql-queries snapshot<br/>(q is in it)
    and
        C->>Q: remove-query q
        Q->>S: remove-query! → RETRACT q
        Q-->>C: remove-query-ok
    end

    R->>S: bump-instaql-version! for q<br/>(else-branch CREATES if missing)
    Note over S: q is back in the session 💀

    C->>Q: add-query q (re-subscribe)
    Q-->>C: add-query-exists
    Note over C: notifyOneQueryOnce → no dfds →<br/>regular subscriber hangs forever
```

The smoking gun is `bump-instaql-version-tx-data` (`server/src/instant/reactive/store.clj:525`) — its else-branch *creates* the entity if missing. That's correct for the `handle-add-query!` call site but wrong for the refresh-recompute call site, where a missing entity means "this query was unsubscribed; skip it."

## IDB caveat that hid this locally

The reactor persists query results to IndexedDB. Once Q's result is in IDB, a fresh subscribe loads from cache *before* `add-query-exists` arrives — the hang is masked.

```mermaid
flowchart LR
    A[Client subscribes Q] --> B{IDB has q?}
    B -->|yes — recently viewed| C[loadKey merge sets result] --> D[notifyOne wakes cb] --> E[no hang]
    B -->|no — first visit or<br/>GC'd 1000-entry cap| F[result stays null] --> G[wait for server] --> H{server reply}
    H -->|add-query-ok| I[data]
    H -->|add-query-exists| J[hang]
    style J fill:#f88
    style E fill:#9f9
    style I fill:#9f9
```

On a Mirando search with many per-card queries, plenty of cards land in the "no cache" state. That lines up with the user's report that hangs happen in batches while rendering search results.

## Repro (100%)

Two nREPL patches on the running server, with corresponding tests in this PR:

**Root-cause repro** — widen the race window so it triggers deterministically:

```clojure
;; cd server && ./scripts/nrepl-eval
(in-ns 'instant.reactive.session)
(def orig-recompute recompute-instaql-query!)
(alter-var-root #'recompute-instaql-query!
  (constantly (fn [opts q] (Thread/sleep 300) (orig-recompute opts q))))
;; restore: (require 'instant.reactive.session :reload)
```

Then un-skip `refresh race re-adds removed query → next sub hangs` → test hangs and fails.

**Symptom isolation** — simulate *any* way the server retains q:

```clojure
(alter-var-root #'instant.reactive.store/remove-query!
  (constantly (fn [& _] nil)))
;; restore: (require 'instant.reactive.store :reload)
```

Then un-skip `add-query-exists hangs a regular subscriber` → test hangs and fails.

In both cases the *only* manipulation is server-side. The client runs unmodified production code paths.

## Investigation notes

I spent a few iterations on a hypothesis that the client was silently dropping `remove-query` (e.g., `_trySendAuthed` bailing during a status transition). Stepan correctly pushed back: in practice, anything that prevents the remove-query from reaching the server also closes the websocket, which kills the server session — so the next add-query lands on a fresh session and gets `add-query-ok`. That ruled out "lost remove-query" as a real production trigger and pointed me at the server-side path that retains q across a successful remove. The refresh race is what I found.

The user's posthog "still loading after 5s" payload includes captured client events (via `installInstantDebug`). One quirk worth noting: the gist's `_trySend` wrap logs `send` *before* checking `transport.isOpen()`, so a logged `send add-query` does not necessarily mean the message reached the wire. That might explain some of the "no response" lines in the captured debug log independently of the bug here.

## Fix direction (not in this PR)

Two complementary changes worth discussing:

| Where | Change | Rationale |
|---|---|---|
| Client (`packages/core/src/Reactor.js`) | Make `case 'add-query-exists'` also wake regular subscribers. Either resolve from cached `querySubs[hash].result` if present, or have the server include the cached result in `add-query-exists` when it knows about it. | Defense in depth — prevents the same hang from any future cause that desyncs server/client state. |
| Server (`server/src/instant/reactive/store.clj`) | Split `bump-instaql-version` into two operations: "create-or-bump" for the add-query call site and "bump if exists" for the refresh call site. | Closes the race at the source. A refresh on a missing entity means "this query was unsubscribed" — should be a no-op. |

## Test plan

- [ ] `pnpm test --project e2e -- stuckQuery.e2e` baseline passes with the server in its normal state.
- [ ] Apply each nREPL patch in turn, un-skip the corresponding test, confirm it hangs (`add-query-exists` reproduces).
- [ ] Restore the server, confirm all tests pass again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
