### PR TITLE
Log error message as JSON string to actually see what `instaql-queries` is

### DIFF
--- a/client/packages/core/src/Reactor.js
+++ b/client/packages/core/src/Reactor.js
@@ -951,7 +951,7 @@ export default class Reactor {
   }
 
   _handleReceiveError(msg) {
-    this._log.info('error', msg);
+    this._log.info('error', JSON.stringify(msg, null, 2));
     const eventId = msg['client-event-id'];
     // This might not be a mutation, but it can't hurt to delete it
     this._inFlightMutationEventIds.delete(eventId);


### PR DESCRIPTION
Right now `instantql-queries` is printed as unhelpful `[[Object]]`