### PR TITLE
Disable 1password icon on non-sensitive fields

### DIFF
--- a/client/packages/components/src/components/explorer/new-namespace-dialog.tsx
+++ b/client/packages/components/src/components/explorer/new-namespace-dialog.tsx
@@ -39,6 +39,7 @@ export function NewNamespaceDialog({
         placeholder="Name your namespace"
         onChange={(n) => setName(n)}
         autoFocus
+        ignorePasswordManager
       />
 
       <ActionButton

--- a/client/packages/components/src/components/ui.tsx
+++ b/client/packages/components/src/components/ui.tsx
@@ -200,6 +200,7 @@ export function TextInput({
   title,
   required,
   onBlur,
+  ignorePasswordManager,
 }: {
   value: string;
   type?: 'text' | 'email' | 'sensitive' | 'password';
@@ -216,6 +217,9 @@ export function TextInput({
   title?: string | undefined;
   required?: boolean | undefined;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  // Suppress the password manager overlay on non-credential fields
+  // (e.g. naming a namespace or app), where their icon is just noise.
+  ignorePasswordManager?: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -225,6 +229,10 @@ export function TextInput({
     }
   }, []);
 
+  // Sensitive inputs already opt out of password managers so they can't
+  // save the secret; plain fields can opt out to drop the noisy icon.
+  const ignorePw = type === 'sensitive' || ignorePasswordManager;
+
   return (
     <label className="flex flex-col gap-1">
       {label ? <Label>{label}</Label> : null}
@@ -232,12 +240,12 @@ export function TextInput({
         disabled={disabled}
         title={title}
         // Try to prevent password managers (LastPass, 1Password,
-        // BitWarden) from attaching to or saving sensitive input.
-        autoComplete={type === 'sensitive' ? 'off' : undefined}
-        data-lpignore={type === 'sensitive' ? 'true' : undefined}
-        data-1p-ignore={type === 'sensitive' ? 'true' : undefined}
-        data-bwignore={type === 'sensitive' ? 'true' : undefined}
-        data-form-type={type === 'sensitive' ? 'other' : undefined}
+        // BitWarden) from attaching to or saving the input.
+        autoComplete={ignorePw ? 'off' : undefined}
+        data-lpignore={ignorePw ? 'true' : undefined}
+        data-1p-ignore={ignorePw ? 'true' : undefined}
+        data-bwignore={ignorePw ? 'true' : undefined}
+        data-form-type={ignorePw ? 'other' : undefined}
         // LastPass attaches its UI to any <input type="password"> even
         // when data-lpignore="true" is set. To opt out we render the
         // field as type="text" and use -webkit-text-security to mask

--- a/client/www/components/admin/AdminPage.tsx
+++ b/client/www/components/admin/AdminPage.tsx
@@ -326,6 +326,7 @@ export function Admin({
                   <TextInput
                     {...appNameForm.inputProps('name')}
                     placeholder="My awesome app"
+                    ignorePasswordManager
                   />
                 </div>
                 <Button

--- a/client/www/components/dash/OAuthApps.tsx
+++ b/client/www/components/dash/OAuthApps.tsx
@@ -820,6 +820,7 @@ function CreateClientForm({
         label="Unique name"
         placeholder="Unique name"
         required={true}
+        ignorePasswordManager
       />
       <AuthorizedRedirectUrlsInput
         urls={authorizedRedirectUrls}
@@ -1306,6 +1307,7 @@ function CreateAppForm({ onClose }: { onClose: () => void }) {
         label="Unique name"
         placeholder="Unique name"
         required={true}
+        ignorePasswordManager
       />
       <TextInput
         value={homepageUrl}

--- a/client/www/components/dash/Onboarding.tsx
+++ b/client/www/components/dash/Onboarding.tsx
@@ -260,6 +260,7 @@ function CreateFirstAppScreen(props: {
             onChange={(t) => {
               props.onAppNameChange(t);
             }}
+            ignorePasswordManager
           />
           <Button
             type="submit"

--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -650,6 +650,7 @@ export function Sandbox({
             label={<div className="pt-2 pb-0 font-normal">Sandbox Name</div>}
             value={newSaveName}
             onChange={setNewSaveName}
+            ignorePasswordManager
           />
           <div className="flex justify-end pt-2">
             <Button type="submit">Save</Button>

--- a/client/www/components/dash/auth/Apple.tsx
+++ b/client/www/components/dash/auth/Apple.tsx
@@ -150,6 +150,7 @@ export function AddClientExpanded({
         onChange={setClientName}
         label="Client Name"
         placeholder="e.g. apple"
+        ignorePasswordManager
       />
       <TextInput
         tabIndex={2}

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -340,6 +340,7 @@ export function AddClerkClientForm({
         onChange={setClientName}
         label="Unique name"
         placeholder="e.g. clerk"
+        ignorePasswordManager
       />
       <TextInput
         tabIndex={2}

--- a/client/www/components/dash/auth/Firebase.tsx
+++ b/client/www/components/dash/auth/Firebase.tsx
@@ -177,6 +177,7 @@ export function AddFirebaseClientForm({
         onChange={setClientName}
         label="Unique name"
         placeholder="e.g. firebase"
+        ignorePasswordManager
       />
       <TextInput
         tabIndex={2}

--- a/client/www/components/dash/auth/GitHub.tsx
+++ b/client/www/components/dash/auth/GitHub.tsx
@@ -122,6 +122,7 @@ export function AddGitHubClientForm({
         onChange={setClientName}
         label="Client name"
         placeholder="e.g. github-web"
+        ignorePasswordManager
       />
 
       <TextInput

--- a/client/www/components/dash/auth/Google.tsx
+++ b/client/www/components/dash/auth/Google.tsx
@@ -206,6 +206,7 @@ export function AddGoogleClientForm({
         onChange={setClientName}
         label="Client name"
         placeholder={`e.g. google-${appType}`}
+        ignorePasswordManager
       />
 
       {useSharedCredentials ? (

--- a/client/www/components/dash/auth/LinkedIn.tsx
+++ b/client/www/components/dash/auth/LinkedIn.tsx
@@ -129,6 +129,7 @@ export function AddLinkedInClientForm({
         onChange={setClientName}
         label="Client name"
         placeholder="e.g. linkedin-web"
+        ignorePasswordManager
       />
 
       <TextInput

--- a/client/www/components/dash/org-management/CreateOrgModal.tsx
+++ b/client/www/components/dash/org-management/CreateOrgModal.tsx
@@ -80,6 +80,7 @@ export const CreateOrgModal = ({
             label="Name"
             placeholder="My Organization"
             onChange={(e) => setValue(e)}
+            ignorePasswordManager
           />
           <div className="flex justify-end gap-2 pt-4">
             <Button

--- a/client/www/components/dash/org-management/RenameOrg.tsx
+++ b/client/www/components/dash/org-management/RenameOrg.tsx
@@ -65,6 +65,7 @@ export const RenameOrg = () => {
           className="min-w-[300px]"
           placeholder="Enter new organization name"
           onChange={(e) => setValue(e)}
+          ignorePasswordManager
         />
 
         <div className="flex justify-end gap-2 pt-2 md:pt-4">


### PR DESCRIPTION
1password will try to infer which fields may be sensitive and add in an icon. It will commonly do this when there is only one input for a form. Got complaints about this for things like our create namespace modal so asked Claude to do a sweep to find where we can fix this.

This updates our create + rename namespace / org modals, as well as our OAuth config forms to hide 1password and bitwarden icons.