### PR TITLE
Add logger to Python SDK

### DIFF
--- a/client/packages/python/src/instantdb/__init__.py
+++ b/client/packages/python/src/instantdb/__init__.py
@@ -4,12 +4,14 @@ Public API:
     - `Instant`: sync admin client (HTTP request/response surface)
     - `AsyncInstant`: async admin client (adds `subscribe_query` + `streams`)
     - `InstantError`, `InstantAPIError`: exception classes
+    - `Logger`: protocol for a custom realtime logger (`verbose=True`)
     - `id()`: generate a new entity id
     - `lookup(attribute, value)`: create a lookup sentinel usable as an eid
 """
 
 from instantdb._async.client import AsyncInstant
 from instantdb._errors import InstantAPIError, InstantError
+from instantdb._logger import Logger
 from instantdb._sync.client import Instant
 from instantdb._transact import id, lookup
 from instantdb._version import __version__
@@ -19,6 +21,7 @@ __all__ = [
     "Instant",
     "InstantAPIError",
     "InstantError",
+    "Logger",
     "__version__",
     "id",
     "lookup",

--- a/client/packages/python/src/instantdb/_async/client.py
+++ b/client/packages/python/src/instantdb/_async/client.py
@@ -20,6 +20,11 @@ from instantdb._async.subscribe import AsyncSubscription
 # UNASYNC_REMOVE_END
 from instantdb._async.webhooks import AsyncWebhooks
 from instantdb._errors import InstantError
+
+# UNASYNC_REMOVE_START
+from instantdb._logger import Logger, make_logger
+
+# UNASYNC_REMOVE_END
 from instantdb._transact import _flatten_chunks, _TxBuilder, _TxChunk
 
 
@@ -30,6 +35,10 @@ class AsyncInstant:
         app_id: str | None = None,
         admin_token: str | None = None,
         api_uri: str = DEFAULT_API_URI,
+        # UNASYNC_REMOVE_START
+        verbose: bool = False,
+        logger: Logger | None = None,
+        # UNASYNC_REMOVE_END
         _impersonation: dict[str, str] | None = None,
         _transport: httpx.AsyncBaseTransport | None = None,
         _shared_client: httpx.AsyncClient | None = None,
@@ -46,6 +55,11 @@ class AsyncInstant:
         self._admin_token = admin_token
         self._api_uri = api_uri
         self._impersonation = _impersonation
+        # UNASYNC_REMOVE_START
+        self._verbose = verbose
+        self._logger = logger
+        self._log = make_logger(verbose, logger)
+        # UNASYNC_REMOVE_END
         self._http = _AsyncHTTP(
             app_id=app_id,
             admin_token=admin_token,
@@ -59,7 +73,7 @@ class AsyncInstant:
         self.storage = AsyncStorage(self._http, app_id=app_id)
         self.rooms = AsyncRooms(self._http, app_id=app_id)
         # UNASYNC_REMOVE_START
-        self.streams = AsyncStreams(self._http)
+        self.streams = AsyncStreams(self._http, log=self._log)
         # UNASYNC_REMOVE_END
         self.webhooks = AsyncWebhooks(self._http, app_id=app_id)
 
@@ -85,6 +99,10 @@ class AsyncInstant:
             app_id=self._app_id,
             admin_token=self._admin_token if self._admin_token is not None else "",
             api_uri=self._api_uri,
+            # UNASYNC_REMOVE_START
+            verbose=self._verbose,
+            logger=self._logger,
+            # UNASYNC_REMOVE_END
             _shared_client=self._http._client,
             **overrides,
         )
@@ -112,7 +130,7 @@ class AsyncInstant:
     ) -> AsyncSubscription:
         if rule_params is not None:
             q = {"$$ruleParams": rule_params, **q}
-        return AsyncSubscription(self._http, query=q)
+        return AsyncSubscription(self._http, query=q, log=self._log)
 
     # UNASYNC_REMOVE_END
     async def transact(self, chunks: _TxChunk | list[_TxChunk]) -> dict[str, Any]:

--- a/client/packages/python/src/instantdb/_async/streams/__init__.py
+++ b/client/packages/python/src/instantdb/_async/streams/__init__.py
@@ -25,11 +25,13 @@ from typing import Any
 from instantdb._async.http import _AsyncHTTP
 from instantdb._async.streams.reader import AsyncStreamReader
 from instantdb._async.streams.writer import AsyncStreamWriter
+from instantdb._logger import _NO_LOG, _Log
 
 
 class AsyncStreams:
-    def __init__(self, http: _AsyncHTTP) -> None:
+    def __init__(self, http: _AsyncHTTP, *, log: _Log = _NO_LOG) -> None:
         self._http = http
+        self._log = log
 
     def write(
         self,
@@ -41,6 +43,7 @@ class AsyncStreams:
             self._http,
             client_id=client_id,
             rule_params=rule_params,
+            log=self._log,
         )
 
     def read(
@@ -57,6 +60,7 @@ class AsyncStreams:
             stream_id=stream_id,
             byte_offset=byte_offset,
             rule_params=rule_params,
+            log=self._log,
         )
 
 

--- a/client/packages/python/src/instantdb/_async/streams/_connection.py
+++ b/client/packages/python/src/instantdb/_async/streams/_connection.py
@@ -24,6 +24,7 @@ import httpx_sse
 from instantdb._async.http import _AsyncHTTP
 from instantdb._errors import InstantError
 from instantdb._http_errors import api_error_from_response
+from instantdb._logger import _NO_LOG, _Log
 from instantdb._transact import id
 from instantdb._version import __version__
 
@@ -52,10 +53,12 @@ class _AsyncStreamConnection:
         *,
         on_message: Callable[[dict[str, Any]], None],
         on_reconnect: Callable[[], Awaitable[None]] | None = None,
+        log: _Log = _NO_LOG,
     ) -> None:
         self._http = http
         self._on_message = on_message
         self._on_reconnect = on_reconnect
+        self._log = log
         self._init_params: dict[str, str] | None = None
         # Set when the connection is ready for user sends. Cleared on each
         # reconnect attempt; re-set once any reconnect hook completes.
@@ -86,6 +89,7 @@ class _AsyncStreamConnection:
         if self._closed:
             return
         self._closed = True
+        self._log.info("[sse][close]")
         self._ready_event.set()
         if self._force_reconnect_tasks:
             tasks = list(self._force_reconnect_tasks)
@@ -151,6 +155,7 @@ class _AsyncStreamConnection:
         """Post bypassing the ready-event gate. Used by reconnect hooks."""
         assert self._init_params is not None
         event_id = client_event_id or id()
+        self._log.debug(f"[send] {event_id} {msg}")
         full_msg = {"client-event-id": event_id, **msg}
         body = {**self._init_params, "messages": [full_msg]}
         async with self._send_lock:
@@ -216,6 +221,7 @@ class _AsyncStreamConnection:
                         self._closed = True
                         self._ready_event.set()
                         return
+                    self._log.info("[sse][open]")
                     async for sse_event in event_source.aiter_sse():
                         if not sse_event.data:
                             continue
@@ -244,10 +250,12 @@ class _AsyncStreamConnection:
             attempts += 1
             last_attempt_at = now
             delay = min(_BACKOFF_MAX_SECONDS, 0.5 * (attempts - 1))
+            self._log.info(f"[sse][reconnect] attempt={attempts} delay={delay}")
             if delay > 0:
                 await asyncio.sleep(delay)
 
     def _dispatch(self, msg: dict[str, Any]) -> None:
+        self._log.debug(f"[receive] {msg}")
         if msg.get("op") == "sse-init":
             self._init_params = {
                 "machine_id": msg["machine-id"],

--- a/client/packages/python/src/instantdb/_async/streams/_connection.py
+++ b/client/packages/python/src/instantdb/_async/streams/_connection.py
@@ -155,7 +155,8 @@ class _AsyncStreamConnection:
         """Post bypassing the ready-event gate. Used by reconnect hooks."""
         assert self._init_params is not None
         event_id = client_event_id or id()
-        self._log.debug(f"[send] {event_id} {msg}")
+        if self._log.enabled:
+            self._log.debug(f"[send] {event_id} {msg}")
         full_msg = {"client-event-id": event_id, **msg}
         body = {**self._init_params, "messages": [full_msg]}
         async with self._send_lock:
@@ -255,7 +256,8 @@ class _AsyncStreamConnection:
                 await asyncio.sleep(delay)
 
     def _dispatch(self, msg: dict[str, Any]) -> None:
-        self._log.debug(f"[receive] {msg}")
+        if self._log.enabled:
+            self._log.debug(f"[receive] {msg}")
         if msg.get("op") == "sse-init":
             self._init_params = {
                 "machine_id": msg["machine-id"],

--- a/client/packages/python/src/instantdb/_async/streams/reader.py
+++ b/client/packages/python/src/instantdb/_async/streams/reader.py
@@ -20,6 +20,7 @@ import httpx
 from instantdb._async.http import _AsyncHTTP
 from instantdb._async.streams._connection import _AsyncStreamConnection
 from instantdb._errors import InstantAPIError, InstantError
+from instantdb._logger import _NO_LOG, _Log
 
 # Server can ask the reader to retry by sending stream-append with `retry: true`,
 # or by responding with a 5xx on an S3 file fetch. Match JS's 10-attempt budget.
@@ -35,6 +36,7 @@ class AsyncStreamReader:
         stream_id: str | None = None,
         byte_offset: int = 0,
         rule_params: dict[str, Any] | None = None,
+        log: _Log = _NO_LOG,
     ) -> None:
         if client_id is None and stream_id is None:
             raise InstantError("Must provide client_id or stream_id")
@@ -43,6 +45,7 @@ class AsyncStreamReader:
         self._stream_id = stream_id
         self._byte_offset = byte_offset
         self._rule_params = rule_params
+        self._log = log
         self._connection: _AsyncStreamConnection | None = None
         self._event_id: str | None = None
         # Outgoing chunks (str), errors, or None sentinel for end-of-stream.
@@ -63,6 +66,7 @@ class AsyncStreamReader:
             self._http,
             on_message=self._on_message,
             on_reconnect=self._on_reconnect,
+            log=self._log,
         )
         await self._connection.__aenter__()
         self._materializer_task = asyncio.create_task(self._materialize_loop())

--- a/client/packages/python/src/instantdb/_async/streams/writer.py
+++ b/client/packages/python/src/instantdb/_async/streams/writer.py
@@ -15,6 +15,7 @@ from typing import Any
 from instantdb._async.http import _AsyncHTTP
 from instantdb._async.streams._connection import _AsyncStreamConnection
 from instantdb._errors import InstantAPIError, InstantError
+from instantdb._logger import _NO_LOG, _Log
 from instantdb._transact import id
 
 _FLUSH_TIMEOUT_SECONDS = 30.0
@@ -27,10 +28,12 @@ class AsyncStreamWriter:
         *,
         client_id: str,
         rule_params: dict[str, Any] | None = None,
+        log: _Log = _NO_LOG,
     ) -> None:
         self._http = http
         self._client_id = client_id
         self._rule_params = rule_params
+        self._log = log
         self._reconnect_token = id()
         self._connection: _AsyncStreamConnection | None = None
         self._start_event_id: str | None = None
@@ -72,6 +75,7 @@ class AsyncStreamWriter:
             self._http,
             on_message=self._on_message,
             on_reconnect=self._on_reconnect,
+            log=self._log,
         )
         await self._connection.__aenter__()
         try:

--- a/client/packages/python/src/instantdb/_async/subscribe.py
+++ b/client/packages/python/src/instantdb/_async/subscribe.py
@@ -142,7 +142,8 @@ class AsyncSubscription:
         self._queue.put_nowait(payload)
 
     def _handle_message(self, msg: dict[str, Any]) -> None:
-        self._log.debug(f"[receive] {msg}")
+        if self._log.enabled:
+            self._log.debug(f"[receive] {msg}")
         op = msg.get("op")
         if op == "sse-init":
             self._has_connected = True

--- a/client/packages/python/src/instantdb/_async/subscribe.py
+++ b/client/packages/python/src/instantdb/_async/subscribe.py
@@ -40,6 +40,7 @@ import httpx_sse
 from instantdb._async.http import _AsyncHTTP
 from instantdb._errors import InstantAPIError
 from instantdb._http_errors import api_error_from_response
+from instantdb._logger import _NO_LOG, _Log
 from instantdb._transact import id
 from instantdb._version import __version__
 
@@ -67,9 +68,11 @@ class AsyncSubscription:
         http: _AsyncHTTP,
         *,
         query: dict[str, Any],
+        log: _Log = _NO_LOG,
     ) -> None:
         self._http = http
         self._query = query
+        self._log = log
         self._queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
         self._task: asyncio.Task[None] | None = None
         self._session_info: dict[str, str] | None = None
@@ -112,6 +115,7 @@ class AsyncSubscription:
             return
         self._closed = True
         self._ready_state = "closed"
+        self._log.info("[sse][close]")
         if self._task is not None and not self._task.done():
             self._task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -138,6 +142,7 @@ class AsyncSubscription:
         self._queue.put_nowait(payload)
 
     def _handle_message(self, msg: dict[str, Any]) -> None:
+        self._log.debug(f"[receive] {msg}")
         op = msg.get("op")
         if op == "sse-init":
             self._has_connected = True
@@ -179,6 +184,7 @@ class AsyncSubscription:
             )
 
     def _emit_error(self, error: InstantAPIError) -> None:
+        self._log.error(f"[error] {error}")
         self._enqueue(
             {
                 "type": "error",
@@ -217,6 +223,7 @@ class AsyncSubscription:
                 attempts += 1
                 last_attempt_at = now
                 delay = _backoff_delay(attempts)
+                self._log.info(f"[sse][reconnect] attempt={attempts} delay={delay}")
                 if delay > 0:
                     await asyncio.sleep(delay)
         finally:
@@ -262,6 +269,7 @@ class AsyncSubscription:
                         return
                     raise api_error_from_response(response)
                 self._ready_state = "open"
+                self._log.info("[sse][open]")
                 async for sse_event in event_source.aiter_sse():
                     if not sse_event.data:
                         continue

--- a/client/packages/python/src/instantdb/_logger.py
+++ b/client/packages/python/src/instantdb/_logger.py
@@ -1,0 +1,49 @@
+"""Optional logging for the realtime client, mirroring the JS SDK.
+
+The realtime surfaces trace their connection lifecycle through a small
+`Logger`: anything exposing `debug`, `info`, and `error`. A stdlib
+`logging.Logger` satisfies this directly, so a custom logger drops in without
+an adapter. The default sink is the `"instantdb"` logger, configured the usual
+way (e.g. `logging.basicConfig(level=logging.DEBUG)`).
+
+When disabled (the default) every method is a no-op, so there is no output and
+no cost off the debugging path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+
+class Logger(Protocol):
+    """A log sink. A stdlib `logging.Logger` satisfies this as-is."""
+
+    def debug(self, message: str) -> None: ...
+    def info(self, message: str) -> None: ...
+    def error(self, message: str) -> None: ...
+
+
+_DEFAULT_LOGGER = logging.getLogger("instantdb")
+
+
+def _noop(message: str) -> None:
+    pass
+
+
+class _Log:
+    """Log sink that no-ops every method when disabled."""
+
+    def __init__(self, enabled: bool, base: Logger) -> None:
+        self.debug = base.debug if enabled else _noop
+        self.info = base.info if enabled else _noop
+        self.error = base.error if enabled else _noop
+
+
+def make_logger(enabled: bool, base: Logger | None = None) -> _Log:
+    return _Log(enabled, base if base is not None else _DEFAULT_LOGGER)
+
+
+# Shared no-op sink. The realtime classes default to this, so they stay silent
+# unless the client wires in a real logger via `make_logger`.
+_NO_LOG = _Log(False, _DEFAULT_LOGGER)

--- a/client/packages/python/src/instantdb/_logger.py
+++ b/client/packages/python/src/instantdb/_logger.py
@@ -32,9 +32,14 @@ def _noop(message: str) -> None:
 
 
 class _Log:
-    """Log sink that no-ops every method when disabled."""
+    """Log sink that no-ops every method when disabled.
+
+    `enabled` lets a caller skip building an expensive log string (e.g.
+    serializing a full message payload) before reaching the no-op.
+    """
 
     def __init__(self, enabled: bool, base: Logger) -> None:
+        self.enabled = enabled
         self.debug = base.debug if enabled else _noop
         self.info = base.info if enabled else _noop
         self.error = base.error if enabled else _noop

--- a/client/packages/python/tests/test_logger.py
+++ b/client/packages/python/tests/test_logger.py
@@ -76,18 +76,41 @@ async def test_subscription_logs_received_messages():
     assert any(level == "debug" and "[receive]" in msg for level, msg in spy.calls)
 
 
+async def test_disabled_subscription_skips_payload_formatting():
+    # The hot-path guard must skip building the log string when disabled, so a
+    # silent connection never serializes the payload on every message.
+    class _Tripwire(dict):
+        formatted = False
+
+        def __repr__(self) -> str:
+            type(self).formatted = True
+            return "<msg>"
+
+    http = _AsyncHTTP(app_id="app", admin_token="abc")
+    try:
+        sub = AsyncSubscription(http, query={"goals": {}})  # no logger -> disabled
+        sub._handle_message(_Tripwire({"op": "refresh-ok", "computations": []}))
+    finally:
+        await http.aclose()
+    assert _Tripwire.formatted is False
+
+
 # ---------- stream connection wires the logger in ----------
 
 
 async def test_stream_connection_logs_received_messages():
     spy = _SpyLogger()
-    conn = _AsyncStreamConnection(
-        _AsyncHTTP(app_id="app", admin_token="abc"),
-        on_message=lambda _: None,
-        log=make_logger(True, spy),
-    )
-    conn._dispatch({"op": "stream-append", "content": "hi"})
-    assert any("[receive]" in msg for _, msg in spy.calls)
+    http = _AsyncHTTP(app_id="app", admin_token="abc")
+    try:
+        conn = _AsyncStreamConnection(
+            http,
+            on_message=lambda _: None,
+            log=make_logger(True, spy),
+        )
+        conn._dispatch({"op": "stream-append", "content": "hi"})
+        assert any("[receive]" in msg for _, msg in spy.calls)
+    finally:
+        await http.aclose()
 
 
 # ---------- client threads verbose/logger through ----------
@@ -121,10 +144,10 @@ async def test_as_user_clone_preserves_logger():
     db = AsyncInstant(app_id="app", admin_token="abc", verbose=True, logger=spy)
     try:
         impersonated = db.as_user(guest=True)
-        assert impersonated._verbose is True
-        assert impersonated._logger is spy
         sub = impersonated.subscribe_query({"goals": {}})
         sub._handle_message({"op": "refresh-ok", "computations": []})
+        # Logging through the clone proves both verbose and logger carried over:
+        # a dropped verbose would silence it; a dropped logger would miss the spy.
         assert any("[receive]" in msg for _, msg in spy.calls)
     finally:
         await db.aclose()

--- a/client/packages/python/tests/test_logger.py
+++ b/client/packages/python/tests/test_logger.py
@@ -1,0 +1,130 @@
+"""Tests for the optional realtime logger (verbose + custom logger)."""
+
+from __future__ import annotations
+
+import logging
+
+from instantdb import AsyncInstant, Logger
+from instantdb._async.http import _AsyncHTTP
+from instantdb._async.streams._connection import _AsyncStreamConnection
+from instantdb._async.subscribe import AsyncSubscription
+from instantdb._logger import make_logger
+
+
+class _SpyLogger:
+    """Duck-typed Logger that records every call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def debug(self, message: str) -> None:
+        self.calls.append(("debug", message))
+
+    def info(self, message: str) -> None:
+        self.calls.append(("info", message))
+
+    def error(self, message: str) -> None:
+        self.calls.append(("error", message))
+
+
+# ---------- make_logger gating ----------
+
+
+def test_disabled_logger_is_a_noop():
+    spy = _SpyLogger()
+    log = make_logger(False, spy)
+    log.debug("x")
+    log.info("y")
+    log.error("z")
+    assert spy.calls == []
+
+
+def test_enabled_logger_forwards_to_base():
+    spy = _SpyLogger()
+    log = make_logger(True, spy)
+    log.debug("hello")
+    log.error("boom")
+    assert spy.calls == [("debug", "hello"), ("error", "boom")]
+
+
+def test_default_sink_is_the_instantdb_stdlib_logger(caplog):
+    log = make_logger(True)
+    with caplog.at_level(logging.DEBUG, logger="instantdb"):
+        log.debug("via stdlib")
+    assert "via stdlib" in caplog.text
+
+
+def test_stdlib_logger_satisfies_the_logger_protocol():
+    # A plain logging.Logger has debug/info/error, so it drops in with no
+    # adapter. The single pre-formatted arg avoids %-formatting surprises.
+    base: Logger = logging.getLogger("test.instant")
+    log = make_logger(True, base)
+    log.debug("single arg, no percent formatting")  # must not raise
+
+
+# ---------- subscription wires the logger in ----------
+
+
+async def test_subscription_logs_received_messages():
+    spy = _SpyLogger()
+    http = _AsyncHTTP(app_id="app", admin_token="abc")
+    try:
+        sub = AsyncSubscription(http, query={"goals": {}}, log=make_logger(True, spy))
+        sub._handle_message({"op": "sse-init", "machine-id": "m", "session-id": "s"})
+    finally:
+        await http.aclose()
+    assert any(level == "debug" and "[receive]" in msg for level, msg in spy.calls)
+
+
+# ---------- stream connection wires the logger in ----------
+
+
+async def test_stream_connection_logs_received_messages():
+    spy = _SpyLogger()
+    conn = _AsyncStreamConnection(
+        _AsyncHTTP(app_id="app", admin_token="abc"),
+        on_message=lambda _: None,
+        log=make_logger(True, spy),
+    )
+    conn._dispatch({"op": "stream-append", "content": "hi"})
+    assert any("[receive]" in msg for _, msg in spy.calls)
+
+
+# ---------- client threads verbose/logger through ----------
+
+
+async def test_client_passes_logger_to_subscriptions():
+    spy = _SpyLogger()
+    db = AsyncInstant(app_id="app", admin_token="abc", verbose=True, logger=spy)
+    try:
+        sub = db.subscribe_query({"goals": {}})
+        sub._handle_message({"op": "sse-init", "machine-id": "m", "session-id": "s"})
+    finally:
+        await db.aclose()
+    assert any("[receive]" in msg for _, msg in spy.calls)
+
+
+async def test_client_is_silent_when_verbose_false():
+    # A logger is supplied but verbose is off, so the log methods are no-ops.
+    spy = _SpyLogger()
+    db = AsyncInstant(app_id="app", admin_token="abc", verbose=False, logger=spy)
+    try:
+        sub = db.subscribe_query({"goals": {}})
+        sub._handle_message({"op": "sse-init", "machine-id": "m", "session-id": "s"})
+    finally:
+        await db.aclose()
+    assert spy.calls == []
+
+
+async def test_as_user_clone_preserves_logger():
+    spy = _SpyLogger()
+    db = AsyncInstant(app_id="app", admin_token="abc", verbose=True, logger=spy)
+    try:
+        impersonated = db.as_user(guest=True)
+        assert impersonated._verbose is True
+        assert impersonated._logger is spy
+        sub = impersonated.subscribe_query({"goals": {}})
+        sub._handle_message({"op": "refresh-ok", "computations": []})
+        assert any("[receive]" in msg for _, msg in spy.calls)
+    finally:
+        await db.aclose()

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.45';
+const version = 'v1.0.46';
 
 export { version };

--- a/client/www/app/docs/init/page.md
+++ b/client/www/app/docs/init/page.md
@@ -106,6 +106,8 @@ and `schema`. Here are all the options you can provide:
 
 - **verbose?**: Enables detailed console logging for debugging. When `true`, logs WebSocket messages and internal operations. Helpful for troubleshooting connection and sync issues.
 
+- **logger?**: Customize how `verbose` output is handled by passing an object with `debug`, `info`, and `error` methods (defaults to `console`). Useful for formatting logs (for example, JSON stringifying objects) or routing them somewhere other than the console. Only takes effect when `verbose` is `true`.
+
 - **queryCacheLimit?**: Maximum number of query subscriptions to cache for offline mode. Defaults to `10`. Cached queries provide instant data on app reload while fresh data loads in the background.
 
 - **useDateObjects?**: When `true`, all date columns in queries will return a Javascript `Date` object. Disabled by default.

--- a/client/www/app/docs/start-python/page.md
+++ b/client/www/app/docs/start-python/page.md
@@ -270,6 +270,26 @@ result = db.query({
 
 See [Streams](/docs/streams) for the full reference.
 
+## Logging
+
+Pass `verbose=True` to `AsyncInstant` to log the realtime connection lifecycle
+to the standard library `instantdb` logger. Pass a `logger` (any object with
+`debug`, `info`, and `error`, such as a `logging.Logger`) to send it elsewhere.
+
+```python {% showCopy=true %}
+import logging
+from instantdb import AsyncInstant
+
+logging.basicConfig(level=logging.DEBUG)
+
+db = AsyncInstant(verbose=True)
+
+# Or send logs to your own logger
+db = AsyncInstant(verbose=True, logger=logging.getLogger("myapp"))
+```
+
+Only `AsyncInstant` has realtime, so the sync `Instant` has no `verbose` option.
+
 ## Auth
 
 Mirrors the JS `db.auth` namespace.


### PR DESCRIPTION
Follow up to https://github.com/instantdb/instant/pull/2745, adds ability to add logger to Python SDK matching JS admin sdk behavior.

Also updates docs to include a note about the `logger` config