### PR TITLE
Fix count estimates on unique fields

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -1174,10 +1174,17 @@
                    0
                    (case (:type vs)
                      :total (:total sketch)
-                     :constant (cms/check sketch
-                                          (when (instance? java.time.Instant (:value vs))
-                                            :date)
-                                          (:value vs))
+                     :constant (let [n (cms/check sketch
+                                                    (when (instance? java.time.Instant (:value vs))
+                                                      :date)
+                                                    (:value vs))]
+                                 (if (and (= :v component)
+                                          (= :av (idx-key (:idx named-p)))
+                                          (not (flags/toggled? :disable-hint-plan-av-fix false)))
+                                   ;; av_index is unique on :v, so it can't be more than one
+                                   ;; if the sketch is overloaded, it may over count
+                                   (min 1 n)
+                                   n))
                      :lookup (if-let [sketch (:sketch (get sketches {:app-id app-id
                                                                      :attr-id (:attr-id vs)}))]
                                ;; Lookups are only on unique attrs, so we know that it will be at most 1


### PR DESCRIPTION
Fixes count estimates on unique fields. 

If you have a query like `{:books {:$ {:where {:id {:$in <list-of-ids>}}}}` and the sketch is overloaded, we might overestimate the number of books. If you put a limit on that query and we overestimate too much, then we'll try to use the triples_created_at to get better sorting.

This change will cap the count for each id in the list to 1. 

In case it causes a regression, there is a `disable-hint-plan-av-fix` flag we can set to `true`.