### PR TITLE
[WWW] Add explicit width to sandbox icons

### DIFF
--- a/client/www/components/dash/Sandbox.tsx
+++ b/client/www/components/dash/Sandbox.tsx
@@ -603,7 +603,7 @@ export function Sandbox({
                 deleteSandbox(selectedSandbox);
               }}
               label="Delete Sandbox"
-              icon={<TrashIcon />}
+              icon={<TrashIcon width={18} />}
             />
 
             <IconButton
@@ -618,7 +618,7 @@ export function Sandbox({
           </>
         )}
         <IconButton
-          icon={<PlusIcon />}
+          icon={<PlusIcon width={18} />}
           label="Save As..."
           onClick={() => {
             saveCurrentDialog.onOpen();


### PR DESCRIPTION
Got a user report that icons save/trash icons weren't appearing in the sandbox page on Safari. Was able to confirm and pushing up a quick fix here!

**Before**
<img width="1550" height="182" alt="CleanShot 2026-07-06 at 14 36 05@2x" src="https://github.com/user-attachments/assets/3a020682-8211-491e-b089-bcd640e96ce2" />

**After**
<img width="1542" height="164" alt="CleanShot 2026-07-06 at 14 36 16@2x" src="https://github.com/user-attachments/assets/0086ff55-3b1e-4c60-9efc-5203eb22f8ca" />
