### PR TITLE
make async storage optional for react-native

### DIFF
--- a/client/packages/react-native-mmkv/README.md
+++ b/client/packages/react-native-mmkv/README.md
@@ -40,7 +40,7 @@ npm i @instantdb/react-native @instantdb/react-native-mmkv
 ### Install peer dependencies
 
 ```shell
-npx expo install react-native-mmkv react-native-nitro-modules @react-native-community/netinfo react-native-get-random-values @react-native-async-storage/async-storage
+npx expo install react-native-mmkv react-native-nitro-modules @react-native-community/netinfo react-native-get-random-values
 ```
 
 ### Prebuild

--- a/client/packages/react-native/package.json
+++ b/client/packages/react-native/package.json
@@ -42,6 +42,11 @@
     "react-native": ">=0.56",
     "react-native-get-random-values": ">=1.5"
   },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@instantdb/core": "workspace:*",
     "@instantdb/react-common": "workspace:*",

--- a/client/packages/react-native/src/Storage.native.ts
+++ b/client/packages/react-native/src/Storage.native.ts
@@ -1,9 +1,16 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StoreInterface, StoreInterfaceStoreName } from '@instantdb/core';
 
 const version = 5;
 
-export default class Store extends StoreInterface {
+// AsyncStorage is an optional peer dependency. When it's not installed we
+// fall back to one of the alternative store packages below, or surface a
+// helpful error from `init` if no store is available at all.
+let AsyncStorage: any = null;
+try {
+  AsyncStorage = require('@react-native-async-storage/async-storage').default;
+} catch {}
+
+export class AsyncStorageStore extends StoreInterface {
   private appId: string;
   private dbName: StoreInterfaceStoreName;
   constructor(appId: string, dbName: StoreInterfaceStoreName) {
@@ -48,3 +55,49 @@ export default class Store extends StoreInterface {
     );
   }
 }
+
+class MissingStore extends StoreInterface {
+  constructor(appId: string, dbName: StoreInterfaceStoreName) {
+    super(appId, dbName);
+    throw new Error(
+      'Instant needs a store to persist data on device. ' +
+        'Install `@react-native-async-storage/async-storage`, ' +
+        'or one of the alternative stores (`@instantdb/react-native-mmkv`, `@instantdb/expo-sqlite`), ' +
+        'or pass a custom `Store` to `init`.',
+    );
+  }
+
+  async getItem(_k: string): Promise<any> {
+    return null;
+  }
+
+  async removeItem(_k: string): Promise<void> {}
+
+  async multiSet(_keyValuePairs: Array<[string, any]>): Promise<void> {}
+
+  async getAllKeys(): Promise<string[]> {
+    return [];
+  }
+}
+
+// Each `require` below must sit directly inside a `try` block: that's what
+// makes Metro treat it as an optional dependency
+// (`transformer.allowOptionalDependencies`, enabled by default in the Expo
+// and React Native metro configs), so bundling doesn't fail when one of
+// these packages isn't installed.
+function resolveDefaultStore() {
+  if (AsyncStorage) {
+    return AsyncStorageStore;
+  }
+  try {
+    const mod = require('@instantdb/react-native-mmkv');
+    return mod.default ?? mod;
+  } catch {}
+  try {
+    const mod = require('@instantdb/expo-sqlite');
+    return mod.default ?? mod;
+  } catch {}
+  return MissingStore;
+}
+
+export default resolveDefaultStore();

--- a/client/packages/react-native/src/Storage.native.ts
+++ b/client/packages/react-native/src/Storage.native.ts
@@ -2,9 +2,12 @@ import { StoreInterface, StoreInterfaceStoreName } from '@instantdb/core';
 
 const version = 5;
 
-// AsyncStorage is an optional peer dependency. When it's not installed we
-// fall back to one of the alternative store packages below, or surface a
-// helpful error from `init` if no store is available at all.
+// AsyncStorage is an optional peer dependency. The `require` must sit
+// directly inside a `try` block: that's what makes Metro treat it as an
+// optional dependency (`transformer.allowOptionalDependencies`, enabled by
+// default in the Expo and React Native metro configs), so bundling doesn't
+// fail when it isn't installed. When it's missing, `init` surfaces a helpful
+// error unless a custom `Store` is passed.
 let AsyncStorage: any = null;
 try {
   AsyncStorage = require('@react-native-async-storage/async-storage').default;
@@ -62,8 +65,7 @@ class MissingStore extends StoreInterface {
     throw new Error(
       'Instant needs a store to persist data on device. ' +
         'Install `@react-native-async-storage/async-storage`, ' +
-        'or one of the alternative stores (`@instantdb/react-native-mmkv`, `@instantdb/expo-sqlite`), ' +
-        'or pass a custom `Store` to `init`.',
+        'or pass a `Store` to `init` (e.g. from `@instantdb/react-native-mmkv` or `@instantdb/expo-sqlite`).',
     );
   }
 
@@ -80,24 +82,4 @@ class MissingStore extends StoreInterface {
   }
 }
 
-// Each `require` below must sit directly inside a `try` block: that's what
-// makes Metro treat it as an optional dependency
-// (`transformer.allowOptionalDependencies`, enabled by default in the Expo
-// and React Native metro configs), so bundling doesn't fail when one of
-// these packages isn't installed.
-function resolveDefaultStore() {
-  if (AsyncStorage) {
-    return AsyncStorageStore;
-  }
-  try {
-    const mod = require('@instantdb/react-native-mmkv');
-    return mod.default ?? mod;
-  } catch {}
-  try {
-    const mod = require('@instantdb/expo-sqlite');
-    return mod.default ?? mod;
-  } catch {}
-  return MissingStore;
-}
-
-export default resolveDefaultStore();
+export default AsyncStorage ? AsyncStorageStore : MissingStore;

--- a/client/packages/react-native/src/Storage.native.ts
+++ b/client/packages/react-native/src/Storage.native.ts
@@ -6,12 +6,15 @@ const version = 5;
 // directly inside a `try` block: that's what makes Metro treat it as an
 // optional dependency (`transformer.allowOptionalDependencies`, enabled by
 // default in the Expo and React Native metro configs), so bundling doesn't
-// fail when it isn't installed. When it's missing, `init` surfaces a helpful
-// error unless a custom `Store` is passed.
+// fail when it isn't installed. When it can't be loaded, `init` surfaces a
+// helpful error unless a custom `Store` is passed.
 let AsyncStorage: any = null;
+let asyncStorageLoadError: unknown = null;
 try {
   AsyncStorage = require('@react-native-async-storage/async-storage').default;
-} catch {}
+} catch (e) {
+  asyncStorageLoadError = e;
+}
 
 export class AsyncStorageStore extends StoreInterface {
   private appId: string;
@@ -65,7 +68,10 @@ class MissingStore extends StoreInterface {
     throw new Error(
       'Instant needs a store to persist data on device. ' +
         'Install `@react-native-async-storage/async-storage`, ' +
-        'or pass a `Store` to `init` (e.g. from `@instantdb/react-native-mmkv` or `@instantdb/expo-sqlite`).',
+        'or pass a `Store` to `init` (e.g. from `@instantdb/react-native-mmkv` or `@instantdb/expo-sqlite`).' +
+        (asyncStorageLoadError
+          ? `\n\nLoading async-storage failed with: ${asyncStorageLoadError}`
+          : ''),
     );
   }
 

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.50';
+const version = 'v1.0.51';
 
 export { version };

--- a/client/www/app/docs/start-rn/page.md
+++ b/client/www/app/docs/start-rn/page.md
@@ -175,6 +175,8 @@ npx expo run:ios # or npx expo run:android
 
 That's it! Instant will now use MMKV for local persistence instead of AsyncStorage.
 
+When you use a custom store, `@react-native-async-storage/async-storage` becomes optional, so you can remove it from your dependencies.
+
 ## Using expo-sqlite for storage (optional)
 
 If your app already uses [expo-sqlite](https://docs.expo.dev/versions/latest/sdk/sqlite/), you can use it for Instant's local persistence too.
@@ -215,6 +217,8 @@ npx expo run:ios # or npx expo run:android
 ```
 
 That's it! Instant will now use expo-sqlite for local persistence instead of AsyncStorage.
+
+When you use a custom store, `@react-native-async-storage/async-storage` becomes optional, so you can remove it from your dependencies.
 
 ## Implementing your own store
 


### PR DESCRIPTION
right now `@instantdb/react-native` hard-imports `@react-native-async-storage/async-storage` at the top of `Storage.native.ts`, so apps that pass a custom `Store` to `init` (mmkv from #2219, expo-sqlite from #2780) still have to install async storage just to make the bundle resolve, and `expo doctor` errors on the missing peer dep.

this makes the default store lazy and optional:

- async storage installed: default store, same as today. no behavior change for existing apps, same keys, same data.
- not installed: fall back to `@instantdb/react-native-mmkv`, then `@instantdb/expo-sqlite`, if one of those is installed. installing a wrapper package is enough, no need to pass `Store` explicitly (though you still can).
- nothing installed and no custom `Store`: `init` throws with instructions, instead of the bundler failing on a module it can't resolve.

the requires sit directly inside `try` blocks, which metro treats as optional dependencies (`transformer.allowOptionalDependencies`, enabled by default in both `@expo/metro-config` and `@react-native/metro-config`), so bundling no longer fails when async storage is absent. the peer dep is also marked optional via `peerDependenciesMeta`, which is what fixes the `expo doctor` error. the async storage store is still exported as `AsyncStorageStore` if anyone wants to force it.

one caveat to flag: on a metro config that does not enable `allowOptionalDependencies` (vanilla metro without the expo or rn presets), the two wrapper requires would now fail to resolve for apps that don't have them installed. both standard configs enable it, so this should be a non-issue in practice, but mentioning it in case you'd rather guard differently.

verified the resolution logic in node with stubbed modules (all four combinations pass: async storage wins when present, mmkv then expo-sqlite as fallbacks, helpful error when nothing is there), and build + `test:ci` pass. also dropped async storage from the mmkv readme install line and added a note to the rn docs page. no lockfile change needed.
