### PR TITLE
resolve storage adapter native modules from the sandbox app

### DIFF
--- a/client/sandbox/react-native-expo/metro.config.js
+++ b/client/sandbox/react-native-expo/metro.config.js
@@ -30,19 +30,21 @@ config.resolver.disableHierarchicalLookup = false;
 // Metro resolves them instead of this app's, and we end up bundling a second react-native.
 // Resolve them from the app so there's only ever one copy.
 const singletonModules = ['expo-sqlite', 'react-native-mmkv'];
+const defaultResolveRequest = config.resolver.resolveRequest;
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const resolve = defaultResolveRequest ?? context.resolveRequest;
   const isSingleton = singletonModules.some(
     (m) => moduleName === m || moduleName.startsWith(`${m}/`),
   );
   if (isSingleton) {
-    return context.resolveRequest(
+    return resolve(
       { ...context, originModulePath: path.join(projectRoot, 'package.json') },
       moduleName,
       platform,
     );
   }
-  return context.resolveRequest(context, moduleName, platform);
+  return resolve(context, moduleName, platform);
 };
 
 module.exports = config;

--- a/client/sandbox/react-native-expo/metro.config.js
+++ b/client/sandbox/react-native-expo/metro.config.js
@@ -24,4 +24,25 @@ config.resolver.nodeModulesPaths = [
 // So instead we do this per https://github.com/expo/expo/issues/17261#issuecomment-1681206857
 config.resolver.disableHierarchicalLookup = false;
 
+// 4. Our storage adapters (@instantdb/react-native-mmkv, @instantdb/expo-sqlite) take
+// their native module as a peerDependency, but also keep a devDependency copy of it to
+// typecheck against. In the workspace those copies are symlinked into the adapter, so
+// Metro resolves them instead of this app's, and we end up bundling a second react-native.
+// Resolve them from the app so there's only ever one copy.
+const singletonModules = ['expo-sqlite', 'react-native-mmkv'];
+
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const isSingleton = singletonModules.some(
+    (m) => moduleName === m || moduleName.startsWith(`${m}/`),
+  );
+  if (isSingleton) {
+    return context.resolveRequest(
+      { ...context, originModulePath: path.join(projectRoot, 'package.json') },
+      moduleName,
+      platform,
+    );
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = config;


### PR DESCRIPTION
We got a PR to add a expo-sqlite package for react native https://github.com/instantdb/instant/pull/2780

Was able to verify it worked but hit one snag with dependency resolution for our sandbox. Putting up this PR to fix that so we can also update #2780 with a sandbox example using expo-sqlite