### PR TITLE
Log dashboard login code when Postmark is disabled

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -244,6 +244,16 @@
                     {:id (UUID/randomUUID)
                      :code (instant-user-magic-code-model/rand-code)
                      :user-id user-id})]
+    (when-not (config/postmark-send-enabled?)
+      (log/infof (str "\n"
+                      "============================================================\n"
+                      "              INSTANT DASHBOARD LOGIN CODE\n"
+                      "\n"
+                      "                         %s\n"
+                      "\n"
+                      "     Postmark is not configured. Use this code to sign in.\n"
+                      "============================================================")
+                 (:code magic-code)))
     (email-router/send-structured!
      (magic-code-email {:user u :magic-code magic-code}))
     (response/ok {:sent true})))


### PR DESCRIPTION
## Summary
- print a prominent dashboard login-code banner when Postmark is not configured
- leave the existing email delivery flow unchanged


Running server with self hosted setup:
<img width="1668" height="482" alt="image" src="https://github.com/user-attachments/assets/869768ab-6304-4834-9906-c5809cd92440" />

Running server with local dev setup (postmark key part of config) (unchanged)
<img width="987" height="895" alt="image" src="https://github.com/user-attachments/assets/de57631f-e30f-4359-8f90-63e1172bd72b" />

