### PR TITLE
Don't throw errors when we shut down the loadbalancer watcher

### DIFF
--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -11,7 +11,6 @@
   (:import
    (java.lang InterruptedException)
    (java.time Duration Instant)
-   (software.amazon.awssdk.core.exception AbortedException)
    (software.amazon.awssdk.services.sns SnsClient)
    (software.amazon.awssdk.services.sns.model ListSubscriptionsByTopicRequest SubscribeRequest Subscription UnsubscribeRequest)
    (software.amazon.awssdk.services.sqs SqsClient)

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -9,7 +9,9 @@
    [instant.util.json :as json]
    [instant.util.tracer :as tracer])
   (:import
+   (java.lang InterruptedException)
    (java.time Duration Instant)
+   (software.amazon.awssdk.core.exception AbortedException)
    (software.amazon.awssdk.services.sns SnsClient)
    (software.amazon.awssdk.services.sns.model ListSubscriptionsByTopicRequest SubscribeRequest Subscription UnsubscribeRequest)
    (software.amazon.awssdk.services.sqs SqsClient)
@@ -99,24 +101,31 @@
     (.deleteMessage (sqs-client) ^DeleteMessageRequest req)))
 
 (defn poll-queue [queue-url on-message]
-  (loop [backoff 0]
-    (let [next-action (try
-                        (let [messages (get-messages queue-url)]
-                          (doseq [^Message message messages]
-                            (on-message (json/<-json (.body message) true))
-                            (delete-message queue-url message))
-                          :continue)
-                        (catch Throwable t
-                          (tracer/record-exception-span! t {:name "loadbalancer/get-messages-error"})
-                          :backoff))]
-      (case next-action
-        :continue (recur 0)
-        :backoff
-        (do (Thread/sleep (long (* 1000
-                                   (get [2 10 30 60] backoff 60))))
-            (recur (inc backoff))))))
-  (tracer/record-exception-span! (ex-info "Poll Queue Existed Early" {:queue-url queue-url})
-                                 {:name "loadbalancer/poll-queue-error"}))
+  (try
+    (loop [backoff 0]
+      (let [next-action (try
+                          (let [messages (get-messages queue-url)]
+                            (doseq [^Message message messages]
+                              (on-message (json/<-json (.body message) true))
+                              (delete-message queue-url message))
+                            :continue)
+                          (catch Throwable t
+                            (when-not (or (instance? InterruptedException t)
+                                          (and (instance? AbortedException t)
+                                               (instance? InterruptedException (.getCause t))))
+                              (tracer/record-exception-span! t {:name "loadbalancer/get-messages-error"}))
+                            :backoff))]
+        (case next-action
+          :quit :quit
+          :continue (recur 0)
+          :backoff
+          (do (Thread/sleep (long (* 1000
+                                     (get [2 10 30 60] backoff 60))))
+              (recur (inc backoff))))))
+    (tracer/record-exception-span! (ex-info "Poll Queue Existed Early" {:queue-url queue-url})
+                                   {:name "loadbalancer/poll-queue-error"})
+    (catch InterruptedException _
+      nil)))
 
 (defn add-conn-drain [conn-drain-futs]
   (let [drain-id (random-uuid)

--- a/server/src/instant/loadbalancer.clj
+++ b/server/src/instant/loadbalancer.clj
@@ -100,7 +100,7 @@
                 (build))]
     (.deleteMessage (sqs-client) ^DeleteMessageRequest req)))
 
-(defn poll-queue [queue-url on-message]
+(defn poll-queue [shutdown? queue-url on-message]
   (try
     (loop [backoff 0]
       (let [next-action (try
@@ -109,23 +109,25 @@
                               (on-message (json/<-json (.body message) true))
                               (delete-message queue-url message))
                             :continue)
-                          (catch Throwable t
-                            (when-not (or (instance? InterruptedException t)
-                                          (and (instance? AbortedException t)
-                                               (instance? InterruptedException (.getCause t))))
-                              (tracer/record-exception-span! t {:name "loadbalancer/get-messages-error"}))
-                            :backoff))]
+                          (catch Exception e
+                            (if (shutdown?)
+                              :quit
+                              (do
+                                (tracer/record-exception-span! e {:name "loadbalancer/get-messages-error"})
+                                :backoff))))]
         (case next-action
-          :quit :quit
+          :quit nil
           :continue (recur 0)
           :backoff
           (do (Thread/sleep (long (* 1000
                                      (get [2 10 30 60] backoff 60))))
               (recur (inc backoff))))))
-    (tracer/record-exception-span! (ex-info "Poll Queue Existed Early" {:queue-url queue-url})
-                                   {:name "loadbalancer/poll-queue-error"})
-    (catch InterruptedException _
-      nil)))
+    (when-not (shutdown?)
+      (tracer/record-exception-span! (ex-info "Poll Queue Existed Early" {:queue-url queue-url})
+                                     {:name "loadbalancer/poll-queue-error"}))
+    (catch InterruptedException e
+      (when-not (shutdown?)
+        (throw e)))))
 
 (defn add-conn-drain [conn-drain-futs]
   (let [drain-id (random-uuid)
@@ -170,10 +172,14 @@
   (let [q (create-queue queue-suffix)
         sns (subscribe-to-sns (:arn q))
         conn-drain-futs (atom {})
+        shutdown-atom (atom false)
+        shutdown? (fn [] @shutdown-atom)
         queue-listener (ua/vfut-bg
-                        (poll-queue (:url q)
+                        (poll-queue shutdown?
+                                    (:url q)
                                     (partial handle-message conn-drain-futs)))
         shutdown (fn []
+                   (reset! shutdown-atom true)
                    (future-cancel queue-listener)
                    (doseq [[_ {:keys [process]}] @conn-drain-futs]
                      (future-cancel @process))


### PR DESCRIPTION
This catches the interrupted exceptions that get thrown when we stop the loadbalancer watcher. 

Should makes deploys a little less noisy.