### PR TITLE
[Flags] Use string instead of UUID for sampled apps

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -102,7 +102,7 @@
                                   (get result "rate-limited-apps"))
 
         log-sampled-apps (reduce (fn [acc {:strs [appId sampleRate]}]
-                                   (assoc acc (uuid-util/coerce appId) sampleRate))
+                                   (assoc acc appId sampleRate))
                                  {}
                                  (get result "log-sampled-apps"))
 
@@ -249,7 +249,7 @@
     (contains? (storage-block-list) app-id)))
 
 (defn log-sampled-apps [app-id]
-  (get-in (query-result) [:log-sampled-apps (uuid-util/coerce app-id)] nil))
+  (get-in (query-result) [:log-sampled-apps app-id] nil))
 
 (defn app-rate-limited? [app-id]
   (contains? (:rate-limited-apps (query-result))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -249,7 +249,7 @@
     (contains? (storage-block-list) app-id)))
 
 (defn log-sampled-apps [app-id]
-  (get-in (query-result) [:log-sampled-apps app-id] nil))
+  (get-in (query-result) [:log-sampled-apps (uuid-util/coerce app-id)] nil))
 
 (defn app-rate-limited? [app-id]
   (contains? (:rate-limited-apps (query-result))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -7,8 +7,7 @@
    [clojure.tools.logging :as log]
    [clojure.walk :as w]
    [instant.config :as config]
-   [instant.util.json :as json]
-   [instant.util.uuid :as uuid-util])
+   [instant.util.json :as json])
   (:import
    (inet.ipaddr IPAddressString)
    (java.net InetAddress)))


### PR DESCRIPTION
What it says on the tin. Before we weren't coercing this as a uuid which was causes the lookup to fail in our config map