### PR TITLE
Load balancer drain notifications

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -112,6 +112,25 @@ prod-down:
 		read ans && [ $$ans = y ] && \
 		migrate -verbose -database "$${DATABASE_URL}" -source "$${SOURCE_URL}" down 1
 
+staging-version:
+	@DATABASE_URL=$$(./scripts/prod_connection_string.sh --cluster-id "instant-aurora-staging"); \
+	SOURCE_URL=$$($(migration_source)); \
+	migrate -verbose -database "$${DATABASE_URL}" -source "$${SOURCE_URL}" version
+
+staging-up:
+	@DATABASE_URL=$$(./scripts/prod_connection_string.sh --cluster-id "instant-aurora-staging"); \
+	SOURCE_URL=$$($(migration_source)); \
+	echo "[IMPORTANT] Migrating staging up to latest -- are you sure you want to do this? [y/N]" && \
+		read ans && [ $$ans = y ] && \
+		migrate -verbose -database "$${DATABASE_URL}" -source "$${SOURCE_URL}" up
+
+staging-down:
+	@DATABASE_URL=$$(./scripts/prod_connection_string.sh --cluster-id "instant-aurora-staging"); \
+	SOURCE_URL=$$($(migration_source)); \
+	echo "[IMPORTANT] Migrating staging db down by 1 -- are you sure you want to do this? [y/N]" && \
+		read ans && [ $$ans = y ] && \
+		migrate -verbose -database "$${DATABASE_URL}" -source "$${SOURCE_URL}" down 1
+
 psql:
 	@echo "Connecting to local db..."
 	psql -h localhost -d instant

--- a/server/deps.edn
+++ b/server/deps.edn
@@ -24,14 +24,16 @@
         org.slf4j/slf4j-api {:mvn/version "2.0.13"}
         cider/cider-nrepl {:mvn/version "0.45.0"}
 
-        software.amazon.awssdk/ec2 {:mvn/version "2.41.31"}
-        software.amazon.awssdk/rds {:mvn/version "2.41.31"}
-        software.amazon.awssdk/secretsmanager {:mvn/version "2.41.31"}
-        software.amazon.awssdk/s3 {:mvn/version "2.41.31"}
-        software.amazon.awssdk/bedrockruntime {:mvn/version "2.41.31"}
-        software.amazon.awssdk/cloudwatch {:mvn/version "2.41.32"}
-        software.amazon.awssdk.crt/aws-crt {:mvn/version "0.40.3"}
-
+        software.amazon.awssdk/ec2 {:mvn/version "2.46.2"}
+        software.amazon.awssdk/rds {:mvn/version "2.46.2"}
+        software.amazon.awssdk/secretsmanager {:mvn/version "2.46.2"}
+        software.amazon.awssdk/s3 {:mvn/version "2.46.2"}
+        software.amazon.awssdk/s3-transfer-manager {:mvn/version "2.46.2"}
+        software.amazon.awssdk/bedrockruntime {:mvn/version "2.46.2"}
+        software.amazon.awssdk/cloudwatch {:mvn/version "2.46.2"}
+        software.amazon.awssdk/sqs {:mvn/version "2.46.2"}
+        software.amazon.awssdk/sns {:mvn/version "2.46.2"}
+        software.amazon.awssdk.crt/aws-crt {:mvn/version "0.46.1"}
         juji/editscript {:mvn/version "0.6.4"}
         io.github.tonsky/clojure-plus {:mvn/version "1.6.3"}
 
@@ -122,8 +124,11 @@
                               io.github.tonsky/clj-reload   {:mvn/version "0.9.8"}
                               ;; https://github.com/kkinnear/zprint/pull/351
                               io.github.tonsky/zprint       {:mvn/version "1.2.10"}
-                              virgil/virgil {:mvn/version "0.5.0"}
-                              com.squareup.okhttp3/mockwebserver3 {:mvn/version "5.3.2"}}
+                              com.squareup.okhttp3/mockwebserver3 {:mvn/version "5.3.2"}
+                              virgil/virgil {:mvn/version "0.5.1"}
+                              ;; asm deps add support for Java 26 (can remove once virgil updates)
+                              org.ow2.asm/asm {:mvn/version "9.9.1"}
+                              org.ow2.asm/asm-tree {:mvn/version "9.9.1"}}
                  :jvm-opts ["-XX:+UseZGC"
                             "-enableassertions"
                             "-Djdk.tracePinnedThreads=full"

--- a/server/resources/config/staging.edn
+++ b/server/resources/config/staging.edn
@@ -41,4 +41,4 @@
 
  :instant-config-app-id #uuid "24a4d71b-7bb2-4630-9aee-01146af26239"
 
- :database-cluster-id "instant-aurora-staging-cluster"}
+ :database-cluster-id "instant-aurora-staging"}

--- a/server/scripts/eb_deploy.clj
+++ b/server/scripts/eb_deploy.clj
@@ -71,7 +71,7 @@
   (println "Deploying " (get version "VersionLabel") " " (get version "Description"))
   (Thread/sleep 500)
   (apply exec
-         (str "eb deploy Instant-docker-prod-env-2 --version " (get version "VersionLabel"))
+         (str "eb deploy Instant-docker-prod-env-2 --version " (get version "VersionLabel") " --timeout 60")
          *command-line-args*))
 
 (defn check-db [version]

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -244,7 +244,7 @@
   (or (System/getenv "INSTANCE_EVENTS_SNS_TOPIC_ARN")
       "arn:aws:sns:us-east-1:597134865416:instance-events"))
 
-(def instance-events-sqs-topic-arn-prefix
+(def instance-events-sqs-queue-arn-prefix
   (or (System/getenv "INSTANCE_EVENTS_SQS_TOPIC_ARN_PREFIX")
       "arn:aws:sqs:us-east-1:597134865416:"))
 

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -240,6 +240,14 @@
          :staging "https://staging.instantdb.com"
          "http://localhost:3000"))))
 
+(def instance-events-sns-topic-arn
+  (or (System/getenv "INSTANCE_EVENTS_SNS_TOPIC_ARN")
+      "arn:aws:sns:us-east-1:597134865416:instance-events"))
+
+(def instance-events-sqs-topic-arn-prefix
+  (or (System/getenv "INSTANCE_EVENTS_SQS_TOPIC_ARN_PREFIX")
+      "arn:aws:sqs:us-east-1:597134865416:"))
+
 ;; ---
 ;; Stripe
 (defn stripe-secret []

--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -29,6 +29,7 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.wal :as wal]
    [instant.lib.ring.undertow :as undertow-adapter]
+   [instant.loadbalancer :as loadbalancer-listener]
    [instant.mma-example :as mma-example]
    [instant.machine-summaries]
    [instant.nippy]
@@ -340,7 +341,10 @@
           (wal-log-model/stop)))
       (future
         (tracer/with-span! {:name "stop-history-truncator"}
-          (history-model/stop)))))
+          (history-model/stop)))
+      (future
+        (tracer/with-span! {:name "stop-loadbalancer-listener"}
+          (loadbalancer-listener/stop)))))
   (tracer/shutdown))
 
 (defn add-shutdown-hook []
@@ -451,6 +455,13 @@
         (admin-tx-queue/start))
       (with-log-init :web-server
         (start))
+      (try
+        (when @config/instance-id
+          (with-log-init :loadbalancer-listener
+            (loadbalancer-listener/start)))
+        (catch Throwable t
+          (tracer/record-exception-span! t {:name "load-balancer-listener-init-error"
+                                            :escaping? false})))
       (log/info "Finished initializing"))
     (catch Throwable t
       (log/error t "Error in startup")

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -436,3 +436,9 @@
 
 (defn refresh-throttle-ms []
   (flag :refresh-throttle-ms 1000))
+
+(defn deregister-targets-drain-ms
+  "The number of milliseconds we should spend draining connections after we
+   get the DeregisterTargets notification from the load balancer."
+  []
+  (flag :deregister-targets-drain-ms (* 1000 60 4.5)))

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -1,0 +1,188 @@
+(ns instant.loadbalancer
+  (:require
+   [instant.config :as config]
+   [instant.flags :as flags]
+   [instant.reactive.store :as rs]
+   [instant.util.async :as ua]
+   [instant.util.coll :as ucoll]
+   [instant.util.json :as json]
+   [instant.util.tracer :as tracer])
+  (:import
+   (java.time Duration Instant)
+   (software.amazon.awssdk.services.sns SnsClient)
+   (software.amazon.awssdk.services.sns.model SubscribeRequest UnsubscribeRequest)
+   (software.amazon.awssdk.services.sqs SqsClient)
+   (software.amazon.awssdk.services.sqs.model CreateQueueRequest DeleteMessageRequest DeleteQueueRequest Message QueueAttributeName ReceiveMessageRequest ReceiveMessageRequest)))
+
+(defonce process (atom nil))
+
+(defonce sns-client* (delay (.. (SnsClient/builder)
+                                (build))))
+
+(defn sns-client ^SnsClient [] @sns-client*)
+
+(defonce sqs-client* (delay (.. (SqsClient/builder)
+                                (build))))
+
+(defn sqs-client ^SqsClient [] @sqs-client*)
+
+(defn sqs-policy ^String [queue-arn]
+  (json/->json
+   {:Version "2012-10-17"
+    :Statement [{:Effect "Allow"
+                 :Principal {:Service "sns.amazonaws.com"}
+                 :Action "sqs:SendMessage"
+                 :Resource queue-arn
+                 :Condition {:ArnEquals {"aws:SourceArn" config/instance-events-sns-topic-arn}}}]}))
+
+(defn create-queue [suffix]
+  (let [queue-name (str "loadbalancer-queue-" @config/process-id suffix)
+        queue-arn (str config/instance-events-sqs-topic-arn-prefix queue-name)
+        req (.. (CreateQueueRequest/builder)
+                (queueName queue-name)
+                (attributes {QueueAttributeName/POLICY (sqs-policy queue-arn)})
+                (tags {"instance-id" @config/instance-id
+                       "created-at" (str (Instant/now))})
+                (build))]
+    {:url (-> (.createQueue (sqs-client) ^CreateQueueRequest req)
+              (.queueUrl))
+     :arn queue-arn}))
+
+(defn delete-queue [queue-url]
+  (let [req (.. (DeleteQueueRequest/builder)
+                (queueUrl queue-url)
+                (build))]
+    (.deleteQueue (sqs-client) ^DeleteQueueRequest req)))
+
+(defn subscribe-to-sns [queue-arn]
+  (let [req (.. (SubscribeRequest/builder)
+                (topicArn config/instance-events-sns-topic-arn)
+                (protocol "sqs")
+                (endpoint queue-arn)
+                (attributes {"RawMessageDelivery" "true"})
+                (build))
+        resp (.subscribe (sns-client) ^SubscribeRequest req)]
+    {:arn (.subscriptionArn resp)}))
+
+(defn unsubscribe-from-sns [subscription-arn]
+  (let [req (.. (UnsubscribeRequest/builder)
+                (subscriptionArn subscription-arn)
+                (build))]
+    (.unsubscribe (sns-client) ^UnsubscribeRequest req)))
+
+(defn get-messages [queue-url]
+  (let [req (.. (ReceiveMessageRequest/builder)
+                (queueUrl queue-url)
+                (maxNumberOfMessages (int 10))
+                (waitTimeSeconds (int 1)) ; 20
+                (build))]
+    (-> (.receiveMessage (sqs-client) ^ReceiveMessageRequest req)
+        (.messages))))
+
+(defn delete-message [queue-url ^Message message]
+  (let [req (.. (DeleteMessageRequest/builder)
+                (queueUrl queue-url)
+                (receiptHandle (.receiptHandle message))
+                (build))]
+    (.deleteMessage (sqs-client) ^DeleteMessageRequest req)))
+
+(defn poll-queue [queue-url on-message]
+  (loop [backoff 0]
+    (let [next-action (try
+                        (let [messages (get-messages queue-url)]
+                          (doseq [^Message message messages]
+                            (on-message (json/<-json (.body message) true))
+                            (delete-message queue-url message))
+                          :continue)
+                        (catch Throwable t
+                          (tracer/record-exception-span! t {:name "loadbalancer/get-messages-errror"})
+                          :backoff))]
+      (case next-action
+        :continue (recur 0)
+        :backoff
+        (do (Thread/sleep (long (* 1000
+                                   (get [2 10 30 60] backoff 60))))
+            (recur (inc backoff))))))
+  (tracer/record-exception-span! (ex-info "Poll Queue Existed Early" {:queue-url queue-url})
+                                 {:name "loadbalancer/poll-queue-error"}))
+
+(defn add-conn-drain [conn-drain-futs]
+  (let [drain-id (random-uuid)
+        conn-drains (swap! conn-drain-futs
+                           (fn [futs]
+                             (let [now (Instant/now)]
+                               (if (ucoll/seek (fn [[_k {:keys [started-at]}]]
+                                                 (pos? (compare (Duration/ofMinutes 2)
+                                                                (Duration/between started-at now))))
+                                               futs)
+                                 ;; We already started a shutdown in the last 2 minutes
+                                 futs
+                                 (assoc futs drain-id {:started-at now
+                                                       :process (promise)})))))]
+    (when-let [process-promise (-> conn-drains (get drain-id) :process)]
+      (let [total-ms (flags/deregister-targets-drain-ms)]
+        (deliver process-promise (ua/vfut-bg
+                                  (try
+                                    (tracer/with-span! {:name "loadbalancer/close-connections"}
+                                      (rs/close-connections rs/store {:total-ms total-ms
+                                                                      :max-gap-ms 1000}))
+                                    (finally
+                                      (swap! conn-drain-futs dissoc drain-id)))))))))
+
+(defn handle-message [conn-drain-futs body]
+  (let [event (-> body :detail :eventName)]
+    (tracer/with-span! {:name "loadbalancer/handle-sns-message"
+                        :attributes {:event event
+                                     :body body}}
+      (when (= "DeregisterTargets" event)
+        (let [target-ids (->> body
+                              :detail
+                              :requestParameters
+                              :targets
+                              (map :id))]
+          (when (ucoll/seek (fn [instance-id]
+                              (and instance-id
+                                   (= instance-id @config/instance-id)))
+                            target-ids)
+            (add-conn-drain conn-drain-futs)))))))
+
+;; XXX: Needs a cleanup process
+
+(defn start
+  ([] (start nil))
+  ([queue-suffix]
+   (let [q (create-queue queue-suffix)
+         sns (subscribe-to-sns (:arn q))
+         conn-drain-futs (atom {})
+         queue-listener (ua/vfut-bg
+                         (poll-queue (:url q)
+                                     (partial handle-message conn-drain-futs)))
+         shutdown (fn []
+                    (future-cancel queue-listener)
+                    (doseq [drain-fut @conn-drain-futs]
+                      (future-cancel drain-fut))
+                    (try
+                      (unsubscribe-from-sns (:arn sns))
+                      (catch Throwable t
+                        (tracer/record-exception-span! t {:name "loadbalancer/unsubscribe-sns-error"})))
+                    (try
+                      (delete-queue (:url q))
+                      (catch Throwable t
+                        (tracer/record-exception-span! t {:name "loadbalancer/delete-sqs-queue-error"}))))]
+     (reset! process {:q q
+                      :queue-suffix queue-suffix
+                      :sns sns
+                      :conn-drain-futs conn-drain-futs
+                      :queue-listener queue-listener
+                      :shutdown shutdown}))))
+
+(defn stop []
+  (let [[old _new] (swap-vals! process (fn [_] nil))]
+    (when-let [shutdown (:shutdown old)]
+      (shutdown))))
+
+(defn restart []
+  (stop)
+  ;; Give it a suffix because you have to wait 60 seconds
+  ;; for the queue to restart
+  (start (str "-" (rand-int 10000))))

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -1,5 +1,6 @@
 (ns instant.loadbalancer
   (:require
+   [clojure.string]
    [instant.config :as config]
    [instant.flags :as flags]
    [instant.reactive.store :as rs]
@@ -10,9 +11,17 @@
   (:import
    (java.time Duration Instant)
    (software.amazon.awssdk.services.sns SnsClient)
-   (software.amazon.awssdk.services.sns.model SubscribeRequest UnsubscribeRequest)
+   (software.amazon.awssdk.services.sns.model ListSubscriptionsByTopicRequest SubscribeRequest Subscription UnsubscribeRequest)
    (software.amazon.awssdk.services.sqs SqsClient)
-   (software.amazon.awssdk.services.sqs.model CreateQueueRequest DeleteMessageRequest DeleteQueueRequest Message QueueAttributeName ReceiveMessageRequest ReceiveMessageRequest)))
+   (software.amazon.awssdk.services.sqs.model CreateQueueRequest DeleteMessageRequest DeleteQueueRequest GetQueueUrlRequest ListQueueTagsRequest ListQueuesRequest Message QueueAttributeName QueueDoesNotExistException ReceiveMessageRequest ReceiveMessageRequest)))
+
+;; There's an EventBridge subscription that publishes loadbalancer events to SNS.
+;; Each machine subscribes to SNS through an SQS queue it creates.
+;; When we get a `DeregisterTargets` message for our instance-id (all machines get
+;; all events), we start closing connections so that they will all be closed before
+;; the loadbalancer forcibly closes them.
+;; SNS topic: https://us-east-1.console.aws.amazon.com/sns/v3/home?region=us-east-1#/topic/arn:aws:sns:us-east-1:597134865416:instance-events
+;; Eventbridge rule: https://us-east-1.console.aws.amazon.com/events/home?region=us-east-1#/eventbus/default/rules/notify-target-group-scaling
 
 (defonce process (atom nil))
 
@@ -35,14 +44,17 @@
                  :Resource queue-arn
                  :Condition {:ArnEquals {"aws:SourceArn" config/instance-events-sns-topic-arn}}}]}))
 
+(def ^{:tag String} queue-prefix "loadbalancer-queue-")
+
 (defn create-queue [suffix]
-  (let [queue-name (str "loadbalancer-queue-" @config/process-id suffix)
+  (let [queue-name (str queue-prefix @config/process-id suffix)
         queue-arn (str config/instance-events-sqs-topic-arn-prefix queue-name)
         req (.. (CreateQueueRequest/builder)
                 (queueName queue-name)
                 (attributes {QueueAttributeName/POLICY (sqs-policy queue-arn)})
                 (tags {"instance-id" @config/instance-id
-                       "created-at" (str (Instant/now))})
+                       "created-at" (str (Instant/now))
+                       "env" (name (config/get-env))})
                 (build))]
     {:url (-> (.createQueue (sqs-client) ^CreateQueueRequest req)
               (.queueUrl))
@@ -112,8 +124,7 @@
                            (fn [futs]
                              (let [now (Instant/now)]
                                (if (ucoll/seek (fn [[_k {:keys [started-at]}]]
-                                                 (pos? (compare (Duration/ofMinutes 2)
-                                                                (Duration/between started-at now))))
+                                                 (>= 120 (.toSeconds (Duration/between started-at now))))
                                                futs)
                                  ;; We already started a shutdown in the last 2 minutes
                                  futs
@@ -146,35 +157,100 @@
                             target-ids)
             (add-conn-drain conn-drain-futs)))))))
 
-;; XXX: Needs a cleanup process
+(defn create-process [queue-suffix]
+  (let [q (create-queue queue-suffix)
+        sns (subscribe-to-sns (:arn q))
+        conn-drain-futs (atom {})
+        queue-listener (ua/vfut-bg
+                        (poll-queue (:url q)
+                                    (partial handle-message conn-drain-futs)))
+        shutdown (fn []
+                   (future-cancel queue-listener)
+                   (doseq [drain-fut @conn-drain-futs]
+                     (future-cancel drain-fut))
+                   (try
+                     (unsubscribe-from-sns (:arn sns))
+                     (catch Throwable t
+                       (tracer/record-exception-span! t {:name "loadbalancer/unsubscribe-sns-error"})))
+                   (try
+                     (delete-queue (:url q))
+                     (catch Throwable t
+                       (tracer/record-exception-span! t {:name "loadbalancer/delete-sqs-queue-error"}))))]
+    {:q q
+     :queue-suffix queue-suffix
+     :sns sns
+     :conn-drain-futs conn-drain-futs
+     :queue-listener queue-listener
+     :shutdown shutdown}))
+
+(defn orphaned-queues []
+  (let [req (.. (ListQueuesRequest/builder)
+                (maxResults (int 1000))
+                (queueNamePrefix queue-prefix)
+                (build))
+        now (Instant/now)]
+    (keep (fn [queue-url]
+            (try
+              (let [req (.. (ListQueueTagsRequest/builder)
+                            (queueUrl queue-url)
+                            (build))
+                    tags (.tags (.listQueueTags (sqs-client) ^ListQueueTagsRequest req))
+                    created-at (some-> tags (get "created-at") (Instant/parse))]
+                (when (and (= (get tags "env") (name (config/get-env)))
+                           (<= 60 (.toDays (Duration/between created-at now))))
+                  {:url queue-url
+                   :tags tags
+                   :created-at created-at}))
+              (catch QueueDoesNotExistException _
+                nil)))
+          (.queueUrls (.listQueues (sqs-client) ^ListQueuesRequest req)))))
+
+(defn queue-exists-by-queue-name? [queue-name]
+  (let [req (.. (GetQueueUrlRequest/builder)
+                (queueName queue-name)
+                (build))]
+    (try
+      (.getQueueUrl (sqs-client) ^GetQueueUrlRequest req)
+      (catch QueueDoesNotExistException _
+        false))))
+
+(defn orphaned-subscriptions []
+  (let [req (.. (ListSubscriptionsByTopicRequest/builder)
+                (topicArn config/instance-events-sns-topic-arn)
+                (build))
+        subscriptions (-> (.listSubscriptionsByTopic (sns-client)
+                                                     ^ListSubscriptionsByTopicRequest req)
+                          (.subscriptions))]
+    (keep (fn [^Subscription sub]
+            (when (and (= (.protocol sub) "sqs")
+                       (some-> (.endpoint sub)
+                               (clojure.string/starts-with? (str config/instance-events-sqs-topic-arn-prefix
+                                                                 queue-prefix))))
+              (let [queue-name (subs (.endpoint sub) (count config/instance-events-sqs-topic-arn-prefix))]
+                (when-not (queue-exists-by-queue-name? queue-name)
+                  {:arn (.subscriptionArn sub)
+                   :endpoint (.endpoint sub)
+                   :protocol (.protocol sub)}))))
+          subscriptions)))
+
+(defn cleanup-stale []
+  (doseq [q (orphaned-queues)]
+    (tracer/with-span! {:name "loadbalancer/remove-orphaned-queue"
+                        :attributes q}
+      (delete-queue (:url q))))
+  (doseq [s (orphaned-subscriptions)]
+    (tracer/with-span! {:name "loadbalancer/remove-orphaned-subs"
+                        :attributes s}
+      (unsubscribe-from-sns (:arn s)))))
 
 (defn start
-  ([] (start nil))
+  ([]
+   (start nil))
   ([queue-suffix]
-   (let [q (create-queue queue-suffix)
-         sns (subscribe-to-sns (:arn q))
-         conn-drain-futs (atom {})
-         queue-listener (ua/vfut-bg
-                         (poll-queue (:url q)
-                                     (partial handle-message conn-drain-futs)))
-         shutdown (fn []
-                    (future-cancel queue-listener)
-                    (doseq [drain-fut @conn-drain-futs]
-                      (future-cancel drain-fut))
-                    (try
-                      (unsubscribe-from-sns (:arn sns))
-                      (catch Throwable t
-                        (tracer/record-exception-span! t {:name "loadbalancer/unsubscribe-sns-error"})))
-                    (try
-                      (delete-queue (:url q))
-                      (catch Throwable t
-                        (tracer/record-exception-span! t {:name "loadbalancer/delete-sqs-queue-error"}))))]
-     (reset! process {:q q
-                      :queue-suffix queue-suffix
-                      :sns sns
-                      :conn-drain-futs conn-drain-futs
-                      :queue-listener queue-listener
-                      :shutdown shutdown}))))
+   (let [v (create-process queue-suffix)]
+     (reset! process v)
+     (cleanup-stale)
+     v)))
 
 (defn stop []
   (let [[old _new] (swap-vals! process (fn [_] nil))]

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -86,7 +86,7 @@
   (let [req (.. (ReceiveMessageRequest/builder)
                 (queueUrl queue-url)
                 (maxNumberOfMessages (int 10))
-                (waitTimeSeconds (int 1)) ; 20
+                (waitTimeSeconds (int 20))
                 (build))]
     (-> (.receiveMessage (sqs-client) ^ReceiveMessageRequest req)
         (.messages))))
@@ -249,7 +249,10 @@
   ([queue-suffix]
    (let [v (create-process queue-suffix)]
      (reset! process v)
-     (cleanup-stale)
+     (try
+       (cleanup-stale)
+       (catch Throwable t
+         (tracer/record-exception-span! t {:name "loadbalancer/cleanup-stale-error"})))
      v)))
 
 (defn stop []

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -166,8 +166,8 @@
                                     (partial handle-message conn-drain-futs)))
         shutdown (fn []
                    (future-cancel queue-listener)
-                   (doseq [drain-fut @conn-drain-futs]
-                     (future-cancel drain-fut))
+                   (doseq [[_ {:keys [process]}] @conn-drain-futs]
+                     (future-cancel @process))
                    (try
                      (unsubscribe-from-sns (:arn sns))
                      (catch Throwable t

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -13,7 +13,7 @@
    (software.amazon.awssdk.services.sns SnsClient)
    (software.amazon.awssdk.services.sns.model ListSubscriptionsByTopicRequest SubscribeRequest Subscription UnsubscribeRequest)
    (software.amazon.awssdk.services.sqs SqsClient)
-   (software.amazon.awssdk.services.sqs.model CreateQueueRequest DeleteMessageRequest DeleteQueueRequest GetQueueUrlRequest ListQueueTagsRequest ListQueuesRequest Message QueueAttributeName QueueDoesNotExistException ReceiveMessageRequest ReceiveMessageRequest)))
+   (software.amazon.awssdk.services.sqs.model CreateQueueRequest DeleteMessageRequest DeleteQueueRequest GetQueueUrlRequest ListQueueTagsRequest ListQueuesRequest Message QueueAttributeName QueueDoesNotExistException ReceiveMessageRequest)))
 
 ;; There's an EventBridge subscription that publishes loadbalancer events to SNS.
 ;; Each machine subscribes to SNS through an SQS queue it creates.
@@ -48,7 +48,7 @@
 
 (defn create-queue [suffix]
   (let [queue-name (str queue-prefix @config/process-id suffix)
-        queue-arn (str config/instance-events-sqs-topic-arn-prefix queue-name)
+        queue-arn (str config/instance-events-sqs-queue-arn-prefix queue-name)
         req (.. (CreateQueueRequest/builder)
                 (queueName queue-name)
                 (attributes {QueueAttributeName/POLICY (sqs-policy queue-arn)})
@@ -107,7 +107,7 @@
                             (delete-message queue-url message))
                           :continue)
                         (catch Throwable t
-                          (tracer/record-exception-span! t {:name "loadbalancer/get-messages-errror"})
+                          (tracer/record-exception-span! t {:name "loadbalancer/get-messages-error"})
                           :backoff))]
       (case next-action
         :continue (recur 0)
@@ -224,9 +224,9 @@
     (keep (fn [^Subscription sub]
             (when (and (= (.protocol sub) "sqs")
                        (some-> (.endpoint sub)
-                               (clojure.string/starts-with? (str config/instance-events-sqs-topic-arn-prefix
+                               (clojure.string/starts-with? (str config/instance-events-sqs-queue-arn-prefix
                                                                  queue-prefix))))
-              (let [queue-name (subs (.endpoint sub) (count config/instance-events-sqs-topic-arn-prefix))]
+              (let [queue-name (subs (.endpoint sub) (count config/instance-events-sqs-queue-arn-prefix))]
                 (when-not (queue-exists-by-queue-name? queue-name)
                   {:arn (.subscriptionArn sub)
                    :endpoint (.endpoint sub)

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -263,5 +263,5 @@
 (defn restart []
   (stop)
   ;; Give it a suffix because you have to wait 60 seconds
-  ;; for the queue to restart
+  ;; for the queue name to be recycled
   (start (str "-" (rand-int 10000))))

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -377,7 +377,6 @@
    org and the app."
   ([params] (transfer-app-to-org! (aurora/conn-pool :write) params))
   ([conn {:keys [app-id org-id]}]
-   ;; NEXTUP: transfer members
    (let [{:keys [paid_app
                  paid_org
                  app_stripe_customer_id

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -592,7 +592,7 @@
            :copy-sql triples-copy-sql
            ;; Check every minute to see if we can claim the slot
            :acquire-slot-interval-ms (* 1000 60)
-           ;; Flush sketch changes to db every 10 seconds or 50k items
+           ;; Flush sketch changes to db every 10 seconds or 500 items
            :sketch-flush-ms (* 1000 10)
            :sketch-flush-max-items 500
            :skip-empty-updates (= :dev (config/get-env))}))

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -1599,7 +1599,8 @@
                            max-gap-ms))]
       (tracer/with-span! {:name "store/close-connections"
                           :attributes {:connection-count (count channels)
-                                       :gap-ms gap-ms}}
+                                       :gap-ms gap-ms
+                                       :total-ms total-ms}}
         (dorun (map-indexed (fn [i ch]
                               (let [sleep-ms (.toMillis (Duration/between (Instant/now)
                                                                           (.plusMillis start (* gap-ms i))))]


### PR DESCRIPTION
This will help our deploys be less disruptive.

When we do a deploy, elastic beanstalk removes our instances from the load balancer before it calls `docker-compose down`. By the time our cleanup logic runs, all of the connections have already been forcibly closed.

With this change, we'll capture notifications that the load balancer is draining our connections and initiate a connection close.

### How it works

1. I manually set up an EventBridge notification that publishes to an SNS queue
2. On startup, each machine creates an SQS queue that subscribes to SNS
3. Any time a target is deregistered, all machines get the same notification and filter to check if it was their instance that was removed
4. If our instance was removed, we call `close-connections`.