### PR TITLE
fix where clause spacing in explorer component

### DIFF
--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -996,8 +996,8 @@ export const InnerExplorer: React.FC<{
                   <strong>{selectedNamespace.name}</strong>{' '}
                   {currentNav.where ? (
                     <>
-                      {' '}
-                      where <strong>{currentNav.where[0]}</strong> ={' '}
+                      &nbsp;where&nbsp;
+                      <strong>{currentNav.where[0]}</strong> ={' '}
                       <em className="rounded-xs border bg-white px-1 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white">
                         {JSON.stringify(currentNav.where[1])}
                       </em>


### PR DESCRIPTION
BEFORE: 
<img width="1044" height="298" alt="image" src="https://github.com/user-attachments/assets/64969810-2dd7-4ccd-b551-7bde4399a431" />

AFTER:
<img width="634" height="154" alt="image" src="https://github.com/user-attachments/assets/c11029b5-d533-4703-9718-ff9c02dfeb63" />
