### PR TITLE
remove feature flag for app email verification

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1352,7 +1352,7 @@
         {postmark-id :postmark_id instant-verified? :verification_verified}
         (app-email-verification/get-by-app-id-and-email-type-with-template
          {:app-id app-id :email-type "magic-code"})]
-    (response/ok {:instant {:verified? (if (flags/use-app-email-verification?) instant-verified? true)}
+    (response/ok {:instant {:verified? instant-verified?}
                   :verification (when postmark-id
                                   (-> (postmark/get-sender! {:id postmark-id})
                                       :body
@@ -1400,9 +1400,6 @@
 (defn sender-verification-send-magic-code
   "sends the email containing a code to verify a custom sender domain with an app id"
   [req]
-  (when-not (flags/use-app-email-verification?)
-    (ex/throw+ {::ex/type ::ex/permission-denied
-                ::ex/message "Permission denied: app-level sender verification not enabled"}))
   (let [app  (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req))
         app-id (:id app)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!
@@ -1421,9 +1418,6 @@
 (defn sender-verification-verify-magic-code
   "verify the code after receiving the email from sender-verification-send-magic-code"
   [req]
-  (when-not (flags/use-app-email-verification?)
-    (ex/throw+ {::ex/type ::ex/permission-denied
-                ::ex/message "Permission denied: app-level sender verification not enabled"}))
   (let [app-id (:id (:app (req->app-accepting-superadmin-or-ref-token! :admin :apps/write req)))
         submitted-code (ex/get-param! req [:body :code] string-util/coerce-non-blank-str)
         verification-info (app-email-verification/get-by-app-id-and-email-type-with-template!

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -374,9 +374,6 @@
 (defn use-get-datalog-queries-for-topics-v2? []
   (toggled? :use-get-datalog-queries-for-topics-v2? true))
 
-(defn use-app-email-verification? []
-  (toggled? :use-app-email-verification? false))
-
 (defn enable-wal-entity-log? [app-id]
   (or (toggled? :enable-wal-entity-log-globally)
       (contains? (flag :enable-wal-entity-log-apps) app-id)

--- a/server/src/instant/model/app_email_sender.clj
+++ b/server/src/instant/model/app_email_sender.clj
@@ -3,8 +3,7 @@
             [instant.jdbc.sql :as sql]
             [instant.model.app-email-verification :as verification]
             [instant.postmark :as postmark]
-            [instant.util.exception :as ex]
-            [instant.flags :as flags])
+            [instant.util.exception :as ex])
   (:import (java.util UUID)))
 
 (defn get-by-email
@@ -86,18 +85,13 @@
                       :name name
                       :app-id app-id
                       :postmark-id postmark-id})
-        _ (if (flags/use-app-email-verification?)
-            (verification/put! {:app-id app-id
-                                :sender-id (:id sender)
-                                :verified false})
-            (verification/put! {:app-id app-id
-                                :sender-id (:id sender)
-                                :verified true}))]
+        _ (verification/put! {:app-id app-id
+                              :sender-id (:id sender)
+                              :verified false})]
     {:sender sender}))
 
 (comment
   (postmark/add-sender! {:email "hi@marky.fyi" :name "Marky"})
-  (flags/use-app-email-verification?)
   (ex-data *e)
   (def r (postmark/list-senders! 50 0))
   (def ss (get-in r [:body :SenderSignatures]))

--- a/server/src/instant/runtime/magic_code_auth.clj
+++ b/server/src/instant/runtime/magic_code_auth.clj
@@ -200,11 +200,9 @@
         custom-email-verified? (and (seq custom-email)
                                     (:verified template))
 
-        sender-email (if (flags/use-app-email-verification?)
-                       (if custom-email-verified?
-                         custom-email
-                         default-sender-email)
-                       (or custom-email default-sender-email))
+        sender-email (if custom-email-verified?
+                       custom-email
+                       default-sender-email)
 
         email-params    (if template
                           {:sender-email sender-email

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [instant.config :as config]
    [instant.fixtures :refer [random-email with-empty-app with-org with-pro-app with-startup-org with-free-org with-user]]
-   [instant.flags :as flags]
    [instant.dash.ephemeral-app :as ephemeral-app]
    [instant.dash.get-a-db :as get-a-db]
    [instant.jdbc.aurora :as aurora]
@@ -1071,9 +1070,8 @@
       (with-empty-app
         (:id user)
         (fn [app]
-          (with-redefs [flags/use-app-email-verification? (constantly true)]
-            (let [sender-email (random-email)
-                  letter (atom nil)]
+          (let [sender-email (random-email)
+                letter (atom nil)]
               (with-redefs [postmark/add-sender! (constantly {:body {:ID 123456}})
                             postmark/send-structured! #(reset! letter %)
                             magic-code-auth/check-custom-sender-rate-limit! (constantly nil)]
@@ -1107,7 +1105,7 @@
                                        :email-type "magic-code"})]
                     (is (= 200 (:status verify-resp)))
                     (is (= true (get-in verify-resp [:body :verified])))
-                    (is (= true (:verification_verified verification)))))))))))))
+                    (is (= true (:verification_verified verification))))))))))))
 
 ;; ---
 ;; get-a-db

--- a/server/test/instant/model/app_email_verification_code_test.clj
+++ b/server/test/instant/model/app_email_verification_code_test.clj
@@ -9,14 +9,14 @@
     [instant.util.exception :as ex]
     [instant.util.test :as test-util]))
 
-(defn- create-sender! [{:keys [user-id email]}]
+(defn- create-sender! [{:keys [email]}]
   (sql/execute-one!
    (aurora/conn-pool :write)
    ["INSERT INTO app_email_senders
-     (id, user_id, postmark_id, email, name)
-     VALUES (?::uuid, ?::uuid, ?, ?, ?)
-     RETURNING *"
-    (random-uuid) user-id 123456 email "Test Sender"]))
+      (id, postmark_id, email, name)
+      VALUES (?::uuid, ?, ?, ?)
+      RETURNING *"
+    (random-uuid) 123456 email "Test Sender"]))
 
 (deftest consume-verification-code-once
   (with-user

--- a/server/test/instant/runtime/routes_test.clj
+++ b/server/test/instant/runtime/routes_test.clj
@@ -170,14 +170,14 @@
     (is (re-find #"123456" body))
     (is (re-find #"10 minutes" body))))
 
-(defn- create-email-sender! [{:keys [user-id email]}]
+(defn- create-email-sender! [{:keys [email]}]
   (sql/execute-one!
    (aurora/conn-pool :write)
    ["INSERT INTO app_email_senders
-     (id, user_id, postmark_id, email, name)
-     VALUES (?::uuid, ?::uuid, ?, ?, ?)
-     RETURNING *"
-    (random-uuid) user-id 123456 email "Custom Sender"]))
+      (id, postmark_id, email, name)
+      VALUES (?::uuid, ?, ?, ?)
+      RETURNING *"
+    (random-uuid) 123456 email "Custom Sender"]))
 
 (defn- create-magic-code-template! [{:keys [app-id sender-id]}]
   (app-email-template-model/put! {:app-id app-id
@@ -187,7 +187,7 @@
                                   :subject "{code} is your code"
                                   :body "Your code is {code}"}))
 
-(deftest magic-code-custom-sender-requires-instant-verification-when-flagged
+(deftest magic-code-custom-sender-requires-instant-verification
   (with-empty-app
     (fn [app]
       (let [custom-email (random-email)
@@ -200,28 +200,26 @@
           (app-email-verification/put! {:app-id (:id app)
                                         :sender-id (:id sender)
                                         :verified false})
-          (binding [flags/*toggle-overrides* {:use-app-email-verification? true}]
-            (let [letter (atom nil)]
-              (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
-                            postmark/send-structured! #(reset! letter %)]
-                (magic-code-auth/send! {:app-id (:id app)
-                                        :email "recipient@example.com"}))
-              (is (= (:email (config/app-email-sender))
-                     (get-in @letter [:from :email]))))))
+          (let [letter (atom nil)]
+            (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
+                          postmark/send-structured! #(reset! letter %)]
+              (magic-code-auth/send! {:app-id (:id app)
+                                      :email "recipient@example.com"}))
+            (is (= (:email (config/app-email-sender))
+                   (get-in @letter [:from :email])))))
 
         (testing "verified custom sender is used"
           (app-email-verification/mark-verified! {:id (:id (app-email-verification/get-by-app-and-sender
                                                             (:id app)
                                                             (:id sender)))
                                                   :app-id (:id app)})
-          (binding [flags/*toggle-overrides* {:use-app-email-verification? true}]
-            (let [letter (atom nil)]
-              (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
-                            postmark/send-structured! #(reset! letter %)]
-                (magic-code-auth/send! {:app-id (:id app)
-                                        :email "recipient@example.com"}))
-              (is (= custom-email
-                     (get-in @letter [:from :email]))))))))))
+          (let [letter (atom nil)]
+            (with-redefs [magic-code-auth/check-send-rate-limit! (constantly nil)
+                          postmark/send-structured! #(reset! letter %)]
+              (magic-code-auth/send! {:app-id (:id app)
+                                      :email "recipient@example.com"}))
+            (is (= custom-email
+                   (get-in @letter [:from :email])))))))))
 
 (defn update-created-at [app-id code created-at]
   (sql/execute!


### PR DESCRIPTION
removes the `use-app-email-verification?` flag. done by claude checked by me

tested a full custom email verification flow


Also removes setting user_id for app_email_senders in the tests so that we can drop the user_id field in the next pr