### PR TITLE
Cleanup after pg_size migration

### DIFF
--- a/server/src/instant/dash/admin.clj
+++ b/server/src/instant/dash/admin.clj
@@ -109,36 +109,20 @@
                                             [:customer-email :user_email]
                                             :monthly-revenue
                                             :start-timestamp
-                                            [(if (flags/new-db-size?)
-                                               {:select [[[:coalesce
-                                                           [:*
-                                                            [:sum :agg.pg_size]
-                                                            [:case
-                                                             [:= [:pg_relation_size "triples"] 0] 1
-                                                             :else [:/
-                                                                    [:cast [:pg_total_relation_size "triples"] :numeric]
-                                                                    [:pg_relation_size "triples"]]]]
-                                                           0]]]
-                                                :from [[:triples-size-aggregate :agg]]
-                                                :join [[:attrs :a] [:= :a.id :agg.attr_id]]
-                                                :where [:and
-                                                        [:= :agg.app_id :apps.id]
-                                                        [:= nil :a.deletion_marked_at]]}
-
-                                               {:select [[[:coalesce
-                                                           [:*
-                                                            [:sum :s.triples_pg_size]
-                                                            [:case
-                                                             [:= [:pg_relation_size "triples"] 0] 1
-                                                             :else [:/
-                                                                    [:cast [:pg_total_relation_size "triples"] :numeric]
-                                                                    [:pg_relation_size "triples"]]]]
-                                                           0]]]
-                                                :from [[:attr-sketches :s]]
-                                                :join [[:attrs :a] [:= :a.id :s.attr_id]]
-                                                :where [:and
-                                                        [:= :s.app_id :apps.id]
-                                                        [:= nil :a.deletion_marked_at]]})
+                                            [{:select [[[:coalesce
+                                                         [:*
+                                                          [:sum :agg.pg_size]
+                                                          [:case
+                                                           [:= [:pg_relation_size "triples"] 0] 1
+                                                           :else [:/
+                                                                  [:cast [:pg_total_relation_size "triples"] :numeric]
+                                                                  [:pg_relation_size "triples"]]]]
+                                                         0]]]
+                                              :from [[:triples-size-aggregate :agg]]
+                                              :join [[:attrs :a] [:= :a.id :agg.attr_id]]
+                                              :where [:and
+                                                      [:= :agg.app_id :apps.id]
+                                                      [:= nil :a.deletion_marked_at]]}
                                              :usage]
                                             [{:select [[[:coalesce [:sum :s.total] 0]]]
                                               :from [[:attr_sketches :s]]
@@ -154,36 +138,20 @@
                                             [:customer-email :user_email]
                                             :monthly-revenue
                                             :start-timestamp
-                                            [(if (flags/new-db-size?)
-                                               {:select [[[:coalesce
-                                                           [:*
-                                                            [:sum :agg.pg_size]
-                                                            [:case
-                                                             [:= [:pg_relation_size "triples"] 0] 1
-                                                             :else [:/
-                                                                    [:cast [:pg_total_relation_size "triples"] :numeric]
-                                                                    [:pg_relation_size "triples"]]]]
-                                                           0]]]
-                                                :from [[:triples-size-aggregate :agg]]
-                                                :join [[:attrs :a] [:= :a.id :agg.attr_id]]
-                                                :where [:and
-                                                        [:in :agg.app_id {:select :id :from :apps :where [:= :apps.org_id :orgs.id]}]
-                                                        [:= nil :a.deletion_marked_at]]}
-
-                                               {:select [[[:coalesce
-                                                           [:*
-                                                            [:sum :s.triples_pg_size]
-                                                            [:case
-                                                             [:= [:pg_relation_size "triples"] 0] 1
-                                                             :else [:/
-                                                                    [:cast [:pg_total_relation_size "triples"] :numeric]
-                                                                    [:pg_relation_size "triples"]]]]
-                                                           0]]]
-                                                :from [[:attr-sketches :s]]
-                                                :join [[:attrs :a] [:= :a.id :s.attr_id]]
-                                                :where [:and
-                                                        [:in :s.app_id {:select :id :from :apps :where [:= :apps.org_id :orgs.id]}]
-                                                        [:= nil :a.deletion_marked_at]]})
+                                            [{:select [[[:coalesce
+                                                         [:*
+                                                          [:sum :agg.pg_size]
+                                                          [:case
+                                                           [:= [:pg_relation_size "triples"] 0] 1
+                                                           :else [:/
+                                                                  [:cast [:pg_total_relation_size "triples"] :numeric]
+                                                                  [:pg_relation_size "triples"]]]]
+                                                         0]]]
+                                              :from [[:triples-size-aggregate :agg]]
+                                              :join [[:attrs :a] [:= :a.id :agg.attr_id]]
+                                              :where [:and
+                                                      [:in :agg.app_id {:select :id :from :apps :where [:= :apps.org_id :orgs.id]}]
+                                                      [:= nil :a.deletion_marked_at]]}
                                              :usage]
                                             [{:select [[[:coalesce [:sum :s.total] 0]]]
                                               :from [[:attr_sketches :s]]

--- a/server/src/instant/dash/admin.clj
+++ b/server/src/instant/dash/admin.clj
@@ -113,10 +113,10 @@
                                                          [:*
                                                           [:sum :agg.pg_size]
                                                           [:case
-                                                           [:= [:pg_relation_size "triples"] 0] 1
+                                                           [:= [:pg_relation_size [:inline "triples"]] 0] 1
                                                            :else [:/
-                                                                  [:cast [:pg_total_relation_size "triples"] :numeric]
-                                                                  [:pg_relation_size "triples"]]]]
+                                                                  [:cast [:pg_total_relation_size [:inline "triples"]] :numeric]
+                                                                  [:pg_relation_size [:inline "triples"]]]]]
                                                          0]]]
                                               :from [[:triples-size-aggregate :agg]]
                                               :join [[:attrs :a] [:= :a.id :agg.attr_id]]
@@ -142,10 +142,10 @@
                                                          [:*
                                                           [:sum :agg.pg_size]
                                                           [:case
-                                                           [:= [:pg_relation_size "triples"] 0] 1
+                                                           [:= [:pg_relation_size [:inline "triples"]] 0] 1
                                                            :else [:/
-                                                                  [:cast [:pg_total_relation_size "triples"] :numeric]
-                                                                  [:pg_relation_size "triples"]]]]
+                                                                  [:cast [:pg_total_relation_size [:inline "triples"]] :numeric]
+                                                                  [:pg_relation_size [:inline "triples"]]]]]
                                                          0]]]
                                               :from [[:triples-size-aggregate :agg]]
                                               :join [[:attrs :a] [:= :a.id :agg.attr_id]]

--- a/server/src/instant/db/attr_sketch.clj
+++ b/server/src/instant/db/attr_sketch.clj
@@ -331,9 +331,7 @@
      :id (:id record)
      :app-id (:app_id record)
      :attr-id (:attr_id record)
-     :max-lsn (:max_lsn record)
-     ;; TODO(dww): Remove after deploying triples-size-updates
-     :triples-pg-size (:triples_pg_size record)}))
+     :max-lsn (:max_lsn record)}))
 
 (defn- find-sketch-rows
   "Takes a set of {:app-id :attr-id} maps and returns a list of sketch
@@ -493,7 +491,7 @@
                 lsn
                 process-id
                 slot-name]}]
-  (let [params (reduce (fn [acc {:keys [id sketch reverse-sketch triples-pg-size]}]
+  (let [params (reduce (fn [acc {:keys [id sketch reverse-sketch]}]
                          (let [{:keys [width depth total total-not-binned]} sketch]
                            (-> acc
                                (update :id conj id)
@@ -506,9 +504,7 @@
                                (update :reverse-depth conj (:depth reverse-sketch))
                                (update :reverse-total conj (:total reverse-sketch))
                                (update :reverse-bins conj (when reverse-sketch
-                                                            (compress-bins reverse-sketch)))
-                               ;; TODO(dww): Remove after deploying triples-size-updates
-                               (update :triples-pg-size conj triples-pg-size))))
+                                                            (compress-bins reverse-sketch))))))
                        {:id (with-meta [] {:pgtype "uuid[]"})
                         :width (with-meta [] {:pgtype "integer[]"})
                         :depth (with-meta [] {:pgtype "integer[]"})
@@ -519,8 +515,6 @@
                         :reverse-depth (with-meta [] {:pgtype "integer[]"})
                         :reverse-total (with-meta [] {:pgtype "bigint[]"})
                         :reverse-bins (with-meta [] {:pgtype "bytea[]"})
-                        ;; TODO(dww): Remove after deploying triples-size-updates
-                        :triples-pg-size (with-meta [] {:pgtype "bigint[]"})
                         :lsn lsn
                         :previous-lsn previous-lsn
                         :slot-name slot-name
@@ -539,8 +533,6 @@
                                    [[:unnest :?reverse-depth] :reverse-depth]
                                    [[:unnest :?reverse-total] :reverse-total]
                                    [[:unnest :?reverse-bins] :reverse-bins]
-                                   ;; TODO(dww): Remove after deploying triples-size-updates
-                                   [[:unnest :?triples-pg-size] :triples-pg-size]
                                    [:?lsn :max-lsn]]}]
                   [:update-sketches
                    {:update :attr_sketches
@@ -554,9 +546,7 @@
                           :reverse-width :data.reverse-width
                           :reverse-depth :data.reverse-depth
                           :reverse-total :data.reverse-total
-                          :reverse-bins :data.reverse-bins
-                          ;; TODO(dww): Remove after deploying triples-size-updates
-                          :triples-pg-size :data.triples-pg-size}
+                          :reverse-bins :data.reverse-bins}
                     :where [:= :attr_sketches.id :data.id]}]
                   [:update-wal-aggregator-status
                    {:update :wal-aggregator-status
@@ -588,7 +578,7 @@
    add attr sketches to the database."
   [conn {:keys [sketches
                 lsn]}]
-  (let [params (reduce (fn [acc {:keys [app-id attr-id sketch reverse-sketch triples-pg-size]}]
+  (let [params (reduce (fn [acc {:keys [app-id attr-id sketch reverse-sketch]}]
                          (let [{:keys [width depth total total-not-binned]} sketch]
                            (-> acc
                                (update :app-id conj app-id)
@@ -602,9 +592,7 @@
                                (update :reverse-depth conj (:depth reverse-sketch))
                                (update :reverse-total conj (:total reverse-sketch))
                                (update :reverse-bins conj (when reverse-sketch
-                                                            (compress-bins reverse-sketch)))
-                               ;; TODO(dww): Remove after deploying triples-size-updates
-                               (update :triples-pg-size conj triples-pg-size))))
+                                                            (compress-bins reverse-sketch))))))
                        {:app-id (with-meta [] {:pgtype "uuid[]"})
                         :attr-id (with-meta [] {:pgtype "uuid[]"})
                         :width (with-meta [] {:pgtype "integer[]"})
@@ -615,13 +603,11 @@
                         :reverse-width (with-meta [] {:pgtype "integer[]"})
                         :reverse-depth (with-meta [] {:pgtype "integer[]"})
                         :reverse-total (with-meta [] {:pgtype "bigint[]"})
-                        :reverse-bins (with-meta [] {:pgtype "bytea[]"})
-                        ;; TODO(dww): Remove after deploying triples-size-updates
-                        :triples-pg-size (with-meta [] {:pgtype "bigint[]"})}
+                        :reverse-bins (with-meta [] {:pgtype "bytea[]"})}
                        sketches)
         cols [:id :max-lsn :app-id :attr-id
               :width :depth :total :total-not-binned :bins
-              :reverse-width :reverse-depth :reverse-total :reverse-bins :triples-pg-size]
+              :reverse-width :reverse-depth :reverse-total :reverse-bins]
         q (hsql/format {:with [[:setting
                                 {:select [[[:set_config [:inline "auto_explain.log_min_duration"] [:inline "-1"] :true] :config]]}
                                 :materialized]
@@ -637,9 +623,7 @@
                                                 [[:unnest :?reverse-width] :reverse-width]
                                                 [[:unnest :?reverse-depth] :reverse-depth]
                                                 [[:unnest :?reverse-total] :reverse-total]
-                                                [[:unnest :?reverse-bins] :reverse-bins]
-                                                ;; TODO(dww): Remove after deploying triples-size-updates
-                                                [[:unnest :?triples-pg-size] :triples-pg-size]]}]
+                                                [[:unnest :?reverse-bins] :reverse-bins]]}]
                                [:changes {:insert-into [[:attr-sketches cols]
                                                         {:select (qualify-cols :data cols)
                                                          :from :data

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -466,7 +466,3 @@
   ;; Defaults to disabled so that we can bootstrap before
   ;; we start the process.
   (flag :disable-triples-size-collection true))
-
-;; TODO(dww): Remove after deploying triples-size-updates
-(defn new-db-size? []
-  (toggled? :use-new-db-size false))

--- a/server/src/instant/model/app.clj
+++ b/server/src/instant/model/app.clj
@@ -474,23 +474,14 @@
    (sql/select-one
     ::app-usage
     conn
-    (if (flags/new-db-size?) ;; TODO(dww): Remove after deploying triples-size-updates
-      ["SELECT
+    ["SELECT
         (sum(agg.pg_size) *
            CASE
                WHEN pg_relation_size('triples') = 0 THEN 1
                ELSE pg_total_relation_size('triples')::numeric / pg_relation_size('triples')
            END) as num_bytes
         FROM triples_size_aggregate agg join attrs a on agg.attr_id = a.id
-        WHERE a.deletion_marked_at is null and agg.app_id = ?::uuid" app-id]
-      ["SELECT
-        (sum(s.triples_pg_size) *
-           CASE
-               WHEN pg_relation_size('triples') = 0 THEN 1
-               ELSE pg_total_relation_size('triples')::numeric / pg_relation_size('triples')
-           END) as num_bytes
-        FROM attr_sketches s join attrs a on s.attr_id = a.id
-        WHERE a.deletion_marked_at is null and s.app_id = ?::uuid" app-id]))))
+        WHERE a.deletion_marked_at is null and agg.app_id = ?::uuid" app-id])))
 
 (defn decrypt-connection-string [app-id encrypted-connection-string]
   (-> (crypt-util/aead-decrypt {:ciphertext encrypted-connection-string

--- a/server/src/instant/model/app_file.clj
+++ b/server/src/instant/model/app_file.clj
@@ -2,7 +2,6 @@
   (:require
    [instant.jdbc.aurora :as aurora]
    [instant.db.model.attr :as attr-model]
-   [instant.flags :as flags]
    [instant.system-catalog :refer [all-attrs] :rename {all-attrs $system-attrs}]
    [instant.system-catalog-ops :refer [update-op query-op]]
    [instant.jdbc.sql :as sql]

--- a/server/src/instant/model/app_file.clj
+++ b/server/src/instant/model/app_file.clj
@@ -236,35 +236,20 @@
    (let [fm-attr (attr-model/resolve-attr-id $system-attrs "$files" "size")]
      (sql/select
       conn
-      (if (flags/new-db-size?)
-        (hsql/format
-         {:select [:s.app_id :a.title
-                   [:u.email :creator_email]
-                   [:agg.files_size :total_byte_size]
-                   [:s.total :total_file_count]]
-          :from [[:apps :a]]
-          :join [[:instant_users :u] [:= :a.creator_id :u.id]
-                 [:attr_sketches :s] [:and
-                                      [:= :s.app_id :a.id]
-                                      [:= :s.attr_id fm-attr]]
-                 [:triples-size-aggregate :agg] [:and
-                                                 [:= :agg.app_id :a.id]
-                                                 [:= :agg.attr_id fm-attr]]]
-          :order-by [[:total_byte_size :desc]]})
-        (hsql/format
-         {:select [:t.app_id :a.title
-                   [:u.email :creator_email]
-                   [[:sum [[:triples_extract_number_value :t.value]]] :total_byte_size]
-                   [[:count :t.*] :total_file_count]]
-          :from [[:triples :t]]
-          :join [[:apps :a] [:= :t.app_id :a.id]
-                 [:instant_users :u] [:= :a.creator_id :u.id]]
-          :where [:and
-                  [:= :t.attr_id fm-attr]
-                  [:= :t.checked-data-type [:cast "number" :checked_data_type]]
-                  :t.ave]
-          :group-by [:t.app_id :a.title :u.email]
-          :order-by [[:total_byte_size :desc]]}))))))
+      (hsql/format
+       {:select [:s.app_id :a.title
+                 [:u.email :creator_email]
+                 [:agg.files_size :total_byte_size]
+                 [:s.total :total_file_count]]
+        :from [[:apps :a]]
+        :join [[:instant_users :u] [:= :a.creator_id :u.id]
+               [:attr_sketches :s] [:and
+                                    [:= :s.app_id :a.id]
+                                    [:= :s.attr_id fm-attr]]
+               [:triples-size-aggregate :agg] [:and
+                                               [:= :agg.app_id :a.id]
+                                               [:= :agg.attr_id fm-attr]]]
+        :order-by [[:total_byte_size :desc]]})))))
 
 (defn get-app-usage
   ([app-id] (get-app-usage (aurora/conn-pool :read) app-id))
@@ -274,31 +259,21 @@
    (let [fm-attr (attr-model/resolve-attr-id $system-attrs "$files" "size")]
      (sql/select-one
       conn
-      (if (flags/new-db-size?)
-        (hsql/format
-         {:select [[[:coalesce
-                     {:select :total
-                      :from :attr_sketches
-                      :where [:and
-                              [:= :app_id app-id]
-                              [:= :attr_id fm-attr]]}
-                     :0] :total_file_count]
-                   [[:coalesce
-                     {:select :files_size
-                      :from :triples-size-aggregate
-                      :where [:and
-                              [:= :app_id app-id]
-                              [:= :attr_id fm-attr]]}
-                     :0] :total_byte_size]]})
-        (hsql/format
-         {:select [[[:count :t.*] :total_file_count]
-                   [[:coalesce [:sum [[:triples_extract_number_value :t.value]]] :0] :total_byte_size]]
-          :from [[:triples :t]]
-          :where [:and
-                  [:= :t.app_id app-id]
-                  [:= :t.attr_id fm-attr]
-                  [:= :t.checked-data-type [:cast "number" :checked_data_type]]
-                  :t.ave]}))))))
+      (hsql/format
+       {:select [[[:coalesce
+                   {:select :total
+                    :from :attr_sketches
+                    :where [:and
+                            [:= :app_id app-id]
+                            [:= :attr_id fm-attr]]}
+                   :0] :total_file_count]
+                 [[:coalesce
+                   {:select :files_size
+                    :from :triples-size-aggregate
+                    :where [:and
+                            [:= :app_id app-id]
+                            [:= :attr_id fm-attr]]}
+                   :0] :total_byte_size]]})))))
 
 (defn get-org-usage
   ([org-id] (get-org-usage (aurora/conn-pool :read) org-id))
@@ -308,28 +283,18 @@
    (let [fm-attr (attr-model/resolve-attr-id $system-attrs "$files" "size")]
      (sql/select-one
       conn
-      (if (flags/new-db-size?)
-        (hsql/format
-         {:select [[{:select [[[:coalesce [:sum :s.total] :0]]]
-                     :from [[:apps :a]]
-                     :join [[:attr_sketches :s] [:= :s.app_id :a.id]]
-                     :where [:and
-                             [:= :a.org_id org-id]
-                             [:= :s.attr-id fm-attr]]}
-                    :total_file_count]
+      (hsql/format
+       {:select [[{:select [[[:coalesce [:sum :s.total] :0]]]
+                   :from [[:apps :a]]
+                   :join [[:attr_sketches :s] [:= :s.app_id :a.id]]
+                   :where [:and
+                           [:= :a.org_id org-id]
+                           [:= :s.attr-id fm-attr]]}
+                  :total_file_count]
 
-                   [{:select [[[:coalesce [:sum :agg.files_size] :0]]]
-                     :from [[:apps :a]]
-                     :join [[:triples_size_aggregate :agg] [:= :agg.app_id :a.id]]
-                     :where [:and
-                             [:= :a.org_id org-id]
-                             [:= :agg.attr-id fm-attr]]} :total_byte_size]]})
-        (hsql/format
-         {:select [[[:count :t.*] :total_file_count]
-                   [[:coalesce [:sum [[:triples_extract_number_value :t.value]]] :0] :total_byte_size]]
-          :from [[:triples :t]]
-          :where [:and
-                  [:in :t.app_id {:select :id :from :apps :where [:= :org_id org-id]}]
-                  [:= :t.attr_id fm-attr]
-                  [:= :t.checked-data-type [:cast "number" :checked_data_type]]
-                  :t.ave]}))))))
+                 [{:select [[[:coalesce [:sum :agg.files_size] :0]]]
+                   :from [[:apps :a]]
+                   :join [[:triples_size_aggregate :agg] [:= :agg.app_id :a.id]]
+                   :where [:and
+                           [:= :a.org_id org-id]
+                           [:= :agg.attr-id fm-attr]]} :total_byte_size]]})))))

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -1,7 +1,6 @@
 (ns instant.model.org
   (:require
    [instant.config :as config]
-   [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]

--- a/server/src/instant/model/org.clj
+++ b/server/src/instant/model/org.clj
@@ -263,7 +263,7 @@
          query (uhsql/formatp delete-org-q params)]
      (sql/execute-one! ::delete! conn query))))
 
-(def usage-q-new
+(def usage-q
   (uhsql/preformat {:select [[[:coalesce
                                [:*
                                 [:sum :agg.pg_size]
@@ -277,26 +277,6 @@
                     :from [[:triples-size-aggregate :agg]]
                     :join [[:apps :app] [:= :agg.app_id :app.id]
                            [:attrs :attr] [:= :agg.attr_id :attr.id]]
-                    :where [:and
-                            [:= :app.org_id :?org-id]
-                            [:= nil :app.deletion-marked-at]
-                            [:= nil :attr.deletion-marked-at]]}))
-
-;; TODO(dww): Remove after deploying triples-size-updates
-(def usage-q-old
-  (uhsql/preformat {:select [[[:coalesce
-                               [:*
-                                [:sum :s.triples_pg_size]
-                                [:case
-                                 [:= :0 [:pg_relation_size [:inline "triples"]]] :1
-                                 :else [:/
-                                        [:cast [:pg_total_relation_size [:inline "triples"]] :numeric]
-                                        [:pg_relation_size [:inline "triples"]]]]]
-                               :0]
-                              :num_bytes]]
-                    :from [[:attr-sketches :s]]
-                    :join [[:apps :app] [:= :s.app_id :app.id]
-                           [:attrs :attr] [:= :s.attr_id :attr.id]]
                     :where [:and
                             [:= :app.org_id :?org-id]
                             [:= nil :app.deletion-marked-at]
@@ -319,10 +299,7 @@
    (sql/select-one
     ::org-usage
     conn
-    (uhsql/formatp (if (flags/new-db-size?)
-                     usage-q-new
-                     usage-q-old)
-                   {:org-id org-id}))))
+    (uhsql/formatp usage-q {:org-id org-id}))))
 
 (def rename-q (uhsql/preformat {:update :orgs
                                 :set {:title :?title}

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -184,8 +184,6 @@
               "created_at" (assoc data :created-at value)
               "ea" (assoc data :ea value)
               "eav" (assoc data :eav value)
-              ;; TODO(dww): Remove after deploying triples-size-updates
-              "pg_size" (assoc data :pg-size value)
               data))
           {}
           columns))
@@ -304,13 +302,9 @@
                             record {:value (:value triples-data)
                                     :checked-data-type (:checked-data-type triples-data)}
                             reverse-record (when (store-reverse? triples-data)
-                                             {:value (:entity-id triples-data)})
-                            ;; TODO(dww): Remove after deploying triples-size-updates
-                            pg-size (:pg-size triples-data)]
+                                             {:value (:entity-id triples-data)})]
                         (cond-> acc
                           true (update-in [key :records record] (fnil + 0) incr)
-                          ;; TODO(dww): Remove after deploying triples-size-updates
-                          pg-size (update-in [key :triples-pg-size] (fnil + 0) (* incr pg-size))
                           true (update-in [key :max-lsn] lsn-max lsn)
                           reverse-record (update-in [key :reverse-records reverse-record] (fnil + 0) incr))))
                     changes
@@ -345,14 +339,12 @@
           _ (tracer/add-data! {:attributes {:deleted-count (- (count changes)
                                                               (count sketches))}})
           sketches (reduce-kv
-                     (fn [acc k {:keys [triples-pg-size records reverse-records max-lsn]}]
+                     (fn [acc k {:keys [records reverse-records max-lsn]}]
                        ;; attr may have been deleted in the interim
                        (if-let [sketch (get sketches k)]
                          (conj acc (cond-> sketch
                                      true (update :sketch cms/add-batch records)
                                      true (assoc :max-lsn max-lsn)
-                                     ;; TODO(dww): Remove after deploying triples-size-updates
-                                     triples-pg-size (update :triples-pg-size (fnil + 0) triples-pg-size)
                                      (seq reverse-records)
                                      (update :reverse-sketch (fnil cms/add-batch (cms/make-sketch)) reverse-records)))
                          acc))


### PR DESCRIPTION
Cleans up old pg_size tracking code now that https://github.com/instantdb/instant/pull/2764 is fully deployed and active.

I will follow up with a PR to remove pg_size from `attr_sketches` and `triples` once this is fully deployed.

