### PR TITLE
Skip no-op triple updates

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -401,6 +401,25 @@
 
 (def value-lookup-error-prefix "missing-lookup-value")
 
+(defn- id-attr-ids [attrs]
+  (with-meta (set (keep (fn [attr]
+                          (when (= "id" (attr-model/fwd-label attr))
+                            (:id attr)))
+                        attrs))
+    {:pgtype "uuid[]"}))
+
+(defn- ea-conflict-update-set [attrs overwrite-t]
+  (let [fields (merge {:value :excluded.value
+                       :value-md5 :excluded.value-md5}
+                      (when overwrite-t
+                        {:created_at [:current_unix_timestamp_ms]}))]
+    (if overwrite-t
+      fields
+      {:fields fields
+       :where [:or
+               [:is-distinct-from :triples.value-md5 :excluded.value-md5]
+               [:= :triples.attr-id [:any (id-attr-ids attrs)]]]})))
+
 (defn insert-multi!
   "Given a set of raw triples, we enhance each triple with metadata based on
    the triple's underlying attr and then insert these enhanced triples into
@@ -596,10 +615,7 @@
                          :from :ea-triples-distinct
                          :order-by [:app-id :entity-id :attr-id :value-md5]}]
           :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
-          :do-update-set (merge {:value :excluded.value
-                                 :value-md5 :excluded.value-md5}
-                                (when overwrite-t
-                                  {:created_at [:current_unix_timestamp_ms]}))
+          :do-update-set (ea-conflict-update-set attrs overwrite-t)
           :returning :*}
 
          remaining-inserts

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -404,16 +404,12 @@
 (defn- id-attr-conflict? []
   [:exists {:select :1
             :from [[:attrs :id-attr]]
-            :join [[:idents :id-ident]
-                   [:and
-                    [:= :id-ident.id :id-attr.forward-ident]
-                    [:= :id-ident.label "id"]]]
             :where [:and
                     [:= :id-attr.id :triples.attr-id]
                     [:or
                      [:= :id-attr.app-id :triples.app-id]
                      [:= :id-attr.app-id system-catalog-app-id]]
-                    [:= nil :id-attr.deletion-marked-at]]}])
+                    [:= :id-attr.label "id"]]}])
 
 (defn- ea-conflict-update-set [overwrite-t]
   (let [fields (merge {:value :excluded.value

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -401,14 +401,21 @@
 
 (def value-lookup-error-prefix "missing-lookup-value")
 
-(defn- id-attr-ids [attrs]
-  (with-meta (set (keep (fn [attr]
-                          (when (= "id" (attr-model/fwd-label attr))
-                            (:id attr)))
-                        attrs))
-    {:pgtype "uuid[]"}))
+(defn- id-attr-conflict? []
+  [:exists {:select :1
+            :from [[:attrs :id-attr]]
+            :join [[:idents :id-ident]
+                   [:and
+                    [:= :id-ident.id :id-attr.forward-ident]
+                    [:= :id-ident.label "id"]]]
+            :where [:and
+                    [:= :id-attr.id :triples.attr-id]
+                    [:or
+                     [:= :id-attr.app-id :triples.app-id]
+                     [:= :id-attr.app-id system-catalog-app-id]]
+                    [:= nil :id-attr.deletion-marked-at]]}])
 
-(defn- ea-conflict-update-set [attrs overwrite-t]
+(defn- ea-conflict-update-set [overwrite-t]
   (let [fields (merge {:value :excluded.value
                        :value-md5 :excluded.value-md5}
                       (when overwrite-t
@@ -418,7 +425,7 @@
       {:fields fields
        :where [:or
                [:is-distinct-from :triples.value-md5 :excluded.value-md5]
-               [:= :triples.attr-id [:any (id-attr-ids attrs)]]]})))
+               (id-attr-conflict?)]})))
 
 (defn insert-multi!
   "Given a set of raw triples, we enhance each triple with metadata based on
@@ -615,7 +622,7 @@
                          :from :ea-triples-distinct
                          :order-by [:app-id :entity-id :attr-id :value-md5]}]
           :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
-          :do-update-set (ea-conflict-update-set attrs overwrite-t)
+          :do-update-set (ea-conflict-update-set overwrite-t)
           :returning :*}
 
          remaining-inserts

--- a/server/test/instant/db/model/triple_test.clj
+++ b/server/test/instant/db/model/triple_test.clj
@@ -1,7 +1,10 @@
 (ns instant.db.model.triple-test
   (:require [instant.db.model.triple :as triple]
+            [instant.db.model.attr :as attr-model]
+            [instant.fixtures :refer [with-empty-app]]
             [instant.jdbc.aurora :as aurora]
             [instant.jdbc.sql :as sql]
+            [instant.util.test :as test-util]
             [instant.util.json :refer [->json]]
             [honey.sql :as hsql]
             [clojure.test :refer [is deftest testing]])
@@ -81,3 +84,31 @@
   (doseq [s ["2025-01-0"
              "\"2025-01-0\""]]
     (is (thrown-with-msg? Exception #"Unable to parse" (triple/parse-date-value s)))))
+
+(defn- result-pairs [rows]
+  (set (map (juxt :entity_id :attr_id) rows)))
+
+(deftest insert-multi-skips-same-value-updates-except-id-triples
+  (with-empty-app
+    (fn [{app-id :id}]
+      (let [{id-attr :items/id
+             title-attr :items/title}
+            (test-util/make-attrs app-id [[:items/id :unique? :index?]
+                                          [:items/title]])
+            attrs (attr-model/get-by-app-id app-id)
+            conn (aurora/conn-pool :write)
+            eid (random-uuid)]
+        (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                 [eid title-attr "first"]])
+
+        (is (= #{[eid id-attr]}
+               (result-pairs
+                (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                         [eid title-attr "first"]]))))
+        (is (= #{[eid title-attr]}
+               (result-pairs
+                (triple/insert-multi! conn attrs app-id [[eid title-attr "second"]]))))
+        (is (= #{[eid title-attr]}
+               (result-pairs
+                (triple/insert-multi! conn attrs app-id [[eid title-attr "second"]]
+                                      {:overwrite-t true}))))))))


### PR DESCRIPTION
## Summary
- skip object triple conflict updates when the value md5 is unchanged
- keep id triples on the update path so invalidation still sees them
- preserve overwrite-t behavior for stream machineId writes

## Testing
- scripts/nrepl-eval --port 6005 targeted test-var for insert-multi-skips-same-value-updates-except-id-triples
- clj-kondo --lint src/instant/db/model/triple.clj test/instant/db/model/triple_test.clj