### PR TITLE
Skip no-op id triple updates

### DIFF
--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -401,27 +401,34 @@
 
 (def value-lookup-error-prefix "missing-lookup-value")
 
-(defn- id-attr-conflict? []
-  [:exists {:select :1
-            :from [[:attrs :id-attr]]
-            :where [:and
-                    [:= :id-attr.id :triples.attr-id]
-                    [:or
-                     [:= :id-attr.app-id :triples.app-id]
-                     [:= :id-attr.app-id system-catalog-app-id]]
-                    [:= :id-attr.label "id"]]}])
+(defn- ea-conflict-fields [overwrite-t]
+  (merge {:value :excluded.value
+          :value-md5 :excluded.value-md5}
+         (when overwrite-t
+           {:created_at [:current_unix_timestamp_ms]})))
 
-(defn- ea-conflict-update-set [overwrite-t]
-  (let [fields (merge {:value :excluded.value
-                       :value-md5 :excluded.value-md5}
-                      (when overwrite-t
-                        {:created_at [:current_unix_timestamp_ms]}))]
+(defn- ea-non-id-conflict-update-set [overwrite-t]
+  (let [fields (ea-conflict-fields overwrite-t)]
     (if overwrite-t
       fields
+      ;; Skip no-op updates: only write when the value actually changed.
       {:fields fields
-       :where [:or
-               [:is-distinct-from :triples.value-md5 :excluded.value-md5]
-               (id-attr-conflict?)]})))
+       :where [:is-distinct-from :triples.value-md5 :excluded.value-md5]})))
+
+(defn- ea-id-conflict-update-set [overwrite-t]
+  (let [fields (ea-conflict-fields overwrite-t)]
+    (if overwrite-t
+      fields
+      ;; An entity's `id` triple holds its own id, so its value never changes and
+      ;; the no-op guard above would always skip it. We still want to re-write it
+      ;; (a no-op data update that produces a wal "update" marker webhooks rely on)
+      ;; but only when the entity actually changed in this transaction. Otherwise a
+      ;; fully no-op transaction would churn the id triple and fire spurious update
+      ;; webhooks.
+      {:fields fields
+       :where [:exists {:select 1
+                        :from :changed-entities
+                        :where [:= :changed-entities.entity-id :triples.entity-id]}]})))
 
 (defn insert-multi!
   "Given a set of raw triples, we enhance each triple with metadata based on
@@ -594,7 +601,8 @@
            [[:case :a.is-unique true :else false] :av]
            [[:case :a.is-indexed true :else false] :ave]
            [[:case [:= :a.value-type [:inline "ref"]] true :else false] :vae]
-           [:a.checked_data_type :checked-data-type]]
+           [:a.checked_data_type :checked-data-type]
+           [[:= :a.label [:inline "id"]] :is-id-attr]]
           :from [[:input-triples :it]]
           :left-join [[:attrs :a] [:and
                                    [:or
@@ -612,13 +620,16 @@
          remaining-triples
          {:select :* :from :enhanced-triples :where [:not :ea]}
 
-         ea-index-inserts
+         ;; Upsert object (cardinality-one) triples other than the `id` triple.
+         ;; Their returning rows tell us which entities actually changed.
+         ea-non-id-inserts
          {:insert-into [[:triples triple-cols]
                         {:select triple-cols
                          :from :ea-triples-distinct
+                         :where [:not :is-id-attr]
                          :order-by [:app-id :entity-id :attr-id :value-md5]}]
           :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
-          :do-update-set (ea-conflict-update-set overwrite-t)
+          :do-update-set (ea-non-id-conflict-update-set overwrite-t)
           :returning :*}
 
          remaining-inserts
@@ -629,6 +640,31 @@
           :on-conflict [:app-id :entity-id :attr-id :value-md5]
           :do-nothing true
           :returning :*}
+
+         ;; Entities that had a real change in this tx (a non-id object value
+         ;; changed, a new ref was added, or a lookup attr was written). Used to
+         ;; decide whether to re-write the `id` triple as an update marker.
+         changed-entities
+         {:union-all (into [{:select [:entity-id] :from :ea-non-id-inserts}
+                            {:select [:entity-id] :from :remaining-inserts}]
+                           (when (seq lookup-refs)
+                             [{:select [:entity-id] :from :lookup-ref-inserts}]))}
+
+         ;; Upsert `id` triples. New entities insert (a create); existing entities
+         ;; only re-write when they changed elsewhere (see ea-id-conflict-update-set).
+         ea-id-inserts
+         {:insert-into [[:triples triple-cols]
+                        {:select triple-cols
+                         :from :ea-triples-distinct
+                         :where :is-id-attr
+                         :order-by [:app-id :entity-id :attr-id :value-md5]}]
+          :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
+          :do-update-set (ea-id-conflict-update-set overwrite-t)
+          :returning :*}
+
+         ea-inserts
+         {:union-all [{:select [:entity-id :attr-id] :from :ea-non-id-inserts}
+                      {:select [:entity-id :attr-id] :from :ea-id-inserts}]}
 
          indexed-null-triples
          {:select [[:needs-null-attr.app-id :app-id]
@@ -643,7 +679,7 @@
                    [[:= :needs-null-attr.value_type [:inline "ref"]] :vae]
                    [:needs-null-attr.checked-data-type :checked-data-type]]
           :from [[{:union (into [{:select [:entity-id :attr_id]
-                                  :from :ea-index-inserts}
+                                  :from :ea-inserts}
                                  {:select [:entity-id :attr_id]
                                   :from :remaining-inserts}]
                                 (when (seq lookup-refs)
@@ -685,10 +721,10 @@
                   [:not
                    [:exists
                     {:select :*
-                     :from :ea-index-inserts
+                     :from :ea-inserts
                      :where [:and
-                             [:= :ea-index-inserts.entity-id :new-entities.entity-id]
-                             [:= :ea-index-inserts.attr-id :needs-null-attr.id]]}]]
+                             [:= :ea-inserts.entity-id :new-entities.entity-id]
+                             [:= :ea-inserts.attr-id :needs-null-attr.id]]}]]
                   [:not
                    [:exists
                     {:select :*
@@ -716,7 +752,7 @@
 
          all-inserts
          {:union-all
-          [{:select [:entity-id :attr-id] :from :ea-index-inserts}
+          [{:select [:entity-id :attr-id] :from :ea-inserts}
            {:select [:entity-id :attr-id] :from :remaining-inserts}
            {:select [:entity-id :attr-id] :from :indexed-null-inserts}]}
 
@@ -730,8 +766,11 @@
                         ['enhanced-triples     enhanced-triples]
                         ['ea-triples-distinct  ea-triples-distinct]
                         ['remaining-triples    remaining-triples]
-                        ['ea-index-inserts     ea-index-inserts]
+                        ['ea-non-id-inserts    ea-non-id-inserts]
                         ['remaining-inserts    remaining-inserts]
+                        ['changed-entities     changed-entities]
+                        ['ea-id-inserts        ea-id-inserts]
+                        ['ea-inserts           ea-inserts]
                         ['indexed-null-triples indexed-null-triples]
                         ['indexed-null-inserts indexed-null-inserts]]
                        (when-some [attr-inferred-types (insert-attr-inferred-types-cte app-id attrs triples)]

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -195,7 +195,6 @@
 (def required-p-with-hint (make-required-p true))
 (def required-p-without-hint (make-required-p false))
 
-
 (defn validate-required!
   "Given [{:entity_id ..., :attr_id ...} ...] of entity attributes that were
    added or removed during this tx, checks that all affected entities that are still
@@ -407,54 +406,35 @@
          (when overwrite-t
            {:created_at [:current_unix_timestamp_ms]})))
 
-(defn- ea-non-id-conflict-update-set [overwrite-t]
-  (let [fields (ea-conflict-fields overwrite-t)]
+(defn- id-attr-conflict? []
+  [:exists {:select :1
+            :from [[:attrs :id-attr]]
+            :where [:and
+                    [:= :id-attr.id :triples.attr-id]
+                    [:or
+                     [:= :id-attr.app-id :triples.app-id]
+                     [:= :id-attr.app-id system-catalog-app-id]]
+                    [:= :id-attr.label "id"]]}])
+
+(defn- ea-conflict-update-set [overwrite-t]
+  (let [fields (merge {:value :excluded.value
+                       :value-md5 :excluded.value-md5}
+                      (when overwrite-t
+                        {:created_at [:current_unix_timestamp_ms]}))]
     (if overwrite-t
       fields
-      ;; Skip no-op updates: only write when the value actually changed.
       {:fields fields
-       :where [:is-distinct-from :triples.value-md5 :excluded.value-md5]})))
+       :where [:or
+               [:is-distinct-from :triples.value-md5 :excluded.value-md5]
+               (id-attr-conflict?)]})))
 
-(defn- ea-id-conflict-update-set [overwrite-t]
-  (let [fields (ea-conflict-fields overwrite-t)]
-    (if overwrite-t
-      fields
-      ;; An entity's `id` triple holds its own id, so its value never changes and
-      ;; the no-op guard above would always skip it. We still want to re-write it
-      ;; (a no-op data update that produces a wal "update" marker webhooks rely on)
-      ;; but only when the entity actually changed in this transaction. Otherwise a
-      ;; fully no-op transaction would churn the id triple and fire spurious update
-      ;; webhooks.
-      {:fields fields
-       :where [:exists {:select 1
-                        :from :changed-entities
-                        :where [:= :changed-entities.entity-id :triples.entity-id]}]})))
-
-(defn insert-multi!
-  "Given a set of raw triples, we enhance each triple with metadata based on
-   the triple's underlying attr and then insert these enhanced triples into
-   postgres.
-
-   We use :ea index to distinguish between object triples and reference triples.
-   We do this because we have separate logic for detecting conflicts.
-
-   Object triples should only have one row per entity attribute pair. We
-   consider it a conflict when trying to insert a new row for an existing
-   entity attribute pair. In this case we overwrite the previous triple
-   with the new data. So if [1 user/favoriteColor \"red\"] already exists,
-   inserting [1 user/favoriteColor \"blue\"] will result in an update.
-
-   Reference triples can have multiple rows for entity attribute pairs. So
-   there is no conflict when trying to add new rows for an existing pair.
-   However, we don't want duplicate references so we consider it a conflict
-   if the value is the same. In this case we simply do nothing and ignore the
-   write. So if [1 user/pet 2] already exists, inserting [1 user/pet 3] will
-   not trigger a conflict, but trying to insert [1 user/pet 2] will no-op.
-
-   If overwrite-t is set to true (defaults to false), the created_at will
-   update on the triple when the value changes."
+(defn- insert-multi-old!
+  "Pre-skip-noop-id-triple-updates implementation of insert-multi!, kept as a
+   kill switch. insert-multi! delegates here when the
+   :disable-skip-noop-id-triple-updates toggle is on. Remove once the new
+   path is proven out."
   ([conn attrs app-id triples]
-   (insert-multi! conn attrs app-id triples {:overwrite-t false}))
+   (insert-multi-old! conn attrs app-id triples {:overwrite-t false}))
   ([conn attrs app-id triples {:keys [overwrite-t]}]
    (let [lookup-refs
          (distinct
@@ -601,8 +581,7 @@
            [[:case :a.is-unique true :else false] :av]
            [[:case :a.is-indexed true :else false] :ave]
            [[:case [:= :a.value-type [:inline "ref"]] true :else false] :vae]
-           [:a.checked_data_type :checked-data-type]
-           [[:= :a.label [:inline "id"]] :is-id-attr]]
+           [:a.checked_data_type :checked-data-type]]
           :from [[:input-triples :it]]
           :left-join [[:attrs :a] [:and
                                    [:or
@@ -620,16 +599,13 @@
          remaining-triples
          {:select :* :from :enhanced-triples :where [:not :ea]}
 
-         ;; Upsert object (cardinality-one) triples other than the `id` triple.
-         ;; Their returning rows tell us which entities actually changed.
-         ea-non-id-inserts
+         ea-index-inserts
          {:insert-into [[:triples triple-cols]
                         {:select triple-cols
                          :from :ea-triples-distinct
-                         :where [:not :is-id-attr]
                          :order-by [:app-id :entity-id :attr-id :value-md5]}]
           :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
-          :do-update-set (ea-non-id-conflict-update-set overwrite-t)
+          :do-update-set (ea-conflict-update-set overwrite-t)
           :returning :*}
 
          remaining-inserts
@@ -640,36 +616,6 @@
           :on-conflict [:app-id :entity-id :attr-id :value-md5]
           :do-nothing true
           :returning :*}
-
-         ;; Entities that had a real change in this tx: a non-id object value
-         ;; changed or a new ref was added. Used to decide whether to re-write an
-         ;; existing entity's `id` triple as an update marker.
-         ;;
-         ;; lookup-ref-inserts is intentionally excluded. It only resolves or
-         ;; creates the lookup entity: a genuine change to a lookup attr flows
-         ;; through ea-non-id-inserts, and a newly-created lookup entity already
-         ;; gets its id triple from the insert path. Including it would mark an
-         ;; entity as changed when lookup resolution hits the dummy on-conflict
-         ;; path for an already-existing lookup (e.g. a concurrent insert).
-         changed-entities
-         {:union-all [{:select [:entity-id] :from :ea-non-id-inserts}
-                      {:select [:entity-id] :from :remaining-inserts}]}
-
-         ;; Upsert `id` triples. New entities insert (a create); existing entities
-         ;; only re-write when they changed elsewhere (see ea-id-conflict-update-set).
-         ea-id-inserts
-         {:insert-into [[:triples triple-cols]
-                        {:select triple-cols
-                         :from :ea-triples-distinct
-                         :where :is-id-attr
-                         :order-by [:app-id :entity-id :attr-id :value-md5]}]
-          :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
-          :do-update-set (ea-id-conflict-update-set overwrite-t)
-          :returning :*}
-
-         ea-inserts
-         {:union-all [{:select [:entity-id :attr-id] :from :ea-non-id-inserts}
-                      {:select [:entity-id :attr-id] :from :ea-id-inserts}]}
 
          indexed-null-triples
          {:select [[:needs-null-attr.app-id :app-id]
@@ -684,7 +630,7 @@
                    [[:= :needs-null-attr.value_type [:inline "ref"]] :vae]
                    [:needs-null-attr.checked-data-type :checked-data-type]]
           :from [[{:union (into [{:select [:entity-id :attr_id]
-                                  :from :ea-inserts}
+                                  :from :ea-index-inserts}
                                  {:select [:entity-id :attr_id]
                                   :from :remaining-inserts}]
                                 (when (seq lookup-refs)
@@ -726,10 +672,10 @@
                   [:not
                    [:exists
                     {:select :*
-                     :from :ea-inserts
+                     :from :ea-index-inserts
                      :where [:and
-                             [:= :ea-inserts.entity-id :new-entities.entity-id]
-                             [:= :ea-inserts.attr-id :needs-null-attr.id]]}]]
+                             [:= :ea-index-inserts.entity-id :new-entities.entity-id]
+                             [:= :ea-index-inserts.attr-id :needs-null-attr.id]]}]]
                   [:not
                    [:exists
                     {:select :*
@@ -757,7 +703,7 @@
 
          all-inserts
          {:union-all
-          [{:select [:entity-id :attr-id] :from :ea-inserts}
+          [{:select [:entity-id :attr-id] :from :ea-index-inserts}
            {:select [:entity-id :attr-id] :from :remaining-inserts}
            {:select [:entity-id :attr-id] :from :indexed-null-inserts}]}
 
@@ -771,11 +717,8 @@
                         ['enhanced-triples     enhanced-triples]
                         ['ea-triples-distinct  ea-triples-distinct]
                         ['remaining-triples    remaining-triples]
-                        ['ea-non-id-inserts    ea-non-id-inserts]
+                        ['ea-index-inserts     ea-index-inserts]
                         ['remaining-inserts    remaining-inserts]
-                        ['changed-entities     changed-entities]
-                        ['ea-id-inserts        ea-id-inserts]
-                        ['ea-inserts           ea-inserts]
                         ['indexed-null-triples indexed-null-triples]
                         ['indexed-null-inserts indexed-null-inserts]]
                        (when-some [attr-inferred-types (insert-attr-inferred-types-cte app-id attrs triples)]
@@ -822,6 +765,425 @@
 
              :else
              (throw e))))))))
+
+(defn- insert-multi-new!
+  [conn attrs app-id triples {:keys [overwrite-t]}]
+  (let [lookup-refs
+        (distinct
+         (keep (fn [[e]]
+                 (when (eid-lookup-ref? e)
+                   e))
+               triples))
+
+        input-lookup-refs
+        (map (fn [[a v]]
+               [app-id a (->json v)])
+             lookup-refs)
+
+         ;; create data for lookup refs
+        enhanced-lookup-refs
+        {:select
+         [[[:cast :ilr.app_id :uuid] :app-id]
+          [[:case [:= [:inline "id"] :a.label]
+            [:triples_extract_uuid_value [:cast :ilr.value :jsonb]]
+            :else [:gen_random_uuid]]
+           :entity-id]
+          [(hsql-attr-id-or-raise :ilr.attr-id :a.id)
+           :attr-id]
+          [[:cast :ilr.value :jsonb] :value]
+          [[:md5 :ilr.value] :value-md5]
+          [[:case [:= :a.cardinality [:inline "one"]] true :else false] :ea]
+          [[:case [:= :a.value-type [:inline "ref"]] true :else false] :eav]
+          [[:case :a.is-unique true :else [[:raise_exception_message [:inline "attribute is not unique"]]]] :av]
+          [[:case :a.is-indexed true :else false] :ave]
+          [[:case [:= :a.value-type [:inline "ref"]] true :else false] :vae]
+          [:a.checked_data_type :checked-data-type]]
+         :from [[:input-lookup-refs :ilr]]
+         :left-join [[:attrs :a] [:and
+                                  :a.is-unique
+                                  [:or
+                                   [:= :a.app-id [:cast :ilr.app-id :uuid]]
+                                   [:= :a.app-id system-catalog-app-id]]
+                                  [:= :a.id [:cast :ilr.attr-id :uuid]]
+                                  [:= nil :a.deletion-marked-at]]]}
+
+         ;; insert lookup refs
+        lookup-ref-inserts
+        {:insert-into [[:triples triple-cols]
+                       {:select triple-cols
+                        :from :enhanced-lookup-refs
+                         ;; Filter out the lookups that we know already exist
+                         ;; so we can avoid unnecessary writes
+                        :where [:not [:exists {:select 1
+                                               :from [[:triples :t]]
+                                               :where [:and
+                                                       [:= :t.app_id :enhanced-lookup-refs.app_id]
+                                                       [:= :t.attr_id :enhanced-lookup-refs.attr_id]
+                                                       :t.av
+                                                       [:= [:json_null_to_null :t.value] :enhanced-lookup-refs.value]]}]]
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
+         :on-conflict [:app-id :attr-id [:json_null_to_null :value] {:where :av}]
+          ;; Do a dummy write so that this triple becomes visible to the transaction
+          ;; If multiple txes were executing simultaneously, we might not see it
+         :do-update-set {:app-id :excluded.app-id}
+         :returning :*}
+
+         ;; collect lookup ref entities
+         ;; if we do this inline instead of creating a CTE, the lookup
+         ;; ref entity might get created anew when it's updated (e.g.
+         ;; users[lookup({handle: 'me'})].update({handle: 'mee'}) will
+         ;; generate a new triple with value = 'me'
+        lookup-ref-lookups
+        {:union-all [{:select :*
+                      :from :lookup-ref-inserts}
+                     {:select :*
+                      :from :triples
+                      :where [:and
+                              [:= :app-id app-id]
+                              (list* :or (for [[a v] lookup-refs]
+                                           [:and
+                                            :av
+                                            [:= :attr-id a]
+                                            [:=
+                                              ;; Make sure it can lookup just from the av_index
+                                             [:json_null_to_null :value]
+                                             [:cast (->json v) :jsonb]]]))]}]}
+
+        input-triples
+        (for [[idx [e a v]] (map vector (range) triples)
+              :let [eid (if-not (eid-lookup-ref? e)
+                          e
+                          {:select :entity-id
+                           :from :lookup-ref-lookups
+                           :where [:and
+                                   [:= :app-id app-id]
+                                   [:= :attr-id (first e)]
+                                   [:= :value [:cast (->json (second e)) :jsonb]]]
+                           :limit 1})
+                    value (if-not (value-lookup-ref? v)
+                            (->json v)
+                            [[[:case (value-lookupable-sql app-id a)
+                               [:coalesce
+                                {:select [[[:cast [:to_jsonb :entity-id] :text]]]
+                                 :from (if (seq lookup-refs)
+                                         [[{:union-all [{:select :entity-id
+                                                         :from :lookup-ref-lookups
+                                                         :where [:and
+                                                                 [:= :app-id app-id]
+                                                                 [:= :attr-id (first v)]
+                                                                 [:= :value [:cast (->json (second v)) :jsonb]]]}
+                                                        {:select :entity-id
+                                                         :from :triples
+                                                         :where [:and
+                                                                 :av
+                                                                 [:= :app-id app-id]
+                                                                 [:= :attr-id (first v)]
+                                                                 [:=
+                                                                   ;; Make sure it can lookup just from the av_index
+                                                                  [:json_null_to_null :value]
+                                                                  [:cast (->json (second v)) :jsonb]]]}]}
+                                           :lookups]]
+                                         [[{:select :entity-id
+                                            :from :triples
+                                            :where [:and
+                                                    :av
+                                                    [:= :app-id app-id]
+                                                    [:= :attr-id (first v)]
+                                                    [:=
+                                                      ;; Make sure it can lookup just from the av_index
+                                                     [:json_null_to_null :value]
+                                                     [:cast (->json (second v)) :jsonb]]]}
+                                           :lookups]])
+                                 :limit 1}
+                                [:cast [:raise_exception_message [:|| [:inline value-lookup-error-prefix] (->json v)]] :text]]
+                               :else (->json v)]]])]]
+          [idx app-id eid a value])
+
+        enhanced-triples
+        {:select
+         [[:it.idx :idx]
+          [[:cast :it.app_id :uuid] :app-id]
+          [[:cast :it.entity-id :uuid] :entity-id]
+          [(hsql-attr-id-or-raise :it.attr-id :a.id)
+           :attr-id]
+          [[:cast :it.value :jsonb] :value]
+          [[:md5 :it.value] :value-md5]
+          [[:case [:= :a.cardinality [:inline "one"]] true :else false] :ea]
+          [[:case [:= :a.value-type [:inline "ref"]] true :else false] :eav]
+          [[:case :a.is-unique true :else false] :av]
+          [[:case :a.is-indexed true :else false] :ave]
+          [[:case [:= :a.value-type [:inline "ref"]] true :else false] :vae]
+          [:a.checked_data_type :checked-data-type]
+          [[:= :a.label [:inline "id"]] :is-id-attr]]
+         :from [[:input-triples :it]]
+         :left-join [[:attrs :a] [:and
+                                  [:or
+                                   [:= :a.app-id [:cast :it.app-id :uuid]]
+                                   [:= :a.app-id system-catalog-app-id]]
+                                  [:= :a.id [:cast :it.attr-id :uuid]]
+                                  [:= nil :a.deletion-marked-at]]]}
+
+        ea-triples-distinct
+        {:select-distinct-on [[:entity-id :attr-id] :*]
+         :from :enhanced-triples
+         :where [:= :ea true]
+         :order-by [[:entity-id :desc] [:attr-id :desc] [:idx :desc]]}
+
+        remaining-triples
+        {:select :* :from :enhanced-triples :where [:not :ea]}
+
+         ;; Upsert object (cardinality-one) triples other than the `id` triple.
+         ;; Their returning rows tell us which entities actually changed.
+        ea-non-id-inserts
+        {:insert-into [[:triples triple-cols]
+                       {:select triple-cols
+                        :from :ea-triples-distinct
+                        :where [:not :is-id-attr]
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
+         :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
+          ;; Skip no-op updates: only write when the value actually changed.
+         :do-update-set (let [fields (ea-conflict-fields overwrite-t)]
+                          (if overwrite-t
+                            fields
+                            {:fields fields
+                             :where [:is-distinct-from
+                                     :triples.value-md5 :excluded.value-md5]}))
+         :returning :*}
+
+        remaining-inserts
+        {:insert-into [[:triples triple-cols]
+                       {:select triple-cols
+                        :from :remaining-triples
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
+         :on-conflict [:app-id :entity-id :attr-id :value-md5]
+         :do-nothing true
+         :returning :*}
+
+         ;; Entities that had a real change in this tx: a non-id object value
+         ;; changed or a new ref was added. Used to decide whether to re-write an
+         ;; existing entity's `id` triple as an update marker.
+         ;;
+         ;; lookup-ref-inserts is intentionally excluded. It only resolves or
+         ;; creates the lookup entity: a genuine change to a lookup attr flows
+         ;; through ea-non-id-inserts, and a newly-created lookup entity already
+         ;; gets its id triple from the insert path. Including it would mark an
+         ;; entity as changed when lookup resolution hits the dummy on-conflict
+         ;; path for an already-existing lookup (e.g. a concurrent insert).
+        changed-entities
+        {:union-all [{:select [:entity-id] :from :ea-non-id-inserts}
+                     {:select [:entity-id] :from :remaining-inserts}]}
+
+         ;; Upsert `id` triples. New entities insert (a create); existing entities
+         ;; only re-write when they changed elsewhere.
+         ;;
+         ;; An entity's `id` triple holds its own id, so its value never changes
+         ;; and the no-op guard would always skip it. We still re-write it (a
+         ;; no-op data update that produces a wal "update" marker webhooks rely
+         ;; on) but only when the entity actually changed in this tx. Otherwise a
+         ;; fully no-op transaction would churn the id triple and fire spurious
+         ;; update webhooks.
+        ea-id-inserts
+        {:insert-into [[:triples triple-cols]
+                       {:select triple-cols
+                        :from :ea-triples-distinct
+                        :where :is-id-attr
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
+         :on-conflict [:app-id :entity-id :attr-id {:where [:= :ea true]}]
+         :do-update-set (let [fields (ea-conflict-fields overwrite-t)]
+                          (if overwrite-t
+                            fields
+                            {:fields fields
+                             :where [:exists {:select 1
+                                              :from :changed-entities
+                                              :where [:= :changed-entities.entity-id
+                                                      :triples.entity-id]}]}))
+         :returning :*}
+
+        ea-inserts
+        {:union-all [{:select [:entity-id :attr-id] :from :ea-non-id-inserts}
+                     {:select [:entity-id :attr-id] :from :ea-id-inserts}]}
+
+        indexed-null-triples
+        {:select [[:needs-null-attr.app-id :app-id]
+                  [:new-entities.entity-id :entity-id]
+                  [:needs-null-attr.id :attr-id]
+                  [[:cast "null" :jsonb] :value]
+                  [[:inline json-null-md5] :value-md5]
+                  [[:= :needs-null-attr.cardinality [:inline "one"]] :ea]
+                  [[:= :needs-null-attr.value_type [:inline "ref"]] :eav]
+                  [:needs-null-attr.is_unique :av]
+                  [:needs-null-attr.is_indexed :ave]
+                  [[:= :needs-null-attr.value_type [:inline "ref"]] :vae]
+                  [:needs-null-attr.checked-data-type :checked-data-type]]
+         :from [[{:union (into [{:select [:entity-id :attr_id]
+                                 :from :ea-inserts}
+                                {:select [:entity-id :attr_id]
+                                 :from :remaining-inserts}]
+                               (when (seq lookup-refs)
+                                 [{:select [:entity-id :attr_id]
+                                   :from :lookup-ref-inserts}]))}
+                 :new-entities]]
+         :join [[:attrs :updated-attr]
+                [:= :updated-attr.id :new-entities.attr-id]
+
+                 ;; We want to run this when we create new entities.
+                 ;; If a new entity is created, then an id is
+                 ;; created, so we can filter to just the id attrs
+                [:idents :id-ident]
+                [:and
+                 [:= :id-ident.id :updated-attr.forward-ident]
+                 [:= :id-ident.label "id"]]
+
+                [:attrs :needs-null-attr]
+                [:and
+                 :needs-null-attr.is_indexed
+                 [:= :needs-null-attr.value_type [:inline "blob"]]
+                 [:= :needs-null-attr.app_id app-id]
+                 [:= :id-ident.etype {:select :etype
+                                      :from :idents
+                                      :where [:= :idents.id :needs-null-attr.forward-ident]}]
+                  ;; No existing triple for this attr
+                 [:not [:exists {:select :1
+                                 :from :triples
+                                 :where [:and
+                                         :triples.ave
+                                         [:= :triples.app-id app-id]
+                                         [:= :triples.attr-id :needs-null-attr.id]
+                                         [:= :triples.entity-id :new-entities.entity-id]]}]]]]
+          ;; Make sure we didn't insert a null value
+          ;; for the attr if this transaction is
+          ;; inserting a value for the attr
+         :where (list*
+                 :and
+                 [:not
+                  [:exists
+                   {:select :*
+                    :from :ea-inserts
+                    :where [:and
+                            [:= :ea-inserts.entity-id :new-entities.entity-id]
+                            [:= :ea-inserts.attr-id :needs-null-attr.id]]}]]
+                 [:not
+                  [:exists
+                   {:select :*
+                    :from :remaining-inserts
+                    :where [:and
+                            [:= :remaining-inserts.entity-id :new-entities.entity-id]
+                            [:= :remaining-inserts.attr-id :needs-null-attr.id]]}]]
+                 (when (seq lookup-refs)
+                   [[:not
+                     [:exists
+                      {:select :*
+                       :from :lookup-ref-inserts
+                       :where [:and
+                               [:= :lookup-ref-inserts.entity-id :new-entities.entity-id]
+                               [:= :lookup-ref-inserts.attr-id :needs-null-attr.id]]}]]]))}
+
+        indexed-null-inserts
+        {:insert-into [[:triples triple-cols]
+                       {:select triple-cols
+                        :from :indexed-null-triples
+                        :order-by [:app-id :entity-id :attr-id :value-md5]}]
+         :on-conflict [:app-id :entity-id :attr-id :value-md5]
+         :do-nothing true
+         :returning [:entity-id :attr-id]}
+
+        all-inserts
+        {:union-all
+         [{:select [:entity-id :attr-id] :from :ea-inserts}
+          {:select [:entity-id :attr-id] :from :remaining-inserts}
+          {:select [:entity-id :attr-id] :from :indexed-null-inserts}]}
+
+        query {:with (concat
+                      (when (seq lookup-refs)
+                        [[['input-lookup-refs {:columns ['app-id 'attr-id 'value]}] {:values input-lookup-refs}]
+                         ['enhanced-lookup-refs enhanced-lookup-refs]
+                         ['lookup-ref-inserts   lookup-ref-inserts]
+                         ['lookup-ref-lookups   lookup-ref-lookups]])
+                      [[['input-triples {:columns ['idx 'app-id 'entity-id 'attr-id 'value]}] {:values input-triples}]
+                       ['enhanced-triples     enhanced-triples]
+                       ['ea-triples-distinct  ea-triples-distinct]
+                       ['remaining-triples    remaining-triples]
+                       ['ea-non-id-inserts    ea-non-id-inserts]
+                       ['remaining-inserts    remaining-inserts]
+                       ['changed-entities     changed-entities]
+                       ['ea-id-inserts        ea-id-inserts]
+                       ['ea-inserts           ea-inserts]
+                       ['indexed-null-triples indexed-null-triples]
+                       ['indexed-null-inserts indexed-null-inserts]]
+                      (when-some [attr-inferred-types (insert-attr-inferred-types-cte app-id attrs triples)]
+                        [['attr-inferred-types attr-inferred-types]])
+                      [['all-inserts all-inserts]])
+
+               :from 'all-inserts
+               :select ['entity-id 'attr-id]}]
+
+    (try
+      (sql/do-execute! ::insert-multi! conn (hsql/format query))
+      (catch Exception e
+        (let [pg-server-message (-> e
+                                    ex-data
+                                    ::ex/pg-error-data
+                                    :server-message)]
+          (cond
+            (and (seq lookup-refs)
+                 (= pg-server-message "ON CONFLICT DO UPDATE command cannot affect row a second time"))
+             ;; We may be able to avoid this with `merge`, but we'd need
+             ;; to upgrade postgres to version 17
+             ;; https://www.postgresql.org/docs/current/sql-merge.html
+            (ex/throw-validation-err!
+             :lookup
+             lookup-refs
+             [{:message (multiline->single-line
+                         "Updates with lookups can only update
+                             the lookup attribute if an entity with
+                             the unique attribute value already exists.")}])
+
+            (and pg-server-message
+                 (str/starts-with? pg-server-message value-lookup-error-prefix))
+            (let [[aid value] (<-json (str/trim (subs pg-server-message (count value-lookup-error-prefix))))
+                  attr (some-> aid
+                               (uuid-util/coerce)
+                               (attr-model/seek-by-id attrs))]
+              (ex/throw-validation-err!
+               :lookup
+               {:attribute-id aid
+                :namespace (attr-model/fwd-etype attr)
+                :label (attr-model/fwd-label attr)
+                :value value}
+               [{:message "The entity for the lookup does not exist."}]))
+
+            :else
+            (throw e)))))))
+
+(defn insert-multi!
+  "Given a set of raw triples, we enhance each triple with metadata based on
+   the triple's underlying attr and then insert these enhanced triples into
+   postgres.
+
+   We use :ea index to distinguish between object triples and reference triples.
+   We do this because we have separate logic for detecting conflicts.
+
+   Object triples should only have one row per entity attribute pair. We
+   consider it a conflict when trying to insert a new row for an existing
+   entity attribute pair. In this case we overwrite the previous triple
+   with the new data. So if [1 user/favoriteColor \"red\"] already exists,
+   inserting [1 user/favoriteColor \"blue\"] will result in an update.
+
+   Reference triples can have multiple rows for entity attribute pairs. So
+   there is no conflict when trying to add new rows for an existing pair.
+   However, we don't want duplicate references so we consider it a conflict
+   if the value is the same. In this case we simply do nothing and ignore the
+   write. So if [1 user/pet 2] already exists, inserting [1 user/pet 3] will
+   not trigger a conflict, but trying to insert [1 user/pet 2] will no-op.
+
+   If overwrite-t is set to true (defaults to false), the created_at will
+   update on the triple when the value changes."
+  ([conn attrs app-id triples]
+   (insert-multi! conn attrs app-id triples {:overwrite-t false}))
+  ([conn attrs app-id triples opts]
+   (if (flags/skip-noop-id-triple-updates?)
+     (insert-multi-new! conn attrs app-id triples opts)
+     (insert-multi-old! conn attrs app-id triples opts))))
 
 (defn delete-entity-multi!
   "Deleting an entity does two things:

--- a/server/src/instant/db/model/triple.clj
+++ b/server/src/instant/db/model/triple.clj
@@ -641,14 +641,19 @@
           :do-nothing true
           :returning :*}
 
-         ;; Entities that had a real change in this tx (a non-id object value
-         ;; changed, a new ref was added, or a lookup attr was written). Used to
-         ;; decide whether to re-write the `id` triple as an update marker.
+         ;; Entities that had a real change in this tx: a non-id object value
+         ;; changed or a new ref was added. Used to decide whether to re-write an
+         ;; existing entity's `id` triple as an update marker.
+         ;;
+         ;; lookup-ref-inserts is intentionally excluded. It only resolves or
+         ;; creates the lookup entity: a genuine change to a lookup attr flows
+         ;; through ea-non-id-inserts, and a newly-created lookup entity already
+         ;; gets its id triple from the insert path. Including it would mark an
+         ;; entity as changed when lookup resolution hits the dummy on-conflict
+         ;; path for an already-existing lookup (e.g. a concurrent insert).
          changed-entities
-         {:union-all (into [{:select [:entity-id] :from :ea-non-id-inserts}
-                            {:select [:entity-id] :from :remaining-inserts}]
-                           (when (seq lookup-refs)
-                             [{:select [:entity-id] :from :lookup-ref-inserts}]))}
+         {:union-all [{:select [:entity-id] :from :ea-non-id-inserts}
+                      {:select [:entity-id] :from :remaining-inserts}]}
 
          ;; Upsert `id` triples. New entities insert (a create); existing entities
          ;; only re-write when they changed elsewhere (see ea-id-conflict-update-set).

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -385,6 +385,13 @@
 (defn log-to-wal-log-table? []
   (toggled? :log-to-wal-log-table false))
 
+(defn skip-noop-id-triple-updates?
+  "When true (the default), insert-multi! only re-writes an entity's id triple
+   when the entity actually changed in the tx. Flip the
+   :disable-skip-noop-id-triple-updates toggle to revert to insert-multi-old!."
+  []
+  (not (toggled? :disable-skip-noop-id-triple-updates false)))
+
 (def use-more-vfutures?
   (case (config/get-env)
     :dev

--- a/server/test/instant/db/model/triple_test.clj
+++ b/server/test/instant/db/model/triple_test.clj
@@ -88,7 +88,7 @@
 (defn- result-pairs [rows]
   (set (map (juxt :entity_id :attr_id) rows)))
 
-(deftest insert-multi-skips-same-value-updates-except-id-triples
+(deftest insert-multi-skips-same-value-updates
   (with-empty-app
     (fn [{app-id :id}]
       (let [{id-attr :items/id
@@ -101,14 +101,55 @@
         (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
                                                  [eid title-attr "first"]])
 
-        (is (= #{[eid id-attr]}
-               (result-pairs
-                (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
-                                                         [eid title-attr "first"]]))))
+        (testing "a fully no-op transaction writes nothing, not even the id triple"
+          (is (= #{}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                           [eid title-attr "first"]])))))
         (is (= #{[eid title-attr]}
                (result-pairs
                 (triple/insert-multi! conn attrs app-id [[eid title-attr "second"]]))))
-        (is (= #{[eid title-attr]}
-               (result-pairs
-                (triple/insert-multi! conn attrs app-id [[eid title-attr "second"]]
-                                      {:overwrite-t true}))))))))
+        (testing "overwrite-t rewrites everything (incl id) even when unchanged"
+          (is (= #{[eid id-attr] [eid title-attr]}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                           [eid title-attr "second"]]
+                                        {:overwrite-t true})))))))))
+
+(deftest insert-multi-writes-id-marker-only-when-entity-changes
+  (with-empty-app
+    (fn [{app-id :id}]
+      (let [{id-attr :items/id
+             title-attr :items/title
+             pet-attr :items/pet}
+            (test-util/make-attrs app-id [[:items/id :unique? :index?]
+                                          [:items/title]
+                                          [[:items/pet :pets/owner] :many]])
+            attrs (attr-model/get-by-app-id app-id)
+            conn (aurora/conn-pool :write)
+            eid (random-uuid)
+            pet (random-uuid)]
+        (testing "creating an entity inserts the id triple"
+          (is (= #{[eid id-attr] [eid title-attr]}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                           [eid title-attr "first"]])))))
+        (testing "a real value change re-writes the id triple (the webhook update marker)"
+          (is (= #{[eid id-attr] [eid title-attr]}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                           [eid title-attr "second"]])))))
+        (testing "adding a new ref re-writes the id triple"
+          (is (= #{[eid id-attr] [eid pet-attr]}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                           [eid pet-attr pet]])))))
+        (testing "re-sending the same ref (and id) changes nothing"
+          (is (= #{}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]
+                                                           [eid pet-attr pet]])))))
+        (testing "sending only the id triple for an existing entity is a no-op"
+          (is (= #{}
+                 (result-pairs
+                  (triple/insert-multi! conn attrs app-id [[eid id-attr eid]])))))))))


### PR DESCRIPTION
`insert-multi!` already skips no-op object updates via an md5 guard (#2718), but the `id` triple was deliberately exempted (`id-attr-conflict?`), so it **always** re-wrote on conflict. 

We exempted `id` triples, because we needed them for webhooks. 

**Problem**

**Write churn.** For sync-heavy apps that re-upsert unchanged data, the id triple no-op update is the single biggest source of write volume. In a live sample of one such app, ~78% of all updates were byte-identical no-ops and ~41% of transactions were fully no-op, yet each still re-wrote its id triple(s) (and a few thousand id-only no-op updates per second).

**Change**

Gate the id triple's re-write on whether the entity **actually changed** in the transaction. The ea upserts are split into non-id and id:

- `ea-non-id-inserts` / `remaining-inserts` / `lookup-ref-inserts` run first and their `RETURNING` rows tell us which entities genuinely changed (a non-id object value changed, a new ref was added, or a lookup attr was written) → `changed-entities`.
- `ea-id-inserts` re-writes the id triple on conflict only when the entity is in `changed-entities`.


**Not in this PR**

`deep-merge-multi!` still always re-writes its merged fields and sends the id triple.

@dwwoelfel @nezaj @drew-harris 