### PR TITLE
Bump slot nums

### DIFF
--- a/server/resources/config/prod.edn
+++ b/server/resources/config/prod.edn
@@ -48,4 +48,6 @@
 
  :database-cluster-id "instant-aurora-17"
 
+ :next-database-cluster-id "aurora-instant-cluster"
+
  :instant-config-app-id #uuid "24a4d71b-7bb2-4630-9aee-01146af26239"}

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -403,7 +403,7 @@
 ;; Should be increased by 1 every time we move the slot to a new
 ;; machine. This gives us a way to have a consistent ordering of LSNs
 ;; across database upgrades.
-(def invalidator-slot-num 0)
+(def invalidator-slot-num 1)
 
 ;; Cuts off when the calendar turns to March in every time zone on Earth
 (def free-teams-cutoff (-> (ZonedDateTime/of 2026 3 1 0 0 0 0 (ZoneId/of "Etc/GMT+12"))

--- a/server/src/instant/isn.clj
+++ b/server/src/instant/isn.clj
@@ -15,7 +15,6 @@
    slot_num in front of the LSN. Any time we migrate to a new db, we increment
    the slot_num."
   (:require
-   [instant.config :as config]
    [instant.util.json :as json])
   (:import
    (java.lang Comparable)
@@ -100,7 +99,7 @@
 (defn test-isn
   "Generates an isn. (test-isn i) will be less than (test-isn (inc i))"
   [^long i]
-  (->ISN config/invalidator-slot-num
+  (->ISN 0
          (LogSequenceNumber/valueOf i)))
 
 (defn ->bytes ^bytes [^ISN isn]

--- a/server/src/instant/jdbc/failover.clj
+++ b/server/src/instant/jdbc/failover.clj
@@ -104,7 +104,7 @@
             (recur (inc i))))))))
 
 (defn replication-origin-status []
-  (with-open [conn (next.jdbc/get-connection (config/get-next-aurora-config))]
+  (with-open [conn (#'wal/get-pg-replication-conn (config/get-next-aurora-config))]
     (let [res (sql/select ::replication-origin-status conn ["select * from pg_replication_origin_status"])]
       (assert (= 1 (count res)))
       (first res))))
@@ -230,7 +230,7 @@
    start reading from it we don't redeliver events that the primary invalidator
    already wrote to history up through `remote_lsn`."
   [local-lsn]
-  (with-open [conn (next.jdbc/get-connection (config/get-next-aurora-config))]
+  (with-open [conn (#'wal/get-pg-replication-conn (config/get-next-aurora-config))]
     (sql/select-one ::advance-replica-invalidator-slot
                     conn
                     ["select pg_replication_slot_advance('invalidator', ?::pg_lsn)" local-lsn])))

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -22,7 +22,7 @@
 
 (declare shutdown)
 
-(def global-slot-num (int 0))
+(def global-slot-num (int 1))
 
 ;; --------------
 ;; Initialization

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -616,7 +616,8 @@
                          :check-disabled (fn []
                                            (flags/toggled? :disable-aggregator))
                          :get-conn-config (fn []
-                                            (config/get-aurora-config))
+                                            (or (config/get-next-aurora-config)
+                                                (config/get-aurora-config)))
                          :slot-num global-slot-num})))
 
 (defn start-global []

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -952,7 +952,7 @@
                           ;; When we're not transitioning to a new cluster,
                           ;; this lets us check if the slot is active without
                           ;; creating a new connection
-                          {:same-as-read-conn true})]
+                          {:same-as-read-conn false})]
     (start-singleton {:get-conn-config get-conn-config
                       :check-disabled (fn []
                                         (flags/toggled? :disable-singleton-invalidator))

--- a/server/src/instant/reactive/invalidator.clj
+++ b/server/src/instant/reactive/invalidator.clj
@@ -945,7 +945,8 @@
                  (cleanup-local-process process-id))}))
 
 (defn start-singleton-global []
-  (let [conn-config (config/get-aurora-config)
+  (let [conn-config (or (config/get-next-aurora-config)
+                        (config/get-aurora-config))
         get-conn-config (with-meta (fn []
                                      conn-config)
                           ;; When we're not transitioning to a new cluster,


### PR DESCRIPTION
To be deployed after migrating the slots via `(migrate-invalidator-to-replica)` and `(migrate-aggregator-to-replica)` from https://github.com/instantdb/instant/pull/2747