### PR TITLE
Remove sendTestEmail flag now that the backend is live

### DIFF
--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -15,7 +15,6 @@ import {
   useDialog,
 } from '@/components/ui';
 import { displayInstantStandardError, useForm } from '@/lib/hooks/useForm';
-import { useFlag } from '@/lib/hooks/useFlag';
 import { errorToast, successToast } from '@/lib/toast';
 import clsx from 'clsx';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
@@ -93,8 +92,6 @@ export function Email({ app }: { app: InstantApp }) {
   const [customSender, setCustomSender] = useState(Boolean(template?.email));
   const [showDnsRecords, setShowDnsRecords] = useState(false);
   const [isSendingTest, setIsSendingTest] = useState(false);
-  // The test-email endpoint ships after the frontend; hide the button until then.
-  const showSendTest = useFlag('sendTestEmail');
   const [bodyTab, setBodyTab] = useState<'edit' | 'preview'>('edit');
   const verification = useCustomSenderVerification(app);
 
@@ -405,17 +402,15 @@ export function Email({ app }: { app: InstantApp }) {
                 ))}
               </div>
             </div>
-            {showSendTest ? (
-              <Button
-                type="button"
-                variant="subtle"
-                size="mini"
-                loading={isSendingTest}
-                onClick={handleSendTest}
-              >
-                Send a test email
-              </Button>
-            ) : null}
+            <Button
+              type="button"
+              variant="subtle"
+              size="mini"
+              loading={isSendingTest}
+              onClick={handleSendTest}
+            >
+              Send a test email
+            </Button>
           </div>
 
           {bodyTab === 'edit' ? (

--- a/client/www/lib/flags.ts
+++ b/client/www/lib/flags.ts
@@ -1,8 +1,4 @@
 export const flags = {
   emails: false,
   createOrgs: true,
-  // Gates the "Send a test email" button in the magic-code email editor. The
-  // backend (POST /dash/apps/:id/send-test-email) lands first; flip to true
-  // once it's deployed.
-  sendTestEmail: false,
 } as const;


### PR DESCRIPTION
The `POST /dash/apps/:id/send-test-email` endpoint is now deployed, so the "Send a test email" button in the magic-code email editor no longer needs to be gated behind the `sendTestEmail` flag.

- Removed the `sendTestEmail` flag from `lib/flags.ts`
- Removed the `useFlag('sendTestEmail')` check in `Email.tsx` and render the button unconditionally
- Dropped the now-unused `useFlag` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)