### PR TITLE
Experiment with combining matching transacts

### DIFF
--- a/server/src/instant/admin/transact_queue.clj
+++ b/server/src/instant/admin/transact_queue.clj
@@ -29,14 +29,14 @@
                                          tx-steps)]
     (nth add-triple-step 2)))
 
-(defn group-key [{:keys [app-id tx-steps]}]
+(defn group-key [_ {:keys [app-id tx-steps]}]
   [app-id (or (attr-key tx-steps)
               (random-uuid))])
 
-(defn combine [_a _b]
+(defn combine [_ctx _a _b]
   nil)
 
-(defn process [_group-key {:keys [ctx tx-steps response-promise
+(defn process [_ctx _group-key {:keys [ctx tx-steps response-promise
                                   open? canceled? span exceptions-silencer
                                   child-vfutures statement-tracker]}]
   (binding [tracer/*span* span
@@ -54,7 +54,8 @@
 (defn start []
   (.bindRoot #'tx-q
              (grouped-queue/start
-               {:group-key-fn #'group-key
+               {:ctx nil
+                :group-key-fn #'group-key
                 :combine-fn   #'combine
                 :process-fn   #'process
                 :max-workers  num-receive-workers

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -401,7 +401,7 @@
       (with-log-init :stripe
         (stripe/init))
       (with-log-init :session
-        (session/start))
+        (session/start rs/store))
       (with-log-init :webhook-processor
         (webhook-processor/start-global))
       (with-log-init :invalidator

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -404,3 +404,6 @@
 
 (defn smokescreen-whitelist-ips []
   (flag :smokescreen-whitelist-ips #{}))
+
+(defn combine-transacts? []
+  (flag :combine-transacts true))

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -10,24 +10,24 @@
    (java.util.concurrent ConcurrentHashMap ConcurrentLinkedQueue Executor Executors ExecutorService TimeUnit)
    (java.util.concurrent.atomic AtomicInteger)))
 
-(defn- execute [{:keys [get-executor error-fn]} ^Runnable task]
+(defn- execute [{:keys [get-executor error-fn ctx]} ^Runnable task]
   (try
     (Executor/.execute (get-executor) task)
     (catch Exception e
       (if error-fn
-        (error-fn e)
+        (error-fn ctx e)
         (throw e)))))
 
 (defn- poll
   "Gets 0..∞ items from group, fetching as many combinable items as possible in a row.
    Returns 1 (possibly combined) item or nil"
-  [group combine-fn]
+  [ctx group combine-fn]
   (loop [item1 (Queue/.poll group)]
     (clojure+/cond+
      (nil? item1) nil
      :let [item2 (Queue/.peek group)]
      (nil? item2) item1
-     :let [item12 (combine-fn item1 item2)]
+     :let [item12 (combine-fn ctx item1 item2)]
      (nil? item12) item1
      :else (do
              (Queue/.remove group) ;; remove item2
@@ -50,7 +50,8 @@
 (defn- process
   "Main worker process function"
   [process-task
-   {:keys [process-fn
+   {:keys [ctx
+           process-fn
            combine-fn
            num-workers
            num-items
@@ -59,10 +60,10 @@
    group]
   (AtomicInteger/.incrementAndGet num-workers)
   (when @processing?
-    (if-some [item (poll group combine-fn)]
+    (if-some [item (poll ctx group combine-fn)]
       (do
         (try
-          (process-fn key item)
+          (process-fn ctx key item)
           (catch Throwable t
             (tracer/record-exception-span! t {:name "grouped-queue/process-error"})))
         (AtomicInteger/.addAndGet num-items (- (::combined item 1)))
@@ -74,10 +75,10 @@
 
 (defn put!
   "Schedule item for execution on q"
-  [{:keys [groups group-key-fn num-items num-puts accepting?] :as q} item]
+  [{:keys [ctx groups group-key-fn num-items num-puts accepting?] :as q} item]
   (when @accepting?
     (let [item   (assoc item ::put-at (System/currentTimeMillis))
-          key    (or (group-key-fn item) ::default)
+          key    (or (group-key-fn ctx item) ::default)
           process-task (locking q
                          (if-some [group (Map/.get groups key)]
                            (do
@@ -101,18 +102,22 @@
 
 (defn start
   "Options:
+     :ctx :: Ctx
 
-     :group-key-fn :: (fn [item]) -> Any
+   A context variable that will be passed as the first arg to group-key-fn, combine-fn, process-fn,
+   and error-fn
+
+     :group-key-fn :: (fn [ctx item]) -> Any
 
    A function to determine to which “track” to send item for processing.
    All tracks are processed in parallel, items inside one track are processed sequentially.
 
-     :combine-fn   :: (fn [item1 item2]) -> item | nil
+     :combine-fn   :: (fn [ctx item1 item2]) -> item | nil
 
    A function that can optionally combine two items into one before processing.
    Return nil if items shouldn’t be combined.
 
-     :process-fn   :: (fn [group-key item])
+     :process-fn   :: (fn [ctx group-key item])
 
    Main processing function. Item passed to it might have additional ::combined and ::put-at keys.
 
@@ -131,7 +136,7 @@
      :metrics-path :: String | nil
 
    A string to report gauge metrics to. If skipped, no reporting"
-  [{:keys [group-key-fn combine-fn process-fn error-fn executor get-executor max-workers metrics-path]
+  [{:keys [ctx group-key-fn combine-fn process-fn error-fn executor get-executor max-workers metrics-path]
     :or {max-workers 2}}]
   (let [groups       (ConcurrentHashMap.)
         accepting?   (atom true)
@@ -181,7 +186,8 @@
                                (ExecutorService/.shutdownNow (get-executor))
                                :terminated)))))]
     {:group-key-fn (or group-key-fn identity)
-     :combine-fn   (or combine-fn (fn [_ _] nil))
+     :ctx          ctx
+     :combine-fn   (or combine-fn (fn [_ _ _] nil))
      :process-fn   process-fn
      :error-fn     error-fn
      :groups       groups

--- a/server/src/instant/join_room_logger.clj
+++ b/server/src/instant/join_room_logger.clj
@@ -21,16 +21,16 @@
     :do-update-set {:join-count [:+ :join-room-logs.join-count :excluded.join-count]}}))
 
 (defn- group-key
-  [{:keys [app-id]}]
+  [_ctx {:keys [app-id]}]
   app-id)
 
 (defn- combine
-  [item1 item2]
+  [_ctx item1 item2]
   (-> item1
       (update :join-count + (:join-count item2))))
 
 (defn- process
-  [_group-key {:keys [app-id join-count]}]
+  [_ctx _group-key {:keys [app-id join-count]}]
   (tracer/with-span! {:name "join-room-logger/process"
                       :attributes {:app-id app-id
                                    :join-count join-count}}
@@ -55,7 +55,8 @@
   (tracer/record-info! {:name "join-room-logger/start"})
   (.bindRoot #'log-q
              (grouped-queue/start
-              {:group-key-fn #'group-key
+              {:ctx nil
+               :group-key-fn #'group-key
                :combine-fn #'combine
                :process-fn #'process
                :max-workers 1

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -153,7 +153,7 @@
   "Combines a list of wal-records into a single wal-record.
    We combine all of the change lists and advance the tx-id to the
    latest tx-id in the list."
-  [r1 r2]
+  [_ctx r1 r2]
   (when (< (::grouped-queue/combined r1 1) (flags/flag :invalidator-batch-limit 500))
     ;; Complain loudly if we accidently mix wal-records from multiple apps
     (when (not= (:app-id r1) (:app-id r2))
@@ -272,9 +272,11 @@
   (tracer/record-info! {:name "invalidation-worker/start"})
   (let [queue
         (grouped-queue/start
-         {:group-key-fn :app-id
+         {:ctx nil
+          :group-key-fn (fn [_ctx item]
+                          (:app-id item))
           :combine-fn   combine-wal-records
-          :process-fn   (fn [_key wal-record]
+          :process-fn   (fn [_ctx _key wal-record]
                           (process-wal-record process-id
                                               store
                                               (::grouped-queue/combined wal-record 1)
@@ -837,9 +839,11 @@
         acquire-slot-interrupt-chan (a/chan (a/sliding-buffer 1))
 
         queue (grouped-queue/start
-               {:group-key-fn :app-id
+               {:ctx nil
+                :group-key-fn (fn [_ctx item]
+                                (:app-id item))
                 :combine-fn combine-wal-records
-                :process-fn (fn [_key wal-record]
+                :process-fn (fn [_ctx _key wal-record]
                               ;; Just testing what kind of latency we'll see with this setup
                               (tracer/with-span! {:name "singleton-topic-latency"
                                                   :attributes {:tx-id (:tx-id wal-record)

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -1427,7 +1427,6 @@
                         (next steps2)))))))))
 
 (defn combine-transact [{:keys [store]} event1 event2]
-  (tool/def-locals)
   (when (and (flags/combine-transacts?)
              (try (matching-steps? store (:session-id event1) (:tx-steps event1) (:tx-steps event2))
                   (catch Throwable t

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -40,6 +40,7 @@
    [instant.util.semver :as semver]
    [instant.util.e2e-tracer :as e2e-tracer]
    [instant.util.instaql :as instaql-util]
+   [instant.util.memoize :refer [vmemoize]]
    [instant.util.request :refer [*request-info*]]
    [instant.util.string :as string-util]
    [instant.util.tracer :as tracer]
@@ -330,8 +331,8 @@
                                                                 :admin? admin?
                                                                 :token token
                                                                 :topics topics})
-                                        ;; Make sure this happens before we update the store
-                                        ;; or else we could get a refresh before we send init
+                                       ;; Make sure this happens before we update the store
+                                       ;; or else we could get a refresh before we send init
                                        (rs/send-event! store app-id sess-id
                                                        {:op :sync-init-finish
                                                         :subscription-id sub-id
@@ -341,8 +342,8 @@
                                                                   (:db/id query-ent)
                                                                   tx-id
                                                                   topics)
-                                        ;; This will cause us to catch up on any transactions that were
-                                        ;; handled while we were syncing
+                                       ;; This will cause us to catch up on any transactions that were
+                                       ;; handled while we were syncing
                                        (receive-queue/put! receive-q
                                                            {:op :refresh-sync-table
                                                             :app-id (:app-id ctx)
@@ -1377,49 +1378,67 @@
 ;; ------
 ;; System
 
-(defn matching-steps? [steps1 steps2]
-  (and (= (count steps1)
-          (count steps2))
-       (loop [steps1 steps1
-              steps2 steps2]
-         (if (empty? steps1)
-           true
-           (let [step1 (first steps1)
-                 step2 (first steps2)]
-             (when (and
-                    ;; same op
-                    ;; limit to just add-triple for now
-                    (= (first step1)
-                       (first step2)
-                       "add-triple")
+(defn matching-steps? [store
+                       session-id
+                       steps1
+                       steps2]
+  (let [get-attrs (vmemoize (fn []
+                              (when-let [app-id (-> (rs/session store session-id)
+                                                    :session/auth
+                                                    :app
+                                                    :id)]
+                                (attr-model/get-by-app-id app-id))))]
+    (and (= (count steps1)
+            (count steps2))
+         (loop [steps1 steps1
+                steps2 steps2]
+           (if (empty? steps1)
+             true
+             (let [step1 (first steps1)
+                   step2 (first steps2)]
+               (when (and
+                      ;; same op
+                      ;; limit to just add-triple for now
+                      (= (first step1)
+                         (first step2)
+                         "add-triple")
 
-                    ;; includes mode
-                    (= (count step1)
-                       (count step2)
-                       5)
+                      ;; includes mode
+                      (= (count step1)
+                         (count step2)
+                         5)
 
-                    ;; same eid
-                    (= (second step1)
-                       (second step2))
+                      ;; same eid
+                      (= (second step1)
+                         (second step2))
 
-                    ;; same aid
-                    (= (nth step1 2)
-                       (nth step2 2))
+                      ;; same aid
+                      (= (nth step1 2)
+                         (nth step2 2))
 
-                    ;; same mode
-                    (= (nth step1 4)
-                       (nth step2 4)))
-               (recur (next steps1)
-                      (next steps2))))))))
+                      ;; same mode
+                      (= (nth step1 4)
+                         (nth step2 4))
 
-(defn combine-transact [event1 event2]
+                      (when-let [attrs (get-attrs)]
+                        (= :one (:cardinality (attr-model/seek-by-id (uuid-util/coerce (nth step1 2))
+                                                                     attrs)))))
+                 (recur (next steps1)
+                        (next steps2)))))))))
+
+(defn combine-transact [{:keys [store]} event1 event2]
+  (tool/def-locals)
   (when (and (flags/combine-transacts?)
-             (matching-steps? (:tx-steps event1) (:tx-steps event2)))
+             (try (matching-steps? store (:session-id event1) (:tx-steps event1) (:tx-steps event2))
+                  (catch Throwable t
+                    (tracer/record-exception-span! t {:name "session/combine-transact-error"
+                                                      :attributes {:session-id (:session-id event1)}})
+                    nil)))
     (-> event2
         (assoc :redundant-events (conj (or (:redundant-events event1) [])
                                        (dissoc event1 :redundant-events))))))
 
-(defn group-key [{:keys [op session-id room-id q subscription-id stream-id] :as event}]
+(defn group-key [_ctx {:keys [op session-id room-id q subscription-id stream-id] :as event}]
   (case op
     :transact
     [:transact session-id]
@@ -1469,29 +1488,29 @@
     [session-id (rand-int 100000)]))
 
 (defmulti combine
-  (fn [event1 event2]
+  (fn [_ctx event1 event2]
     [(:op event1) (:op event2)]))
 
-(defmethod combine :default [_ _]
+(defmethod combine :default [_ _ _]
   nil)
 
-(defmethod combine [:refresh :refresh] [event1 event2]
+(defmethod combine [:refresh :refresh] [_ctx event1 event2]
   (e2e-tracer/invalidator-tracking-step!
    {:name          "skipped-refresh"
     :tx-id         (:tx-id event1)
     :tx-created-at (:tx-created-at event1)})
   event2)
 
-(defmethod combine [:refresh-presence :refresh-presence] [event1 event2]
+(defmethod combine [:refresh-presence :refresh-presence] [_ctx event1 event2]
   (update event2 :edits #(into (vec (:edits event1)) %)))
 
-(defmethod combine [:set-presence :set-presence] [_event1 event2]
+(defmethod combine [:set-presence :set-presence] [_ctx _event1 event2]
   event2)
 
-(defmethod combine [:refresh-sync-table :refresh-sync-table] [_ event2]
+(defmethod combine [:refresh-sync-table :refresh-sync-table] [_ctx _ event2]
   event2)
 
-(defmethod combine [:server-broadcast :server-broadcast] [event1 event2]
+(defmethod combine [:server-broadcast :server-broadcast] [_ctx event1 event2]
   (if-let [payloads (::payloads event1)]
     (assoc event1 ::payloads (conj payloads {:topic (:topic event2)
                                              :data (:data event2)}))
@@ -1502,24 +1521,25 @@
                             :data (:data event2)}])
         (dissoc :topic :data))))
 
-(defmethod combine [:append-stream :append-stream] [event1 event2]
+(defmethod combine [:append-stream :append-stream] [_ctx event1 event2]
   (-> event2
       (update :chunks (fn [new-chunks]
                         (into (:chunks event1) new-chunks)))
       (assoc :offset (:offset event1))))
 
-(defmethod combine [:transact :transact] [event1 event2]
-  (combine-transact event1 event2))
+(defmethod combine [:transact :transact] [ctx event1 event2]
+  (combine-transact ctx event1 event2))
 
-(defn process [group-key event]
+(defn process [_ctx group-key event]
   (straight-jacket-process-receive-q-event rs/store group-key event))
 
-(defn start []
+(defn start [store]
   (let [vfutures-executor (ua/make-limited-concurrency-executor vfutures-num-receive-workers)
         threads-executor (Executors/newFixedThreadPool threads-num-receive-workers)]
     (receive-queue/start
      (grouped-queue/start
-      {:group-key-fn #'group-key
+      {:ctx {:store store}
+       :group-key-fn #'group-key
        :combine-fn   #'combine
        :process-fn   #'process
        :get-executor (fn []
@@ -1533,10 +1553,10 @@
 
 (defn restart []
   (stop)
-  (start))
+  (start rs/store))
 
 (defn before-ns-unload []
   (stop))
 
 (defn after-ns-reload []
-  (start))
+  (start rs/store))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -531,7 +531,7 @@
 ;; transact
 
 (defn handle-transact!
-  [store sess-id {:keys [tx-steps client-event-id] :as _event}]
+  [store sess-id {:keys [tx-steps] :as event}]
   (let [start (System/currentTimeMillis)
         auth (get-auth! store sess-id)
         app-id (-> auth :app :id)
@@ -564,11 +564,12 @@
                                     :max-isn-wait-ms max-wait-ms
                                     :used-fallback-isn (not isn)}})
 
-    (rs/send-event! store app-id sess-id
-                    {:op :transact-ok
-                     :tx-id tx-id
-                     :isn (or isn fallback-isn)
-                     :client-event-id client-event-id})))
+    (doseq [{:keys [client-event-id]} (conj (:redundant-events event) event)]
+      (rs/send-event! store app-id sess-id
+                      {:op :transact-ok
+                       :tx-id tx-id
+                       :isn (or isn fallback-isn)
+                       :client-event-id client-event-id}))))
 
 ;; -----
 ;; error
@@ -580,13 +581,24 @@
                                            type
                                            message
                                            hint]}]
+  (doseq [event (:redundant-events original-event)]
+    (rs/send-event! store
+                    app-id
+                    sess-id
+                    {:op :error
+                     :status status
+                     :client-event-id (:client-event-id event)
+                     :original-event event
+                     :type type
+                     :message message
+                     :hint hint}))
   (rs/send-event! store
                   app-id
                   sess-id
                   {:op :error
                    :status status
                    :client-event-id client-event-id
-                   :original-event original-event
+                   :original-event (dissoc original-event :redundant-events)
                    :type type
                    :message message
                    :hint hint}))
@@ -1365,6 +1377,48 @@
 ;; ------
 ;; System
 
+(defn matching-steps? [steps1 steps2]
+  (and (= (count steps1)
+          (count steps2))
+       (loop [steps1 steps1
+              steps2 steps2]
+         (if (empty? steps1)
+           true
+           (let [step1 (first steps1)
+                 step2 (first steps2)]
+             (when (and
+                    ;; same op
+                    ;; limit to just add-triple for now
+                    (= (first step1)
+                       (first step2)
+                       "add-triple")
+
+                    ;; includes mode
+                    (= (count step1)
+                       (count step2)
+                       5)
+
+                    ;; same eid
+                    (= (second step1)
+                       (second step2))
+
+                    ;; same aid
+                    (= (nth step1 2)
+                       (nth step2 2))
+
+                    ;; same mode
+                    (= (nth step1 4)
+                       (nth step2 4)))
+               (recur (next steps1)
+                      (next steps2))))))))
+
+(defn combine-transact [event1 event2]
+  (when (and (flags/combine-transacts?)
+             (matching-steps? (:tx-steps event1) (:tx-steps event2)))
+    (-> event2
+        (assoc :redundant-events (conj (or (:redundant-events event1) [])
+                                       (dissoc event1 :redundant-events))))))
+
 (defn group-key [{:keys [op session-id room-id q subscription-id stream-id] :as event}]
   (case op
     :transact
@@ -1453,6 +1507,9 @@
       (update :chunks (fn [new-chunks]
                         (into (:chunks event1) new-chunks)))
       (assoc :offset (:offset event1))))
+
+(defmethod combine [:transact :transact] [event1 event2]
+  (combine-transact event1 event2))
 
 (defn process [group-key event]
   (straight-jacket-process-receive-q-event rs/store group-key event))

--- a/server/test/instant/grouped_queue_test.clj
+++ b/server/test/instant/grouped_queue_test.clj
@@ -38,8 +38,9 @@
             output (atom [])
             q (grouped-queue/start
                (merge
-                {:group-key-fn :group
-                 :process-fn (fn [_group item]
+                {:group-key-fn (fn [_ item]
+                                 (:group item))
+                 :process-fn (fn [_ctx _group item]
                                (swap! output conj item))}
                 opts))]
         (try
@@ -63,11 +64,12 @@
             output (atom [])
             q (grouped-queue/start
                (merge
-                {:group-key-fn :group
-                 :combine-fn   (fn [item1 item2]
+                {:group-key-fn (fn [_ctx item]
+                                 (:group item))
+                 :combine-fn   (fn [_ item1 item2]
                                  (when (= (:id item2) (inc (:id item1)))
                                    item2))
-                 :process-fn   (fn [_group item]
+                 :process-fn   (fn [_ _group item]
                                  (swap! output conj item))}
                 opts))]
         (try
@@ -90,9 +92,10 @@
                 {:group group :id id})
         latch (CountDownLatch. 500)
         q     (grouped-queue/start
-               {:group-key-fn :group
+               {:group-key-fn (fn [_ctx item]
+                                (:group item))
                 :max-workers  10
-                :process-fn   (fn [_group _item]
+                :process-fn   (fn [_ctx _group _item]
                                 (Thread/sleep 10)
                                 (.countDown latch))})
         t0    (System/currentTimeMillis)]
@@ -116,9 +119,10 @@
         processed (atom [])
         stopped (promise)
         q (grouped-queue/start
-           {:group-key-fn :group
+           {:group-key-fn (fn [_ctx item]
+                            (:group item))
             :max-workers  1
-            :process-fn   (fn [_group items]
+            :process-fn   (fn [_ctx _group items]
                           (if (< 3 (count (swap! processed conj items)))
                             (do
                               (deliver stopped true)
@@ -126,7 +130,7 @@
                             (do
                               (grouped-queue/put! @q-promise {:group 2})
                               (grouped-queue/put! @q-promise {:group 1}))))
-            :error-fn     (fn [_])})]
+            :error-fn     (fn [_ctx _])})]
     (deliver q-promise q)
 
     (grouped-queue/put! q {:group 1})

--- a/server/test/instant/reactive/invalidator_singleton_test.clj
+++ b/server/test/instant/reactive/invalidator_singleton_test.clj
@@ -39,8 +39,9 @@
   []
   (let [records (atom [])
         queue (grouped-queue/start
-               {:group-key-fn :app-id
-                :process-fn (fn [_k r]
+               {:group-key-fn (fn [_ctx item]
+                                (:app-id item))
+                :process-fn (fn [_ctx _k r]
                               (swap! records conj
                                      (dissoc r :instant.grouped-queue/put-at)))
                 :max-workers 1})]

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -58,9 +58,10 @@
           (let [store (rs/init)
                 _ (eph/init-store store)
                 receive-q
-                (grouped-queue/start {:group-key-fn session/group-key
+                (grouped-queue/start {:ctx {:store store}
+                                      :group-key-fn session/group-key
                                       :combine-fn   session/combine
-                                      :process-fn   #(session/straight-jacket-process-receive-q-event store %1 %2)
+                                      :process-fn   #(session/straight-jacket-process-receive-q-event store %2 %3)
                                       :max-workers  1})
 
                 realized-eph?   (atom false)
@@ -1414,17 +1415,17 @@
       (with-session
         (fn [_store {:keys [socket]}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
-          (let [eid         (resolvers/->uuid r "eid-robocop")
-                attr-id     (resolvers/->uuid r :movie/title)
-                a-entered   (promise)
-                release     (promise)
-                call-count  (atom 0)
+          (let [eid (resolvers/->uuid r "eid-robocop")
+                attr-id (resolvers/->uuid r :movie/title)
+                a-entered (promise)
+                release (promise)
+                call-count (atom 0)
                 orig-handle session/handle-transact!
-                event       (fn [client-id v]
-                              {:op :transact
-                               :session-id (:id socket)
-                               :client-event-id client-id
-                               :tx-steps [["add-triple" eid attr-id v {:mode :upsert}]]})]
+                event (fn [client-id v]
+                        {:op :transact
+                         :session-id (:id socket)
+                         :client-event-id client-id
+                         :tx-steps [["add-triple" eid attr-id v {:mode :upsert}]]})]
             (with-redefs [session/handle-transact!
                           (fn [store sess-id evt]
                             (swap! call-count inc)
@@ -1464,15 +1465,14 @@
               (testing "value-c (event2 of the combined batch) is what's persisted"
                 (let [resp   (blocking-send-msg :add-query-ok
                                                 socket {:op :add-query
-                                                        :q (:kw-q query-1987)})
-                      titles (->> resp :result
-                                  (mapcat iq/data-seq)
-                                  (map :datalog-result)
-                                  (mapcat :join-rows)
-                                  (#(apply concat %))
-                                  (map (comp last drop-last))
-                                  set)]
-                  (is (contains? titles "value-c")))))))))))
+                                                        :return-type :tree
+                                                        :q {:movie {:$ {:where {:id (str eid)}}}}})
+                      title (-> resp
+                                :result
+                                (get "movie")
+                                first
+                                (get "title"))]
+                  (is (= title "value-c")))))))))))
 
 (deftest transact-combiner-fans-out-errors
   (with-movies-app
@@ -1480,17 +1480,17 @@
       (with-session
         (fn [_store {:keys [socket]}]
           (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
-          (let [eid         (resolvers/->uuid r "eid-robocop")
-                attr-id     (resolvers/->uuid r :movie/title)
-                a-entered   (promise)
-                release     (promise)
-                call-count  (atom 0)
+          (let [eid (resolvers/->uuid r "eid-robocop")
+                attr-id (resolvers/->uuid r :movie/title)
+                a-entered (promise)
+                release (promise)
+                call-count (atom 0)
                 orig-handle session/handle-transact!
-                event       (fn [client-id v]
-                              {:op :transact
-                               :session-id (:id socket)
-                               :client-event-id client-id
-                               :tx-steps [["add-triple" eid attr-id v {:mode :upsert}]]})]
+                event (fn [client-id v]
+                        {:op :transact
+                         :session-id (:id socket)
+                         :client-event-id client-id
+                         :tx-steps [["add-triple" eid attr-id v {:mode :upsert}]]})]
             (with-redefs [permissioned-tx/transact!
                           (fn [_ctx _coerced]
                             (ex/throw-validation-err! :tx-steps [] [{:message "test boom"}]))
@@ -1538,3 +1538,75 @@
 
               (testing "handle-transact! ran twice (a alone, b+c combined)"
                 (is (= 2 @call-count))))))))))
+
+(deftest transact-combiner-skips-has-many-refs
+  (with-zeneca-app
+    (fn [{app-id :id} r]
+      (with-session
+        (fn [_store {:keys [socket]}]
+          (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
+          (let [shelf (resolvers/->uuid r "eid-the-way-of-the-gentleman")
+                books-attr (resolvers/->uuid r :bookshelves/books)
+                ;; Three books that are NOT already on the Worldview shelf
+                book-a (resolvers/->uuid r "eid-hackers-&-painters")
+                book-b (resolvers/->uuid r "eid-antifragile")
+                book-c (resolvers/->uuid r "eid-fooled-by-randomness")
+                a-entered (promise)
+                release (promise)
+                call-count (atom 0)
+                orig-handle session/handle-transact!
+                event (fn [client-id target]
+                        {:op :transact
+                         :session-id (:id socket)
+                         :client-event-id client-id
+                         :tx-steps [["add-triple" shelf books-attr target]]})]
+            (with-redefs [session/handle-transact!
+                          (fn [store sess-id evt]
+                            (swap! call-count inc)
+                            (when (= "client-a" (:client-event-id evt))
+                              (deliver a-entered :go)
+                              (deref release 2000 :timeout))
+                            (orig-handle store sess-id evt))]
+              (receive-queue/put! (event "client-a" book-a))
+              (is (not= :timeout (deref a-entered 2000 :timeout))
+                  "worker should enter handle-transact! for client-a")
+              ;; b and c land in the queue together; they would combine if
+              ;; matching-steps? said yes. For has-many refs, each add carries
+              ;; a different target value, so combine-transact must reject.
+              (receive-queue/put! (event "client-b" book-b))
+              (receive-queue/put! (event "client-c" book-c))
+              (deliver release :go)
+
+              (let [msgs (vec (repeatedly 3
+                                          #(let [m (ua/<!!-timeout (:ws-conn socket))]
+                                             (when (= :timeout m)
+                                               (throw (ex-info "timeout waiting for ack" {})))
+                                             m)))
+                    by-id (into {} (map (juxt :client-event-id identity) msgs))]
+                (testing "every add got its own transact-ok"
+                  (is (every? #(= :transact-ok (:op %)) msgs))
+                  (is (= #{"client-a" "client-b" "client-c"} (set (keys by-id)))))
+
+                (testing "tx-ids are all distinct — no two adds collapsed"
+                  (is (= 3 (count (set (map :tx-id (vals by-id))))))))
+
+              (testing "handle-transact! ran three times (no combining)"
+                (is (= 3 @call-count)))
+
+              (testing "all three refs were persisted"
+                (let [resp     (blocking-send-msg
+                                :add-query-ok
+                                socket {:op :add-query
+                                        :return-type :tree
+                                        :q {:bookshelves {:$ {:where {:id (str shelf)}}
+                                                          :books {}}}})
+                      book-ids (->> resp
+                                    :result
+                                    (#(get % "bookshelves"))
+                                    first
+                                    (#(get % "books"))
+                                    (map #(get % "id"))
+                                    set)]
+                  (is (contains? book-ids (str book-a)))
+                  (is (contains? book-ids (str book-b)))
+                  (is (contains? book-ids (str book-c))))))))))))

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -9,6 +9,7 @@
    [instant.db.datalog :as d]
    [instant.db.instaql :as iq]
    [instant.db.model.attr :as attr-model]
+   [instant.db.permissioned-transaction :as permissioned-tx]
    [instant.db.transaction :as tx]
    [instant.fixtures :refer [with-empty-app with-movies-app with-zeneca-app]]
    [instant.flags :as flags]
@@ -27,6 +28,7 @@
    [instant.util.async :as ua]
    [instant.util.cache :as cache]
    [instant.util.coll :as ucoll]
+   [instant.util.exception :as ex]
    [instant.util.test :as test-util])
   (:import
    (com.hazelcast.core HazelcastInstance)
@@ -1405,3 +1407,134 @@
 
                 :else
                 (is (some? s))))))))))
+
+(deftest transact-combiner-collapses-redundant-events
+  (with-movies-app
+    (fn [{app-id :id} r]
+      (with-session
+        (fn [_store {:keys [socket]}]
+          (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
+          (let [eid         (resolvers/->uuid r "eid-robocop")
+                attr-id     (resolvers/->uuid r :movie/title)
+                a-entered   (promise)
+                release     (promise)
+                call-count  (atom 0)
+                orig-handle session/handle-transact!
+                event       (fn [client-id v]
+                              {:op :transact
+                               :session-id (:id socket)
+                               :client-event-id client-id
+                               :tx-steps [["add-triple" eid attr-id v {:mode :upsert}]]})]
+            (with-redefs [session/handle-transact!
+                          (fn [store sess-id evt]
+                            (swap! call-count inc)
+                            (when (= "client-a" (:client-event-id evt))
+                              (deliver a-entered :go)
+                              (deref release 2000 :timeout))
+                            (orig-handle store sess-id evt))]
+              ;; Put client-a alone, then wait until the worker has polled it
+              ;; out and is blocked inside handle-transact!. That guarantees
+              ;; b and c will land in the queue together and combine.
+              (receive-queue/put! (event "client-a" "value-a"))
+              (is (not= :timeout (deref a-entered 2000 :timeout))
+                  "worker should enter handle-transact! for client-a")
+
+              (receive-queue/put! (event "client-b" "value-b"))
+              (receive-queue/put! (event "client-c" "value-c"))
+              (deliver release :go)
+
+              (let [msgs (vec (repeatedly 3
+                                          #(let [m (ua/<!!-timeout (:ws-conn socket))]
+                                             (when (= :timeout m)
+                                               (throw (ex-info "timeout waiting for ack" {})))
+                                             m)))]
+                (testing "every client-event-id received a transact-ok"
+                  (is (every? #(= :transact-ok (:op %)) msgs))
+                  (is (= #{"client-a" "client-b" "client-c"}
+                         (set (map :client-event-id msgs)))))
+                (testing "client-b and client-c share a tx-id (combined run)"
+                  (let [by-id (into {} (map (juxt :client-event-id :tx-id) msgs))]
+                    (is (= (get by-id "client-b") (get by-id "client-c")))
+                    (is (not= (get by-id "client-a") (get by-id "client-b"))
+                        "client-a ran alone, so its tx-id differs"))))
+
+              (testing "handle-transact! ran twice (a alone, b+c combined)"
+                (is (= 2 @call-count)))
+
+              (testing "value-c (event2 of the combined batch) is what's persisted"
+                (let [resp   (blocking-send-msg :add-query-ok
+                                                socket {:op :add-query
+                                                        :q (:kw-q query-1987)})
+                      titles (->> resp :result
+                                  (mapcat iq/data-seq)
+                                  (map :datalog-result)
+                                  (mapcat :join-rows)
+                                  (#(apply concat %))
+                                  (map (comp last drop-last))
+                                  set)]
+                  (is (contains? titles "value-c")))))))))))
+
+(deftest transact-combiner-fans-out-errors
+  (with-movies-app
+    (fn [{app-id :id} r]
+      (with-session
+        (fn [_store {:keys [socket]}]
+          (blocking-send-msg :init-ok socket {:op :init :app-id app-id})
+          (let [eid         (resolvers/->uuid r "eid-robocop")
+                attr-id     (resolvers/->uuid r :movie/title)
+                a-entered   (promise)
+                release     (promise)
+                call-count  (atom 0)
+                orig-handle session/handle-transact!
+                event       (fn [client-id v]
+                              {:op :transact
+                               :session-id (:id socket)
+                               :client-event-id client-id
+                               :tx-steps [["add-triple" eid attr-id v {:mode :upsert}]]})]
+            (with-redefs [permissioned-tx/transact!
+                          (fn [_ctx _coerced]
+                            (ex/throw-validation-err! :tx-steps [] [{:message "test boom"}]))
+
+                          session/handle-transact!
+                          (fn [store sess-id evt]
+                            (swap! call-count inc)
+                            (when (= "client-a" (:client-event-id evt))
+                              (deliver a-entered :go)
+                              (deref release 2000 :timeout))
+                            (orig-handle store sess-id evt))]
+              (receive-queue/put! (event "client-a" "value-a"))
+              (is (not= :timeout (deref a-entered 2000 :timeout))
+                  "worker should enter handle-transact! for client-a")
+              (receive-queue/put! (event "client-b" "value-b"))
+              (receive-queue/put! (event "client-c" "value-c"))
+              (deliver release :go)
+
+              ;; Three errors: one for client-a (ran alone), then two from
+              ;; the combined b+c run fanned out to each client-event-id.
+              (let [errs (vec (repeatedly 3
+                                          #(let [m (ua/<!!-timeout (:ws-conn socket))]
+                                             (when (= :timeout m)
+                                               (throw (ex-info "timeout waiting for error" {})))
+                                             m)))
+                    by-id (into {} (map (juxt :client-event-id identity) errs))]
+                (testing "each client-event-id received its own :error"
+                  (is (every? #(= :error (:op %)) errs))
+                  (is (= #{"client-a" "client-b" "client-c"}
+                         (set (keys by-id))))
+                  (is (every? #(= :validation-failed (:type %)) errs)))
+
+                (testing "every error's :original-event matches the client that sent it"
+                  (doseq [[client-id expected-value] [["client-a" "value-a"]
+                                                      ["client-b" "value-b"]
+                                                      ["client-c" "value-c"]]]
+                    (let [oe (:original-event (get by-id client-id))]
+                      (is (= client-id (:client-event-id oe))
+                          (str "original-event.client-event-id mismatch for " client-id))
+                      (is (= expected-value
+                             (-> oe :tx-steps first (nth 3)))
+                          (str "tx-steps should hold this client's own value for " client-id))
+                      (is (not (contains? oe :redundant-events))
+                          (str ":redundant-events must be stripped for " client-id))))))
+
+              (testing "handle-transact! ran twice (a alone, b+c combined)"
+                (is (= 2 @call-count))))))))))


### PR DESCRIPTION
Sometimes we get a rapid repeated transactions. For example, if you use getadb with figma/claude design/etc. to build a postit board, it will do a transact per mousemove when you drag the postit.

This PR will collapse those repeated transactions into a single transaction. We can just ignore the earlier txes because they'll get overwritten anyway. Then we report the same `transact-ok` for all of them. To the client, it looks like they executed all of their transacts, but it's much less load on the db.

If we hit an error, then we'll return the same error for each transaction. This part isn't ideal because one of the transactions might have been ok. We could potentially re-enqueue the redundant transacts if the error was a non-timeout error, but I think what we have here is a good place to start.

I limited it to transacts that only have `add-triple` ops for now.