### PR TITLE
Update invalidator `like` regex to match postgres on newline matching

### DIFF
--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -954,9 +954,10 @@
   [case-insensitive? pattern]
   (let [parts (like-parts pattern)]
     (Pattern/compile (string/join "" parts)
-                     (if case-insensitive?
-                       Pattern/CASE_INSENSITIVE
-                       0))))
+                     (bit-or Pattern/DOTALL ; match newlines, same as postgres
+                             (if case-insensitive?
+                               Pattern/CASE_INSENSITIVE
+                               0)))))
 
 (defn make-like-match? [case-insensitive? text pattern]
   (let [regex-pattern (like-pattern case-insensitive? pattern)]

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -255,6 +255,23 @@
                                                  :value "he%"
                                                  :data-type :string}} false)
 
+  ;; Wildcards must match newlines to agree with Postgres LIKE/ILIKE
+  (is-match-topic-part #{"a\nb"} {:$comparator {:op :$like
+                                                :value "a%b"
+                                                :data-type :string}} true)
+
+  (is-match-topic-part #{"a\nb"} {:$comparator {:op :$like
+                                                :value "a_b"
+                                                :data-type :string}} true)
+
+  (is-match-topic-part #{"x\ny"} {:$comparator {:op :$like
+                                                :value "%"
+                                                :data-type :string}} true)
+
+  (is-match-topic-part #{"A\nB"} {:$comparator {:op :$ilike
+                                                :value "a%b"
+                                                :data-type :string}} true)
+
   (is-match-topic-part #{true} {:$comparator {:op :$gte
                                               :value true
                                               :data-type :boolean}} true)

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -272,6 +272,20 @@
                                                 :value "a%b"
                                                 :data-type :string}} true)
 
+  ;; `_` still matches exactly one char, so \r\n (two chars) should not match
+  (is-match-topic-part #{"a\r\nb"} {:$comparator {:op :$like
+                                                  :value "a_b"
+                                                  :data-type :string}} false)
+
+  (is-match-topic-part #{"a\r\nb"} {:$comparator {:op :$like
+                                                  :value "a__b"
+                                                  :data-type :string}} true)
+
+  ;; A trailing newline should not match a pattern with no trailing wildcard
+  (is-match-topic-part #{"abc\n"} {:$comparator {:op :$like
+                                                 :value "abc"
+                                                 :data-type :string}} false)
+
   (is-match-topic-part #{true} {:$comparator {:op :$gte
                                               :value true
                                               :data-type :boolean}} true)


### PR DESCRIPTION
Fixes our `like` matcher on the backend to support newlines in the same way that postgres does. 

It's the same fix as the sdk fix at https://github.com/instantdb/instant/pull/2714