### PR TITLE
skip onboarding questionnaire if self hosted

### DIFF
--- a/client/www/components/dash/Onboarding.tsx
+++ b/client/www/components/dash/Onboarding.tsx
@@ -10,7 +10,7 @@ import { v4 } from 'uuid';
 
 import { Button, Content, ScreenHeading, TextInput } from '@/components/ui';
 import { signOut } from '@/lib/auth';
-import config from '@/lib/config';
+import config, { isSelfHosted } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
 import { useRouter } from 'next/router';
@@ -291,11 +291,11 @@ export function OnboardingScreen(props: {
   const { profile, appCreateState, onAppCreate, onAppNameChange } = props;
   const [showWelcome, setShowWelcome] = useState(true);
 
-  if (showWelcome) {
+  if (showWelcome && !isSelfHosted) {
     return <WelcomeScreen onClick={() => setShowWelcome(false)} />;
   }
 
-  if (!profile) {
+  if (!profile && !isSelfHosted) {
     return (
       <ProfileScreen
         profileCreateState={props.profileCreateState}


### PR DESCRIPTION
Self hosted instances of the dashboard will skip straight to the "name your app" screen after creating an account. Bypassing the questionnaire about experience

<img width="741" height="512" alt="image" src="https://github.com/user-attachments/assets/6e23ac28-e653-4d6a-ba95-ca06a14399a8" />
