### PR TITLE
Test reactive query for verify token

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -454,5 +454,4 @@
   (toggled? :send-with-sendgrid))
 
 (defn use-reactive-cache-for-verify-token? [app-id]
-  (or (config/test?)
-      (contains? (flag :use-reactive-cache-for-verify-token-apps) app-id)))
+  (contains? (flag :use-reactive-cache-for-verify-token-apps) app-id))

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -162,7 +162,8 @@
                   (update :enable-wal-entity-log-apps-map parse-uuids-map-flag)
                   (update :cloudfront-signed-url-apps parse-uuids-flag)
                   (update :smokescreen-whitelist-ips parse-ips-flag)
-                  (update :refresh-throttled-apps parse-uuids-flag))
+                  (update :refresh-throttled-apps parse-uuids-flag)
+                  (update :use-reactive-cache-for-verify-token-apps parse-uuids-flag))
         handle-receive-timeout (reduce (fn [acc {:strs [appId timeoutMs]}]
                                          (assoc acc (parse-uuid appId) timeoutMs))
                                        {}
@@ -451,3 +452,7 @@
 
 (defn send-with-sendgrid? []
   (toggled? :send-with-sendgrid))
+
+(defn use-reactive-cache-for-verify-token? [app-id]
+  (or (config/test?)
+      (contains? (flag :use-reactive-cache-for-verify-token-apps) app-id)))

--- a/server/src/instant/model/app_user.clj
+++ b/server/src/instant/model/app_user.clj
@@ -3,12 +3,15 @@
    [instant.db.cel :as cel]
    [instant.db.datalog :as d]
    [instant.db.model.attr :as attr-model]
+   [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
    [instant.model.instant-user :as instant-user-model]
    [instant.model.app-user-refresh-token :refer [hash-token]]
    [instant.model.rule :as rule-model]
+   [instant.reactive.query :refer [instaql-query-reactive!]]
+   [instant.reactive.store :as rs]
    [instant.system-catalog :as system-catalog]
    [instant.system-catalog-ops :refer [update-op query-op]]
    [instant.util.exception :as ex]
@@ -49,9 +52,9 @@
   [app-id user-data has-extra-fields?]
   (let [rules (rule-model/get-by-app-id {:app-id app-id})
         program (rule-model/get-program! rules
-                  {:etype "$users"
-                   :action "create"
-                   :paths [["$users" "allow" "create"]]})]
+                                         {:etype "$users"
+                                          :action "create"
+                                          :paths [["$users" "allow" "create"]]})]
     (cond
       program
       (let [ctx {:db {:conn-pool (aurora/conn-pool :read)}
@@ -153,12 +156,24 @@
   ([params] (get-by-refresh-token (aurora/conn-pool :read) params))
   ([conn {:keys [app-id refresh-token]}]
    (when refresh-token
-     (query-op
-      conn
-      {:app-id app-id
-       :etype etype}
-      (fn [{:keys [get-entity-where]}]
-        (get-entity-where {:$userRefreshTokens.hashedToken (hash-token refresh-token)}))))))
+     (if (flags/use-reactive-cache-for-verify-token? app-id)
+       (let [ctx {:session-id rs/admin-query-synthetic-session-id
+                  :app-id app-id
+                  :attrs (attr-model/get-by-app-id app-id)
+                  :admin? true
+                  :db {:conn-pool (aurora/conn-pool :read)}}
+             query {:$users {:$ {:where {:$userRefreshTokens.hashedToken (hash-token refresh-token)}}}}
+             result (instaql-query-reactive! rs/store ctx query :tree true)]
+         (-> result
+             :instaql-result
+             (get "$users")
+             first))
+       (query-op
+        conn
+        {:app-id app-id
+         :etype etype}
+        (fn [{:keys [get-entity-where]}]
+          (get-entity-where {:$userRefreshTokens.hashedToken (hash-token refresh-token)})))))))
 
 (defn get-by-refresh-token! [params]
   (ex/assert-record! (get-by-refresh-token params) :app-user {:args [params]}))

--- a/server/src/instant/model/app_user.clj
+++ b/server/src/instant/model/app_user.clj
@@ -161,7 +161,7 @@
                   :app-id app-id
                   :attrs (attr-model/get-by-app-id app-id)
                   :admin? true
-                  :db {:conn-pool (aurora/conn-pool :read)}}
+                  :db {:conn-pool conn}}
              query {:$users {:$ {:where {:$userRefreshTokens.hashedToken (hash-token refresh-token)}}}}
              result (instaql-query-reactive! rs/store ctx query :tree true)]
          (-> result

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -234,6 +234,8 @@
                      :record-stats true
                      :executor executor}))
 
+;; Special token that allows the system catalog apps to use the
+;; reactive query cache. Temporary while we test out the impact
 (def admin-query-synthetic-session-id (random-uuid))
 
 (defn create-conn [schema app-id]

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -234,6 +234,8 @@
                      :record-stats true
                      :executor executor}))
 
+(def admin-query-synthetic-session-id (random-uuid))
+
 (defn create-conn [schema app-id]
   (let [conn (-> (d/empty-db schema)
                  (d/with [{:tx-meta/app-id app-id

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -403,6 +403,44 @@
                                             [[:= :entity_id (parse-uuid (:id user3))]
                                              [:= :attr_id (:id system-catalog/$users-linked-primary-user)]]))))])))))
 
+(defn verify-refresh-token-req [app-id refresh-token]
+  (request {:method :post
+            :url    "/runtime/auth/verify_refresh_token"
+            :body   {:app-id app-id
+                     :refresh-token refresh-token}}))
+
+(deftest verify-refresh-token-reactive-cache-test
+  (with-empty-app
+    (fn [{app-id :id :as app}]
+      (with-redefs [flags/use-reactive-cache-for-verify-token?
+                    (fn [aid] (= aid app-id))
+                    rs/store (rs/init)]
+        (let [code  (send-code-runtime app {:email "a@b.c"})
+              user  (verify-code-runtime app {:email "a@b.c" :code code})
+              token (:refresh_token user)]
+
+          (testing "happy path returns the user with the same refresh_token"
+            (let [verified (-> (verify-refresh-token-req app-id token) :body :user)]
+              (is (= (:id user) (:id verified)))
+              (is (= "a@b.c" (:email verified)))
+              (is (= token (:refresh_token verified)))))
+
+          (testing "repeated calls hit the cache and stay correct"
+            (dotimes [_ 5]
+              (let [verified (-> (verify-refresh-token-req app-id token) :body :user)]
+                (is (= (:id user) (:id verified))))))
+
+          (testing "unknown refresh-token errors"
+            (is (thrown-with-msg? ExceptionInfo #"status 400"
+                                  (verify-refresh-token-req app-id (str (random-uuid))))))
+
+          (testing "after signout the token no longer verifies"
+            (request {:method :post
+                      :url    "/runtime/signout"
+                      :body   {:app_id app-id :refresh_token token}})
+            (is (thrown-with-msg? ExceptionInfo #"status 400"
+                                  (verify-refresh-token-req app-id token)))))))))
+
 (deftest upsert-oauth-link!
   (with-empty-app
     (fn [app]

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -9,6 +9,7 @@
    [instant.db.permissioned-transaction :as permissioned-tx]
    [instant.fixtures :refer [random-email with-empty-app]]
    [instant.flags :as flags]
+   [instant.isn :as isn]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
@@ -17,6 +18,7 @@
    [instant.model.app-email-verification :as app-email-verification]
    [instant.model.app-oauth-service-provider :as provider-model]
    [instant.model.app-user :as app-user-model]
+   [instant.model.app-user-refresh-token :as refresh-token-model]
    [instant.model.rule :as rule-model]
    [instant.model.shared-oauth-client :refer [shared-credentials-user-limit]]
    [instant.postmark :as postmark]
@@ -438,6 +440,26 @@
             (request {:method :post
                       :url    "/runtime/signout"
                       :body   {:app_id app-id :refresh_token token}})
+            ;; Simulate the invalidator: the WAL delete on
+            ;; $userRefreshTokens would normally fire
+            ;; `mark-stale-topics!` with the topics that
+            ;; `topics-for-triple-delete` produces. With no invalidator
+            ;; running, do it ourselves — modelling the delete of the
+            ;; `hashedToken` triple, which is the attr the cached query
+            ;; subscribes to. tx-id/isn use Long/MAX_VALUE so we win
+            ;; against whatever tx-id the cached entry was stamped with.
+            (let [hashed-token-attr (system-catalog/get-attr-id
+                                     "$userRefreshTokens" "hashedToken")
+                  topic [#{:ea :eav :av :ave}
+                         #{(random-uuid)}
+                         #{hashed-token-attr}
+                         #{(refresh-token-model/hash-token token)}]]
+              (rs/mark-stale-topics! rs/store
+                                     app-id
+                                     Long/MAX_VALUE
+                                     (isn/test-isn Long/MAX_VALUE)
+                                     #{topic}
+                                     {}))
             (is (thrown-with-msg? ExceptionInfo #"status 400"
                                   (verify-refresh-token-req app-id token)))))))))
 


### PR DESCRIPTION
We're seeing a ton of requests for verify_refresh_token, which makes a request for the user by the token.

This is a quick test to see if using the reactive query cache might lessen the load on the db.

If this works well, we can look at a more permanent solution and use it for all of the system catalog apps and maybe for `/admin/query`.

It's behind a feature flag for now. The `use-reactive-cache-for-verify-token-apps` lets us turn it on for individual apps.