### PR TITLE
Use hiccup to construct all emails

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -206,19 +206,16 @@
      :reply-to sender-email
      :html
      (email/standard-body
-      "<p><strong>Welcome,</strong></p>
-       <p>
-         You asked to join " title ". To complete your registration, use this
-         verification code:
-       </p>
-       <h2 style=\"text-align: center\"><strong>" code "</strong></h2>
-       <p>
-         Copy and paste this into the confirmation box, and you'll be on your way.
-       </p>
-       <p>
-         Note: This code will expire in 10 minutes, and can only be used once. If you
-         didn't request this code, please reply to this email.
-       </p>")}))
+      (h/html
+       [:p [:strong "Welcome,"]]
+       [:p
+        "You asked to join " title ". To complete your registration, use this "
+        "verification code:"]
+       [:h2 {:style "text-align: center"} [:strong code]]
+       [:p "Copy and paste this into the confirmation box, and you'll be on your way."]
+       [:p
+        "Note: This code will expire in 10 minutes, and can only be used once. If you "
+        "didn't request this code, please reply to this email."]))}))
 
 (comment
   (def user (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -96,15 +96,17 @@
      :html
      body}))
 
-(defn template-replace [template params]
+(defn template-replace [template params escape?]
   (reduce
    (fn [acc [k v]]
-     (string/replace acc (str "{" (name k) "}") (str (h/html v))))
+     (string/replace acc (str "{" (name k) "}") (if escape?
+                                                  (str (h/html v))
+                                                  v)))
    template
    params))
 
 (comment
-  (template-replace "Hello {name}, your code is {code}" {:name "Stepan" :code "123"}))
+  (template-replace "Hello {name}, your code is {code}" {:name "Stepan" :code "123"} true))
 
 (defn friendly-expiration [app]
   (let [minutes (app-model/get-magic-code-expiry-minutes {:id (:id app)})]
@@ -131,8 +133,8 @@
         email-params    (if template
                           {:sender-email sender-email
                            :sender-name (or (:name template) (:title app))
-                           :subject (template-replace (:subject template) template-params)
-                           :body (template-replace (:body template) template-params)}
+                           :subject (template-replace (:subject template) template-params false)
+                           :body (template-replace (:body template) template-params true)}
                           {:sender-name (:title app)
                            :sender-email default-sender-email
                            :subject (str code " is your verification code for " (:title app))

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -99,7 +99,7 @@
 (defn template-replace [template params]
   (reduce
    (fn [acc [k v]]
-     (string/replace acc (str "{" (name k) "}") v))
+     (string/replace acc (str "{" (name k) "}") (str (h/html v))))
    template
    params))
 

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -1,6 +1,7 @@
 (ns instant.runtime.magic-code-auth
   (:require
    [clojure.string :as string]
+   [hiccup2.core :as h]
    [instant.config :as config]
    [instant.flags :as flags]
    [instant.model.app :as app-model]
@@ -73,19 +74,17 @@
         (= code postmark-not-found-sender-body-error-code))))
 
 (defn default-body [{:keys [app_title code expiration]}]
-  (postmark/standard-body "<p><strong>Welcome,</strong></p>
-        <p>
-          You asked to join " app_title ". To complete your registration, use this
-          verification code:
-        </p>
-        <h2 style=\"text-align: center\"><strong>" code "</strong></h2>
-       <p>
-         Copy and paste this into the confirmation box, and you'll be on your way.
-       </p>
-       <p>
-         Note: This code will expire in " expiration ", and can only be used once. If you
-         didn't request this code, please reply to this email.
-       </p>"))
+  (postmark/standard-body
+   (h/html
+    [:p [:strong "Welcome,"]]
+    [:p
+     "You asked to join " app_title ". To complete your registration, use this "
+     "verification code:"]
+    [:h2 {:style "text-align: center"} [:strong code]]
+    [:p "Copy and paste this into the confirmation box, and you'll be on your way."]
+    [:p
+     "Note: This code will expire in " expiration ", and can only be used once. If you "
+     "didn't request this code, please reply to this email."])))
 
 (defn magic-code-email [to params]
   (let [{:keys [sender-name sender-email subject body]} params]

--- a/server/src/instant/scripts/analytics.clj
+++ b/server/src/instant/scripts/analytics.clj
@@ -2,6 +2,7 @@
   (:require
    [chime.core :as chime-core]
    [clojure.tools.logging :as log]
+   [hiccup2.core :as h]
    [instant.flags :refer [get-emails]]
    [instant.grab :as grab]
    [instant.jdbc.aurora :as aurora]
@@ -98,51 +99,40 @@
   (build-data))
 
 (defn metric-row [label value]
-  (str "<p style='margin:0;padding:0'>"
-       label
-       ": "
-       value
-       "</p>"))
+  [:p {:style "margin:0;padding:0"} label ": " value])
 
 (defn email-row [{:keys [email]}]
-  (str "<p style='margin:0;padding:0'>"
-       email
-       "</p>"))
+  [:p {:style "margin:0;padding:0"} email])
 
 (defn top-table []
-  (str
-   "<table style='text-align:left'>"
-   "<thead>"
-   "<tr>"
-   "<th style='width:120px;'>email</th>"
-   "<th style='width:120px;'>app</th>"
-   "<th style='width:50px'>num-triples</th>"
-   "</tr>"
-   "</thead>"
-   "<tbody>"
-   (apply str (map (fn [{:keys [email title n]}]
-                     (str "<tr>"
-                          "<td style='width:120px;'>" email "</td>"
-                          "<td style='width:120px;'>" title "</td>"
-                          "<td style='width:100px'>" n "</td>"
-                          "</tr>")) (take 10 (top-recent-users))))
-   "</tbody>"
-   "</table>"))
+  [:table {:style "text-align:left"}
+   [:thead
+    [:tr
+     [:th {:style "width:120px;"} "email"]
+     [:th {:style "width:120px;"} "app"]
+     [:th {:style "width:50px"} "num-triples"]]]
+   [:tbody
+    (for [{:keys [email title n]} (take 10 (top-recent-users))]
+      [:tr
+       [:td {:style "width:120px;"} email]
+       [:td {:style "width:120px;"} title]
+       [:td {:style "width:100px"} n]])]])
 
 (comment
   (top-table))
 
 (defn html-body [{:keys [num-triples num-users new-users num-apps new-apps new-emails]}]
-  (str
-   "<h2>Analytics for: " (date/numeric-date-str (LocalDate/now)) "</h2>"
+  (h/html
+   [:h2 "Analytics for: " (date/numeric-date-str (LocalDate/now))]
    (metric-row "num-triples" num-triples)
    (metric-row "num-users" num-users)
    (metric-row "new-users" new-users)
    (metric-row "num-apps" num-apps)
    (metric-row "new-apps" new-apps)
-   "<h3>Transactors Leaderboard</h3>" (top-table)
-   "<h3>Users who made new apps</h3>"
-   (apply str (map email-row new-emails))))
+   [:h3 "Transactors Leaderboard"] (top-table)
+   [:h3 "Users who made new apps"]
+   (for [email new-emails]
+     (email-row email))))
 
 (comment
   (html-body (build-data)))
@@ -152,7 +142,7 @@
     {:from "assistant@pm.instantdb.com"
      :to "stopa@instantdb.com, joe@instantdb.com"
      :subject (str "Instant Summary: " report-date)
-     :html (apply postmark/standard-body (html-body (build-data)))}))
+     :html (postmark/standard-body (html-body (build-data)))}))
 
 (defn period []
   (let [now (date/et-now)

--- a/server/src/instant/superadmin/routes.clj
+++ b/server/src/instant/superadmin/routes.clj
@@ -1,6 +1,7 @@
 (ns instant.superadmin.routes
   (:require [clojure.walk :as w]
             [compojure.core :as compojure :refer [defroutes DELETE GET POST]]
+            [hiccup2.core :as h]
             [instant.db.model.attr :as attr-model]
             [instant.model.app :as app-model]
             [instant.model.instant-personal-access-token :as instant-personal-access-token-model]
@@ -217,17 +218,17 @@
      :subject (str "[Instant] You've been asked to take ownership of " (:title app))
      :html
      (postmark/standard-body
-      "<p><strong>Hey there!</strong></p>
-       <p>
-         " (:email inviter-user) " invited you to become the new owner of " (:title app) ".
-       </p>
-       <p>
-         Navigate to <a href=\"https://instantdb.com/dash?s=invites\">Instant</a> to accept the invite.
-       </p>
-       <p>
-         Note: This invite will expire in 3 days. If you
-         don't know the user inviting you, please reply to this email.
-       </p>")}))
+      (h/html
+       [:p [:strong "Hey there!"]]
+       [:p
+        (:email inviter-user) " invited you to become the new owner of " (:title app) "."]
+       [:p
+        "Navigate to "
+        [:a {:href "https://instantdb.com/dash?s=invites"} "Instant"]
+        " to accept the invite."]
+       [:p
+        "Note: This invite will expire in 3 days. If you "
+        "don't know the user inviting you, please reply to this email."]))}))
 
 (defn app-transfer-send-invite-post [req]
   (let [{:keys [app user]} (req->superadmin-user-and-app! :apps/transfer :owner req)


### PR DESCRIPTION
Updates all of our emails to use hiccup instead of raw html strings. 

Hiccup will escape html in the user-provided inputs.