### PR TITLE
fix: clear search filter when namespace changes

### DIFF
--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -627,9 +627,10 @@ export const InnerExplorer: React.FC<{
     {},
   );
 
-  // Clear selection when namespace changes
+  // Clear selection & search filter when namespace changes
   useEffect(() => {
     setCheckedIds({});
+    setSearchFilters([]);
     lastSelectedIdRef.current = null;
   }, [selectedNamespace?.id]);
 


### PR DESCRIPTION
When I'm in the explorer, after I added a search filter and search, it applies the search filter to the current query of data:

<img width="1910" height="376" alt="Screenshot 2026-05-24 200546" src="https://github.com/user-attachments/assets/b2fc2a4e-45ba-46fa-a7d8-a9c26a15bb67" />

(At this point, the data shown is still correct as expected)

if I navigate away to other namespace (via the namespace list at the sidebar), the new page will always show empty data

<img width="1913" height="369" alt="Screenshot 2026-05-24 200552" src="https://github.com/user-attachments/assets/6407b394-4090-4fd4-91a8-2d9c341ff936" />


After debugging using React dev tools, it seems like due to 'Inner Explorer' component maintaining its own search filter state, and this search filter state wasn't cleared if the associcated namespace id has been changed

<img width="1735" height="951" alt="Screenshot 2026-05-24 200351" src="https://github.com/user-attachments/assets/6d410ba0-ec60-4fdc-9a93-c795826b71ec" />


So the PR here set the search filter to empty array if it detects the namespace id has changed

