### PR TITLE
fix(core): $like/$ilike should match newlines (dotall) to match the server

### DIFF
--- a/client/packages/core/src/instaql.ts
+++ b/client/packages/core/src/instaql.ts
@@ -137,9 +137,13 @@ function makeLikeMatcher(caseSensitive: boolean, pattern: string) {
   const escapedPattern = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const regexPattern = escapedPattern.replace(/%/g, '.*').replace(/_/g, '.');
 
+  // The `s` (dotall) flag makes `%` (-> .*) and `_` (-> .) match newline
+  // characters, matching Postgres LIKE/ILIKE on the server. Without it, the
+  // optimistic client result diverges from the server for values containing
+  // newlines (the wildcards would stop at a `\n`).
   const regex = new RegExp(
     `^${regexPattern}$`,
-    caseSensitive ? undefined : 'i',
+    caseSensitive ? 's' : 'is',
   );
 
   return function likeMatcher(value) {

--- a/client/packages/core/src/instaql.ts
+++ b/client/packages/core/src/instaql.ts
@@ -138,13 +138,8 @@ function makeLikeMatcher(caseSensitive: boolean, pattern: string) {
   const regexPattern = escapedPattern.replace(/%/g, '.*').replace(/_/g, '.');
 
   // The `s` (dotall) flag makes `%` (-> .*) and `_` (-> .) match newline
-  // characters, matching Postgres LIKE/ILIKE on the server. Without it, the
-  // optimistic client result diverges from the server for values containing
-  // newlines (the wildcards would stop at a `\n`).
-  const regex = new RegExp(
-    `^${regexPattern}$`,
-    caseSensitive ? 's' : 'is',
-  );
+  // characters, matching Postgres LIKE/ILIKE on the server.
+  const regex = new RegExp(`^${regexPattern}$`, caseSensitive ? 's' : 'is');
 
   return function likeMatcher(value) {
     if (typeof value !== 'string') {


### PR DESCRIPTION
## Summary

`makeLikeMatcher` (used by `$like`/`$ilike` in the client-side query store, `instaql.ts`) compiles the LIKE pattern to a `RegExp` **without** the `s` (dotall) flag, so `%` (→ `.*`) and `_` (→ `.`) don't match newline characters. The server evaluates `$like`/`$ilike` as Postgres `LIKE`/`ILIKE`, where the wildcards **do** match newlines — so the optimistic/local result silently diverges from the server for any value containing a newline.

## Reproduce

- value `'a\nb'`, `{ $like: 'a%b' }` → client `false`, server (Postgres) `true`
- value `'a\nb'`, `{ $like: 'a_b' }` → client `false`, server `true`
- value `'x\ny'`, `{ $like: '%' }`   → client `false`, server `true`

## Fix

Add the `s` (dotall) flag. Regex metacharacters are already escaped, and JS `$` (without the `m` flag) stays anchored to the end of the whole string, so this is the only change needed. Cross-checked against Postgres `LIKE` with a small reference script: the current matcher diverges on 3/6 newline cases; with `s` it matches all of them, with no change to the non-newline cases.

## Note

`makeLikeMatcher` is internal (not exported), so I didn't add a unit test — happy to add coverage via the store/query test harness if you'd prefer. Opened as a draft pending CI.