### PR TITLE
Populate triples.pg_size inline at INSERT (drop the per-insert UPDATE)

### DIFF
--- a/server/resources/migrations/113_triples_pg_size_before_insert.down.sql
+++ b/server/resources/migrations/113_triples_pg_size_before_insert.down.sql
@@ -1,0 +1,8 @@
+drop trigger triples_before_insert_size on triples;
+drop function triples_before_insert_size();
+
+create trigger triples_batched_after_insert
+  after insert on triples
+  referencing new table as newrows
+  for each statement
+  execute function triples_insert_batch_trigger();

--- a/server/resources/migrations/113_triples_pg_size_before_insert.up.sql
+++ b/server/resources/migrations/113_triples_pg_size_before_insert.up.sql
@@ -1,0 +1,34 @@
+-- `triples.pg_size` (the on-disk byte size of a triple, used for storage
+-- accounting) was populated by an AFTER INSERT statement-level trigger
+-- (`triples_batched_after_insert` -> `triples_insert_batch_trigger`) that
+-- issued a second UPDATE over every freshly-inserted row:
+--
+--   update triples t set pg_size = triples_column_size(t) from newrows n ...
+--
+-- So every triple INSERT was immediately followed by an UPDATE of the same
+-- row. On the hot triples path that means a redundant tuple version + WAL for
+-- every insert (n_tup_upd ~= n_tup_ins), for every app.
+--
+-- Populate pg_size inline with a BEFORE INSERT row trigger instead, so the row
+-- is written once with pg_size already set. No second write.
+--
+-- NOTE: `triples_column_size(new)` is computed on the NEW record (pre-write).
+-- Verified on PG 16.6 that this yields identical pg_size values to the old
+-- AFTER-INSERT path for normal (non-TOASTed) triples. Spot-check large/TOASTed
+-- values on the production Postgres version before merging, since pg_column_size
+-- can in theory differ between the in-memory and stored tuple on PG < 17.
+
+create or replace function triples_before_insert_size()
+returns trigger as $$
+begin
+  new.pg_size := public.triples_column_size(new);
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger triples_batched_after_insert on triples;
+
+create trigger triples_before_insert_size
+  before insert on triples
+  for each row
+  execute function triples_before_insert_size();


### PR DESCRIPTION
## Problem

`triples.pg_size` (on-disk byte size of a triple, used for storage accounting) is populated by an `AFTER INSERT` **statement** trigger (`triples_batched_after_insert` → `triples_insert_batch_trigger`) that runs a second `UPDATE` over every freshly-inserted row:

```sql
update triples t set pg_size = triples_column_size(t) from newrows n
 where t.app_id = n.app_id and t.entity_id = n.entity_id
   and t.attr_id = n.attr_id and t.value_md5 = n.value_md5;
```

So **every triple INSERT is immediately followed by an UPDATE of the same row** — a redundant tuple version + WAL record per insert on the hot `triples` path, for **every app**. It shows up as `n_tup_upd ≈ n_tup_ins` on `triples`, and in the WAL as an insert followed by a same-`value_md5` "no-op" update of every triple (only `pg_size` changes).

I found this while investigating why a high-write app's Aurora write I/O wasn't dropping after upstream write-reduction work — this per-insert shadow update is a constant amplifier underneath everything, unrelated to any one app.

## Fix

Set `pg_size` inline with a `BEFORE INSERT` row trigger, so the row is written once with `pg_size` already populated, and drop the `AFTER INSERT` statement trigger.

## Verified locally (PG 16.6)

- 1000 single-message transacts, measured via `pg_stat_user_tables` on `triples`:
  - **before:** +2000 `n_tup_ins`, **+2000 `n_tup_upd`**
  - **after:** +2000 `n_tup_ins`, **+0 `n_tup_upd`**
- `pg_size` values identical to the old path for normal triples (`[164, 180]` both ways) — the new trigger reuses the same `triples_column_size()`.

## Impact

Removes one of every two tuple operations on `triples` for inserts (the shadow `UPDATE` + its WAL), fleet-wide. The shadow update is HOT (`pg_size` isn't indexed) so it doesn't bloat indexes, but it's still a heap tuple version + WAL + dead tuple per insert. Eliminating it cuts the heap/WAL cost of every triple insert and the corresponding autovacuum churn.

## Review / validation

- Only changes new inserts; existing rows already have `pg_size`. No backfill.
- The UPDATE path (`triples_update_batch_trigger`) is unchanged — it still maintains `pg_size` on value changes and the `app_files_to_sweep` logic.
- `triples_column_size(NEW)` is computed pre-write. Verified exact on PG 16.6 for non-TOASTed triples; please spot-check large/TOASTed values on the production Postgres version (`pg_column_size` can in theory differ in-memory vs stored on PG < 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
