### PR TITLE
[Backend] Reset datascript tx counter

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -350,6 +350,9 @@
 (defn hard-deletion-sweeper-disabled? []
   (toggled? :hard-deletion-sweeper-disabled?))
 
+(defn conn-tx-reset-disabled? []
+  (toggled? :conn-tx-reset-disabled?))
+
 (defn rate-limit-tx-based-on-conn-pool? []
   (toggled? :rate-limit-tx-based-on-conn-pool?))
 

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -459,7 +459,8 @@
    before each transaction so a conn that has already hit the limit (every txn
    throws while building the datom) recovers on its next transaction."
   [conn]
-  (when (> (long (:max-tx @conn)) ds-tx-reset-threshold)
+  (when (and (> (long (:max-tx @conn)) ds-tx-reset-threshold)
+             (not (flags/conn-tx-reset-disabled?)))
     (reset-conn-tx! conn)))
 
 (defn transact! [span-name conn tx-data]

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -428,21 +428,18 @@
                    datalog-query-eids))
 
 (def ^:const ds-tx0
-  "Datascript's starting transaction id (see datascript.db/tx0)."
+  "Datascript's starting tx id (datascript.db/tx0)."
   0x20000000)
 
 (def ^:const ds-tx-reset-threshold
-  "Datascript stores datom tx-ids as 32-bit ints (max 0x7FFFFFFF). A long-lived
-   store conn for a busy app keeps bumping max-tx on every transaction and would
-   eventually overflow. We rebuild the db to reset the counter once max-tx gets
-   within ~1M of the limit, which leaves ample headroom for in-flight txns."
+  "Reset the tx counter once max-tx gets this close to datascript's 32-bit
+   tx-id limit (0x7FFFFFFF)."
   (- 0x7FFFFFFF 1000000))
 
 (defn reset-conn-tx!
   "Rebuilds the conn's db with every datom's tx reset to tx0 to avoid overflowing
-   datascript's 32-bit tx-id. Eids are preserved (so refs and the datalog cache
-   stay valid) and the conn is reused (so its executors, cache, and live
-   subscriptions survive)."
+   datascript's 32-bit tx-id. Reuses the conn and preserves eids, so refs, the
+   datalog cache, and live subscriptions survive."
   [conn]
   (lang/with-reentrant-lock (:lock (meta conn))
     (let [db @conn]
@@ -452,7 +449,10 @@
         (let [datoms (mapv (fn [d]
                              (d/datom (:e d) (:a d) (:v d) ds-tx0 true))
                            (d/datoms db :eavt))]
-          (reset! conn (d/init-db datoms (:schema db))))))))
+          ;; Carry :max-eid forward; init-db would recompute it from live datoms,
+          ;; letting a retracted highest eid get reused and alias stale cache keys.
+          (reset! conn (assoc (d/init-db datoms (:schema db))
+                              :max-eid (:max-eid db))))))))
 
 (defn maybe-reset-conn-tx!
   "Resets the conn's tx counter when it nears datascript's 32-bit limit. Checked

--- a/server/src/instant/reactive/store.clj
+++ b/server/src/instant/reactive/store.clj
@@ -427,7 +427,43 @@
                    []
                    datalog-query-eids))
 
+(def ^:const ds-tx0
+  "Datascript's starting transaction id (see datascript.db/tx0)."
+  0x20000000)
+
+(def ^:const ds-tx-reset-threshold
+  "Datascript stores datom tx-ids as 32-bit ints (max 0x7FFFFFFF). A long-lived
+   store conn for a busy app keeps bumping max-tx on every transaction and would
+   eventually overflow. We rebuild the db to reset the counter once max-tx gets
+   within ~1M of the limit, which leaves ample headroom for in-flight txns."
+  (- 0x7FFFFFFF 1000000))
+
+(defn reset-conn-tx!
+  "Rebuilds the conn's db with every datom's tx reset to tx0 to avoid overflowing
+   datascript's 32-bit tx-id. Eids are preserved (so refs and the datalog cache
+   stay valid) and the conn is reused (so its executors, cache, and live
+   subscriptions survive)."
+  [conn]
+  (lang/with-reentrant-lock (:lock (meta conn))
+    (let [db @conn]
+      (tracer/with-span! {:name "store/reset-conn-tx!"
+                          :attributes {:app-id (:app-id (meta conn))
+                                       :max-tx (:max-tx db)}}
+        (let [datoms (mapv (fn [d]
+                             (d/datom (:e d) (:a d) (:v d) ds-tx0 true))
+                           (d/datoms db :eavt))]
+          (reset! conn (d/init-db datoms (:schema db))))))))
+
+(defn maybe-reset-conn-tx!
+  "Resets the conn's tx counter when it nears datascript's 32-bit limit. Checked
+   before each transaction so a conn that has already hit the limit (every txn
+   throws while building the datom) recovers on its next transaction."
+  [conn]
+  (when (> (long (:max-tx @conn)) ds-tx-reset-threshold)
+    (reset-conn-tx! conn)))
+
 (defn transact! [span-name conn tx-data]
+  (maybe-reset-conn-tx! conn)
   (let [report (if (or (flags/toggled? :enable-store-batching-globally)
                        (contains? (flags/flag :enable-store-batching-apps)
                                   (:app-id (meta conn))))

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -487,5 +487,35 @@
       (is (<= (* 0.5 total-ms) elapsed (* 3 total-ms))
           (str "expected wall time near " total-ms "ms, got " elapsed "ms")))))
 
+(deftest reset-conn-tx!
+  (let [store  (rs/init)
+        app-id (random-uuid)
+        conn   (rs/app-conn store app-id)]
+    ;; Advance the tx counter past tx0 and create a few entities.
+    (rs/transact! "test" conn [{:db/id -1
+                                :datalog-query/app-id app-id
+                                :datalog-query/query [[:ea 1]]}])
+    (rs/transact! "test" conn [{:db/id -2
+                                :datalog-query/app-id app-id
+                                :datalog-query/query [[:ea 2]]}])
+    (let [db-before     @conn
+          datoms-before (set (map (juxt :e :a :v) (d/datoms db-before :eavt)))]
+      (is (> (:max-tx db-before) rs/ds-tx0))
+
+      (rs/reset-conn-tx! conn)
+
+      (let [db-after @conn]
+        (testing "tx counter is reset to tx0"
+          (is (= rs/ds-tx0 (:max-tx db-after))))
+        (testing "datoms (eids, attrs, values) are preserved"
+          (is (= datoms-before
+                 (set (map (juxt :e :a :v) (d/datoms db-after :eavt))))))
+        (testing "max-eid is preserved so new entities don't collide"
+          (is (= (:max-eid db-before) (:max-eid db-after))))
+        (testing "lookups still resolve after reset"
+          (is (some? (d/entity db-after [:tx-meta/app-id app-id])))
+          (is (some? (d/entity db-after [:datalog-query/app-id+query
+                                         [app-id [[:ea 1]]]]))))))))
+
 (comment
   (test/run-tests *ns*))

--- a/server/test/instant/reactive/store_test.clj
+++ b/server/test/instant/reactive/store_test.clj
@@ -517,5 +517,31 @@
           (is (some? (d/entity db-after [:datalog-query/app-id+query
                                          [app-id [[:ea 1]]]]))))))))
 
+(deftest reset-conn-tx!-preserves-max-eid
+  ;; Regression: a retracted highest eid must not be reused after a reset, so the
+  ;; reset carries :max-eid forward instead of letting init-db recompute it.
+  (let [store   (rs/init)
+        app-id  (random-uuid)
+        conn    (rs/app-conn store app-id)
+        report  (rs/transact! "test" conn [{:db/id -1
+                                            :datalog-query/app-id app-id
+                                            :datalog-query/query [[:ea 1]]}])
+        top-eid (get (:tempids report) -1)]
+    ;; fully retract the entity holding the highest eid
+    (rs/transact! "test" conn [[:db/retractEntity top-eid]])
+    (let [max-eid-before (:max-eid @conn)]
+      (is (= top-eid max-eid-before)
+          "the retracted entity should have held the highest eid")
+
+      (rs/reset-conn-tx! conn)
+
+      (testing "max-eid is carried forward, not recomputed from live datoms"
+        (is (= max-eid-before (:max-eid @conn))))
+      (testing "a new entity gets a fresh eid above the retracted one (no reuse)"
+        (let [report' (rs/transact! "test" conn [{:db/id -1
+                                                  :datalog-query/app-id app-id
+                                                  :datalog-query/query [[:ea 2]]}])]
+          (is (> (get (:tempids report') -1) top-eid)))))))
+
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Datascript uses 32-bit integers for tx-ids. Given enough transactions we will exhaust that. This PR makes it so that when we are within ~1M tx-ids from our max we reset the app's tx-id back to the starting point.

Start / max values come from https://github.com/tonsky/datascript/blob/master/src/datascript/db.cljc