### PR TITLE
Add a flag to fallback to sendgrid

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -14,6 +14,7 @@
             [instant.db.model.attr :as attr-model]
             [instant.db.transaction :as tx]
             [instant.discord :as discord]
+            [instant.email-router :as email-router]
             [instant.fixtures :as fixtures]
             [instant.flags :as flags :refer [admin-email?]]
             [instant.hard-deletion-sweeper :as sweeper]
@@ -226,7 +227,7 @@
 (comment
   (def user (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))
   (def m {:code (string-util/rand-num-str 6)})
-  (postmark/send-structured! (magic-code-email {:user user :magic-code m})))
+  (email-router/send-structured! (magic-code-email {:user user :magic-code m})))
 
 (defn send-magic-code-post [req]
   (let [email (ex/get-param! req [:body :email] email/coerce)
@@ -242,7 +243,7 @@
                     {:id (UUID/randomUUID)
                      :code (instant-user-magic-code-model/rand-code)
                      :user-id user-id})]
-    (postmark/send-structured!
+    (email-router/send-structured!
      (magic-code-email {:user u :magic-code magic-code}))
     (response/ok {:sent true})))
 
@@ -1401,7 +1402,7 @@
            {:code code
             :app-id app-id
             :verification-id verification-id})]
-    (postmark/send-structured! (app-email-verification-code/format-email {:code code :sender-email sender-email :app-title (:title app)}))
+    (email-router/send-structured! (app-email-verification-code/format-email {:code code :sender-email sender-email :app-title (:title app)}))
     (response/ok {:sent true})))
 
 (defn sender-verification-verify-magic-code

--- a/server/src/instant/email_router.clj
+++ b/server/src/instant/email_router.clj
@@ -1,0 +1,15 @@
+(ns instant.email-router
+  (:require
+   [instant.flags :as flags]
+   [instant.postmark :as postmark]
+   [instant.sendgrid :as sendgrid]))
+
+(def sendgrid-froms
+  {"verify@auth-pm.instantdb.com" "verify@auth-sg.instantdb.com"
+   "verify@dash-pm.instantdb.com" "verify@auth-sg.instantdb.com"})
+
+(defn send-structured! [req]
+  (if (and (flags/send-with-sendgrid?)
+           (contains? sendgrid-froms (-> req :from :email)))
+    (sendgrid/send! (update-in req [:from :email] sendgrid-froms))
+    (postmark/send-structured! req)))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -442,3 +442,6 @@
    get the DeregisterTargets notification from the load balancer."
   []
   (flag :deregister-targets-drain-ms (* 1000 60 4.5)))
+
+(defn send-with-sendgrid? []
+  (toggled? :send-with-sendgrid))

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -3,6 +3,7 @@
    [clojure.string :as string]
    [hiccup2.core :as h]
    [instant.config :as config]
+   [instant.email-router :as email-router]
    [instant.flags :as flags]
    [instant.model.app :as app-model]
    [instant.model.app-email-sender :as app-email-sender-model]
@@ -153,14 +154,14 @@
                       :body (template-replace body template-params true)}
         email-req (magic-code-email to email-params)]
     (try
-      (postmark/send-structured! email-req)
+      (email-router/send-structured! email-req)
       (catch clojure.lang.ExceptionInfo e
         (if (invalid-sender? e)
           (do
             (tracer/record-info! {:name "magic-code/test-unconfirmed-or-unknown-sender"
                                   :attributes {:email from-email
                                                :app-id (:id app)}})
-            (postmark/send-structured!
+            (email-router/send-structured!
              (magic-code-email to (assoc email-params :sender-email default-sender-email))))
           (throw e))))))
 
@@ -199,13 +200,13 @@
 
         email-req       (magic-code-email email email-params)
         email-res       (try
-                          (postmark/send-structured! email-req)
+                          (email-router/send-structured! email-req)
                           (catch clojure.lang.ExceptionInfo e
                             (cond
                               (invalid-sender? e)
                               (do
                                 (tracer/record-info! {:name "magic-code/unconfirmed-or-unknown-sender" :attributes {:email sender-email :app-id app-id}})
-                                (postmark/send-structured! (magic-code-email email (assoc email-params :sender-email default-sender-email))))
+                                (email-router/send-structured! (magic-code-email email (assoc email-params :sender-email default-sender-email))))
 
                               ;; Don't throw if it's a test user, even if we can't send email to it
                               (and (= ::ex/validation-failed (-> e ex-data ::ex/type))


### PR DESCRIPTION
Adds a flag that falls back to sendgrid that we can toggle when postmark goes down.

Will only work for emails that don't have a custom sender.

The flag is `send-with-sendgrid` and we check that we have a valid sendgrid email before we try to send with it.