### PR TITLE
Upgrade clj-async-profiler

### DIFF
--- a/server/deps.edn
+++ b/server/deps.edn
@@ -188,7 +188,11 @@
                              ;; headless charts
                              "-Djava.awt.headless=true"]}
            :retest {:extra-paths ["test" "dev-resources"]
-                    :main-opts ["-m" "circleci.test.retest"]}
+                    :main-opts ["-m" "circleci.test.retest"]
+                    :jvm-opts [;; clj-async-profiler
+                               "-XX:+UnlockDiagnosticVMOptions"
+                               "-XX:+DebugNonSafepoints"
+                               "-Djdk.attach.allowAttachSelf"]}
            :repl-connect {:main-opts ["-m" "nrepl.cmdline" "--connect" "--host" "localhost" "--port" "6005"]}
            :encrypt-secret {:extra-deps {org.clojure/tools.cli {:mvn/version "1.1.230"}}
                             :exec-fn tasks/encrypt-config-secret}

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -54,7 +54,7 @@
         circleci/circleci.test {:mvn/version "0.5.0"}
         org.clojure/test.check {:mvn/version "1.1.1"}
         com.github.vertical-blank/sql-formatter {:mvn/version "2.0.3"}
-        com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.6.1"}
+        com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.7.0"}
         org.clj-commons/claypoole {:mvn/version "1.2.2"}
 
         ;; opentelemetry

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -54,7 +54,7 @@
         circleci/circleci.test {:mvn/version "0.5.0"}
         org.clojure/test.check {:mvn/version "1.1.1"}
         com.github.vertical-blank/sql-formatter {:mvn/version "2.0.3"}
-        com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.7.0"}
+        com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.6.1"}
         org.clj-commons/claypoole {:mvn/version "1.2.2"}
 
         ;; opentelemetry

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -178,6 +178,11 @@
                              "--add-opens" "java.management/sun.management=ALL-UNNAMED"
                              "--add-opens" "jdk.management/com.sun.management.internal=ALL-UNNAMED"
 
+                             ;; clj-async-profiler
+                             "-XX:+UnlockDiagnosticVMOptions"
+                             "-XX:+DebugNonSafepoints"
+                             "-Djdk.attach.allowAttachSelf"
+
                              ;; throw on invalid go block usage in tests
                              "-Dclojure.core.async.go-checking=true"
                              ;; headless charts

--- a/server/test/instant/async_profiler_test.clj
+++ b/server/test/instant/async_profiler_test.clj
@@ -1,0 +1,7 @@
+(ns instant.async-profiler-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [clj-async-profiler.core :as prof]))
+
+(deftest clj-async-profiler-works
+  (is (prof/profile (inc 1))))


### PR DESCRIPTION
The profiler was crashing when trying to use it in production--replicated it with a failing test, although the failure in the test was different than the failure in production.

Will test in staging before trying it again in prod.