### PR TITLE
Resurrect recipe urls

### DIFF
--- a/client/sandbox/react-nextjs/pages/play/hazelcast-broadcast.tsx
+++ b/client/sandbox/react-nextjs/pages/play/hazelcast-broadcast.tsx
@@ -52,7 +52,7 @@ function Page() {
             >
               <iframe
                 className="flex-1"
-                src={`http://localhost:3000/recipes/5-reactions?__appId=${config.appId}&port=${port}`}
+                src={`http://localhost:3000/recipes/reactions?__appId=${config.appId}&port=${port}`}
               />
               <div className="absolute p-2">Port {port}</div>
               <button

--- a/client/sandbox/react-nextjs/pages/play/hazelcast.tsx
+++ b/client/sandbox/react-nextjs/pages/play/hazelcast.tsx
@@ -72,7 +72,7 @@ function Page() {
             >
               <iframe
                 className="flex-1"
-                src={`http://localhost:3000/recipes/3-cursors?__appId=${config.appId}&port=${port}`}
+                src={`http://localhost:3000/recipes/cursors?__appId=${config.appId}&port=${port}`}
               />
               <div className="absolute p-2">Port {port}</div>
               <button

--- a/client/www/app/recipes/[name]/page.tsx
+++ b/client/www/app/recipes/[name]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { capitalize } from 'lodash';
+import { recipeFiles } from 'recipes';
+import RecipePage from './recipe-page';
+
+export async function generateStaticParams() {
+  return recipeFiles.map((name) => ({ name }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}): Promise<Metadata> {
+  const { name } = await params;
+  if (!recipeFiles.includes(name)) return {};
+  const title = capitalize(name.split('-').join(' '));
+  return { title: `${title} · Instant Recipe` };
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  if (!recipeFiles.includes(name)) notFound();
+  return <RecipePage name={name} />;
+}

--- a/client/www/app/recipes/[name]/recipe-page.tsx
+++ b/client/www/app/recipes/[name]/recipe-page.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  InstantReactWebDatabase,
+  InstantUnknownSchema,
+  init,
+} from '@instantdb/react';
+import { Toaster } from '@instantdb/components';
+import config from '@/lib/config';
+import { errorToast } from '@/lib/toast';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
+import { RecipeDBProvider } from '@/lib/recipes/db';
+import { recipeComponents } from '@/lib/recipes/registry';
+import {
+  provisionEphemeralApp,
+  verifyEphemeralApp,
+  recipesAppIdStorageKey,
+  provisionErrorMessage,
+} from '@/lib/recipes/ephemeralApp';
+
+type InstantDB = InstantReactWebDatabase<InstantUnknownSchema>;
+
+export default function RecipePage({ name }: { name: string }) {
+  return (
+    <ErrorBoundary renderError={() => null}>
+      <Main name={name} />
+    </ErrorBoundary>
+  );
+}
+
+function Main({ name }: { name: string }) {
+  const router = useRouter();
+  const isHydrated = useIsHydrated();
+  const [appId, setAppId] = useState<string | undefined>(undefined);
+  const dbRef = useRef<InstantDB | null>(null);
+
+  function getDb(appId: string): InstantDB {
+    if (!dbRef.current) {
+      dbRef.current = init({
+        ...config,
+        appId,
+        __extraDedupeKey: `recipe-page-${name}`,
+      } as any);
+    }
+    return dbRef.current;
+  }
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    onInit();
+  }, [isHydrated]);
+
+  function saveAppId(newAppId: string) {
+    setAppId(newAppId);
+    localStorage.setItem(recipesAppIdStorageKey, newAppId);
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('app') !== newAppId) {
+      params.set('app', newAppId);
+      router.replace(
+        `${window.location.pathname}?${params.toString()}${window.location.hash}`,
+      );
+    }
+  }
+
+  async function onInit() {
+    const params = new URLSearchParams(window.location.search);
+    const incomingAppId =
+      params.get('app') || localStorage.getItem(recipesAppIdStorageKey);
+
+    if (incomingAppId) {
+      const verifyRes = await verifyEphemeralApp({ appId: incomingAppId });
+      if (verifyRes.ok) {
+        saveAppId(incomingAppId);
+        return;
+      }
+    }
+
+    const provisionRes = await provisionEphemeralApp();
+    if (provisionRes.ok) {
+      saveAppId(provisionRes.json.app.id);
+    } else {
+      errorToast(provisionErrorMessage);
+    }
+  }
+
+  const RecipeComponent = recipeComponents[name];
+
+  return (
+    <>
+      <Toaster />
+      <div className="fixed inset-0 overflow-auto bg-white">
+        {appId ? (
+          <ErrorBoundary
+            renderError={() => (
+              <p className="p-4 text-sm text-red-500">Error loading preview</p>
+            )}
+          >
+            <RecipeDBProvider value={getDb(appId)}>
+              <RecipeComponent />
+            </RecipeDBProvider>
+          </ErrorBoundary>
+        ) : (
+          <div className="animate-slow-pulse h-full w-full bg-gray-200" />
+        )}
+      </div>
+    </>
+  );
+}

--- a/client/www/app/recipes/content.tsx
+++ b/client/www/app/recipes/content.tsx
@@ -2,11 +2,10 @@
 
 import { CodeEditor } from '@/components/new-landing/TabbedCodeExample';
 import { File } from 'recipes';
-import { InstantApp } from '@/lib/types';
 import config from '@/lib/config';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useInView } from 'react-intersection-observer';
-import { ComponentType, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useIsHydrated } from '@/lib/hooks/useIsHydrated';
 import {
@@ -20,25 +19,13 @@ import { CopyToClipboardButton } from '@/components/new-landing/CopyToClipboardB
 import { BrowserChrome } from '@/components/BrowserChrome';
 
 import { RecipeDBProvider } from '@/lib/recipes/db';
-import InstantTodos from '@/lib/recipes/todos';
-import InstantAuth from '@/lib/recipes/auth';
-import InstantCursors from '@/lib/recipes/cursors';
-import InstantCustomCursors from '@/lib/recipes/custom-cursors';
-import InstantTopics from '@/lib/recipes/reactions';
-import InstantTypingIndicator from '@/lib/recipes/typing-indicator';
-import InstantAvatarStack from '@/lib/recipes/avatar-stack';
-import InstantMergeTileGame from '@/lib/recipes/merge-tile-game';
-
-const recipeComponents: Record<string, ComponentType> = {
-  todos: InstantTodos,
-  auth: InstantAuth,
-  cursors: InstantCursors,
-  'custom-cursors': InstantCustomCursors,
-  reactions: InstantTopics,
-  'typing-indicator': InstantTypingIndicator,
-  'avatar-stack': InstantAvatarStack,
-  'merge-tile-game': InstantMergeTileGame,
-};
+import { recipeComponents } from '@/lib/recipes/registry';
+import {
+  provisionEphemeralApp,
+  verifyEphemeralApp,
+  recipesAppIdStorageKey,
+  provisionErrorMessage,
+} from '@/lib/recipes/ephemeralApp';
 
 const MAX_COLUMNS = 5;
 
@@ -66,7 +53,12 @@ function Main({ files }: { files: File[] }) {
   });
   const [selectedExample, setSelectedExample] = useState<string | undefined>();
   const [appId, setAppId] = useState<string | undefined>(undefined);
+  const [host, setHost] = useState<string | undefined>(undefined);
   const columnDbsRef = useRef<InstantDB[]>([]);
+
+  useEffect(() => {
+    setHost(window.location.host);
+  }, []);
 
   function getColumnDb(appId: string, index: number): InstantDB {
     while (columnDbsRef.current.length <= index) {
@@ -112,7 +104,7 @@ function Main({ files }: { files: File[] }) {
 
   function saveAppId(newAppId: string) {
     setAppId(newAppId);
-    localStorage.setItem(storageKey, newAppId);
+    localStorage.setItem(recipesAppIdStorageKey, newAppId);
     const params = new URLSearchParams(window.location.search);
     if (params.get('app') !== newAppId) {
       params.set('app', newAppId);
@@ -125,7 +117,8 @@ function Main({ files }: { files: File[] }) {
   async function onInit() {
     // 1. check for an app ID in the URL or local storage - URL takes precedence over local storage
     const params = new URLSearchParams(window.location.search);
-    const incomingAppId = params.get('app') || localStorage.getItem(storageKey);
+    const incomingAppId =
+      params.get('app') || localStorage.getItem(recipesAppIdStorageKey);
 
     // 2a. if we have an app ID, verify it
     if (incomingAppId) {
@@ -185,6 +178,7 @@ function Main({ files }: { files: File[] }) {
                 key={file.pathName}
                 file={file}
                 appId={isHydrated && appId ? appId : undefined}
+                host={host}
                 getColumnDb={getColumnDb}
                 onViewChange={(inView) => {
                   if (!isHydrated) return;
@@ -206,12 +200,14 @@ function Main({ files }: { files: File[] }) {
 function Example({
   file,
   appId,
+  host,
   getColumnDb,
   onViewChange,
   lazy,
 }: {
   file: File;
   appId: string | undefined;
+  host: string | undefined;
   getColumnDb: (appId: string, index: number) => InstantDB;
   onViewChange: (inView: boolean) => void;
   lazy: boolean;
@@ -305,7 +301,13 @@ function Example({
                   zIndex: i,
                 }}
               >
-                <BrowserChrome />
+                <BrowserChrome
+                  url={
+                    host && appId
+                      ? recipePageUrl(host, file.pathName, appId)
+                      : undefined
+                  }
+                />
                 <div className="h-[calc(100%-32px)] overflow-auto">
                   {appId && RecipeComponent ? (
                     <ErrorBoundary
@@ -356,46 +358,10 @@ function RoomStatus({ db, appId }: { db: InstantDB; appId: string }) {
 
 type InstantDB = InstantReactWebDatabase<InstantUnknownSchema>;
 
-const defaultAppTitle = 'Instant Example App';
-const storageKey = 'recipes-appId';
-
-const provisionErrorMessage =
-  'Oops! Something went wrong when provisioning your app ID. Please reload the page and try again!';
-
 function recipesUrl(appId: string) {
   return 'https://instantdb.com/recipes?app=' + appId;
 }
 
-async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: defaultAppTitle,
-    }),
-  });
-
-  const json: { app: InstantApp } = await r.json();
-
-  return {
-    ok: r.ok,
-    json,
-  };
-}
-
-async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  const json: { app: InstantApp } = await r.json();
-
-  return {
-    ok: r.ok,
-    json,
-  };
+function recipePageUrl(host: string, pathName: string, appId: string) {
+  return `${host}/recipes/${pathName}?app=${appId}`;
 }

--- a/client/www/lib/recipes/ephemeralApp.ts
+++ b/client/www/lib/recipes/ephemeralApp.ts
@@ -1,3 +1,4 @@
+import { validate as isUuid } from 'uuid';
 import config from '@/lib/config';
 import { InstantApp } from '@/lib/types';
 
@@ -8,36 +9,45 @@ export const provisionErrorMessage =
 
 const defaultAppTitle = 'Instant Example App';
 
-export async function provisionEphemeralApp() {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      title: defaultAppTitle,
-    }),
-  });
+type EphemeralAppResult =
+  | { ok: true; json: { app: InstantApp } }
+  | { ok: false; json: null };
 
-  const json: { app: InstantApp } = await r.json();
-
-  return {
-    ok: r.ok,
-    json,
-  };
+export async function provisionEphemeralApp(): Promise<EphemeralAppResult> {
+  try {
+    const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: defaultAppTitle,
+      }),
+    });
+    const json: { app: InstantApp } = await r.json();
+    return r.ok ? { ok: true, json } : { ok: false, json: null };
+  } catch {
+    return { ok: false, json: null };
+  }
 }
 
-export async function verifyEphemeralApp({ appId }: { appId: string }) {
-  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  const json: { app: InstantApp } = await r.json();
-
-  return {
-    ok: r.ok,
-    json,
-  };
+export async function verifyEphemeralApp({
+  appId,
+}: {
+  appId: string;
+}): Promise<EphemeralAppResult> {
+  if (!isUuid(appId)) {
+    return { ok: false, json: null };
+  }
+  try {
+    const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const json: { app: InstantApp } = await r.json();
+    return r.ok ? { ok: true, json } : { ok: false, json: null };
+  } catch {
+    return { ok: false, json: null };
+  }
 }

--- a/client/www/lib/recipes/ephemeralApp.ts
+++ b/client/www/lib/recipes/ephemeralApp.ts
@@ -1,0 +1,43 @@
+import config from '@/lib/config';
+import { InstantApp } from '@/lib/types';
+
+export const recipesAppIdStorageKey = 'recipes-appId';
+
+export const provisionErrorMessage =
+  'Oops! Something went wrong when provisioning your app ID. Please reload the page and try again!';
+
+const defaultAppTitle = 'Instant Example App';
+
+export async function provisionEphemeralApp() {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      title: defaultAppTitle,
+    }),
+  });
+
+  const json: { app: InstantApp } = await r.json();
+
+  return {
+    ok: r.ok,
+    json,
+  };
+}
+
+export async function verifyEphemeralApp({ appId }: { appId: string }) {
+  const r = await fetch(`${config.apiURI}/dash/apps/ephemeral/${appId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const json: { app: InstantApp } = await r.json();
+
+  return {
+    ok: r.ok,
+    json,
+  };
+}

--- a/client/www/lib/recipes/registry.ts
+++ b/client/www/lib/recipes/registry.ts
@@ -1,0 +1,20 @@
+import { ComponentType } from 'react';
+import InstantTodos from '@/lib/recipes/todos';
+import InstantAuth from '@/lib/recipes/auth';
+import InstantCursors from '@/lib/recipes/cursors';
+import InstantCustomCursors from '@/lib/recipes/custom-cursors';
+import InstantTopics from '@/lib/recipes/reactions';
+import InstantTypingIndicator from '@/lib/recipes/typing-indicator';
+import InstantAvatarStack from '@/lib/recipes/avatar-stack';
+import InstantMergeTileGame from '@/lib/recipes/merge-tile-game';
+
+export const recipeComponents: Record<string, ComponentType> = {
+  todos: InstantTodos,
+  auth: InstantAuth,
+  cursors: InstantCursors,
+  'custom-cursors': InstantCustomCursors,
+  reactions: InstantTopics,
+  'typing-indicator': InstantTypingIndicator,
+  'avatar-stack': InstantAvatarStack,
+  'merge-tile-game': InstantMergeTileGame,
+};

--- a/client/www/recipes.ts
+++ b/client/www/recipes.ts
@@ -8,7 +8,7 @@ export type File = {
   pathName: string;
 };
 
-const recipeFiles = [
+export const recipeFiles = [
   'todos',
   'cursors',
   'custom-cursors',


### PR DESCRIPTION
Adds individual urls for the recipes pages. 

The url shows up in the mini browser chrome. You can copy it and put it in your browser url bar and see the individual recipe on a page by itself.

Direct link to the todo recipe: https://instant-www-js-recipe-urls-jsv.vercel.app/recipes/todos?app=38f277d3-6450-416f-a908-ae6521d9a7a2

It's useful for testing hazelcast stuff, and it fixes the hazelcast playgrounds.

Here's what it looks like in the browser chrome:
<img width="639" height="770" alt="Screenshot 2026-05-20 at 5 22 33 PM" src="https://github.com/user-attachments/assets/de18b385-8295-4990-8ccd-f60fa601e19c" />
