### PR TITLE
server changes for email cli (2/3)

### DIFF
--- a/server/resources/migrations/112_allow_null_sender_user_id.down.sql
+++ b/server/resources/migrations/112_allow_null_sender_user_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_email_senders ALTER COLUMN user_id SET NOT NULL;

--- a/server/resources/migrations/112_allow_null_sender_user_id.down.sql
+++ b/server/resources/migrations/112_allow_null_sender_user_id.down.sql
@@ -1,1 +1,5 @@
+-- WARNING: This rollback will fail if any app_email_senders rows have user_id = NULL.
+-- Before running this migration, manually clean up or backfill null user_ids:
+--   UPDATE app_email_senders SET user_id = <sentinel_user_id> WHERE user_id IS NULL;
+-- Rollback is only safe if deployed before any null user_ids were written.
 ALTER TABLE app_email_senders ALTER COLUMN user_id SET NOT NULL;

--- a/server/resources/migrations/112_allow_null_sender_user_id.up.sql
+++ b/server/resources/migrations/112_allow_null_sender_user_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_email_senders ALTER COLUMN user_id DROP NOT NULL;

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1344,8 +1344,6 @@
   (let [params (magic-code-auth/default-email-template-params)]
     (response/ok {:email-type "magic-code"
                   :sender-email (:sender-email params)
-                  :email (:sender-email params)
-                  :reply-to (:sender-email params)
                   :subject (:subject params)
                   :body (:body params)})))
 

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1340,7 +1340,7 @@
 ;; Email templates
 ;; ---------------
 
-(defn get-default-email-template [_req]
+(defn default-email-template-get [_req]
   (let [params (magic-code-auth/default-email-template-params)]
     (response/ok {:email-type "magic-code"
                   :sender-email (:sender-email params)
@@ -2319,7 +2319,7 @@
   (DELETE "/dash/apps/:app_id/members/remove" [] team-member-remove-delete)
   (POST "/dash/apps/:app_id/members/update" [] team-member-update-post)
 
-  (GET "/dash/default-email-template" [] get-default-email-template)
+  (GET "/dash/default-email-template" [] default-email-template-get)
   (GET "/dash/apps/:app_id/sender-verification" [] sender-verification-get)
   (POST "/dash/apps/:app_id/sender-verification/send-magic-code" [] sender-verification-send-magic-code)
   (POST "/dash/apps/:app_id/sender-verification/verify-magic-code" [] sender-verification-verify-magic-code)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1338,9 +1338,19 @@
 
 ;; ---------------
 ;; Email templates
+;; ---------------
+
+(defn get-default-email-template [_req]
+  (let [params (magic-code-auth/default-email-template-params)]
+    (response/ok {:email-type "magic-code"
+                  :sender-email (:sender-email params)
+                  :email (:sender-email params)
+                  :reply-to (:sender-email params)
+                  :subject (:subject params)
+                  :body (:body params)})))
 
 (defn sender-verification-get [req]
-  (let [{{app-id :id} :app} (req->app-and-user! :admin req)
+  (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :admin :apps/read req)
         {postmark-id :postmark_id instant-verified? :verification_verified}
         (app-email-verification/get-by-app-id-and-email-type-with-template
          {:app-id app-id :email-type "magic-code"})]
@@ -1353,8 +1363,14 @@
                                                     :DKIMPendingTextValue :DKIMTextValue
                                                     :ReturnPathDomain :ReturnPathDomainCNAMEValue])))})))
 
+(defn email-status-get [req]
+  (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :admin :apps/read req)
+        res  (app-email-verification/get-by-app-id-and-email-type-with-template
+              {:app-id app-id :email-type "magic-code"})]
+    (response/ok {:info res})))
+
 (defn email-template-post [req]
-  (let [{app :app user :user} (req->app-and-user! :admin req)
+  (let [{app :app} (req->app-accepting-superadmin-or-ref-token! :admin :apps/read req)
         email-type (ex/get-param! req [:body :email-type] string-util/coerce-non-blank-str)
         subject (ex/get-param! req [:body :subject] string-util/coerce-non-blank-str)
         _ (ex/assert-valid! :subject subject
@@ -1372,7 +1388,6 @@
         {sender :sender} (when sender-email
                            (app-email-sender-model/sync-sender!
                             {:app-id (:id app)
-                             :user-id (:id user)
                              :email sender-email
                              :name sender-name}))
         template (app-email-template-model/put!
@@ -1444,7 +1459,7 @@
   (email-template-delete (assoc-in (fixtures/mock-app-req any-app) [:params :id] tmpl-id)))
 
 (defn email-template-delete [req]
-  (let [{app :app} (req->app-and-user! req)
+  (let [{app :app} (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)
         id (ex/get-param! req [:params :id] uuid-util/coerce)]
     (app-email-template-model/delete-by-id! {:id id :app-id (:id app)})
     (response/ok {})))
@@ -2306,9 +2321,11 @@
   (DELETE "/dash/apps/:app_id/members/remove" [] team-member-remove-delete)
   (POST "/dash/apps/:app_id/members/update" [] team-member-update-post)
 
+  (GET "/dash/default-email-template" [] get-default-email-template)
   (GET "/dash/apps/:app_id/sender-verification" [] sender-verification-get)
   (POST "/dash/apps/:app_id/sender-verification/send-magic-code" [] sender-verification-send-magic-code)
   (POST "/dash/apps/:app_id/sender-verification/verify-magic-code" [] sender-verification-verify-magic-code)
+  (GET "/dash/apps/:app_id/email_status" [] email-status-get)
   (POST "/dash/apps/:app_id/email_templates" [] email-template-post)
   (POST "/dash/apps/:app_id/send-test-email" [] send-test-email-post)
   (DELETE "/dash/apps/:app_id/email_templates/:id" [] email-template-delete)

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -18,18 +18,18 @@
 
 (defn put!
   ([params] (put! (aurora/conn-pool :write) params))
-  ([conn {:keys [email name user-id postmark-id]}]
+  ([conn {:keys [email name postmark-id]}]
    (sql/execute-one!
     conn
     ["INSERT INTO
         app_email_senders
-        (id, email, name, user_id, postmark_id)
+        (id, email, name, postmark_id)
       VALUES
-        (?::uuid, ?, ?, ?, ?)
+        (?::uuid, ?, ?, ?)
       ON CONFLICT (email)
       DO UPDATE SET
         name = EXCLUDED.name"
-     (UUID/randomUUID) email name user-id postmark-id])))
+     (UUID/randomUUID) email name postmark-id])))
 
 ;; https://postmarkapp.com/developer/api/overview#error-codes
 
@@ -48,10 +48,8 @@
       3. The sender exists in postmark, but not in our database
             a. In this case, we reach an invariant. This can happen when we add a sender in development
       "
-  [{:keys [app-id user-id email name]}]
+  [{:keys [app-id email name]}]
   (let [sender (get-by-email {:email email})
-        _ (when (and sender (not= user-id (:user_id sender)))
-            (ex/throw-validation-err! :sender-user user-id [{:message sender-claimed-error-message}]))
         postmark-id (:postmark_id sender)
         postmark-sender (when sender
                           (try
@@ -87,7 +85,6 @@
         sender (put! {:email email
                       :name name
                       :app-id app-id
-                      :user-id user-id
                       :postmark-id postmark-id})
         _ (if (flags/use-app-email-verification?)
             (verification/put! {:app-id app-id

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -165,6 +165,24 @@
              (magic-code-email to (assoc email-params :sender-email default-sender-email))))
           (throw e))))))
 
+(defn default-email-params [app code]
+  (let [{default-sender-email :email} (config/app-email-sender)
+        template-params {:code code
+                         :app_title (:title app)
+                         :expiration (friendly-expiration app)}]
+    {:sender-name (:title app)
+     :sender-email default-sender-email
+     :subject (str code " is your verification code for " (:title app))
+     :body (default-body template-params)}))
+
+(defn default-email-template-params []
+  (let [{default-sender-email :email} (config/app-email-sender)]
+    {:sender-email default-sender-email
+     :subject "{code} is your verification code for {app_title}"
+     :body (default-body {:code "{code}"
+                          :app_title "{app_title}"
+                          :expiration "{expiration}"})}))
+
 (defn send! [{:keys [app-id email] :as req}]
   (check-send-rate-limit! req)
   (let [app             (app-model/get-by-id! {:id app-id})
@@ -193,10 +211,7 @@
                            :sender-name (or (:name template) (:title app))
                            :subject (template-replace (:subject template) template-params false)
                            :body (template-replace (:body template) template-params true)}
-                          {:sender-name (:title app)
-                           :sender-email default-sender-email
-                           :subject (str code " is your verification code for " (:title app))
-                           :body (default-body template-params)})
+                          (default-email-params app code))
 
         email-req       (magic-code-email email email-params)
         email-res       (try


### PR DESCRIPTION
# BEFORE MERGING: use-app-email-verification? must be togged on. 

Includes migration to drop user_id field from custom senders table. 
Need to run migration before deploying.

Purpose of this pr is to remove the restriction against superuser tokens for auth email routes. 