### PR TITLE
Throttle refresh after too much spam

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -144,7 +144,8 @@
                                                      (set vs)))
                   (update :enable-wal-entity-log-apps parse-uuids-flag)
                   (update :cloudfront-signed-url-apps parse-uuids-flag)
-                  (update :smokescreen-whitelist-ips parse-ips-flag))
+                  (update :smokescreen-whitelist-ips parse-ips-flag)
+                  (update :refresh-throttled-apps parse-uuids-flag))
         handle-receive-timeout (reduce (fn [acc {:strs [appId timeoutMs]}]
                                          (assoc acc (parse-uuid appId) timeoutMs))
                                        {}
@@ -410,3 +411,9 @@
 
 (defn combine-transacts? []
   (flag :combine-transacts true))
+
+(defn throttle-refresh? [app-id]
+  (contains? (flag :refresh-throttled-apps) app-id))
+
+(defn refresh-throttle-ms []
+  (flag :refresh-throttle-ms 1000))

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -7,12 +7,28 @@
    [instant.util.tracer :as tracer])
   (:import
    (java.util Map Queue)
-   (java.util.concurrent ConcurrentHashMap ConcurrentLinkedQueue Executor Executors ExecutorService TimeUnit)
+   (java.util.concurrent ConcurrentHashMap ConcurrentLinkedQueue Executor Executors ExecutorService ScheduledThreadPoolExecutor TimeUnit)
    (java.util.concurrent.atomic AtomicInteger)))
 
 (defn- execute [{:keys [get-executor error-fn ctx]} ^Runnable task]
   (try
     (Executor/.execute (get-executor) task)
+    (catch Exception e
+      (if error-fn
+        (error-fn ctx e)
+        (throw e)))))
+
+(defn- schedule [{:keys [scheduled-thread-pool-executor error-fn ctx] :as q}
+                 ^Long delay-ms
+                 ^Runnable task]
+  (try
+    (ScheduledThreadPoolExecutor/.schedule
+     scheduled-thread-pool-executor
+     (reify Runnable
+       (run [_]
+         (execute q task)))
+     delay-ms
+     TimeUnit/MILLISECONDS)
     (catch Exception e
       (if error-fn
         (error-fn ctx e)
@@ -24,14 +40,14 @@
   [ctx group combine-fn]
   (loop [item1 (Queue/.poll group)]
     (clojure+/cond+
-     (nil? item1) nil
-     :let [item2 (Queue/.peek group)]
-     (nil? item2) item1
-     :let [item12 (combine-fn ctx item1 item2)]
-     (nil? item12) item1
-     :else (do
-             (Queue/.remove group) ;; remove item2
-             (recur (assoc item12 ::combined (inc (::combined item1 1))))))))
+      (nil? item1) nil
+      :let [item2 (Queue/.peek group)]
+      (nil? item2) item1
+      :let [item12 (combine-fn ctx item1 item2)]
+      (nil? item12) item1
+      :else (do
+              (Queue/.remove group) ;; remove item2
+              (recur (assoc item12 ::combined (inc (::combined item1 1))))))))
 
 (declare process)
 
@@ -47,6 +63,11 @@
                             (Map/.remove groups key))))
     (execute q process-task)))
 
+(def throttle-key ::throttle-ms)
+
+(defn return-throttle [^long throttle-ms]
+  {throttle-key throttle-ms})
+
 (defn- process
   "Main worker process function"
   [process-task
@@ -61,15 +82,16 @@
   (AtomicInteger/.incrementAndGet num-workers)
   (when @processing?
     (if-some [item (poll ctx group combine-fn)]
-      (do
-        (try
-          (process-fn ctx key item)
-          (catch Throwable t
-            (tracer/record-exception-span! t {:name "grouped-queue/process-error"})))
+      (let [process-result (try
+                             (process-fn ctx key item)
+                             (catch Throwable t
+                               (tracer/record-exception-span! t {:name "grouped-queue/process-error"})))]
         (AtomicInteger/.addAndGet num-items (- (::combined item 1)))
-        (if (some? (Queue/.peek group))
-          (execute q process-task)
-          (clean-or-reschedule process-task q group key)))
+        (if-let [throttle-ms (tool/inspect (throttle-key (tool/inspect process-result)))]
+          (schedule q throttle-ms process-task)
+          (if (some? (Queue/.peek group))
+            (execute q process-task)
+            (clean-or-reschedule process-task q group key))))
       (clean-or-reschedule process-task q group key)))
   (AtomicInteger/.decrementAndGet num-workers))
 
@@ -80,7 +102,7 @@
     (let [item   (assoc item ::put-at (System/currentTimeMillis))
           key    (or (group-key-fn ctx item) ::default)
           process-task (locking q
-                         (if-some [group (Map/.get groups key)]
+                         (if-some [group (tool/inspect (Map/.get groups (tool/inspect key)))]
                            (do
                              (Queue/.offer group item)
                              nil)
@@ -127,6 +149,10 @@
 
      :get-executor :: (fn []) -> ExecutorService
 
+   A ScheduledThreadPoolExecutor to handle continuing throttled queues
+
+     :scheduled-thread-pool-executor :: ScheduledThreadPoolExecutor | nil
+
    Function that returns an executor, used for testing different executors
 
      :max-workers  :: long | nil
@@ -136,8 +162,11 @@
      :metrics-path :: String | nil
 
    A string to report gauge metrics to. If skipped, no reporting"
-  [{:keys [ctx group-key-fn combine-fn process-fn error-fn executor get-executor max-workers metrics-path]
-    :or {max-workers 2}}]
+  [{:keys [ctx group-key-fn combine-fn process-fn error-fn
+           executor get-executor scheduled-thread-pool-executor
+           max-workers metrics-path]
+    :or {max-workers 2
+         scheduled-thread-pool-executor (ScheduledThreadPoolExecutor. 1)}}]
   (let [groups       (ConcurrentHashMap.)
         accepting?   (atom true)
         processing?  (atom true)
@@ -197,6 +226,7 @@
      :num-puts     num-puts
      :num-workers  num-workers
      :get-executor get-executor
+     :scheduled-thread-pool-executor scheduled-thread-pool-executor
      :shutdown-fn  shutdown-fn}))
 
 (defn stop

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -102,7 +102,7 @@
     (let [item   (assoc item ::put-at (System/currentTimeMillis))
           key    (or (group-key-fn ctx item) ::default)
           process-task (locking q
-                         (if-some [group (tool/inspect (Map/.get groups (tool/inspect key)))]
+                         (if-some [group (Map/.get groups key)]
                            (do
                              (Queue/.offer group item)
                              nil)

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -87,7 +87,7 @@
                              (catch Throwable t
                                (tracer/record-exception-span! t {:name "grouped-queue/process-error"})))]
         (AtomicInteger/.addAndGet num-items (- (::combined item 1)))
-        (if-let [throttle-ms (tool/inspect (throttle-key (tool/inspect process-result)))]
+        (if-let [throttle-ms (throttle-key process-result)]
           (schedule q throttle-ms process-task)
           (if (some? (Queue/.peek group))
             (execute q process-task)

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -165,8 +165,7 @@
   [{:keys [ctx group-key-fn combine-fn process-fn error-fn
            executor get-executor scheduled-thread-pool-executor
            max-workers metrics-path]
-    :or {max-workers 2
-         scheduled-thread-pool-executor (ScheduledThreadPoolExecutor. 1)}}]
+    :or {max-workers 2}}]
   (let [groups       (ConcurrentHashMap.)
         accepting?   (atom true)
         processing?  (atom true)
@@ -185,6 +184,10 @@
                        :else
                        (ua/make-limited-concurrency-executor max-workers))
         get-executor (or get-executor (fn [] executor))
+        [scheduled-thread-pool-executor shutdown-scheduled-executor?]
+        (if scheduled-thread-pool-executor
+          [scheduled-thread-pool-executor false]
+          [(ScheduledThreadPoolExecutor. 1) true])
         cleanup-fn   (when metrics-path
                        (gauges/add-gauge-metrics-fn
                         (fn [_]
@@ -205,6 +208,9 @@
                          (cleanup-fn))
                        (reset! accepting? false)
                        (ExecutorService/.shutdown (get-executor))
+                       (when shutdown-scheduled-executor?
+                         (ScheduledThreadPoolExecutor/.shutdownNow scheduled-thread-pool-executor))
+
                        (if (ExecutorService/.awaitTermination (get-executor) timeout-ms TimeUnit/MILLISECONDS)
                          :shutdown
                          (do

--- a/server/src/instant/grouped_queue.clj
+++ b/server/src/instant/grouped_queue.clj
@@ -149,11 +149,11 @@
 
      :get-executor :: (fn []) -> ExecutorService
 
-   A ScheduledThreadPoolExecutor to handle continuing throttled queues
+   Function that returns an executor, used for testing different executors
 
      :scheduled-thread-pool-executor :: ScheduledThreadPoolExecutor | nil
 
-   Function that returns an executor, used for testing different executors
+   A ScheduledThreadPoolExecutor to handle continuing throttled queues
 
      :max-workers  :: long | nil
 

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -513,20 +513,24 @@
                                             :name "finish-refresh-queries"
                                             :attributes (assoc tracer-attrs
                                                                :session-id sess-id)})
-    (tracer/with-span! {:name "handle-refresh/send-event!"
-                        :attributes tracer-attrs}
-      (when (or (seq computations) attrs-changed?)
+    (if (or (seq computations) attrs-changed?)
+      (tracer/with-span! {:name "handle-refresh/send-event!"
+                          :attributes tracer-attrs}
         (rs/send-event! store app-id sess-id (with-meta
                                                (cond->
-                                                {:op :refresh-ok
-                                                 :processed-tx-id processed-tx-id
-                                                 :processed-isn processed-isn
-                                                 :computations (vec computations)}
+                                                   {:op :refresh-ok
+                                                    :processed-tx-id processed-tx-id
+                                                    :processed-isn processed-isn
+                                                    :computations (vec computations)}
                                                  (or (not can-skip-attrs?) attrs-changed?)
                                                  (assoc :attrs attrs))
                                                {:tx-id (:tx-id event)
                                                 :tx-created-at (:tx-created-at event)
-                                                :session-id sess-id}))))))
+                                                :session-id sess-id})))
+      (when (flags/throttle-refresh? app-id)
+        (let [throttle-ms (flags/refresh-throttle-ms)]
+          (tracer/add-data! {:attributes {:throttle-ms throttle-ms}})
+          (grouped-queue/return-throttle throttle-ms))))))
 
 ;; -----
 ;; transact
@@ -1142,8 +1146,9 @@
           (tracer/add-data! {:attributes {:timeout-ms timeout-ms
                                           :concurrent-handler-count (pending-handler-count session)}})
           (try
-            (let [ret (deref event-fut timeout-ms :timeout)]
-              (when (= :timeout ret)
+            (let [ret (deref event-fut timeout-ms ::timeout)]
+              (if-not (= ::timeout ret)
+                ret
                 (let [in-progress-count (count @(:stmts in-progress-stmts))
                       _ (sql/cancel-in-progress in-progress-stmts (flags/statement-cancel-wait-ms))
                       cancel-res (future-cancel event-fut)]
@@ -1152,8 +1157,8 @@
                                       :in-progress-query-count in-progress-count
                                       ;; If false, then canceling the queries let
                                       ;; the future complete before we could cancel it
-                                      :future-cancel-result cancel-res}}))
-                (ex/throw-operation-timeout! :handle-receive timeout-ms)))
+                                      :future-cancel-result cancel-res}})
+                  (ex/throw-operation-timeout! :handle-receive timeout-ms))))
 
             (catch CancellationException _e
               ;; We must have cancelled this in the on-close, so don't try to do any

--- a/server/test/instant/grouped_queue_test.clj
+++ b/server/test/instant/grouped_queue_test.clj
@@ -83,8 +83,6 @@
             (doseq [group groups
                     :let [filtered  (filterv #(= group (:group %)) @output)
                           processed (transduce (map #(::grouped-queue/combined % 1)) + 0 filtered)]]
-              (when-not (= (count ids) processed)
-                (println group (count ids) processed filtered))
               (testing group
                 (is (= (count ids) processed))))))))))
 

--- a/server/test/instant/grouped_queue_test.clj
+++ b/server/test/instant/grouped_queue_test.clj
@@ -1,8 +1,10 @@
 (ns instant.grouped-queue-test
   (:require
-   [clojure.test :refer [deftest testing is]]
-   [instant.grouped-queue :as grouped-queue])
+   [clojure.test :refer [deftest is testing]]
+   [instant.grouped-queue :as grouped-queue]
+   [instant.util.test :refer [wait-for]])
   (:import
+   (java.time Duration Instant)
    (java.util.concurrent CountDownLatch Executors)
    (java.util.concurrent.atomic AtomicInteger)))
 
@@ -104,7 +106,7 @@
         (grouped-queue/put! q item))
       (testing "put! is not blocked by execution"
         (is (< (- (System/currentTimeMillis) t0) 250)))
-    ;; give threads a chance to start
+      ;; give threads a chance to start
       (Thread/sleep (- 500 (- (System/currentTimeMillis) t0)))
       (testing "More than 1 thread spawned, but no more than 1 per group"
         (is (<= 2 (grouped-queue/num-workers q) 5)))
@@ -123,13 +125,13 @@
                             (:group item))
             :max-workers  1
             :process-fn   (fn [_ctx _group items]
-                          (if (< 3 (count (swap! processed conj items)))
-                            (do
-                              (deliver stopped true)
-                              (grouped-queue/stop @q-promise))
-                            (do
-                              (grouped-queue/put! @q-promise {:group 2})
-                              (grouped-queue/put! @q-promise {:group 1}))))
+                            (if (< 3 (count (swap! processed conj items)))
+                              (do
+                                (deliver stopped true)
+                                (grouped-queue/stop @q-promise))
+                              (do
+                                (grouped-queue/put! @q-promise {:group 2})
+                                (grouped-queue/put! @q-promise {:group 1}))))
             :error-fn     (fn [_ctx _])})]
     (deliver q-promise q)
 
@@ -140,3 +142,38 @@
 
     (is (= (map :group @processed)
            [1 2 1 2]))))
+
+(deftest throttle
+  (let [throttled? (atom false)
+        processed (atom [])
+        q (grouped-queue/start
+           {:group-key-fn (fn [_ctx item]
+                            (:group item))
+
+            :max-workers  1
+            :process-fn   (fn [_ctx _group items]
+                            (println "ITEMS" items)
+                            (swap! processed conj {:items items
+                                                   :time (Instant/now)})
+                            (when-not @throttled?
+                              (reset! throttled? true)
+                              (grouped-queue/return-throttle 500)))
+            :error-fn     (fn [_ctx _])})]
+
+    (grouped-queue/put! q {:group 1})
+    (grouped-queue/put! q {:group 1})
+    (grouped-queue/put! q {:group 1})
+
+    (wait-for (fn []
+                (<= 3 (count @processed)))
+              1000)
+
+    (is (= 3 (count @processed)))
+
+    (let [[a b c] @processed]
+      (testing "throttles the next execution"
+        (is (<= 500 (.toMillis (Duration/between (:time a)
+                                                 (:time b))))))
+      (testing "normal execution is still fast"
+        (is (> 250 (.toMillis (Duration/between (:time b)
+                                                (:time c)))))))))

--- a/server/test/instant/reactive/session_test.clj
+++ b/server/test/instant/reactive/session_test.clj
@@ -770,6 +770,60 @@
                         (resolvers/walk-friendly r)
                         pretty-subs)))))))))
 
+(deftest refresh-throttles-when-flag-enabled
+  (with-session
+    (fn [_store {:keys [socket movies-app-id]}]
+      ;; Init with a version that supports skip-attrs so the session caches an
+      ;; attrs-hash. A refresh with no stale queries then has no computations
+      ;; and an unchanged attrs hash — the conditions handle-refresh! uses to
+      ;; emit a throttle return.
+      (send-msg socket {:op :init
+                        :app-id movies-app-id
+                        :versions {session/core-version-key "0.20.5"}})
+      (is (= :init-ok (:op (read-msg socket))))
+
+      (let [refresh-times (atom [])
+            release (promise)
+            first-entered (promise)
+            orig-handle-refresh @#'session/handle-refresh!]
+        (with-redefs [flags/throttle-refresh? (constantly true)
+                      flags/refresh-throttle-ms (constantly 500)
+                      session/handle-refresh!
+                      (fn [store sess-id event debug-info]
+                        (let [n (count (swap! refresh-times conj
+                                              (System/currentTimeMillis)))]
+                          (when (= 1 n)
+                            (deliver first-entered :go)
+                            (deref release 2000 :timeout))
+                          (orig-handle-refresh store sess-id event debug-info)))]
+          ;; Put the first refresh; the worker polls it and blocks inside
+          ;; handle-refresh! until we deliver `release`. That keeps the worker
+          ;; busy so the second put lands alone in the queue rather than
+          ;; combining with the first via the [:refresh :refresh] combiner.
+          (receive-queue/put! {:op :refresh :session-id (:id socket)})
+          (is (not= :timeout (deref first-entered 2000 :timeout))
+              "worker should enter handle-refresh!")
+
+          (receive-queue/put! {:op :refresh :session-id (:id socket)})
+
+          ;; Release the blocked refresh. It returns a throttle map, which the
+          ;; grouped queue treats as a signal to delay the next process-task
+          ;; by refresh-throttle-ms.
+          (let [released-at (System/currentTimeMillis)]
+            (deliver release :go)
+
+            (test-util/wait-for #(= 2 (count @refresh-times)) 2000)
+
+            (let [[_ t2] @refresh-times
+                  gap-after-release (- t2 released-at)]
+              (testing "throttle delays the next refresh by ~refresh-throttle-ms"
+                (is (<= 500 gap-after-release)
+                    (str "expected gap-after-release >= 500ms, got "
+                         gap-after-release "ms")))))
+
+          (testing "no refresh-ok is sent when there's nothing new to report"
+            (is (= :timeout (ua/<!!-timeout (:ws-conn socket) 100)))))))))
+
 (deftest transact-requires-auth
   (with-session
     (fn [_store {:keys [socket]}]


### PR DESCRIPTION
If we have a refresh that doesn't generate any results, throttles the refresh for a second (configurable with the `refresh-throttle-ms` flag).

Being extra cautious here with a `refresh-throttled-apps` flag.

You indicate that you want to throttle by returning `(grouped-queue/return-throttle some-ms)`. When the queue sees that result, it will schedule a new execute in `some-ms` milliseconds. It skips clearing the queue, which prevents us from executing anything on that queue until the scheduler runs. 