### PR TITLE
feat: improve explorer table tooltips, cell editing, and edit row dialog UX

### DIFF
--- a/client/packages/components/src/components/explorer/edit-row-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-row-dialog.tsx
@@ -3,6 +3,7 @@ import { id, InstantReactWebDatabase, tx } from '@instantdb/react';
 import {
   TextareaHTMLAttributes,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -37,7 +38,6 @@ import { validate } from 'uuid';
 import clsx from 'clsx';
 import { ClockIcon } from '@heroicons/react/24/outline';
 import { useExplorerProps } from '.';
-import { useShadowRoot } from '@lib/components/StyleMe';
 
 type FieldType = 'string' | 'number' | 'boolean' | 'json';
 type FieldTypeOption = { value: FieldType; label: string };
@@ -525,7 +525,6 @@ function RefItem({
   refUpdates,
   handleLinkRef,
   handleUnlinkRef,
-  autoOpenSearch,
 }: {
   db: InstantReactWebDatabase<any>;
   item: Record<string, any>;
@@ -534,13 +533,8 @@ function RefItem({
   refUpdates: null | Record<string, { action: 'link' | 'unlink'; item: any }>;
   handleLinkRef: (attr: SchemaAttr, item: any) => void;
   handleUnlinkRef: (attr: SchemaAttr, id: string) => void;
-  autoOpenSearch?: boolean;
 }) {
-  const [showAddLink, setShowAddLink] = useState(autoOpenSearch ?? false);
-
-  useEffect(() => {
-    setShowAddLink(autoOpenSearch ?? false);
-  }, [autoOpenSearch]);
+  const [showAddLink, setShowAddLink] = useState(false);
   const searchIgnoreIds = useMemo(() => {
     const res: Set<string> = new Set();
     for (const [k] of Object.entries(refUpdates || {})) {
@@ -617,11 +611,7 @@ function RefItem({
           onClose={() => setShowAddLink(false)}
         />
       ) : (
-        <Button
-          data-explorer-add-link
-          variant="secondary"
-          onClick={() => setShowAddLink(true)}
-        >
+        <Button variant="secondary" onClick={() => setShowAddLink(true)}>
           {cardinality === 'many' || !hasLink ? 'Add link' : 'Replace link'}
         </Button>
       )}
@@ -667,6 +657,22 @@ export function isEditableExplorerAttr(
   );
 }
 
+function scrollFieldSectionIntoView(
+  section: HTMLElement,
+  scrollParent: HTMLElement | null,
+) {
+  if (scrollParent) {
+    const parentRect = scrollParent.getBoundingClientRect();
+    const sectionRect = section.getBoundingClientRect();
+    scrollParent.scrollTop +=
+      sectionRect.top -
+      parentRect.top -
+      (parentRect.height - sectionRect.height) / 2;
+    return;
+  }
+  section.scrollIntoView({ block: 'center', inline: 'nearest' });
+}
+
 export function EditRowDialog({
   db,
   namespace,
@@ -682,7 +688,15 @@ export function EditRowDialog({
 }) {
   const op: 'edit' | 'add' = item.id ? 'edit' : 'add';
   const explorerProps = useExplorerProps();
-  const shadowRoot = useShadowRoot();
+  const formBodyRef = useRef<HTMLDivElement>(null);
+  const fieldSectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const setFieldSectionRef =
+    (name: string) => (el: HTMLDivElement | null) => {
+      fieldSectionRefs.current[name] = el;
+    };
+  const [pendingFocusField, setPendingFocusField] = useState<string | null>(
+    null,
+  );
 
   const editableBlobAttrs: SchemaAttr[] = [];
   const editableRefAttrs: SchemaAttr[] = [];
@@ -749,6 +763,38 @@ export function EditRowDialog({
   const hasFormErrors =
     Object.values(blobUpdates).some((u) => !!u.error) || hasRefFieldErrors;
   const [shouldDisplayErrors, setShouldDisplayErrors] = useState(false);
+
+  const shouldAutoFocus = (fieldName: string) => focusAttr === fieldName;
+
+  useLayoutEffect(() => {
+    if (!focusAttr) {
+      return;
+    }
+    const section = fieldSectionRefs.current[focusAttr];
+    if (section) {
+      scrollFieldSectionIntoView(section, formBodyRef.current);
+    }
+    const field = blobUpdates[focusAttr];
+    if (field?.type === 'boolean' && !nullFields[focusAttr]) {
+      section
+        ?.querySelector<HTMLElement>('[role="combobox"]')
+        ?.focus();
+    }
+  }, [focusAttr, blobUpdates, nullFields]);
+
+  useLayoutEffect(() => {
+    if (!pendingFocusField) {
+      return;
+    }
+    const section = fieldSectionRefs.current[pendingFocusField];
+    if (section) {
+      scrollFieldSectionIntoView(section, formBodyRef.current);
+      section
+        .querySelector<HTMLElement>('input, textarea')
+        ?.focus();
+    }
+    setPendingFocusField(null);
+  }, [pendingFocusField, nullFields]);
 
   const handleResetForm = () => {
     setRefUpdates({});
@@ -880,6 +926,7 @@ export function EditRowDialog({
       if (currentType === 'json') {
         setJsonUpdates((prev) => ({ ...prev, [field]: '{}' }));
       }
+      setPendingFocusField(field);
     }
   };
 
@@ -950,89 +997,6 @@ export function EditRowDialog({
       };
     });
   };
-
-  const focusElementAtTabIndex = (index: number) => {
-    // Use requestAnimationFrame to wait for the next render cycle
-    // so that the input is shown to focus
-    requestAnimationFrame(() => {
-      const root = shadowRoot ?? document;
-      const element = root.querySelector(`[tabindex="${index}"]`);
-      if (element && element instanceof HTMLElement) {
-        element.focus();
-      }
-    });
-  };
-
-  const scrollFieldSectionIntoView = (section: Element) => {
-    const scrollParent = section.closest(
-      '[data-explorer-edit-form-body], [data-slot="dialog-content"]',
-    ) as HTMLElement | null;
-    if (scrollParent) {
-      const parentRect = scrollParent.getBoundingClientRect();
-      const sectionRect = section.getBoundingClientRect();
-      scrollParent.scrollTop +=
-        sectionRect.top -
-        parentRect.top -
-        (parentRect.height - sectionRect.height) / 2;
-      return;
-    }
-    section.scrollIntoView({ block: 'center', inline: 'nearest' });
-  };
-
-  const mainFieldFocusSelector =
-    'input:not([type="hidden"]):not([type="checkbox"]), textarea, [contenteditable="true"], button, .monaco-editor textarea';
-
-  const findFocusableInEditor = (
-    editor: HTMLElement | null,
-  ): HTMLElement | null => {
-    if (!editor) {
-      return null;
-    }
-    if (editor.matches(mainFieldFocusSelector)) {
-      return editor;
-    }
-    return editor.querySelector<HTMLElement>(mainFieldFocusSelector);
-  };
-
-  const focusExplorerField = (section: Element) => {
-    scrollFieldSectionIntoView(section);
-    const editor = section.querySelector<HTMLElement>(
-      '[data-explorer-field-input]',
-    );
-    const focusable = findFocusableInEditor(editor);
-    if (focusable) {
-      focusable.focus();
-      return;
-    }
-    const addLink = section.querySelector<HTMLElement>(
-      '[data-explorer-add-link]',
-    );
-    if (addLink) {
-      addLink.click();
-      requestAnimationFrame(() => {
-        section.querySelector<HTMLElement>('input')?.focus();
-        scrollFieldSectionIntoView(section);
-      });
-    }
-  };
-
-  useEffect(() => {
-    if (!focusAttr) {
-      return;
-    }
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const root = shadowRoot ?? document;
-        const section = root.querySelector(
-          `[data-explorer-field="${focusAttr}"]`,
-        );
-        if (!section) {
-          return;
-        }
-        focusExplorerField(section);
-      });
-    });
-  }, [focusAttr, shadowRoot]);
 
   const handleSaveRow = async () => {
     const requiredBlobErrors: Record<string, string> = {};
@@ -1144,7 +1108,7 @@ export function EditRowDialog({
         </code>
       </div>
       <div
-        data-explorer-edit-form-body
+        ref={formBodyRef}
         className="mt-4 min-h-0 flex-1 overflow-y-auto px-4 scrollbar-gutter-stable"
       >
         <div className="flex flex-col gap-4">
@@ -1192,11 +1156,12 @@ export function EditRowDialog({
             jsonUpdates[attr.name] ||
             (value !== null ? JSON.stringify(value, null, 2) : 'null');
           const isNullField = nullFields[attr.name];
+          const autoFocusField = shouldAutoFocus(attr.name);
 
           return (
             <div
               key={attr.name}
-              data-explorer-field={attr.name}
+              ref={setFieldSectionRef(attr.name)}
               className="flex flex-col gap-1"
             >
               <div className="flex items-center justify-between">
@@ -1233,7 +1198,7 @@ export function EditRowDialog({
               <div className="flex flex-col gap-1">
                 {!isNullField ? (
                   <div className="flex space-x-1">
-                    <div className="flex-1" data-explorer-field-input>
+                    <div className="flex-1">
                       {type === 'json' ? (
                         <div className="h-32 w-full rounded-sm border">
                           <CodeEditor
@@ -1244,6 +1209,11 @@ export function EditRowDialog({
                             onChange={(code) =>
                               handleUpdateJson(attr.name, code)
                             }
+                            onMount={(editor) => {
+                              if (autoFocusField) {
+                                editor.focus();
+                              }
+                            }}
                           />
                         </div>
                       ) : type === 'boolean' ? (
@@ -1262,6 +1232,7 @@ export function EditRowDialog({
                         <input
                           tabIndex={tabIndex}
                           type="number"
+                          autoFocus={autoFocusField}
                           className="flex w-full flex-1 rounded-xs border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800"
                           value={value ?? ''}
                           onChange={(num) =>
@@ -1271,6 +1242,7 @@ export function EditRowDialog({
                       ) : (
                         <ResizingTextArea
                           tabIndex={tabIndex}
+                          autoFocus={autoFocusField}
                           value={value ?? ''}
                           onChange={(e) =>
                             handleUpdateFieldValue(attr.name, e.target.value)
@@ -1299,11 +1271,9 @@ export function EditRowDialog({
                   </div>
                 ) : (
                   <button
-                    data-explorer-field-input
-                    onClick={() => {
-                      handleNullToggle(attr.name, false);
-                      focusElementAtTabIndex(tabIndex);
-                    }}
+                    type="button"
+                    autoFocus={autoFocusField}
+                    onClick={() => handleNullToggle(attr.name, false)}
                     className="flex-1 rounded-xs border border-gray-200 bg-gray-50 px-3 py-1 text-left text-gray-500 italic dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
                   >
                     null
@@ -1332,7 +1302,7 @@ export function EditRowDialog({
           return (
             <div
               key={attr.name}
-              data-explorer-field={attr.name}
+              ref={setFieldSectionRef(attr.name)}
               className="flex flex-col gap-1"
             >
               <div className="flex items-center justify-between">
@@ -1350,7 +1320,6 @@ export function EditRowDialog({
                   refUpdates={refUpdates[attr.name]}
                   handleLinkRef={handleLinkRef}
                   handleUnlinkRef={handleUnlinkRef}
-                  autoOpenSearch={focusAttr === attr.name}
                 />
                 {refFieldErrors[attr.name] && shouldDisplayErrors && (
                   <span className="text-sm font-medium text-red-500">

--- a/client/packages/components/src/components/explorer/edit-row-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-row-dialog.tsx
@@ -37,6 +37,7 @@ import { validate } from 'uuid';
 import clsx from 'clsx';
 import { ClockIcon } from '@heroicons/react/24/outline';
 import { useExplorerProps } from '.';
+import { useShadowRoot } from '@lib/components/StyleMe';
 
 type FieldType = 'string' | 'number' | 'boolean' | 'json';
 type FieldTypeOption = { value: FieldType; label: string };
@@ -483,6 +484,7 @@ function RefItem({
   refUpdates,
   handleLinkRef,
   handleUnlinkRef,
+  autoOpenSearch,
 }: {
   db: InstantReactWebDatabase<any>;
   item: Record<string, any>;
@@ -491,8 +493,13 @@ function RefItem({
   refUpdates: null | Record<string, { action: 'link' | 'unlink'; item: any }>;
   handleLinkRef: (attr: SchemaAttr, item: any) => void;
   handleUnlinkRef: (attr: SchemaAttr, id: string) => void;
+  autoOpenSearch?: boolean;
 }) {
-  const [showAddLink, setShowAddLink] = useState(false);
+  const [showAddLink, setShowAddLink] = useState(autoOpenSearch ?? false);
+
+  useEffect(() => {
+    setShowAddLink(autoOpenSearch ?? false);
+  }, [autoOpenSearch]);
   const searchIgnoreIds = useMemo(() => {
     const res: Set<string> = new Set();
     for (const [k] of Object.entries(refUpdates || {})) {
@@ -569,7 +576,11 @@ function RefItem({
           onClose={() => setShowAddLink(false)}
         />
       ) : (
-        <Button variant="secondary" onClick={() => setShowAddLink(true)}>
+        <Button
+          data-explorer-add-link
+          variant="secondary"
+          onClick={() => setShowAddLink(true)}
+        >
           {cardinality === 'many' || !hasLink ? 'Add link' : 'Replace link'}
         </Button>
       )}
@@ -602,19 +613,35 @@ const isEditableRefAttr = (attr: SchemaAttr) => {
   }
 };
 
+export function isEditableExplorerAttr(
+  namespace: SchemaNamespace,
+  attr: SchemaAttr,
+) {
+  if (attr.name === 'id') {
+    return false;
+  }
+  return (
+    isEditableBlobAttr(namespace, attr) ||
+    (attr.type === 'ref' && isEditableRefAttr(attr))
+  );
+}
+
 export function EditRowDialog({
   db,
   namespace,
   item,
   onClose,
+  focusAttr,
 }: {
   db: InstantReactWebDatabase<any>;
   namespace: SchemaNamespace;
   item: Record<string, any>;
   onClose: () => void;
+  focusAttr?: string;
 }) {
   const op: 'edit' | 'add' = item.id ? 'edit' : 'add';
   const explorerProps = useExplorerProps();
+  const shadowRoot = useShadowRoot();
 
   const editableBlobAttrs: SchemaAttr[] = [];
   const editableRefAttrs: SchemaAttr[] = [];
@@ -867,12 +894,72 @@ export function EditRowDialog({
     // Use requestAnimationFrame to wait for the next render cycle
     // so that the input is shown to focus
     requestAnimationFrame(() => {
-      const element = document.querySelector(`[tabindex="${index}"]`);
+      const root = shadowRoot ?? document;
+      const element = root.querySelector(`[tabindex="${index}"]`);
       if (element && element instanceof HTMLElement) {
         element.focus();
       }
     });
   };
+
+  const scrollFieldSectionIntoView = (section: Element) => {
+    const scrollParent = section.closest(
+      '[data-slot="dialog-content"]',
+    ) as HTMLElement | null;
+    if (scrollParent) {
+      const parentRect = scrollParent.getBoundingClientRect();
+      const sectionRect = section.getBoundingClientRect();
+      scrollParent.scrollTop +=
+        sectionRect.top -
+        parentRect.top -
+        (parentRect.height - sectionRect.height) / 2;
+      return;
+    }
+    section.scrollIntoView({ block: 'center', inline: 'nearest' });
+  };
+
+  const mainFieldFocusSelector =
+    'input:not([type="hidden"]):not([type="checkbox"]), textarea, [contenteditable="true"], button[tabindex], .monaco-editor textarea';
+
+  const focusExplorerField = (section: Element) => {
+    scrollFieldSectionIntoView(section);
+    const editor = section.querySelector('[data-explorer-field-input]');
+    const focusable = editor?.querySelector<HTMLElement>(
+      mainFieldFocusSelector,
+    );
+    if (focusable) {
+      focusable.focus();
+      return;
+    }
+    const addLink = section.querySelector<HTMLElement>(
+      '[data-explorer-add-link]',
+    );
+    if (addLink) {
+      addLink.click();
+      requestAnimationFrame(() => {
+        section.querySelector<HTMLElement>('input')?.focus();
+        scrollFieldSectionIntoView(section);
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (!focusAttr) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const root = shadowRoot ?? document;
+        const section = root.querySelector(
+          `[data-explorer-field="${focusAttr}"]`,
+        );
+        if (!section) {
+          return;
+        }
+        focusExplorerField(section);
+      });
+    });
+  }, [focusAttr, shadowRoot]);
 
   const handleSaveRow = async () => {
     if (hasFormErrors) {
@@ -986,7 +1073,11 @@ export function EditRowDialog({
           const isNullField = nullFields[attr.name];
 
           return (
-            <div key={attr.name} className="flex flex-col gap-1">
+            <div
+              key={attr.name}
+              data-explorer-field={attr.name}
+              className="flex flex-col gap-1"
+            >
               <div className="flex items-center justify-between">
                 <Label className="font-mono">{attr.name}</Label>
                 <div className="flex items-center gap-2">
@@ -1021,7 +1112,7 @@ export function EditRowDialog({
               <div className="flex flex-col gap-1">
                 {!isNullField ? (
                   <div className="flex space-x-1">
-                    <div className="flex-1">
+                    <div className="flex-1" data-explorer-field-input>
                       {type === 'json' ? (
                         <div className="h-32 w-full rounded-sm border">
                           <CodeEditor
@@ -1087,6 +1178,7 @@ export function EditRowDialog({
                   </div>
                 ) : (
                   <button
+                    data-explorer-field-input
                     onClick={() => {
                       handleNullToggle(attr.name, false);
                       focusElementAtTabIndex(tabIndex);
@@ -1117,7 +1209,11 @@ export function EditRowDialog({
           }
 
           return (
-            <div key={attr.name} className="flex flex-col gap-1">
+            <div
+              key={attr.name}
+              data-explorer-field={attr.name}
+              className="flex flex-col gap-1"
+            >
               <div className="flex items-center justify-between">
                 <Label className="font-mono">{attr.name}</Label>
                 <span className="rounded-sm px-2 py-0.5 text-sm">
@@ -1133,6 +1229,7 @@ export function EditRowDialog({
                   refUpdates={refUpdates[attr.name]}
                   handleLinkRef={handleLinkRef}
                   handleUnlinkRef={handleUnlinkRef}
+                  autoOpenSearch={focusAttr === attr.name}
                 />
               </div>
             </div>

--- a/client/packages/components/src/components/explorer/edit-row-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-row-dialog.tsx
@@ -690,10 +690,9 @@ export function EditRowDialog({
   const explorerProps = useExplorerProps();
   const formBodyRef = useRef<HTMLDivElement>(null);
   const fieldSectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
-  const setFieldSectionRef =
-    (name: string) => (el: HTMLDivElement | null) => {
-      fieldSectionRefs.current[name] = el;
-    };
+  const setFieldSectionRef = (name: string) => (el: HTMLDivElement | null) => {
+    fieldSectionRefs.current[name] = el;
+  };
   const [pendingFocusField, setPendingFocusField] = useState<string | null>(
     null,
   );
@@ -776,9 +775,7 @@ export function EditRowDialog({
     }
     const field = blobUpdates[focusAttr];
     if (field?.type === 'boolean' && !nullFields[focusAttr]) {
-      section
-        ?.querySelector<HTMLElement>('[role="combobox"]')
-        ?.focus();
+      section?.querySelector<HTMLElement>('[role="combobox"]')?.focus();
     }
   }, [focusAttr, blobUpdates, nullFields]);
 
@@ -789,9 +786,7 @@ export function EditRowDialog({
     const section = fieldSectionRefs.current[pendingFocusField];
     if (section) {
       scrollFieldSectionIntoView(section, formBodyRef.current);
-      section
-        .querySelector<HTMLElement>('input, textarea')
-        ?.focus();
+      section.querySelector<HTMLElement>('input, textarea')?.focus();
     }
     setPendingFocusField(null);
   }, [pendingFocusField, nullFields]);
@@ -1019,7 +1014,9 @@ export function EditRowDialog({
       if (!attr.isRequired) {
         continue;
       }
-      if (getEffectiveRefLinkCount(item, attr.name, refUpdates[attr.name]) === 0) {
+      if (
+        getEffectiveRefLinkCount(item, attr.name, refUpdates[attr.name]) === 0
+      ) {
         requiredRefErrors[attr.name] = REQUIRED_FIELD_ERROR;
       }
     }
@@ -1109,251 +1106,254 @@ export function EditRowDialog({
       </div>
       <div
         ref={formBodyRef}
-        className="mt-4 min-h-0 flex-1 overflow-y-auto px-4 scrollbar-gutter-stable"
+        className="scrollbar-gutter-stable mt-4 min-h-0 flex-1 overflow-y-auto px-4"
       >
         <div className="flex flex-col gap-4">
-        {op === 'add' ? (
-          <div key="id" className="flex flex-col gap-1">
-            <div className="flex items-center justify-between">
-              <Label className="font-mono">
-                <div className="flex gap-1">
-                  id{' '}
-                  <Button
-                    type="link"
-                    size="mini"
-                    variant="subtle"
-                    onClick={() => handleUpdateFieldValue('id', id())}
-                  >
-                    <ArrowPathIcon height={14} />
-                  </Button>
-                </div>
-              </Label>
-            </div>
-            <div className="flex flex-col gap-1">
-              <input
-                className="flex w-full flex-1 rounded-xs border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800"
-                value={blobUpdates.id?.value ?? ''}
-                onChange={(e) =>
-                  handleUpdateFieldValue('id', e.target.value, uuidValidate)
-                }
-              />
-            </div>{' '}
-            {blobUpdates.id?.error && shouldDisplayErrors && (
-              <span className="text-sm font-medium text-red-500">
-                {blobUpdates.id.error}
-              </span>
-            )}
-          </div>
-        ) : null}
-
-        {editableBlobAttrs.map((attr, i) => {
-          const tabIndex = i + 1;
-          const { type, value, error } = blobUpdates[attr.name] || {
-            type: 'string',
-            value: defaultValueByType['string'],
-          };
-          const json =
-            jsonUpdates[attr.name] ||
-            (value !== null ? JSON.stringify(value, null, 2) : 'null');
-          const isNullField = nullFields[attr.name];
-          const autoFocusField = shouldAutoFocus(attr.name);
-
-          return (
-            <div
-              key={attr.name}
-              ref={setFieldSectionRef(attr.name)}
-              className="flex flex-col gap-1"
-            >
+          {op === 'add' ? (
+            <div key="id" className="flex flex-col gap-1">
               <div className="flex items-center justify-between">
-                <Label className="font-mono">{attr.name}</Label>
-                <div className="flex items-center gap-2">
-                  <div className="flex items-center">
-                    {!attr.isRequired && (
-                      <Checkbox
-                        checked={isNullField}
-                        onChange={(checked) =>
-                          handleNullToggle(attr.name, checked)
-                        }
-                        label={
-                          <span className="text-[10px] text-gray-600 uppercase dark:text-neutral-600">
-                            null
-                          </span>
-                        }
-                      />
-                    )}
+                <Label className="font-mono">
+                  <div className="flex gap-1">
+                    id{' '}
+                    <Button
+                      type="link"
+                      size="mini"
+                      variant="subtle"
+                      onClick={() => handleUpdateFieldValue('id', id())}
+                    >
+                      <ArrowPathIcon height={14} />
+                    </Button>
                   </div>
-                  <Select
-                    className="w-24 rounded-sm px-2 py-0.5 text-sm"
-                    value={type}
-                    options={validFieldTypeOptions(attr.checkedDataType)}
-                    onChange={(option) =>
-                      handleChangeFieldType(
-                        attr.name,
-                        option!.value as FieldType,
-                      )
-                    }
-                  />
-                </div>
+                </Label>
               </div>
               <div className="flex flex-col gap-1">
-                {!isNullField ? (
-                  <div className="flex space-x-1">
-                    <div className="flex-1">
-                      {type === 'json' ? (
-                        <div className="h-32 w-full rounded-sm border">
-                          <CodeEditor
-                            darkMode={explorerProps.darkMode}
-                            tabIndex={tabIndex}
-                            language="json"
-                            value={json}
-                            onChange={(code) =>
-                              handleUpdateJson(attr.name, code)
-                            }
-                            onMount={(editor) => {
-                              if (autoFocusField) {
-                                editor.focus();
-                              }
-                            }}
-                          />
-                        </div>
-                      ) : type === 'boolean' ? (
-                        <Select
-                          tabIndex={tabIndex}
-                          value={value}
-                          options={[
-                            { value: 'false', label: 'false' },
-                            { value: 'true', label: 'true' },
-                          ]}
-                          onChange={(option) =>
-                            handleUpdateFieldValue(attr.name, option!.value)
+                <input
+                  className="flex w-full flex-1 rounded-xs border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800"
+                  value={blobUpdates.id?.value ?? ''}
+                  onChange={(e) =>
+                    handleUpdateFieldValue('id', e.target.value, uuidValidate)
+                  }
+                />
+              </div>{' '}
+              {blobUpdates.id?.error && shouldDisplayErrors && (
+                <span className="text-sm font-medium text-red-500">
+                  {blobUpdates.id.error}
+                </span>
+              )}
+            </div>
+          ) : null}
+
+          {editableBlobAttrs.map((attr, i) => {
+            const tabIndex = i + 1;
+            const { type, value, error } = blobUpdates[attr.name] || {
+              type: 'string',
+              value: defaultValueByType['string'],
+            };
+            const json =
+              jsonUpdates[attr.name] ||
+              (value !== null ? JSON.stringify(value, null, 2) : 'null');
+            const isNullField = nullFields[attr.name];
+            const autoFocusField = shouldAutoFocus(attr.name);
+
+            return (
+              <div
+                key={attr.name}
+                ref={setFieldSectionRef(attr.name)}
+                className="flex flex-col gap-1"
+              >
+                <div className="flex items-center justify-between">
+                  <Label className="font-mono">{attr.name}</Label>
+                  <div className="flex items-center gap-2">
+                    <div className="flex items-center">
+                      {!attr.isRequired && (
+                        <Checkbox
+                          checked={isNullField}
+                          onChange={(checked) =>
+                            handleNullToggle(attr.name, checked)
                           }
-                        />
-                      ) : type === 'number' ? (
-                        <input
-                          tabIndex={tabIndex}
-                          type="number"
-                          autoFocus={autoFocusField}
-                          className="flex w-full flex-1 rounded-xs border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800"
-                          value={value ?? ''}
-                          onChange={(num) =>
-                            handleUpdateFieldValue(attr.name, num.target.value)
+                          label={
+                            <span className="text-[10px] text-gray-600 uppercase dark:text-neutral-600">
+                              null
+                            </span>
                           }
-                        />
-                      ) : (
-                        <ResizingTextArea
-                          tabIndex={tabIndex}
-                          autoFocus={autoFocusField}
-                          value={value ?? ''}
-                          onChange={(e) =>
-                            handleUpdateFieldValue(attr.name, e.target.value)
-                          }
-                          onSave={handleSaveRow}
                         />
                       )}
                     </div>
-                    {attr.checkedDataType === 'date' && (
-                      <Button
-                        variant="subtle"
-                        size="mini"
-                        onClick={() => {
-                          handleUpdateFieldValue(
-                            attr.name,
-                            type === 'number'
-                              ? Date.now()
-                              : new Date().toISOString(),
-                          );
-                        }}
-                      >
-                        <ClockIcon height={14} />
-                        now
-                      </Button>
-                    )}
+                    <Select
+                      className="w-24 rounded-sm px-2 py-0.5 text-sm"
+                      value={type}
+                      options={validFieldTypeOptions(attr.checkedDataType)}
+                      onChange={(option) =>
+                        handleChangeFieldType(
+                          attr.name,
+                          option!.value as FieldType,
+                        )
+                      }
+                    />
                   </div>
-                ) : (
-                  <button
-                    type="button"
-                    autoFocus={autoFocusField}
-                    onClick={() => handleNullToggle(attr.name, false)}
-                    className="flex-1 rounded-xs border border-gray-200 bg-gray-50 px-3 py-1 text-left text-gray-500 italic dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
-                  >
-                    null
-                  </button>
-                )}
-                {error && shouldDisplayErrors && (
-                  <span className="text-sm font-medium text-red-500">
-                    {error}
+                </div>
+                <div className="flex flex-col gap-1">
+                  {!isNullField ? (
+                    <div className="flex space-x-1">
+                      <div className="flex-1">
+                        {type === 'json' ? (
+                          <div className="h-32 w-full rounded-sm border">
+                            <CodeEditor
+                              darkMode={explorerProps.darkMode}
+                              tabIndex={tabIndex}
+                              language="json"
+                              value={json}
+                              onChange={(code) =>
+                                handleUpdateJson(attr.name, code)
+                              }
+                              onMount={(editor) => {
+                                if (autoFocusField) {
+                                  editor.focus();
+                                }
+                              }}
+                            />
+                          </div>
+                        ) : type === 'boolean' ? (
+                          <Select
+                            tabIndex={tabIndex}
+                            value={value}
+                            options={[
+                              { value: 'false', label: 'false' },
+                              { value: 'true', label: 'true' },
+                            ]}
+                            onChange={(option) =>
+                              handleUpdateFieldValue(attr.name, option!.value)
+                            }
+                          />
+                        ) : type === 'number' ? (
+                          <input
+                            tabIndex={tabIndex}
+                            type="number"
+                            autoFocus={autoFocusField}
+                            className="flex w-full flex-1 rounded-xs border-gray-200 bg-white px-3 py-1 placeholder:text-gray-400 dark:border-neutral-700 dark:bg-neutral-800"
+                            value={value ?? ''}
+                            onChange={(num) =>
+                              handleUpdateFieldValue(
+                                attr.name,
+                                num.target.value,
+                              )
+                            }
+                          />
+                        ) : (
+                          <ResizingTextArea
+                            tabIndex={tabIndex}
+                            autoFocus={autoFocusField}
+                            value={value ?? ''}
+                            onChange={(e) =>
+                              handleUpdateFieldValue(attr.name, e.target.value)
+                            }
+                            onSave={handleSaveRow}
+                          />
+                        )}
+                      </div>
+                      {attr.checkedDataType === 'date' && (
+                        <Button
+                          variant="subtle"
+                          size="mini"
+                          onClick={() => {
+                            handleUpdateFieldValue(
+                              attr.name,
+                              type === 'number'
+                                ? Date.now()
+                                : new Date().toISOString(),
+                            );
+                          }}
+                        >
+                          <ClockIcon height={14} />
+                          now
+                        </Button>
+                      )}
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      autoFocus={autoFocusField}
+                      onClick={() => handleNullToggle(attr.name, false)}
+                      className="flex-1 rounded-xs border border-gray-200 bg-gray-50 px-3 py-1 text-left text-gray-500 italic dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
+                    >
+                      null
+                    </button>
+                  )}
+                  {error && shouldDisplayErrors && (
+                    <span className="text-sm font-medium text-red-500">
+                      {error}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+          {editableRefAttrs.map((attr, i) => {
+            const namespace = attr.isForward
+              ? attr.linkConfig.reverse!.nsMap
+              : attr.linkConfig.forward.nsMap;
+
+            if (!namespace) {
+              // Sometimes we get links to namespaces that don't exist
+              return null;
+            }
+
+            return (
+              <div
+                key={attr.name}
+                ref={setFieldSectionRef(attr.name)}
+                className="flex flex-col gap-1"
+              >
+                <div className="flex items-center justify-between">
+                  <Label className="font-mono">{attr.name}</Label>
+                  <span className="rounded-sm px-2 py-0.5 text-sm">
+                    Link to <code>{namespace.name}</code>
                   </span>
-                )}
+                </div>
+                <div className="flex flex-col gap-1">
+                  <RefItem
+                    db={db}
+                    item={item}
+                    namespace={namespace}
+                    attr={attr}
+                    refUpdates={refUpdates[attr.name]}
+                    handleLinkRef={handleLinkRef}
+                    handleUnlinkRef={handleUnlinkRef}
+                  />
+                  {refFieldErrors[attr.name] && shouldDisplayErrors && (
+                    <span className="text-sm font-medium text-red-500">
+                      {refFieldErrors[attr.name]}
+                    </span>
+                  )}
+                </div>
               </div>
-            </div>
-          );
-        })}
-
-        {editableRefAttrs.map((attr, i) => {
-          const namespace = attr.isForward
-            ? attr.linkConfig.reverse!.nsMap
-            : attr.linkConfig.forward.nsMap;
-
-          if (!namespace) {
-            // Sometimes we get links to namespaces that don't exist
-            return null;
-          }
-
-          return (
-            <div
-              key={attr.name}
-              ref={setFieldSectionRef(attr.name)}
-              className="flex flex-col gap-1"
-            >
-              <div className="flex items-center justify-between">
-                <Label className="font-mono">{attr.name}</Label>
-                <span className="rounded-sm px-2 py-0.5 text-sm">
-                  Link to <code>{namespace.name}</code>
-                </span>
-              </div>
-              <div className="flex flex-col gap-1">
-                <RefItem
-                  db={db}
-                  item={item}
-                  namespace={namespace}
-                  attr={attr}
-                  refUpdates={refUpdates[attr.name]}
-                  handleLinkRef={handleLinkRef}
-                  handleUnlinkRef={handleUnlinkRef}
-                />
-                {refFieldErrors[attr.name] && shouldDisplayErrors && (
-                  <span className="text-sm font-medium text-red-500">
-                    {refFieldErrors[attr.name]}
-                  </span>
-                )}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
         </div>
       </div>
-      <div className="shrink-0 border-t border-gray-200 bg-white mt-2 px-1 pt-4 dark:border-neutral-700 dark:bg-neutral-800">
+      <div className="mt-2 shrink-0 border-t border-gray-200 bg-white px-1 pt-4 dark:border-neutral-700 dark:bg-neutral-800">
         <div className="flex flex-row items-center justify-between gap-1">
           {shouldDisplayErrors && hasFormErrors ? (
-          <span className="text-sm font-medium text-red-500">
-            Failed to save. Please check above for errors.
-          </span>
+            <span className="text-sm font-medium text-red-500">
+              Failed to save. Please check above for errors.
+            </span>
           ) : (
             <span />
           )}
           <div className="flex flex-row items-center gap-1">
-          <Button type="button" variant="secondary" onClick={handleResetForm}>
-            Reset
-          </Button>
-          <ActionButton
-            tabIndex={editableBlobAttrs.length + 1}
-            type="submit"
-            variant="primary"
-            label="Save"
-            submitLabel="Saving..."
-            errorMessage="Failed to save row."
-            onClick={handleSaveRow}
-          />
+            <Button type="button" variant="secondary" onClick={handleResetForm}>
+              Reset
+            </Button>
+            <ActionButton
+              tabIndex={editableBlobAttrs.length + 1}
+              type="submit"
+              variant="primary"
+              label="Save"
+              submitLabel="Saving..."
+              errorMessage="Failed to save row."
+              onClick={handleSaveRow}
+            />
           </div>
         </div>
       </div>

--- a/client/packages/components/src/components/explorer/edit-row-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-row-dialog.tsx
@@ -980,14 +980,26 @@ export function EditRowDialog({
   };
 
   const mainFieldFocusSelector =
-    'input:not([type="hidden"]):not([type="checkbox"]), textarea, [contenteditable="true"], button[tabindex], .monaco-editor textarea';
+    'input:not([type="hidden"]):not([type="checkbox"]), textarea, [contenteditable="true"], button, .monaco-editor textarea';
+
+  const findFocusableInEditor = (
+    editor: HTMLElement | null,
+  ): HTMLElement | null => {
+    if (!editor) {
+      return null;
+    }
+    if (editor.matches(mainFieldFocusSelector)) {
+      return editor;
+    }
+    return editor.querySelector<HTMLElement>(mainFieldFocusSelector);
+  };
 
   const focusExplorerField = (section: Element) => {
     scrollFieldSectionIntoView(section);
-    const editor = section.querySelector('[data-explorer-field-input]');
-    const focusable = editor?.querySelector<HTMLElement>(
-      mainFieldFocusSelector,
+    const editor = section.querySelector<HTMLElement>(
+      '[data-explorer-field-input]',
     );
+    const focusable = findFocusableInEditor(editor);
     if (focusable) {
       focusable.focus();
       return;

--- a/client/packages/components/src/components/explorer/edit-row-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-row-dialog.tsx
@@ -212,6 +212,47 @@ function uuidValidate(uuid: string): string | null {
   return validate(uuid) ? null : 'Invalid UUID.';
 }
 
+const REQUIRED_FIELD_ERROR = 'This field is required.';
+
+function isEmptyRequiredBlobValue(type: FieldType, value: any): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  switch (type) {
+    case 'string':
+      return String(value).trim() === '';
+    case 'number':
+      if (value === '') {
+        return true;
+      }
+      if (typeof value === 'string') {
+        return value === '-' || value === '.' || value === '-.';
+      }
+      return false;
+    case 'boolean':
+    case 'json':
+      return false;
+    default:
+      return false;
+  }
+}
+
+function getEffectiveRefLinkCount(
+  item: Record<string, any>,
+  attrName: string,
+  refUpdatesForAttr:
+    | Record<string, { action: 'link' | 'unlink'; item: any }>
+    | undefined,
+): number {
+  const existingCount = (item[attrName] || []).filter(
+    (x: any) => refUpdatesForAttr?.[x.id]?.action !== 'unlink',
+  ).length;
+  const newLinkCount = Object.values(refUpdatesForAttr || {}).filter(
+    (v) => v.action === 'link',
+  ).length;
+  return existingCount + newLinkCount;
+}
+
 function RefItemTooltip({
   db,
   namespace,
@@ -688,6 +729,9 @@ export function EditRowDialog({
   >({});
 
   const [jsonUpdates, setJsonUpdates] = useState<Record<string, any>>({});
+  const [refFieldErrors, setRefFieldErrors] = useState<
+    Record<string, string | null>
+  >({});
   const [nullFields, setNullFields] = useState<Record<string, boolean>>(
     editableBlobAttrs.reduce((acc, attr) => {
       // Don't set nullFields for new rows
@@ -701,11 +745,14 @@ export function EditRowDialog({
     }, {}),
   );
 
-  const hasFormErrors = Object.values(blobUpdates).some((u) => !!u.error);
+  const hasRefFieldErrors = Object.values(refFieldErrors).some(Boolean);
+  const hasFormErrors =
+    Object.values(blobUpdates).some((u) => !!u.error) || hasRefFieldErrors;
   const [shouldDisplayErrors, setShouldDisplayErrors] = useState(false);
 
   const handleResetForm = () => {
     setRefUpdates({});
+    setRefFieldErrors({});
 
     // Reset the blobUpdates to the original values
     setUpdatedBlobValues({ ...currentBlobs });
@@ -758,9 +805,12 @@ export function EditRowDialog({
     value: any,
     validate?: (value: any) => string | null,
   ) => {
-    const error = validate ? validate(value) : null;
+    let error = validate ? validate(value) : null;
     setUpdatedBlobValues((prev) => {
       const type = prev[field]?.type || 'string';
+      if (!error && prev[field]?.error === REQUIRED_FIELD_ERROR) {
+        error = null;
+      }
 
       return {
         ...prev,
@@ -786,11 +836,16 @@ export function EditRowDialog({
         };
       }
 
+      if (isValidJson(value)) {
+        return {
+          ...prev,
+          [field]: { type: 'json', value: JSON.parse(value), error: null },
+        };
+      }
+
       return {
         ...prev,
-        [field]: isValidJson(value)
-          ? { type: 'json', value: JSON.parse(value), error: null }
-          : { ...current, type: 'json', error: 'Invalid JSON' },
+        [field]: { ...current, type: 'json', error: 'Invalid JSON' },
       };
     });
   };
@@ -850,6 +905,12 @@ export function EditRowDialog({
   };
 
   const handleLinkRef = (attr: SchemaAttr, linkItem: any) => {
+    setRefFieldErrors((prev) => {
+      if (!prev[attr.name]) {
+        return prev;
+      }
+      return { ...prev, [attr.name]: null };
+    });
     setRefUpdates((v) => {
       const id = linkItem.id;
       const existing = v[attr.name]?.[id];
@@ -904,7 +965,7 @@ export function EditRowDialog({
 
   const scrollFieldSectionIntoView = (section: Element) => {
     const scrollParent = section.closest(
-      '[data-slot="dialog-content"]',
+      '[data-explorer-edit-form-body], [data-slot="dialog-content"]',
     ) as HTMLElement | null;
     if (scrollParent) {
       const parentRect = scrollParent.getBoundingClientRect();
@@ -962,7 +1023,49 @@ export function EditRowDialog({
   }, [focusAttr, shadowRoot]);
 
   const handleSaveRow = async () => {
-    if (hasFormErrors) {
+    const requiredBlobErrors: Record<string, string> = {};
+    const requiredRefErrors: Record<string, string> = {};
+
+    for (const attr of editableBlobAttrs) {
+      if (!attr.isRequired) {
+        continue;
+      }
+      const field = blobUpdates[attr.name];
+      if (
+        nullFields[attr.name] ||
+        isEmptyRequiredBlobValue(field?.type ?? 'string', field?.value)
+      ) {
+        requiredBlobErrors[attr.name] = REQUIRED_FIELD_ERROR;
+      }
+    }
+
+    for (const attr of editableRefAttrs) {
+      if (!attr.isRequired) {
+        continue;
+      }
+      if (getEffectiveRefLinkCount(item, attr.name, refUpdates[attr.name]) === 0) {
+        requiredRefErrors[attr.name] = REQUIRED_FIELD_ERROR;
+      }
+    }
+
+    const hasRequiredErrors =
+      Object.keys(requiredBlobErrors).length > 0 ||
+      Object.keys(requiredRefErrors).length > 0;
+    const hasExistingErrors =
+      Object.values(blobUpdates).some((u) => !!u.error) ||
+      Object.values(refFieldErrors).some(Boolean);
+
+    if (hasRequiredErrors || hasExistingErrors) {
+      if (hasRequiredErrors) {
+        setUpdatedBlobValues((prev) => {
+          const next = { ...prev };
+          for (const [field, error] of Object.entries(requiredBlobErrors)) {
+            next[field] = { ...next[field], error };
+          }
+          return next;
+        });
+        setRefFieldErrors((prev) => ({ ...prev, ...requiredRefErrors }));
+      }
       setShouldDisplayErrors(true);
       return;
     }
@@ -1013,20 +1116,26 @@ export function EditRowDialog({
   };
 
   return (
-    <ActionForm className="p-4">
-      <h5 className="flex text-lg font-bold">
-        {op == 'edit' ? 'Edit row' : 'Add row'}
-      </h5>
-      <code className="font-mono text-sm font-medium text-gray-500 dark:text-neutral-500">
-        {op == 'edit' ? (
-          <>
-            {namespace.name}['{item.id}']
-          </>
-        ) : (
-          <>{namespace.name}</>
-        )}
-      </code>
-      <div className="mt-4 flex flex-col gap-4">
+    <ActionForm className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="shrink-0 px-1">
+        <h5 className="flex text-lg font-bold">
+          {op == 'edit' ? 'Edit row' : 'Add row'}
+        </h5>
+        <code className="font-mono text-sm font-medium text-gray-500 dark:text-neutral-500">
+          {op == 'edit' ? (
+            <>
+              {namespace.name}['{item.id}']
+            </>
+          ) : (
+            <>{namespace.name}</>
+          )}
+        </code>
+      </div>
+      <div
+        data-explorer-edit-form-body
+        className="mt-4 min-h-0 flex-1 overflow-y-auto px-4 scrollbar-gutter-stable"
+      >
+        <div className="flex flex-col gap-4">
         {op === 'add' ? (
           <div key="id" className="flex flex-col gap-1">
             <div className="flex items-center justify-between">
@@ -1231,20 +1340,27 @@ export function EditRowDialog({
                   handleUnlinkRef={handleUnlinkRef}
                   autoOpenSearch={focusAttr === attr.name}
                 />
+                {refFieldErrors[attr.name] && shouldDisplayErrors && (
+                  <span className="text-sm font-medium text-red-500">
+                    {refFieldErrors[attr.name]}
+                  </span>
+                )}
               </div>
             </div>
           );
         })}
+        </div>
       </div>
-      <div className="mt-8 flex flex-row items-center justify-between gap-1">
-        {shouldDisplayErrors && hasFormErrors ? (
+      <div className="shrink-0 border-t border-gray-200 bg-white mt-2 px-1 pt-4 dark:border-neutral-700 dark:bg-neutral-800">
+        <div className="flex flex-row items-center justify-between gap-1">
+          {shouldDisplayErrors && hasFormErrors ? (
           <span className="text-sm font-medium text-red-500">
             Failed to save. Please check above for errors.
           </span>
-        ) : (
-          <span />
-        )}
-        <div className="flex flex-row items-center gap-1">
+          ) : (
+            <span />
+          )}
+          <div className="flex flex-row items-center gap-1">
           <Button type="button" variant="secondary" onClick={handleResetForm}>
             Reset
           </Button>
@@ -1257,6 +1373,7 @@ export function EditRowDialog({
             errorMessage="Failed to save row."
             onClick={handleSaveRow}
           />
+          </div>
         </div>
       </div>
     </ActionForm>

--- a/client/packages/components/src/components/explorer/index.tsx
+++ b/client/packages/components/src/components/explorer/index.tsx
@@ -143,7 +143,7 @@ export type EditSchemaScreen =
 
 export type ExplorerDialog =
   | { type: 'add-row' }
-  | { type: 'edit-row'; rowId: string }
+  | { type: 'edit-row'; rowId: string; focusAttr?: string }
   | { type: 'edit-schema'; screen: EditSchemaScreen }
   | { type: 'new-namespace' }
   | { type: 'recently-deleted-ns' };

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -84,7 +84,7 @@ import { ViewSettings } from './view-settings';
 
 import { isObject } from 'lodash';
 import { EditNamespaceDialog } from './edit-namespace-dialog';
-import { EditRowDialog } from './edit-row-dialog';
+import { EditRowDialog, isEditableExplorerAttr } from './edit-row-dialog';
 import copy from 'copy-to-clipboard';
 
 const fallbackItems: any[] = [];
@@ -95,6 +95,7 @@ export type TableColMeta = {
   isLink?: boolean;
   attr: SchemaAttr;
   copyable?: boolean;
+  editable?: boolean;
 };
 
 function exportToCSV(
@@ -429,7 +430,7 @@ export const InnerExplorer: React.FC<{
       },
       cell: ({ row, column }) => {
         return (
-          <div className="flex h-1 justify-around gap-2">
+          <div className="flex h-full w-full items-center gap-2">
             <Checkbox
               className="relative z-10 text-[#2563EB] dark:checked:border-[#2563EB] dark:checked:bg-[#2563EB]"
               checked={row.getIsSelected()}
@@ -458,7 +459,9 @@ export const InnerExplorer: React.FC<{
             />
             {readOnlyNs ? null : (
               <button
-                className="translate-y-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+                type="button"
+                title="Edit row"
+                className="rounded-xs p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-neutral-100 dark:hover:bg-neutral-700"
                 onClick={() => setDialog({ type: 'edit-row', rowId: row.id })}
               >
                 <PencilSquareIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
@@ -482,6 +485,10 @@ export const InnerExplorer: React.FC<{
           isLink: attr.type === 'ref',
           attr,
           disablePadding: attr.namespace === '$files' && attr.name === 'url',
+          editable:
+            !readOnlyNs &&
+            selectedNamespace != null &&
+            isEditableExplorerAttr(selectedNamespace, attr),
         } satisfies TableColMeta,
         cell: (info) => {
           if (
@@ -541,7 +548,7 @@ export const InnerExplorer: React.FC<{
     });
 
     return result;
-  }, [selectedNamespace?.attrs, localDates]);
+  }, [selectedNamespace, readOnlyNs, localDates]);
 
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 
@@ -919,6 +926,9 @@ export const InnerExplorer: React.FC<{
             db={db}
             namespace={selectedNamespace}
             item={selectedEditableItem}
+            focusAttr={
+              dialog?.type === 'edit-row' ? dialog.focusAttr : undefined
+            }
             onClose={() => setDialog(null)}
           />
         ) : null}

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -906,6 +906,7 @@ export const InnerExplorer: React.FC<{
         title="Add Row"
         open={addItemDialogOpen}
         onClose={() => setDialog(null)}
+        className="flex max-h-[calc(100dvh-4rem)] flex-col overflow-hidden"
       >
         {selectedNamespace ? (
           <EditRowDialog
@@ -920,6 +921,7 @@ export const InnerExplorer: React.FC<{
         title="Edit Row"
         open={!!selectedEditableItem}
         onClose={() => setDialog(null)}
+        className="flex max-h-[calc(100dvh-4rem)] flex-col overflow-hidden"
       >
         {!!selectedNamespace && !!selectedEditableItem ? (
           <EditRowDialog

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -244,7 +244,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
   const realValue = cell.getValue();
 
   return (
-    <Tooltip>
+    <Tooltip delayDuration={400}>
       {' '}
       <TooltipTrigger className="text-left" asChild>
         <div

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -222,23 +222,31 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
   });
   const [showCopy, setShowCopy] = useState(false);
   const { ref: overflowRef, isOverflow, setIsOverflow } = useIsOverflow();
+  const realValue = cell.getValue();
   const shouldShowTooltip =
-    (isOverflow || isObject(cell.getValue())) && !meta?.isLink;
+    (isOverflow || isObject(realValue)) && !meta?.isLink;
 
   useEffect(() => {
-    const observer = new ResizeObserver(() => {
-      const hasOverflow =
-        overflowRef.current.scrollWidth > overflowRef.current.clientWidth ||
-        overflowRef.current.scrollHeight > overflowRef.current.clientHeight;
+    const el = overflowRef.current;
+    if (!el) {
+      return;
+    }
 
-      setIsOverflow(hasOverflow);
-    });
-    observer.observe(overflowRef.current!);
+    const checkOverflow = () => {
+      setIsOverflow(
+        el.scrollWidth > el.clientWidth ||
+          el.scrollHeight > el.clientHeight,
+      );
+    };
+
+    checkOverflow();
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(el);
 
     return () => {
       observer.disconnect();
     };
-  }, [overflowRef.current]);
+  }, [realValue, cell.column.getSize(), setIsOverflow]);
 
   const style: CSSProperties = {
     opacity: isDragging ? 0.8 : 1,
@@ -255,7 +263,6 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
   const disablePadding = meta?.disablePadding ?? false;
   const isSelectCol = cell.column.id === 'select-col';
 
-  const realValue = cell.getValue();
   const hasNavigableLink =
     meta?.isLink &&
     meta.attr &&
@@ -266,10 +273,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
 
   const cellInner = (
     <div
-      ref={(el) => {
-        setNodeRef(el);
-        overflowRef.current = el;
-      }}
+      ref={setNodeRef}
       style={{
         ...style,
         ...(isSelectCol || disablePadding
@@ -283,6 +287,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
       key={cell.id}
     >
       <span
+        ref={isSelectCol ? undefined : overflowRef}
         className={cn(
           `h-full min-h-full min-w-0 td-${cell.column.id}`,
           isSelectCol

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -396,7 +396,7 @@ function isCopyableCellValue(
     return Object.keys(value).length > 0;
   }
   if (typeof value === 'string') {
-    return value.length > 0;
+    return value.trim().length > 0;
   }
   return true;
 }

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -215,7 +215,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
   const { setDialog } = useExplorerDialog();
 
   const meta = cell.column.columnDef.meta as TableColMeta | null;
-  const showEditButton = meta?.editable && meta.attr;
+  const showEditButton = meta?.editable && meta.attr && !meta?.isLink;
   const { isDragging, setNodeRef, transform } = useSortable({
     id: cell.column.id,
     disabled: cell.column.id === 'select-col',

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -122,87 +122,87 @@ export const TableHeader = ({
             : flexRender(header.column.columnDef.header, header.getContext())}
         </div>
       ) : (
-      <div className="flex h-full items-stretch justify-between overflow-hidden">
-        <div
-          className={`flex shrink items-center gap-1 truncate px-2 py-1 font-semibold th-${header.column.id}`}
-        >
-          {isSortable ? (
-            <button
-              className="relative z-50 flex items-center gap-1 py-2 pr-5"
-              onClick={() => {
-                if (onSort) {
-                  let thisAttrName =
-                    headerText === 'id' ? 'serverCreatedAt' : headerText;
-                  onSort(thisAttrName, currentSortAttr, currentSortAsc);
-                }
-              }}
-            >
-              <span className={cn(isCurrentSort && 'underline')}>
+        <div className="flex h-full items-stretch justify-between overflow-hidden">
+          <div
+            className={`flex shrink items-center gap-1 truncate px-2 py-1 font-semibold th-${header.column.id}`}
+          >
+            {isSortable ? (
+              <button
+                className="relative z-50 flex items-center gap-1 py-2 pr-5"
+                onClick={() => {
+                  if (onSort) {
+                    let thisAttrName =
+                      headerText === 'id' ? 'serverCreatedAt' : headerText;
+                    onSort(thisAttrName, currentSortAttr, currentSortAsc);
+                  }
+                }}
+              >
+                <span className={cn(isCurrentSort && 'underline')}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                </span>
+                <span
+                  className="opacity-50 transition-opacity group-hover:opacity-70"
+                  style={{
+                    opacity: isCurrentSort ? 1 : undefined,
+                    fontWeight: isCurrentSort ? 'bold' : 'normal',
+                  }}
+                >
+                  {isCurrentSort ? (
+                    currentSortAsc ? (
+                      <ArrowUpIcon strokeWidth={3} width={10} />
+                    ) : (
+                      <ArrowDownIcon strokeWidth={3} width={10} />
+                    )
+                  ) : (
+                    <ArrowsUpDownIcon strokeWidth={3} width={10} />
+                  )}
+                </span>
+              </button>
+            ) : (
+              <>
                 {header.isPlaceholder
                   ? null
                   : flexRender(
                       header.column.columnDef.header,
                       header.getContext(),
                     )}
-              </span>
-              <span
-                className="opacity-50 transition-opacity group-hover:opacity-70"
-                style={{
-                  opacity: isCurrentSort ? 1 : undefined,
-                  fontWeight: isCurrentSort ? 'bold' : 'normal',
-                }}
-              >
-                {isCurrentSort ? (
-                  currentSortAsc ? (
-                    <ArrowUpIcon strokeWidth={3} width={10} />
-                  ) : (
-                    <ArrowDownIcon strokeWidth={3} width={10} />
-                  )
-                ) : (
-                  <ArrowsUpDownIcon strokeWidth={3} width={10} />
-                )}
-              </span>
-            </button>
-          ) : (
-            <>
-              {header.isPlaceholder
-                ? null
-                : flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )}
-            </>
-          )}
-        </div>
-
-        <div className="flex h-full items-center justify-between">
-          <div
-            {...{
-              onDoubleClick: () => setMinViableColWidth(header.column.id),
-              onMouseDown: (e) => {
-                e.stopPropagation();
-                return header.getResizeHandler()(e);
-              },
-              onTouchStart: header.getResizeHandler(),
-              className: cn(
-                `resizer h-full flex justify-center z-50 ${
-                  table.options.columnResizeDirection
-                } ${header.column.getIsResizing() ? 'isResizing' : ''}`,
-                headerGroup.headers.length - 1 == index && 'justify-end',
-                header.id !== 'select-col' && 'hover:cursor-col-resize',
-              ),
-              style: {
-                width: 8,
-                pointerEvents: 'auto',
-              },
-            }}
-          >
-            {headerGroup.headers.length - 1 !== index && (
-              <div className="h-full w-0.5 bg-neutral-200 dark:bg-neutral-700"></div>
+              </>
             )}
           </div>
+
+          <div className="flex h-full items-center justify-between">
+            <div
+              {...{
+                onDoubleClick: () => setMinViableColWidth(header.column.id),
+                onMouseDown: (e) => {
+                  e.stopPropagation();
+                  return header.getResizeHandler()(e);
+                },
+                onTouchStart: header.getResizeHandler(),
+                className: cn(
+                  `resizer h-full flex justify-center z-50 ${
+                    table.options.columnResizeDirection
+                  } ${header.column.getIsResizing() ? 'isResizing' : ''}`,
+                  headerGroup.headers.length - 1 == index && 'justify-end',
+                  header.id !== 'select-col' && 'hover:cursor-col-resize',
+                ),
+                style: {
+                  width: 8,
+                  pointerEvents: 'auto',
+                },
+              }}
+            >
+              {headerGroup.headers.length - 1 !== index && (
+                <div className="h-full w-0.5 bg-neutral-200 dark:bg-neutral-700"></div>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
       )}
     </div>
   );
@@ -234,8 +234,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
 
     const checkOverflow = () => {
       setIsOverflow(
-        el.scrollWidth > el.clientWidth ||
-          el.scrollHeight > el.clientHeight,
+        el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight,
       );
     };
 
@@ -268,17 +267,14 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
     meta.attr &&
     Array.isArray(realValue) &&
     realValue.length > 0;
-  const canCopy =
-    meta?.copyable && isCopyableCellValue(realValue, meta);
+  const canCopy = meta?.copyable && isCopyableCellValue(realValue, meta);
 
   const cellInner = (
     <div
       ref={setNodeRef}
       style={{
         ...style,
-        ...(isSelectCol || disablePadding
-          ? {}
-          : { padding: '0.5rem' }),
+        ...(isSelectCol || disablePadding ? {} : { padding: '0.5rem' }),
       }}
       className={cn(
         'group/cell relative flex min-w-0 cursor-default items-center whitespace-nowrap',
@@ -333,7 +329,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
         <button
           type="button"
           title={`Edit ${meta.attr.name}`}
-          className="absolute top-1/2 right-1 z-20 -translate-y-1/2 rounded-xs p-0.5 opacity-0 transition-opacity group-hover/cell:opacity-100 hover:bg-neutral-100 focus-visible:opacity-100 focus-visible:bg-neutral-100 focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:outline-hidden dark:hover:bg-neutral-700 dark:focus-visible:bg-neutral-700 dark:focus-visible:ring-neutral-500"
+          className="absolute top-1/2 right-1 z-20 -translate-y-1/2 rounded-xs p-0.5 opacity-0 transition-opacity group-hover/cell:opacity-100 hover:bg-neutral-100 focus-visible:bg-neutral-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:outline-hidden dark:hover:bg-neutral-700 dark:focus-visible:bg-neutral-700 dark:focus-visible:ring-neutral-500"
           onClick={(e) => {
             e.stopPropagation();
             setDialog({
@@ -363,7 +359,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
         <TooltipContent
           collisionPadding={10}
           className={cn(
-            'max-h-[min(50vh,var(--radix-popper-available-height))] max-w-[min(75rem,80vw)] min-w-0 overflow-x-hidden overflow-y-auto whitespace-pre-wrap wrap-break-word [&_code]:wrap-break-word [&_pre]:whitespace-pre-wrap [&_pre]:wrap-break-word',
+            'max-h-[min(50vh,var(--radix-popper-available-height))] max-w-[min(75rem,80vw)] min-w-0 overflow-x-hidden overflow-y-auto wrap-break-word whitespace-pre-wrap [&_code]:wrap-break-word [&_pre]:wrap-break-word [&_pre]:whitespace-pre-wrap',
             isObject(realValue) && 'p-0',
           )}
           side="bottom"

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -22,11 +22,12 @@ import {
   ArrowDownIcon,
   ArrowsUpDownIcon,
   ArrowUpIcon,
+  PencilSquareIcon,
 } from '@heroicons/react/24/outline';
 import { useIsOverflow } from '@lib/hooks/useIsOverflow';
 import { isObject } from 'lodash';
 import copy from 'copy-to-clipboard';
-import { useExplorerProps, useExplorerState } from '.';
+import { useExplorerDialog, useExplorerProps, useExplorerState } from '.';
 import { TableColMeta } from './inner-explorer';
 
 export const TableHeader = ({
@@ -112,6 +113,15 @@ export const TableHeader = ({
           style={{ pointerEvents: 'auto' }}
         />
       )}
+      {header.id === 'select-col' ? (
+        <div
+          className={`flex h-full w-full items-center px-2 py-1 th-${header.column.id}`}
+        >
+          {header.isPlaceholder
+            ? null
+            : flexRender(header.column.columnDef.header, header.getContext())}
+        </div>
+      ) : (
       <div className="flex h-full items-stretch justify-between overflow-hidden">
         <div
           className={`flex shrink items-center gap-1 truncate px-2 py-1 font-semibold th-${header.column.id}`}
@@ -193,6 +203,7 @@ export const TableHeader = ({
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 };
@@ -201,8 +212,10 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
   const resizing = cell.column.getIsResizing();
 
   const { history } = useExplorerState();
+  const { setDialog } = useExplorerDialog();
 
   const meta = cell.column.columnDef.meta as TableColMeta | null;
+  const showEditButton = meta?.editable && meta.attr;
   const { isDragging, setNodeRef, transform } = useSortable({
     id: cell.column.id,
     disabled: cell.column.id === 'select-col',
@@ -240,64 +253,106 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
   };
 
   const disablePadding = meta?.disablePadding ?? false;
+  const isSelectCol = cell.column.id === 'select-col';
 
   const realValue = cell.getValue();
+  const hasNavigableLink =
+    meta?.isLink &&
+    meta.attr &&
+    Array.isArray(realValue) &&
+    realValue.length > 0;
+  const canCopy =
+    meta?.copyable && isCopyableCellValue(realValue, meta);
+
+  const cellInner = (
+    <div
+      ref={(el) => {
+        setNodeRef(el);
+        overflowRef.current = el;
+      }}
+      style={{
+        ...style,
+        ...(isSelectCol || disablePadding
+          ? {}
+          : { padding: '0.5rem' }),
+      }}
+      className={cn(
+        'group/cell relative flex min-w-0 cursor-default items-center whitespace-nowrap',
+        isSelectCol && 'px-2 py-1',
+      )}
+      key={cell.id}
+    >
+      <span
+        className={cn(
+          `h-full min-h-full min-w-0 td-${cell.column.id}`,
+          isSelectCol
+            ? 'flex w-full items-center gap-2 overflow-visible'
+            : cn(
+                'min-w-0 flex-1 truncate',
+                (hasNavigableLink || canCopy) && 'cursor-pointer',
+              ),
+          !isSelectCol && (disablePadding ? '' : 'pr-2'),
+          showEditButton && 'pr-6',
+        )}
+        onClick={
+          isSelectCol
+            ? undefined
+            : () => {
+                if (hasNavigableLink && meta?.attr) {
+                  const attr = meta.attr;
+                  const linkConfigDir =
+                    attr.linkConfig[!attr.isForward ? 'forward' : 'reverse'];
+
+                  if (linkConfigDir) {
+                    history.push({
+                      namespace: linkConfigDir.namespace,
+                      where: [`${linkConfigDir.attr}.id`, cell.row.original.id],
+                    });
+                    return;
+                  }
+                }
+                if (canCopy && copy(formatVal(realValue))) {
+                  setShowCopy(true);
+                  setTimeout(() => setShowCopy(false), 1000);
+                }
+              }
+        }
+      >
+        {showCopy ? (
+          <div className="h-1">Copied!</div>
+        ) : (
+          flexRender(cell.column.columnDef.cell, cell.getContext())
+        )}
+      </span>
+      {showEditButton ? (
+        <button
+          type="button"
+          title={`Edit ${meta.attr.name}`}
+          className="absolute top-1/2 right-1 z-20 -translate-y-1/2 rounded-xs p-0.5 opacity-0 transition-opacity group-hover/cell:opacity-100 hover:bg-neutral-100 dark:hover:bg-neutral-700"
+          onClick={(e) => {
+            e.stopPropagation();
+            setDialog({
+              type: 'edit-row',
+              rowId: cell.row.original.id as string,
+              focusAttr: meta.attr.name,
+            });
+          }}
+        >
+          <PencilSquareIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
+        </button>
+      ) : null}
+    </div>
+  );
+
+  if (isSelectCol) {
+    return cellInner;
+  }
 
   return (
     <Tooltip delayDuration={400}>
       {' '}
       <TooltipTrigger className="text-left" asChild>
-        <div
-          ref={(el) => {
-            setNodeRef(el);
-            overflowRef.current = el;
-          }}
-          style={{
-            ...style,
-            padding: disablePadding ? 0 : '0.5rem',
-          }}
-          className={cn(`cursor-default truncate whitespace-nowrap`)}
-          key={cell.id}
-        >
-          <span
-            className={cn(
-              `h-full min-h-full cursor-pointer td-${cell.column.id}`,
-              disablePadding ? '' : 'pr-2',
-            )}
-            onClick={() => {
-              if (
-                meta?.isLink &&
-                meta.attr &&
-                Array.isArray(realValue) &&
-                realValue.length > 0
-              ) {
-                const attr = meta.attr;
-                const linkConfigDir =
-                  attr.linkConfig[!attr.isForward ? 'forward' : 'reverse'];
-
-                if (linkConfigDir) {
-                  history.push({
-                    namespace: linkConfigDir.namespace,
-                    where: [`${linkConfigDir.attr}.id`, cell.row.original.id],
-                  });
-                  return;
-                }
-              }
-              if (meta?.copyable) {
-                if (copy(formatVal(realValue))) {
-                  setShowCopy(true);
-                  setTimeout(() => setShowCopy(false), 1000);
-                }
-              }
-            }}
-          >
-            {showCopy ? (
-              <div className="h-1">Copied!</div>
-            ) : (
-              flexRender(cell.column.columnDef.cell, cell.getContext())
-            )}
-          </span>
-        </div>
+        {cellInner}
       </TooltipTrigger>
       {shouldShowTooltip && !resizing && (
         <TooltipContent
@@ -318,6 +373,28 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
     </Tooltip>
   );
 };
+
+function isCopyableCellValue(
+  value: unknown,
+  meta: TableColMeta | null,
+): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (meta?.isLink) {
+    return Array.isArray(value) && value.length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (isObject(value)) {
+    return Object.keys(value).length > 0;
+  }
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+  return true;
+}
 
 function formatVal(data: any, pretty?: boolean): string {
   if (isObject(data)) {

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -301,7 +301,11 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
       </TooltipTrigger>
       {shouldShowTooltip && !resizing && (
         <TooltipContent
-          className={cn(isObject(realValue) && 'p-0')}
+          collisionPadding={10}
+          className={cn(
+            'max-h-[min(50vh,var(--radix-popper-available-height))] max-w-[min(75rem,80vw)] min-w-0 overflow-x-hidden overflow-y-auto whitespace-pre-wrap wrap-break-word [&_code]:wrap-break-word [&_pre]:whitespace-pre-wrap [&_pre]:wrap-break-word',
+            isObject(realValue) && 'p-0',
+          )}
           side="bottom"
         >
           {typeof realValue === 'string' ? (

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -333,7 +333,7 @@ export const TableCell = ({ cell }: { cell: Cell<any, unknown> }) => {
         <button
           type="button"
           title={`Edit ${meta.attr.name}`}
-          className="absolute top-1/2 right-1 z-20 -translate-y-1/2 rounded-xs p-0.5 opacity-0 transition-opacity group-hover/cell:opacity-100 hover:bg-neutral-100 dark:hover:bg-neutral-700"
+          className="absolute top-1/2 right-1 z-20 -translate-y-1/2 rounded-xs p-0.5 opacity-0 transition-opacity group-hover/cell:opacity-100 hover:bg-neutral-100 focus-visible:opacity-100 focus-visible:bg-neutral-100 focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:outline-hidden dark:hover:bg-neutral-700 dark:focus-visible:bg-neutral-700 dark:focus-visible:ring-neutral-500"
           onClick={(e) => {
             e.stopPropagation();
             setDialog({

--- a/client/www/lib/hooks/useExplorerState.ts
+++ b/client/www/lib/hooks/useExplorerState.ts
@@ -63,9 +63,17 @@ function validateExplorerDialog(v: unknown): ExplorerDialog | null {
       return { type: 'new-namespace' };
     case 'recently-deleted-ns':
       return { type: 'recently-deleted-ns' };
-    case 'edit-row':
+    case 'edit-row': {
       if (typeof obj.rowId !== 'string') return null;
-      return { type: 'edit-row', rowId: obj.rowId };
+      const dialog: { type: 'edit-row'; rowId: string; focusAttr?: string } = {
+        type: 'edit-row',
+        rowId: obj.rowId,
+      };
+      if (typeof obj.focusAttr === 'string' && obj.focusAttr.length > 0) {
+        dialog.focusAttr = obj.focusAttr;
+      }
+      return dialog;
+    }
     case 'edit-schema': {
       const screen = validateEditSchemaScreen(obj.screen);
       if (!screen) return null;


### PR DESCRIPTION
From discord thread: https://discord.com/channels/1031957483243188235/1506882312351256616

**Description**

This PR improves the dashboard explorer’s table and edit-row dialog UX: clearer tooltips, faster in-cell editing, and more reliable form validation/layout.

### Changes

**Tooltips**
- Added a **400ms hover delay** on cell tooltips to reduce accidental popups
- Made long tooltip content **scrollable and word-wrapped**, with responsive max width/height
- Fixed overflow detection so truncated text (not just JSON) shows tooltips again

**Table interactions**
- Added **hover edit buttons** on editable cells; opens the row dialog with that field focused and scrolled into view, a feature requested in this [discord thread](https://discord.com/channels/1031957483243188235/1504028488078725172).
- Unified edit button sizing; **disabled copy** for empty/null/meaningless values
- Focuses the **main value input** in the edit dialog (not the null toggle)

**Edit row dialog**
- Added **client-side validation** for required blob and ref fields
- Pinned **Reset/Save footer** with a single inner scroll area so that saving data does not necessitate scrolling all the way down to the bottom.

### How to Test

1. **Tooltip delay** — Hover a truncated cell; tooltip should appear after ~400ms, instead of 100ms.
2. **Tooltip overflow** — Hover a cell with long text or JSON; content should wrap and scroll within the tooltip.
3. **Truncated text tooltips** — Hover a truncated string cell (non-JSON); tooltip should appear with full content.
4. **Cell edit button** — Hover an editable cell; click the pencil icon; dialog opens with that field focused and centered.
5. **Empty copy** — Click empty/null cells; copy should not trigger (no pointer cursor / no “Copied!”).
6. **Required validation** — Add/edit a row and leave a required field empty; Save should block with an inline error.
7. **Dialog layout** — Open a row with many fields; only the body scrolls, Reset/Save stay visible at the bottom.

### Screenshots

1. Table cell with edit button and scrollable tooltip:
<img width="1246" height="616" alt="CleanShot 2026-05-24 at 14 58 07" src="https://github.com/user-attachments/assets/4505e906-01ab-4b56-bf2f-adde572472f5" />

2. Edit dialog when client validation failed:
<img width="1614" height="1123" alt="CleanShot 2026-05-24 at 14 56 58" src="https://github.com/user-attachments/assets/a57313a3-dc7c-4a46-ba1f-13320b87a635" />