### PR TITLE
fix snapshot resetting in useInfiniteQuery (#2710) [bump to v1.0.41]

### DIFF
--- a/client/packages/react-common/src/useInfiniteQuerySubscription.ts
+++ b/client/packages/react-common/src/useInfiniteQuerySubscription.ts
@@ -73,12 +73,6 @@ export function useInfiniteQuerySubscription<
   const subscribe = useCallback(
     (cb: () => void) => {
       subRef.current = null;
-      stateCacheRef.current = {
-        error: undefined,
-        data: undefined,
-        isLoading: true,
-        canLoadNextPage: false,
-      };
       cb();
 
       if (!query) {

--- a/client/packages/react-common/src/useInfiniteQuerySubscription.ts
+++ b/client/packages/react-common/src/useInfiniteQuerySubscription.ts
@@ -73,6 +73,13 @@ export function useInfiniteQuerySubscription<
   const subscribe = useCallback(
     (cb: () => void) => {
       subRef.current = null;
+
+      const nextSnapshot = getInfiniteQueryInitialSnapshot(core, query, opts);
+      stateCacheRef.current = {
+        ...nextSnapshot,
+        isLoading: !nextSnapshot.data && !nextSnapshot.error,
+      };
+
       cb();
 
       if (!query) {

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.40';
+const version = 'v1.0.41';
 
 export { version };


### PR DESCRIPTION
This PR fixes an issue where if the client has saved data for an initial starting snapshot the react hook for useInifiniteQuery will briefly clear the data and set isLoading to true when not necessary.

At the start of the useCallback for subscribe we reset any current data we have and then start the subscription. In local dev this issue wasn't a factor because the callback for `this.core.subscribeInfiniteQuery` would set the data correctly before react had a chance to render the state where data=undefined and loading=true. 

Notes: I think there still should be a good way to figure out if the data comes from a snapshot or if its from the subscription but since the basic useQuery doesn't include this, I won't bother in this PR. 


Before:
<img width="213" height="152" alt="image" src="https://github.com/user-attachments/assets/5c1a0e4e-7a44-4876-a69e-4a2f38a380da" />
<img width="378" height="113" alt="image" src="https://github.com/user-attachments/assets/bf0711f9-1eda-4106-9f56-6793215a9c13" />
console log statement placed at end of infinite scroll sandbox. 

after:
<img width="186" height="59" alt="image" src="https://github.com/user-attachments/assets/6405d2e2-1fa8-4493-ae06-eacc054e4670" />

Note for #2707:  The user is saying that the hook would "accidentally flash the empty state" before loading. This is actually correct behavior because the state truly is empty but we were showing a loading state when we should not have been at all. i.e. the issue wasn't a flashing "has data" state prior to loading, the issue was that the pre-loading and post-loading states were correct but there shouldn't have been a loading state since we had snapshotted data in local memory


patch to test:
```patch
diff --git a/client/packages/react-common/src/useInfiniteQuerySubscription.ts b/client/packages/react-common/src/useInfiniteQuerySubscription.ts
index 108a249741..a8e98fb1cc 100644
--- a/client/packages/react-common/src/useInfiniteQuerySubscription.ts
+++ b/client/packages/react-common/src/useInfiniteQuerySubscription.ts
@@ -82,11 +82,14 @@
       const sub = core.subscribeInfiniteQuery(
         query,
         (resp) => {
-          stateCacheRef.current = {
-            ...resp,
-            isLoading: false,
-          };
-          cb();
+          // wait a second
+          new Promise((resolve) => setTimeout(resolve, 1000)).then(() => {
+            stateCacheRef.current = {
+              ...resp,
+              isLoading: false,
+            };
+            cb();
+          });
         },
         opts,
       );
diff --git a/client/sandbox/react-nextjs/pages/play/infinite-scroll.tsx b/client/sandbox/react-nextjs/pages/play/infinite-scroll.tsx
index ebb690048b..c689edc816 100644
--- a/client/sandbox/react-nextjs/pages/play/infinite-scroll.tsx
+++ b/client/sandbox/react-nextjs/pages/play/infinite-scroll.tsx
@@ -107,8 +107,15 @@
     [allNumbersResult.data],
   );
 
+  console.log(
+    'IS LOADING!',
+    scrollResult.isLoading,
+    scrollResult?.data?.items?.length,
+  );
+
   return (
     <div>
+      {scrollResult.isLoading && <div>Loading...</div>}
       <div>
         <input
           className="m-2 border border-gray-400 p-2"
```
