### PR TITLE
drop user_id column from app_email_senders

### DIFF
--- a/server/resources/migrations/113_drop_user_id_email_senders.down.sql
+++ b/server/resources/migrations/113_drop_user_id_email_senders.down.sql
@@ -1,2 +1,4 @@
 ALTER TABLE app_email_senders
-ADD column user_id uuid;
+ADD column user_id uuid
+REFERENCES instant_users(id)
+ON DELETE CASCADE;

--- a/server/resources/migrations/113_drop_user_id_email_senders.down.sql
+++ b/server/resources/migrations/113_drop_user_id_email_senders.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_email_senders
+ADD column user_id uuid;

--- a/server/resources/migrations/113_drop_user_id_email_senders.up.sql
+++ b/server/resources/migrations/113_drop_user_id_email_senders.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_email_senders
+DROP COLUMN user_id;


### PR DESCRIPTION
Drops the user_id column from 'app_email_senders'

<img width="557" height="404" alt="image" src="https://github.com/user-attachments/assets/e41a7da8-bfcb-4420-b8e1-44286bd4819a" />



## Deploy Plan
Wait for https://github.com/instantdb/instant/pull/2753 to fully deploy
Run migration