### PR TITLE
Replace Cloudwatch with Athena on the debug page

### DIFF
--- a/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
+++ b/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
@@ -55,9 +55,14 @@ function fetchDebugUriInfo(
 
 function AdminInfo({
   urls,
+  traceId,
+  spanId,
 }: {
   urls: { label: string; url: string; query?: string }[];
+  traceId: string;
+  spanId: string;
 }) {
+  const agentPrompt = `Investigate this trace. Read server/querying-logs.md.\n\ntrace_id: ${traceId}\nspan_id: ${spanId}`;
   return (
     <div className="flex w-full max-w-2xl flex-col items-center gap-4">
       <div>Admin URLs</div>
@@ -80,6 +85,10 @@ function AdminInfo({
           {u.query ? <QueryBlock query={u.query} /> : null}
         </div>
       ))}
+      <div className="flex w-full flex-col items-center gap-2">
+        <div>Prompt for agent</div>
+        <QueryBlock query={agentPrompt} />
+      </div>
     </div>
   );
 }
@@ -109,7 +118,11 @@ function Page() {
     <div className="mx-auto flex max-w-5xl flex-col items-center justify-center gap-4 p-8 px-4 py-12">
       <div className="text-4xl">🐞</div>
       {adminInfo ? (
-        <AdminInfo urls={adminInfo.urls} />
+        <AdminInfo
+          urls={adminInfo.urls}
+          traceId={router.query['trace-id'] as string}
+          spanId={router.query['span-id'] as string}
+        />
       ) : (
         <p>We don't have any additional information about this error.</p>
       )}

--- a/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
+++ b/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
@@ -1,10 +1,41 @@
 import { asClientOnlyPage, useReadyRouter } from '@/components/clientOnlyPage';
-import { Button, Content, Copyable, SectionHeading } from '@/components/ui';
+import { Button, Copyable } from '@/components/ui';
 import { useAuthToken } from '@/lib/auth';
 import config, { bugsAndQuestionsInviteUrl } from '@/lib/config';
 import { jsonFetch } from '@/lib/fetch';
-import { useRouter } from 'next/router';
+import { CheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useState } from 'react';
+
+function QueryBlock({ query }: { query: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="relative w-full">
+      <pre className="w-full overflow-x-auto rounded border bg-gray-50 p-3 pr-10 text-left font-mono text-xs text-gray-700">
+        {query}
+      </pre>
+      <button
+        type="button"
+        aria-label="Copy query"
+        onClick={() => {
+          navigator.clipboard
+            .writeText(query)
+            .then(() => {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            })
+            .catch(() => {});
+        }}
+        className="absolute top-2 right-2 cursor-pointer rounded border border-gray-200 bg-white p-1 text-gray-500 shadow-xs hover:bg-gray-50 hover:text-gray-700"
+      >
+        {copied ? (
+          <CheckIcon className="h-4 w-4" />
+        ) : (
+          <ClipboardDocumentIcon className="h-4 w-4" />
+        )}
+      </button>
+    </div>
+  );
+}
 
 function fetchDebugUriInfo(
   { traceId, spanId }: { traceId: string; spanId: string },
@@ -22,20 +53,32 @@ function fetchDebugUriInfo(
   );
 }
 
-function AdminInfo({ urls }: { urls: { label: string; url: string }[] }) {
+function AdminInfo({
+  urls,
+}: {
+  urls: { label: string; url: string; query?: string }[];
+}) {
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex w-full max-w-2xl flex-col items-center gap-4">
       <div>Admin URLs</div>
       {urls.map((u) => (
-        <a
-          key={u.url}
-          target="_blank"
-          href={u.url}
-          rel="noopener noreferrer"
-          className="text-blue-600 underline hover:text-blue-800"
-        >
-          {u.label}
-        </a>
+        <div key={u.url} className="flex w-full flex-col items-center gap-2">
+          <a
+            target="_blank"
+            href={u.url}
+            rel="noopener noreferrer"
+            onClick={() => {
+              if (u.query) {
+                navigator.clipboard.writeText(u.query).catch(() => {});
+              }
+            }}
+            className="text-blue-600 underline hover:text-blue-800"
+          >
+            {u.label}
+            {u.query ? ' (opens link and copies query to clipboard)' : ''}
+          </a>
+          {u.query ? <QueryBlock query={u.query} /> : null}
+        </div>
       ))}
     </div>
   );

--- a/server/querying-logs.md
+++ b/server/querying-logs.md
@@ -114,8 +114,13 @@ One-time setup at the top of each session:
 INSTALL httpfs;
 LOAD httpfs;
 SET s3_region = 'us-east-1';
+SET threads = 16;
 CREATE SECRET (TYPE S3, PROVIDER credential_chain);
 ```
+
+`threads = 16` is the only knob that controls S3 fetch parallelism.
+Each thread runs its own range-GETs and spends most of its time blocked
+on the network, so going above core count is fine.
 
 (If `credential_chain` doesn't pick up the right credentials, you can pin
 to a profile explicitly with `..., PROFILE '<your-profile>'`.)
@@ -136,7 +141,7 @@ Or as a bash one-liner, handy for piping into other tools:
 
 ```bash
 duckdb -markdown -c "
-INSTALL httpfs; LOAD httpfs; SET s3_region = 'us-east-1';
+INSTALL httpfs; LOAD httpfs; SET s3_region = 'us-east-1'; SET threads = 16;
 CREATE SECRET (TYPE S3, PROVIDER credential_chain);
 SELECT *
 FROM read_parquet('s3://eb-logs-597134865416-us-east-1-an/logs/env=Instant-docker-prod-env-2/year=2026/month=06/day=06/hour=23/minute=*/*.parquet', union_by_name=true)
@@ -145,17 +150,53 @@ ORDER BY timestamp;
 "
 ```
 
-Glob narrower than an hour: `hour=23/minute={15..30}/*.parquet`. Whole hour:
-`hour=23/minute=*/*.parquet`. Multiple hours: `hour={22,23}/minute=*/*.parquet`.
-Whole day: `hour=*/minute=*/*.parquet`. DuckDB expands these and reads files
-in parallel.
+DuckDB does not support brace expansion (`{15..30}`, `{22,23}`) in S3
+paths. Whole hour: `hour=23/minute=*/*.parquet`. Whole day:
+`hour=*/minute=*/*.parquet`. For a narrower window, pass a list of
+explicit paths:
+
+```sql
+SELECT *
+FROM read_parquet([
+  's3://.../hour=23/minute=15/*.parquet',
+  's3://.../hour=23/minute=16/*.parquet',
+  's3://.../hour=23/minute=17/*.parquet'
+], union_by_name = true)
+WHERE trace_id = '<the-trace-id>';
+```
+
+For a trace ID, decode the timestamp (see "Trace ID → partition" above)
+and list every minute from 5 before to 5 after. That covers Vector's
+ingestion-vs-event-time skew without scanning a whole hour.
 
 `union_by_name = true` is required. Different parquet files (especially
 from before/after a vector.yaml change) have different column sets and
 sometimes different column types; `union_by_name` merges them. Without it
 DuckDB errors on the first column mismatch.
 
+### Save results to a local file
+
+If you'll look at the same window more than once, write it to a local
+parquet file and query that instead of re-scanning S3:
+
+```sql
+COPY (
+  SELECT *
+  FROM read_parquet([...], union_by_name = true)
+  WHERE trace_id = '<the-trace-id>'
+) TO '/tmp/trace-<id>.parquet' (FORMAT PARQUET);
+```
+
+Then:
+
+```bash
+duckdb -markdown -c "SELECT * FROM read_parquet('/tmp/trace-<id>.parquet') ORDER BY timestamp;"
+```
+
 ## Common queries
+
+Prefer `SELECT *`. The schema is wide (see `athena/instant_logs_prod.sql`)
+and op-specific columns are easy to leave out by accident.
 
 ### Errors
 
@@ -163,7 +204,7 @@ Catches both span-thrown exceptions (most failures) and the rare
 library-logged ERROR.
 
 ```sql
-SELECT timestamp, name, logger, exception_type, exception_message, message
+SELECT *
 FROM read_parquet('s3://.../hour=23/minute=*/*.parquet', union_by_name=true)
 WHERE exception_type IS NOT NULL OR level = 'ERROR'
 ORDER BY timestamp DESC;
@@ -172,7 +213,7 @@ ORDER BY timestamp DESC;
 ### Find every event for a trace
 
 ```sql
-SELECT timestamp, name, level, message, duration_ms, exception_message
+SELECT *
 FROM read_parquet('s3://eb-logs-.../env=Instant-docker-prod-env-2/year=2026/month=06/day=06/hour=23/minute=*/*.parquet', union_by_name=true)
 WHERE trace_id = '<id>'
 ORDER BY timestamp;
@@ -201,7 +242,7 @@ ORDER BY timestamp;
 
 ```sql
 -- DuckDB
-SELECT * EXCLUDE (exception_stacktrace, label)
+SELECT * EXCLUDE (some_noisy_column)
 FROM read_parquet('s3://.../hour=23/minute=*/*.parquet', union_by_name=true)
 WHERE trace_id = '<id>';
 ```

--- a/server/querying-logs.md
+++ b/server/querying-logs.md
@@ -169,6 +169,23 @@ For a trace ID, decode the timestamp (see "Trace ID → partition" above)
 and list every minute from 5 before to 5 after. That covers Vector's
 ingestion-vs-event-time skew without scanning a whole hour.
 
+Watch the rollover: if the decoded minute is within 5 of :00 or :59 the
+window spans two hours, and at 23:55–00:04 it spans two days. The
+`hour=`/`day=` segments change too, so you have to emit paths for both
+sides or you'll silently miss files. Generate them with proper datetime
+arithmetic rather than tweaking the minute by hand:
+
+```bash
+DECODED="2026-06-11 16:57:30"  # from the python decode step
+for off in $(seq -5 5); do
+  python3 -c "
+import datetime as d
+t = d.datetime.fromisoformat('$DECODED').replace(tzinfo=d.timezone.utc) + d.timedelta(minutes=$off)
+print(f's3://eb-logs-597134865416-us-east-1-an/logs/env=Instant-docker-prod-env-2/year={t.year}/month={t.month:02d}/day={t.day:02d}/hour={t.hour:02d}/minute={t.minute:02d}/*.parquet')
+"
+done
+```
+
 `union_by_name = true` is required. Different parquet files (especially
 from before/after a vector.yaml change) have different column sets and
 sometimes different column types; `union_by_name` merges them. Without it

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -385,9 +385,8 @@
     (response/ok {:urls [{:label "View trace in Honeycomb"
                           :url (tracer/honeycomb-uri {:trace-id trace-id
                                                       :span-id span-id})}
-                         {:label "Search trace in Cloudwatch"
-                          :url (tracer/cloudwatch-uri {:trace-id trace-id
-                                                       :span-id span-id})}]})))
+                         (merge {:label "Search trace in Athena"}
+                                (tracer/athena-query {:trace-id trace-id}))]})))
 
 ;; ---
 ;; Dash

--- a/server/src/instant/util/tracer.clj
+++ b/server/src/instant/util/tracer.clj
@@ -18,6 +18,7 @@
    (io.opentelemetry.sdk.resources Resource)
    (io.opentelemetry.sdk.trace SdkTracer SdkTracerProvider SpanLimits)
    (io.opentelemetry.sdk.trace.export BatchSpanProcessor SimpleSpanProcessor)
+   (java.time Instant OffsetDateTime ZoneOffset)
    (java.util.concurrent TimeUnit)))
 
 (def ^:dynamic *span* nil)
@@ -284,7 +285,40 @@
           trace-id
           span-id))
 
-(defn cloudwatch-uri [{:keys [trace-id span-id]}]
-  (format "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-43200~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*27%s*2f%s*27*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2010000~queryId~'974cdbee-1e72-4492-9aef-c79ac11afe79~source~(~'*2faws*2felasticbeanstalk*2fInstant-docker-prod-env-2*2fvar*2flog*2feb-docker*2fcontainers*2feb-current-app*2fstdouterr.log)~lang~'CWLI)"
-          trace-id
-          span-id))
+(def athena-log-table
+  {:prod "instant_logs"
+   :staging "instant_logs_staging"})
+
+(defn- athena-window-clause
+  [^Instant start ^long window-mins]
+  (let [partitions (->> (range (- window-mins) (inc window-mins))
+                        (map (fn [^long n]
+                               (.atOffset (.plusSeconds start (* 60 n)) ZoneOffset/UTC)))
+                        (reduce (fn [acc ^OffsetDateTime odt]
+                                  (let [k [(.getYear odt) (.getMonthValue odt)
+                                           (.getDayOfMonth odt) (.getHour odt)]]
+                                    (update acc k (fnil conj (sorted-set)) (.getMinute odt))))
+                                {}))
+        clauses (for [[[y mo d h] mins] partitions]
+                  (format "(year = %d AND month = %d AND day = %d AND hour = %d AND minute BETWEEN %d AND %d)"
+                          y mo d h (apply min mins) (apply max mins)))]
+    (apply str (interpose "\n       OR " clauses))))
+
+(defn athena-query
+  "Build a SQL query that finds every log row for `trace-id`.
+
+   The partition filter covers ten minutes on either side of the trace's
+   decoded start time."
+  [{:keys [trace-id]}]
+  (let [start (id-gen/trace-id->instant trace-id)
+        table (get athena-log-table (config/get-env) "instant_logs")
+        query (format (str "SELECT *\n"
+                           "FROM %s\n"
+                           "WHERE (%s)\n"
+                           "  AND trace_id = '%s'\n"
+                           "ORDER BY \"timestamp\"")
+                      table
+                      (athena-window-clause start 10)
+                      trace-id)]
+    {:url "https://us-east-1.console.aws.amazon.com/athena/home?region=us-east-1#/query-editor"
+     :query query}))


### PR DESCRIPTION
Replaces the link to a cloudwatch search for the traceid with a link to athena.

Athena doesn't let you include a query in the url, so I put the query in a select box beneath and also copy it to your clipboard when you click the link.

I also improved the querying-logs.md file with some improvements after going on a debugging session with claude.

This is what it looks likes when you're logged in as an admin:

<img width="742" height="591" alt="Screenshot 2026-06-11 at 1 27 06 PM" src="https://github.com/user-attachments/assets/cb408873-05df-4606-a54c-59d1106fcf03" />
