### PR TITLE
Track webhook latency for the status page

### DIFF
--- a/server/src/instant/cloudwatch.clj
+++ b/server/src/instant/cloudwatch.clj
@@ -1,14 +1,23 @@
 (ns instant.cloudwatch
   (:require
    [clojure.string]
+   [instant.config :as config]
    [instant.util.coll :as ucoll]
    [instant.util.crypt :as crypt-util]
    [instant.util.tracer :as tracer])
   (:import
+   (com.google.common.collect EvictingQueue Queues)
+   (java.io ByteArrayInputStream)
    (java.time Instant)
    (java.time.temporal ChronoUnit)
-   (software.amazon.awssdk.services.cloudwatch CloudWatchClient)
-   (software.amazon.awssdk.services.cloudwatch.model GetMetricDataRequest GetMetricDataResponse MetricDataQuery MetricDataResult ScanBy)
+   (java.util Queue)
+   (software.amazon.awssdk.auth.credentials AwsBasicCredentials StaticCredentialsProvider)
+   (software.amazon.awssdk.core.client.config ClientOverrideConfiguration)
+   (software.amazon.awssdk.core.interceptor ExecutionInterceptor)
+   (software.amazon.awssdk.http AbortableInputStream ExecutableHttpRequest HttpExecuteResponse SdkHttpClient SdkHttpResponse)
+   (software.amazon.awssdk.regions Region)
+   (software.amazon.awssdk.services.cloudwatch CloudWatchClient CloudWatchClientBuilder)
+   (software.amazon.awssdk.services.cloudwatch.model GetMetricDataRequest GetMetricDataResponse MetricDataQuery MetricDataResult MetricDatum PutMetricDataRequest ScanBy StandardUnit)
    (software.amazon.awssdk.services.rds RdsClient)
    (software.amazon.awssdk.services.rds.model DBInstance DescribeDbInstancesResponse)))
 
@@ -16,6 +25,76 @@
 
 (defonce rds-client (delay (-> (RdsClient/builder)
                                (.build))))
+
+(defonce ^{:tag Queue} captured-metric-data
+  (Queues/synchronizedQueue (EvictingQueue/create 1000)))
+
+(def ^:private capturing-interceptor
+  (reify ExecutionInterceptor
+    (beforeTransmission [_ context _attrs]
+      (let [req (.request context)]
+        (when (instance? PutMetricDataRequest req)
+          (doseq [data (PutMetricDataRequest/.metricData req)]
+            (.add captured-metric-data data)))))))
+
+(def ^{:tag String} fake-put-metric-response-xml
+  "<PutMetricDataResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\"><ResponseMetadata><RequestId>dev-mock</RequestId></ResponseMetadata></PutMetricDataResponse>")
+
+(def ^{:tag SdkHttpClient} noop-http-client
+  (reify SdkHttpClient
+    (prepareRequest [_ _req]
+      (reify ExecutableHttpRequest
+        (call [_]
+          (-> (HttpExecuteResponse/builder)
+              (.response (-> (SdkHttpResponse/builder)
+                             (.statusCode 200)
+                             (.putHeader "Content-Type" "text/xml")
+                             (.build)))
+              (.responseBody (AbortableInputStream/create
+                              (ByteArrayInputStream.
+                               (.getBytes fake-put-metric-response-xml))))
+              (.build)))
+        (abort [_])))
+    (close [_])))
+
+(defn- make-capturing-cloudwatch-client
+  "Creates a dev/test client that stores the last 1000 metrics in
+  `captured-metric-data` instead of posting to cloudwatch."
+  ^CloudWatchClient []
+  (let [^ClientOverrideConfiguration override-config
+        (-> (ClientOverrideConfiguration/builder)
+            (.addExecutionInterceptor capturing-interceptor)
+
+            (.build))]
+    (-> (CloudWatchClient/builder)
+        (.region Region/US_EAST_1)
+        (.credentialsProvider (StaticCredentialsProvider/create
+                               (AwsBasicCredentials/create "fake" "fake")))
+
+        (CloudWatchClientBuilder/.httpClient noop-http-client)
+        (CloudWatchClientBuilder/.overrideConfiguration override-config)
+        (.build))))
+
+(defonce write-cloudwatch-client
+  (delay (if (config/aws-env?)
+           (CloudWatchClient/create)
+           (make-capturing-cloudwatch-client))))
+
+(defn record-webhook-latency-ms!
+  ([^Instant recorded-at latency-ms]
+   (record-webhook-latency-ms! @write-cloudwatch-client recorded-at latency-ms))
+  ([^CloudWatchClient client recorded-at latency-ms]
+   (let [datum (-> (MetricDatum/builder)
+                   (.metricName "webhook-latency")
+                   (.value (double latency-ms))
+                   (.unit StandardUnit/MILLISECONDS)
+                   (.timestamp recorded-at)
+                   (.build))
+         request (-> (PutMetricDataRequest/builder)
+                     (.namespace "Instant")
+                     (.metricData (ucoll/array-of MetricDatum [datum]))
+                     (.build))]
+     (.putMetricData client ^PutMetricDataRequest request))))
 
 (defn all-rds-instance-ids
   "Returns all resource ids for all database instances in RDS."

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -3,6 +3,7 @@
    [clojure.core.async :as a]
    [clojure.set :as set]
    [datascript.core :as ds]
+   [instant.cloudwatch :as cloudwatch]
    [instant.config :as config]
    [instant.db.pg-introspect :as pg-introspect]
    [instant.flags :as flags]
@@ -29,10 +30,11 @@
    (instant.grpc InvalidatorSubscribe PackedWalRecord SlotDisconnect WalRecord WebhookEvents)
    (io.grpc Status Status$Code)
    (io.grpc.stub ServerCallStreamObserver StreamObserver)
+   (java.lang Thread$UncaughtExceptionHandler)
    (java.sql Timestamp)
    (java.time Instant)
    (java.time.temporal ChronoUnit)
-   (java.util ArrayList Map Queue)
+   (java.util ArrayList Map Queue DoubleSummaryStatistics)
    (java.util.concurrent ConcurrentHashMap Executors LinkedBlockingQueue TimeUnit)
    (org.postgresql.replication LogSequenceNumber)))
 
@@ -396,6 +398,16 @@
            on-error
            notify-webhook-events]}]
   (let [executor (Executors/newSingleThreadExecutor)
+        stats-executor (Executors/newThreadPerTaskExecutor
+                        (.. (Thread/ofVirtual)
+                            (uncaughtExceptionHandler
+                             (reify Thread$UncaughtExceptionHandler
+                               (uncaughtException [_ _ e]
+                                 (tracer/record-exception-span!
+                                  e
+                                  {:name "invalidator/publish-stats-error"
+                                   :escaping? false}))))
+                            (factory)))
         q (LinkedBlockingQueue.)
         stop-gauge (gauges/add-gauge-metrics-fn (fn [_]
                                                   [{:path "instant.reactive.invalidator.save-history-queue.size"
@@ -411,6 +423,8 @@
                   (run [_]
                     (try
                       (loop [batch (ArrayList.)
+                             stats (DoubleSummaryStatistics.)
+                             last-stat-send 0
                              ;; First item will block
                              item (.take q)]
                         (.add batch item)
@@ -431,11 +445,29 @@
                                   events (webhook-model/create-events! logging-batches webhook-matches)]
                               (when (seq events)
                                 (notify-webhook-events events)))
+
+                            (let [latency (- (System/currentTimeMillis)
+                                             (Instant/.toEpochMilli (:tx-created-at (first batch))))]
+                              (.accept stats latency))
+
                             (a/put! flush-lsn-chan (:nextlsn (.get batch (dec (.size batch))))))
 
                           (when-not quit?
-                            (recur (ArrayList.)
-                                   (.take q)))))
+                            (let [now (System/currentTimeMillis)
+                                  send-stats? (and (pos? (.getCount stats))
+                                                   ;; Send stats once a minute
+                                                   (<= 60000 (- now last-stat-send)))]
+                              (when send-stats?
+                                (.execute stats-executor (reify Runnable
+                                                           (run [_]
+                                                             (cloudwatch/record-webhook-latency-ms!
+                                                              (Instant/ofEpochMilli now)
+                                                              (.getAverage stats))))))
+                              (tool/def-locals)
+                              (recur (ArrayList.)
+                                     (if send-stats? (DoubleSummaryStatistics.) stats)
+                                     (if send-stats? now last-stat-send)
+                                     (.take q))))))
                       (catch Throwable t
                         (on-error t))
                       (finally
@@ -450,7 +482,9 @@
                  (reset! shutdown? true)
                  (.put q shutdown-sentinel)
                  (.shutdown executor)
+                 (.shutdown stats-executor)
                  (.awaitTermination executor 20 TimeUnit/SECONDS)
+                 (.awaitTermination stats-executor 5 TimeUnit/SECONDS)
                  (stop-gauge))}))
 
 (defn broadcast-wal-record [get-remote-observers packed-wal-record]

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -463,7 +463,6 @@
                                                              (cloudwatch/record-webhook-latency-ms!
                                                               (Instant/ofEpochMilli now)
                                                               (.getAverage stats))))))
-                              (tool/def-locals)
                               (recur (ArrayList.)
                                      (if send-stats? (DoubleSummaryStatistics.) stats)
                                      (if send-stats? now last-stat-send)
@@ -482,8 +481,8 @@
                  (reset! shutdown? true)
                  (.put q shutdown-sentinel)
                  (.shutdown executor)
-                 (.shutdown stats-executor)
                  (.awaitTermination executor 20 TimeUnit/SECONDS)
+                 (.shutdown stats-executor)
                  (.awaitTermination stats-executor 5 TimeUnit/SECONDS)
                  (stop-gauge))}))
 


### PR DESCRIPTION
Tracks webhook latency for the status page.

We send the latency to a cloudwatch metric once every minute. I chose to use a cloudwatch metric because the status page already uses a cloudwatch metric for uptime. It will cost us $0.30/month.

This metric will track from the time the tx is created to the time that it is written to the webhook events table. I couldn't find a nice way to track all of the way until we send the event--but I think this is fine. When the event is in the table, it's possible for a client to query for it directly through the API.

In dev/test/non-aws, we store the last 1000 metrics in memory. This way we don't pay an extra cost for those cloudwatch metrics, but we can still test it out a bit.