### PR TITLE
Update our ECR publish so that we can gc

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -347,15 +347,29 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
+    - name: Determine deploy target
+      id: target
+      env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: |
+        if [[ "$COMMIT_MSG" == *"[staging]"* ]]; then
+          echo "target=staging" >> "$GITHUB_OUTPUT"
+        else
+          echo "target=prod" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Build, tag, and push docker image to Amazon ECR
       working-directory: server
       env:
         IMAGE_TAG: ${{ github.sha }}
+        DEPLOY_TARGET: ${{ steps.target.outputs.target }}
       run: |
         docker buildx build --push \
-          --cache-to mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:cache \
+          --cache-to mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr-buildcache:cache \
+          --cache-from type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr-buildcache:cache \
           --cache-from type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:cache \
-          -t 597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:$IMAGE_TAG .
+          -t 597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:$IMAGE_TAG \
+          -t 597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:$DEPLOY_TARGET .
 
   publish-eb:
     runs-on: ubuntu-latest

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -367,7 +367,6 @@ jobs:
         docker buildx build --push \
           --cache-to mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr-buildcache:cache \
           --cache-from type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr-buildcache:cache \
-          --cache-from type=registry,ref=597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:cache \
           -t 597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:$IMAGE_TAG \
           -t 597134865416.dkr.ecr.us-east-1.amazonaws.com/instant-prod-ecr:$DEPLOY_TARGET .
 

--- a/server/.elasticbeanstalk/config.yml
+++ b/server/.elasticbeanstalk/config.yml
@@ -1,6 +1,6 @@
 branch-defaults:
   default:
-    environment: instant-docker-prod-env
+    environment: Instant-docker-prod-env-2
     group_suffix: null
 global:
   application_name: instant-docker-prod

--- a/server/config/ecr/README.md
+++ b/server/config/ecr/README.md
@@ -25,10 +25,10 @@ Keeps the moving `prod` and `staging` tags forever. SHA-tagged images age out af
   "rules": [
     {
       "rulePriority": 1,
-      "description": "Keep the moving prod and staging tags forever",
+      "description": "Keep the moving prod tag forever",
       "selection": {
         "tagStatus": "tagged",
-        "tagPatternList": ["prod", "staging"],
+        "tagPatternList": ["prod"],
         "countType": "imageCountMoreThan",
         "countNumber": 9999
       },
@@ -36,6 +36,17 @@ Keeps the moving `prod` and `staging` tags forever. SHA-tagged images age out af
     },
     {
       "rulePriority": 2,
+      "description": "Keep the moving staging tag forever",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPatternList": ["staging"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 9999
+      },
+      "action": {"type": "expire"}
+    },
+    {
+      "rulePriority": 3,
       "description": "Expire other tagged images after 90 days",
       "selection": {
         "tagStatus": "tagged",
@@ -47,7 +58,7 @@ Keeps the moving `prod` and `staging` tags forever. SHA-tagged images age out af
       "action": {"type": "expire"}
     },
     {
-      "rulePriority": 3,
+      "rulePriority": 4,
       "description": "Expire untagged images after 7 days",
       "selection": {
         "tagStatus": "untagged",

--- a/server/config/ecr/README.md
+++ b/server/config/ecr/README.md
@@ -72,7 +72,7 @@ Keeps the moving `prod` and `staging` tags forever. SHA-tagged images age out af
 }
 ```
 
-ECR is aware of image indexes, a tagged manifest list protects its referenced platform manifests even when those children appear untagged. So rule 3 only expires true orphans.
+ECR is aware of image indexes, a tagged manifest list protects its referenced platform manifests even when those children appear untagged. So rule 4 only expires true orphans.
 
 ## Policy: `instant-prod-ecr-buildcache`
 

--- a/server/config/ecr/README.md
+++ b/server/config/ecr/README.md
@@ -1,0 +1,119 @@
+# ECR lifecycle policies
+
+The ECR lifecycle policies live here. Nothing applies them automatically, so re-run the commands at the bottom of this file after editing.
+
+## Repos
+
+- `instant-prod-ecr`: deployable server images, multi-arch buildx output.
+- `instant-prod-ecr-buildcache`: BuildKit registry cache pushed by `--cache-to`. Build cache only, not deployable.
+
+## Tagging scheme for `instant-prod-ecr`
+
+Every build pushed by `.github/workflows/clojure.yml` carries:
+
+- `<git-sha>`: immutable, used by Elastic Beanstalk app versions for rollback.
+- `prod` or `staging`: moving tag, advances every push that targets that env. The choice is driven by the commit message: if `[staging]` is in the message it goes to `staging`, otherwise `prod`.
+
+The lifecycle policy below relies on this scheme.
+
+## Policy: `instant-prod-ecr`
+
+Keeps the moving `prod` and `staging` tags forever. SHA-tagged images age out after 90 days. Untagged images (for example, orphaned manifest-list children from deleted indexes) are cleared after 7 days.
+
+```json
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Keep the moving prod and staging tags forever",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPatternList": ["prod", "staging"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 9999
+      },
+      "action": {"type": "expire"}
+    },
+    {
+      "rulePriority": 2,
+      "description": "Expire other tagged images after 90 days",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPatternList": ["*"],
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 90
+      },
+      "action": {"type": "expire"}
+    },
+    {
+      "rulePriority": 3,
+      "description": "Expire untagged images after 7 days",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 7
+      },
+      "action": {"type": "expire"}
+    }
+  ]
+}
+```
+
+ECR is aware of image indexes, a tagged manifest list protects its referenced platform manifests even when those children appear untagged. So rule 3 only expires true orphans.
+
+## Policy: `instant-prod-ecr-buildcache`
+
+Everything expires after 30 days. The worst case of a too-aggressive policy here is a slow CI build.
+
+```json
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire any image after 30 days",
+      "selection": {
+        "tagStatus": "any",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 30
+      },
+      "action": {"type": "expire"}
+    }
+  ]
+}
+```
+
+## Applying
+
+### Via UI
+
+[Production Images](https://us-east-1.console.aws.amazon.com/ecr/repositories/private/597134865416/instant-prod-ecr/_/details?region=us-east-1)
+
+[BuildCache Images](https://us-east-1.console.aws.amazon.com/ecr/repositories/private/597134865416/instant-prod-ecr-buildcache/_/details?region=us-east-1)
+
+### Via CLI
+
+```bash
+# Apply policies (re-run after editing this README)
+aws --region us-east-1 ecr put-lifecycle-policy \
+  --repository-name instant-prod-ecr \
+  --lifecycle-policy-text "$(jq -c '.' <<'JSON'
+<paste the instant-prod-ecr policy JSON above>
+JSON
+)"
+
+aws --region us-east-1 ecr put-lifecycle-policy \
+  --repository-name instant-prod-ecr-buildcache \
+  --lifecycle-policy-text "$(jq -c '.' <<'JSON'
+<paste the instant-prod-ecr-buildcache policy JSON above>
+JSON
+)"
+```
+
+After applying, ECR runs the policy asynchronously. Check what would be expired with:
+
+```bash
+aws --region us-east-1 ecr get-lifecycle-policy-preview --repository-name instant-prod-ecr
+```


### PR DESCRIPTION
Changes our ECR publishing so that we can set up lifecycle rules to delete old containers.

Two changes to how we publish:
1. Use a separate repo for the build cache. This lets us more easily expire the build cache images without worrying about accidentally removing images we care about.
2. Tag the latest image with a `prod` tag, so that we definitely don't delete the version we rely on in prod

Then the other change is to add a lifecycle rule that will expire old images. I put that in the `config/ecr/README.md` file.

After merging this in, I'll add the lifecycle rules for the ecr repo and preview what it deletes to confirm we're not deleting stuff we need.