### PR TITLE
Only write to the history table if we need it for webhooks

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -53,7 +53,8 @@
   [vs]
   (try
     (reduce-kv (fn [acc k v]
-                 (when v
+                 (if-not v
+                   acc
                    (try
                      (conj acc (parse-uuid k))
                      (catch Exception e

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -48,6 +48,22 @@
                    (log/error e "Error parsing UUID" v))))
              vs)))
 
+(defn parse-uuids-map-flag
+  "Useful when you want to do merge to update a flag."
+  [vs]
+  (try
+    (reduce-kv (fn [acc k v]
+                 (when v
+                   (try
+                     (conj acc (parse-uuid k))
+                     (catch Exception e
+                       (log/error e "Error parsing UUID" v)
+                       acc))))
+               #{}
+               vs)
+    (catch Throwable t
+      (log/error t "Error parsing uuids-map flag"))))
+
 (defn parse-ips-flag [vs]
   (set (keep (fn [v]
                (try
@@ -143,6 +159,7 @@
                   (update :more-vfutures-instances (fn [vs]
                                                      (set vs)))
                   (update :enable-wal-entity-log-apps parse-uuids-flag)
+                  (update :enable-wal-entity-log-apps-map parse-uuids-map-flag)
                   (update :cloudfront-signed-url-apps parse-uuids-flag)
                   (update :smokescreen-whitelist-ips parse-ips-flag))
         handle-receive-timeout (reduce (fn [acc {:strs [appId timeoutMs]}]
@@ -360,7 +377,8 @@
 
 (defn enable-wal-entity-log? [app-id]
   (or (toggled? :enable-wal-entity-log-globally)
-      (contains? (flag :enable-wal-entity-log-apps) app-id)))
+      (contains? (flag :enable-wal-entity-log-apps) app-id)
+      (contains? (flag :enable-wal-entity-log-apps-map) app-id)))
 
 (defn log-to-wal-log-table? []
   (toggled? :log-to-wal-log-table false))

--- a/server/src/instant/model/webhook.clj
+++ b/server/src/instant/model/webhook.clj
@@ -3,6 +3,7 @@
    [honey.sql.pg-ops :as pg-ops]
    [instant.config :as config]
    [instant.db.model.attr :as attr-model]
+   [instant.db.transaction :as tx]
    [instant.flags :as flags]
    [instant.isn :as isn]
    [instant.jdbc.aurora :as aurora]
@@ -326,6 +327,20 @@
     {:id-attr-ids id-attr-ids
      :topics topics}))
 
+(defn enable-webhooks-config-flag
+  "Enables the flag that tells us to include wal-logs for this instance."
+  [app-id]
+  (when-let [config-app-id (config/instant-config-app-id)]
+    (let [attrs (attr-model/get-by-app-id config-app-id)
+          id-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "id"] attrs))
+          setting-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "setting"] attrs))
+          value-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "value"] attrs))]
+      (tx/transact! (aurora/conn-pool :write)
+                    attrs
+                    config-app-id
+                    [[:add-triple [setting-aid "enable-wal-entity-log-apps-map"] id-aid [setting-aid "enable-wal-entity-log-apps-map"]]
+                     [:deep-merge-triple [setting-aid "enable-wal-entity-log-apps-map"] value-aid {(str app-id) true}]]))))
+
 (defn create!
   "Creates a new webhook, validating that the namespaces are valid, the webhook url is valid,
    and that the app has not exceeded the maximum number of webhooks."
@@ -335,6 +350,8 @@
    (let [{:keys [id-attr-ids topics]} (namespaces->id-attr-ids+topics! app-id namespaces)]
      (when-not (seq actions)
        (ex/throw-validation-err! :webhook {:actions actions} [{:message "Webhook must have at least one action."}]))
+
+     (enable-webhooks-config-flag app-id)
      (next.jdbc/with-transaction [conn conn]
        (take-webhook-count-lock! conn app-id)
        (check-webhook-limit! conn app-id)

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -423,9 +423,9 @@
                             ;; We create the history entries and the webhook events before flushing the
                             ;; lsn so that we never miss a wal entry. We may handle the same entry twice,
                             ;; but `push-batch` and `create-events!` are idempotent functions
-                            (let [logging-batches (filter (fn [wal-record]
-                                                            (or (not (empty? (:messages wal-record)))
-                                                                (not (empty? (:wal-logs wal-record)))))
+                            (let [logging-batches (remove (fn [wal-record]
+                                                            (and (empty? (:messages wal-record))
+                                                                 (empty? (:wal-logs wal-record))))
                                                           batch)
                                   webhook-matches (history-model/push-batch! logging-batches)
                                   events (webhook-model/create-events! logging-batches webhook-matches)]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -423,8 +423,12 @@
                             ;; We create the history entries and the webhook events before flushing the
                             ;; lsn so that we never miss a wal entry. We may handle the same entry twice,
                             ;; but `push-batch` and `create-events!` are idempotent functions
-                            (let [webhook-matches (history-model/push-batch! batch)
-                                  events (webhook-model/create-events! batch webhook-matches)]
+                            (let [logging-batches (filter (fn [wal-record]
+                                                            (or (not (empty? (:messages wal-record)))
+                                                                (not (empty? (:wal-logs wal-record)))))
+                                                          batch)
+                                  webhook-matches (history-model/push-batch! logging-batches)
+                                  events (webhook-model/create-events! logging-batches webhook-matches)]
                               (when (seq events)
                                 (notify-webhook-events events)))
                             (a/put! flush-lsn-chan (:nextlsn (.get batch (dec (.size batch))))))


### PR DESCRIPTION
This PR should reduce the load on the database a bit. After this PR, we'll only write to the history table if the app has webhooks enabled.

To make sure that we capture wal-logs for apps with webhooks, we update an instant-config setting with the new app. I added a new `enable-wal-entity-log-apps-map` flag that lets us call deep-merge-triple (the other setting is just a vector).