### PR TITLE
[RFC] Use ea for where id queries

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -51,6 +51,7 @@
 ;; Pattern
 
 (s/def ::$entityIdStartsWith string?)
+(s/def ::$eid (s/coll-of uuid? :kind set? :min-count 0))
 
 (defn pattern-component [v-type]
   (s/or :constant (s/coll-of v-type :kind set? :min-count 0)
@@ -84,7 +85,7 @@
                                                             :min-count 0)
                                        :any #{'_}
                                        :variable symbol?
-                                       :function (s/keys :req-un [(or ::$not ::$isNull ::$comparator ::$entityIdStartsWith)])))
+                                       :function (s/keys :req-un [(or ::$not ::$isNull ::$comparator ::$entityIdStartsWith ::$eid)])))
 
 (s/def ::idx-key #{:ea :eav :av :ave :vae})
 (s/def ::data-type #{:string :number :boolean :date})
@@ -146,7 +147,8 @@
                 (or (contains? c :$not)
                     (contains? c :$isNull)
                     (contains? c :$comparator)
-                    (contains? c :$entityIdStartsWith)))
+                    (contains? c :$entityIdStartsWith)
+                    (contains? c :$eid)))
            (symbol? c)
            (set? c))
         c
@@ -383,8 +385,9 @@
   "Given a named-pattern and the symbol-values from previous patterns,
    returns the topic that would invalidate the query"
   [{:keys [idx e a v]} symbol-values]
-  (if (and (= :function (first v))
-           (contains? (second v) :$isNull))
+  (cond
+    (and (= :function (first v))
+         (contains? (second v) :$isNull))
     ;; This might be a lot simpler if we had a way to do
     ;; (not [?e :attr-id])
     [[#{:ea}
@@ -395,6 +398,16 @@
       '_
       #{(-> v second :$isNull :attr-id)}
       '_]]
+
+    (and (= :function (first v))
+         (contains? (second v) :$eid))
+    ;; Matching on entity-id, so invalidate when those entities change.
+    [[#{:ea}
+      (-> v second :$eid)
+      (component->topic-component symbol-values :a a)
+      '_]]
+
+    :else
     [[#{(idx-key idx)}
       (component->topic-component symbol-values :e e)
       (component->topic-component symbol-values :a a)
@@ -752,7 +765,12 @@
                   (let [prefix val]
                     [[:and
                       [:>= :entity-id (prefix->uuid-start prefix)]
-                      [:<= :entity-id (prefix->uuid-end prefix)]]])))
+                      [:<= :entity-id (prefix->uuid-end prefix)]]])
+                  ;; The `id` attr's value is the entity-id, so match on
+                  ;; entity-id directly to use the pkey instead of scanning
+                  ;; every id triple by value.
+                  :$eid
+                  [(in-any :entity-id val :uuid)]))
     []))
 
 (defn- entity-function-clauses [[e-tag e-value]]
@@ -1166,6 +1184,7 @@
                                         ;; No good way to count entity-ids, so plan
                                         ;; for the worst case
                                         :$entityIdStartsWith [{:type :total}]
+                                        :$eid [{:type :total}]
                                         :$comparator [{:type :compare
                                                        :op (:op body)
                                                        :data-type (:data-type body)

--- a/server/src/instant/db/model/attr_pat.clj
+++ b/server/src/instant/db/model/attr_pat.clj
@@ -387,6 +387,18 @@
                                rev-attr)
                            :attr
                            {:args [value-etype value-label]})
+        ;; The `id` attr stores the entity-id as its value. When matching on it
+        ;; for equality (or `$in`), translate to an entity-id lookup so we use
+        ;; the pkey instead of scanning every id triple by value.
+        id-eids (when (and (not= :ref value-type)
+                           (= fwd-attr attr)
+                           (= "id" (attr-model/fwd-label attr)))
+                  (let [vs (if (set? v) v #{v})]
+                    (when (every? (fn [x]
+                                    (and (not (map? x))
+                                         (uuid-util/coerce x)))
+                                  vs)
+                      (into #{} (map uuid-util/coerce) vs))))
         v-coerced (if (not= :ref value-type)
                     (let [state (update state :in conj :$ :where value-label)]
                       (coerce-value-for-typed-comparison! state
@@ -428,9 +440,15 @@
                                   :message (format "Only indexed attrs can check for `nil` in `$in`. %s.%s is not indexed."
                                                    (attr-model/fwd-etype fwd-attr)
                                                    (attr-model/fwd-label fwd-attr))}]))
-    (if (and (= :ref value-type)
-             (= attr rev-attr))
+    (cond
+      id-eids
+      [(level-sym value-etype value-level) id {:$eid id-eids}]
+
+      (and (= :ref value-type)
+           (= attr rev-attr))
       [v-coerced id (level-sym value-etype value-level)]
+
+      :else
       [(level-sym value-etype value-level) id v-coerced])))
 
 (defn attr-pats->patterns-impl
@@ -452,7 +470,12 @@
          (let [[e a v] attr-pat
                attr (attr-by-id ctx a)
                v-actualized? (component-actualized? seen v)
-               pat [(best-index attr v-actualized?) e a v]
+               ;; `$eid` matches on the entity-id, so it must use the :ea
+               ;; index regardless of the attr's unique?/index? flags.
+               idx (if (and (map? v) (contains? v :$eid))
+                     :ea
+                     (best-index attr v-actualized?))
+               pat [idx e a v]
                acc' (update acc :pats conj pat)]
            (cond-> acc'
              (d/variable? e) (update :seen conj e)

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -1536,7 +1536,7 @@
            (query-pretty
             {:users
              {:$ {:where {:id (resolvers/->uuid r "eid-alex")}}}})
-           '({:topics ([#{:av} _ #{:users/id} #{"eid-alex"}]
+           '({:topics ([#{:ea} #{"eid-alex"} #{:users/id} _]
                        --
                        [#{:ea} #{"eid-alex"}
                         #{:users/createdAt :users/email :users/id :users/fullName
@@ -1548,6 +1548,32 @@
                         ("eid-alex" :users/email "alex@instantdb.com")
                         ("eid-alex" :users/handle "alex")
                         ("eid-alex" :users/createdAt "2021-01-09 18:53:07.993689"))})))))))
+
+(deftest where-by-id-targets-entity-id
+  ;; Regression: `where {id: X}` must compile to an entity-id lookup (which uses
+  ;; the pkey) instead of a value match that scans every id triple of the etype.
+  (with-zeneca-app
+    (fn [app r]
+      (let [ctx (make-ctx app)
+            alex (resolvers/->uuid r "eid-alex")
+            stepan (resolvers/->uuid r "eid-stepan-parunashvili")
+            musashi (resolvers/->uuid r "eid-musashi")
+            where-pats (fn [q]
+                         (get-in (iq/instaql-query->patterns ctx q)
+                                 [:patterns :children :pattern-groups 0 :patterns]))]
+        (testing "equality on id compiles to an :ea $eid match"
+          (let [[idx _e _a v] (first (where-pats {:users {:$ {:where {:id alex}}}}))]
+            (is (= :ea idx))
+            (is (= {:$eid #{alex}} v))))
+        (testing "$in on id compiles to an :ea $eid match over all ids"
+          (let [[idx _e _a v] (first (where-pats {:users {:$ {:where {:id {:$in [alex stepan]}}}}}))]
+            (is (= :ea idx))
+            (is (= {:$eid #{alex stepan}} v))))
+        (testing "a nested path ending in id is also an entity-id match"
+          (let [pats (where-pats {:users {:$ {:where {:bookshelves.books.id musashi}}}})]
+            (is (some (fn [p]
+                        (and (vector? p) (= {:$eid #{musashi}} (nth p 3 nil))))
+                      pats))))))))
 
 (deftest deep-where
   (with-zeneca-app
@@ -1583,7 +1609,7 @@
              (query-pretty
               {:users
                {:$ {:where {:bookshelves.books.id bookshelves-id}}}})
-             '({:topics ([#{:av} _ #{:books/id} #{"eid-musashi"}]
+             '({:topics ([#{:ea} #{"eid-musashi"} #{:books/id} _]
                          [#{:vae} _ #{:bookshelves/books} #{"eid-musashi"}]
                          [#{:vae} _ #{:users/bookshelves} #{"eid-the-way-of-the-gentleman"}]
                          --
@@ -3772,7 +3798,7 @@
             r (resolvers/make-zeneca-resolver (:id app))]
         (is-pretty-eq?
          (query-pretty ctx r {:users {:$ {:where {:id shared-id}}}})
-         '({:topics ([#{:av} _ #{:users/id} #{"eid-title"}]
+         '({:topics ([#{:ea} #{"eid-title"} #{:users/id} _]
                      --
                      [#{:ea} #{"eid-title"}
                       #{:users/createdAt :users/email :users/id :users/fullName
@@ -3784,7 +3810,7 @@
                       ("eid-title" :users/id "eid-title"))}))
         (is-pretty-eq?
          (query-pretty ctx r {:books {:$ {:where {:id shared-id}}}})
-         '({:topics ([#{:av} _ #{:books/id} #{"eid-title"}]
+         '({:topics ([#{:ea} #{"eid-title"} #{:books/id} _]
                      --
                      [#{:ea} #{"eid-title"}
                       #{:books/pageCount :books/isbn13 :books/description :books/id


### PR DESCRIPTION
### Problem

`db.query({ messages: { $: { where: { id: X } } } })` could take 25s+ on apps with large tables. A user hit this fetching a single message by id. The nested link traversal was a red herring; the cost was entirely the top-level `where { id }`.

### Background: how we choose an index

Every triple lives in one Postgres table. We keep several partial indexes over `(app_id, entity_id, attr_id, value)` in different column orders, each gated by a boolean flag on the row: `ea`, `eav`, `av`, `ave`, `vae`. Those flags come from the attr's shape:

- `ea` (and the pkey): set when cardinality is `one`. Keyed on `entity_id`.
- `av`: set when the attr is `unique`. Keyed on `value`.
- `ave`: set when the attr is `indexed`. Keyed on `value`.

`best-index` (in `attr_pat.clj`) picks which index a pattern uses, based on the attr's flags plus which component is already bound. For `where { id: X }` we build the pattern `[?e id-attr X]`: the *value* is bound (X), the entity is the variable we want back.

Here's the catch. The `id` attr is a plain `blob`, and by default it is **not unique and not indexed**. So `best-index` has no value-keyed index to offer and falls back to `:ea`. But `:ea` is keyed on `entity_id`, which we do not have bound. Postgres cannot seek, so it grabs `triples_created_at_idx` (`app_id, attr_id, ...`) and filters `value = X` one row at a time.

### Query-plan impact

That filter walks **every id triple of the etype**:

```
Index Scan ... triples_created_at_idx
  Filter: value = '"<id>"'
  Rows Removed by Filter: 315623     ← scanned 315k rows to return 1
```

Cost is O(rows in the table). `messages` is huge and `conversations` is small, which is exactly why the same query felt instant rooted at conversations and took 25s rooted at messages. At 315k rows it is already ~180ms; at the user's millions-of-messages scale it is tens of seconds.

The key insight: for the `id` attr, **`value == entity_id`**. So "find the entity whose id is X" is just `entity_id = X`, which is a primary-key point lookup (sub-millisecond).

### Fix

When the where attr is `id`, compile to an entity-id match instead of a value match. We reuse the existing `$entityIdStartsWith` pattern: keep the entity symbol in the entity slot (so child joins still bind to it) and put a function form in the value slot that the SQL builder turns into `entity_id = X`.

```
;; before: [:ea ?e id-attr X]           value match  -> table scan
;; after:  [:ea ?e id-attr {:$eid #{X}}] entity match -> pkey point lookup
```

`{:$eid #{...}}` is a new internal datalog form (covers equality and `$in`). `value-function-clauses` translates it to `entity_id = X` / `entity_id = ANY(...)`.

### Hints (the subtle part)

For apps where the `id` attr *is* unique, `best-index` would pick `:av` and attach a pg-hint telling Postgres to use `av_index` (the value-keyed index). But our new clause filters on `entity_id`, not `value`, so an av hint there points Postgres at the wrong index. To avoid that, for the `$eid` form we override the index choice to `:ea` regardless of the attr's flags. The hint then matches the actual filter, and we get the pkey/ea point lookup whether or not `id` happens to be unique.

### Reactivity

The invalidation topic also shifts from value-keyed (`[#{:av} _ #{:users/id} #{X}]`) to the more precise entity-keyed (`[#{:ea} #{X} #{:users/id} _]`), meaning "invalidate when entity X changes." Affected topic snapshots were updated.

### Tests

- New `where-by-id-targets-entity-id` test asserting `where {id}`, `$in`, and nested `.id` all compile to the `:ea` `$eid` form.
- Updated topic snapshots in `flat-where`, `deep-where`, `same-ids`.
- datalog, instaql, reactive (session/store/topics/invalidator), rule, and cel suites pass.
- Verified on real data: `messages where {id}` went from a `triples_created_at_idx` scan (5,684 rows filtered) to an `ea_index` point lookup (0 filtered), and both unique and non-unique `id` attrs now hit the pkey.
