### PR TITLE
Cleanup hazelcast code after flipping flag

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -404,6 +404,3 @@
 
 (defn smokescreen-whitelist-ips []
   (flag :smokescreen-whitelist-ips #{}))
-
-(defn batch-hz-room-map-actions? []
-  (flag :batch-hz-room-map-actions (config/dev?)))

--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -6,7 +6,6 @@
    [datascript.core :as ds]
    [editscript.core :as editscript]
    [instant.config :as config :refer [aws-env?]]
-   [instant.flags :as flags]
    [instant.gauges :as gauges]
    [instant.rate-limit :as rate-limit]
    [instant.reactive.receive-queue :as receive-queue]
@@ -387,12 +386,7 @@
                  (empty? session-ids) (medley/dissoc-in [:rooms room-key])
                  (seq session-ids) (assoc-in [:rooms room-key :session-ids]
                                              session-ids)))))
-
-    (hazelcast/remove-session! (when (flags/batch-hz-room-map-actions?)
-                                 (partial enqueue-room-map-update store))
-                               (get-hz-rooms-map)
-                               room-key
-                               sess-id)))
+    (enqueue-room-map-update store room-key (hazelcast/remove-session-action sess-id))))
 
 (defn clean-orphan-sessions [_time]
   (tracer/with-span! {:name "clean-orphan-sessions"}
@@ -462,25 +456,20 @@
 
 (defn join-room! [store app-id sess-id current-user room-id data]
   (register-session! app-id room-id sess-id)
-  (hazelcast/join-room! (when (flags/batch-hz-room-map-actions?)
-                          (partial enqueue-room-map-update store))
-                        (get-hz-rooms-map)
-                        (hazelcast/room-key app-id room-id)
-                        sess-id
-                        (:instance-id @hz)
-                        (:id current-user)
-                        data))
+  (enqueue-room-map-update store
+                           (hazelcast/room-key app-id room-id)
+                           (hazelcast/join-room-action sess-id
+                                                       (:instance-id @hz)
+                                                       (:id current-user)
+                                                       data)))
 
 (defn leave-room! [store app-id sess-id room-id]
   (remove-session! store app-id room-id sess-id))
 
 (defn set-presence! [store app-id sess-id room-id data]
-  (hazelcast/set-presence! (when (flags/batch-hz-room-map-actions?)
-                             (partial enqueue-room-map-update store))
-                           (get-hz-rooms-map)
+  (enqueue-room-map-update store
                            (hazelcast/room-key app-id room-id)
-                           sess-id
-                           data))
+                           (hazelcast/set-presence-action sess-id data)))
 
 (defn leave-by-session-id! [store app-id sess-id]
   (doseq [room-id (get-in @room-maps [:sessions sess-id])]

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -9,7 +9,7 @@
    [taoensso.nippy :as nippy])
   (:import
    (com.hazelcast.config GlobalSerializerConfig SerializerConfig)
-   (com.hazelcast.map EntryProcessor IMap)
+   (com.hazelcast.map EntryProcessor)
    (com.hazelcast.map.impl LockAwareLazyMapEntry)
    (com.hazelcast.nio.serialization ByteArraySerializer)
    (java.io DataOutputStream DataInputStream ByteArrayInputStream ByteArrayOutputStream)

--- a/server/src/instant/util/hazelcast.clj
+++ b/server/src/instant/util/hazelcast.clj
@@ -98,18 +98,8 @@
         nil
         res))))
 
-(defn remove-session! [execute-on-key ^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id]
-  (let [action (->RemoveSessionMergeV1 session-id)]
-    (if execute-on-key
-      (execute-on-key room-key action)
-      (.merge hz-map
-              room-key
-              ;; If the current value of the key is null, then the new value
-              ;; should just be an empty map. We'd like to put nil here to
-              ;; remove the entry (like we do in the bifunction), but that's
-              ;; not allowed.
-              {}
-              action))))
+(defn remove-session-action [^UUID session-id]
+  (->RemoveSessionMergeV1 session-id))
 
 (def ^ByteArraySerializer remove-session-serializer
   (reify ByteArraySerializer
@@ -159,18 +149,8 @@
   (make-serializer-config JoinRoomMergeV3
                           join-room-v3-serializer))
 
-(defn join-room! [execute-on-key ^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id ^String instance-id ^UUID user-id data]
-  (let [action (->JoinRoomMergeV3 session-id instance-id user-id data)]
-    (if execute-on-key
-      (execute-on-key room-key action)
-      (.merge hz-map
-              room-key
-              {session-id {:peer-id     session-id
-                           :instance-id instance-id
-                           :user        (when user-id
-                                          {:id user-id})
-                           :data        (or data {})}}
-              action))))
+(defn join-room-action [^UUID session-id ^String instance-id ^UUID user-id data]
+  (->JoinRoomMergeV3 session-id instance-id user-id data))
 
 ;; ------------
 ;; Set presence
@@ -184,16 +164,8 @@
                      :data
                      data)))
 
-(defn set-presence! [execute-on-key ^IMap hz-map ^RoomKeyV1 room-key ^UUID session-id data]
-  (let [action (->SetPresenceMergeV1 session-id data)]
-    (if execute-on-key
-      (execute-on-key room-key action)
-      (.merge hz-map
-              room-key
-              ;; if current value is nil, then we're not in the room, so we
-              ;; shouldn't set presence
-              {}
-              action))))
+(defn set-presence-action [^UUID session-id data]
+  (->SetPresenceMergeV1 session-id data))
 
 (def ^ByteArraySerializer set-presence-serializer
   (reify ByteArraySerializer


### PR DESCRIPTION
I flipped the `batch-hz-room-map-actions` flag yesterday.

Everything is looking good in production, so we can clean up this old code.