### PR TITLE
show instant verification status as true

### DIFF
--- a/client/www/lib/hooks/useCustomSenderVerification.ts
+++ b/client/www/lib/hooks/useCustomSenderVerification.ts
@@ -119,7 +119,7 @@ export const useCustomSenderVerification = (app: InstantApp) => {
 
   return {
     raw: resp,
-    instantVerified: resp.data?.instant?.['verified?'] ?? false,
+    instantVerified: resp.data?.instant?.['verified?'] ?? true,
     postmarkVerified: resp.data?.verification?.Confirmed ?? false,
     loading: resp.isValidating,
     refetch: resp.mutate,


### PR DESCRIPTION
www client side code expects shape like:
```json
{
  "instant": {
    "verified?": false
  },
  "verification": {
    "ID": 5971037,
    "Confirmed": true,
    "EmailAddress": "baba1@drewh.cloud",
    "DKIMHost": "REDACTED",
    "ReturnPathDomain": "pm-bounces.drewh.cloud",
    "DKIMPendingTextValue": "",
    "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
    "DKIMTextValue": "READCTED",
    "DKIMPendingHost": ""
  }
}
```

but in current backend the shape is {verification: {..}} without instant top level key. 

current code defaults lack of key to be equal to not verified when it should be opposite