### PR TITLE
[WWW] Add padding to bottom of explorer form

### DIFF
--- a/client/packages/components/src/components/explorer/edit-row-dialog.tsx
+++ b/client/packages/components/src/components/explorer/edit-row-dialog.tsx
@@ -1106,7 +1106,7 @@ export function EditRowDialog({
       </div>
       <div
         ref={formBodyRef}
-        className="scrollbar-gutter-stable mt-4 min-h-0 flex-1 overflow-y-auto px-4"
+        className="scrollbar-gutter-stable mt-4 min-h-0 flex-1 overflow-y-auto px-4 pb-4"
       >
         <div className="flex flex-col gap-4">
           {op === 'add' ? (


### PR DESCRIPTION
I remember we mentioned this during our weekly meeting and I encountered it today. Thought it would be nice to clean up!

**Before**
<img width="1018" height="302" alt="CleanShot 2026-06-19 at 12 51 18@2x" src="https://github.com/user-attachments/assets/7fa61ba5-498a-4804-b2cd-a16ed54efb8a" />

**After**
<img width="1160" height="322" alt="CleanShot 2026-06-19 at 12 51 04@2x" src="https://github.com/user-attachments/assets/1f6a8297-85dd-42d9-ba58-8bb92f5dfe2e" />