### PR TITLE
allow setting apiUri in instant.config.ts (#2793) [bump v1.0.52]

### DIFF
--- a/client/packages/cli/src/context/currentApp.ts
+++ b/client/packages/cli/src/context/currentApp.ts
@@ -8,7 +8,7 @@ import { runUIEffect } from '../lib/ui.ts';
 import { AuthToken } from './authToken.ts';
 import { GlobalOpts } from './globalOpts.ts';
 import { PlatformApi } from './platformApi.ts';
-import { readInstantConfigFile } from '../old.js';
+import { readInstantConfigFile } from '../util/instantConfig.ts';
 import { BadArgsError } from '../errors.ts';
 
 export type CurrentAppInfo = {

--- a/client/packages/cli/src/lib/http.ts
+++ b/client/packages/cli/src/lib/http.ts
@@ -4,6 +4,8 @@ import { Config, Context, Data, Effect, Layer, Option, Schema } from 'effect';
 import { AuthToken } from '../context/authToken.ts';
 import { TimeoutException } from 'effect/Cause';
 import { RequestError } from '@effect/platform/HttpClientError';
+import { readInstantConfigFile } from '../util/instantConfig.ts';
+import { BadArgsError } from '../errors.ts';
 
 export class InstantHttp extends Context.Tag(
   'instant-cli/new/lib/http/InstantHttp',
@@ -46,6 +48,15 @@ class InstantTypicalHttpErrorResponse extends Schema.Struct({
     Schema.optional,
   ),
 }) {}
+
+const HttpUrl = Schema.URL.pipe(
+  Schema.filter(
+    (url) =>
+      url.protocol === 'http:' ||
+      url.protocol === 'https:' ||
+      'Expected an HTTP(S) URL',
+  ),
+);
 
 export const InstantHttpLive = Layer.effect(
   InstantHttp,
@@ -132,12 +143,24 @@ export const getBaseUrl = Effect.gen(function* () {
     Config.withDefault(false),
   );
 
-  return Option.match(setEnv, {
-    onSome: (url) => url,
-    onNone: () => {
-      return dev ? 'http://localhost:8888' : 'https://api.instantdb.com';
-    },
-  });
+  if (Option.isSome(setEnv)) {
+    return setEnv.value;
+  }
+
+  const instantConfig = yield* Effect.tryPromise(readInstantConfigFile);
+  if (instantConfig?.apiURI !== undefined) {
+    yield* Schema.decodeUnknown(HttpUrl)(instantConfig.apiURI).pipe(
+      Effect.mapError(() =>
+        BadArgsError.make({
+          message:
+            'Invalid apiURI in instant.config.ts. Expected a valid HTTP(S) URL.',
+        }),
+      ),
+    );
+    return instantConfig.apiURI;
+  }
+
+  return dev ? 'http://localhost:8888' : 'https://api.instantdb.com';
 });
 
 export const getDashUrl = Effect.gen(function* () {

--- a/client/packages/cli/src/lib/pushSchema.ts
+++ b/client/packages/cli/src/lib/pushSchema.ts
@@ -20,7 +20,7 @@ import {
   resolveRenames,
   waitForIndexingJobsToFinish,
 } from '../old.js';
-import { InstantHttpAuthed, withCommand } from './http.ts';
+import { getBaseUrl, InstantHttpAuthed, withCommand } from './http.ts';
 
 import boxen from 'boxen';
 import { GlobalOpts } from '../context/globalOpts.ts';
@@ -179,12 +179,14 @@ export const pushSchema = (
 
     if (pushRes?.['indexing-jobs']) {
       // TODO: rewrite in effect
+      const apiURI = yield* getBaseUrl;
       yield* Effect.tryPromise({
         try: () =>
           waitForIndexingJobsToFinish(
             appId,
             pushRes?.['indexing-jobs'] || [],
             authToken,
+            apiURI,
           ),
         catch: (e: any) =>
           WaitForJobsError.make({

--- a/client/packages/cli/src/old.js
+++ b/client/packages/cli/src/old.js
@@ -32,10 +32,6 @@ const instantDashOrigin = dev
   ? 'http://localhost:3000'
   : 'https://instantdb.com';
 
-const instantBackendOrigin =
-  process.env.INSTANT_CLI_API_URI ||
-  (dev ? 'http://localhost:8888' : 'https://api.instantdb.com');
-
 function indexingJobCompletedActionMessage(job) {
   if (job.job_type === 'check-data-type') {
     return `setting type of ${job.attr_name} to ${job.checked_data_type}`;
@@ -185,7 +181,12 @@ function jobGroupDescription(jobs) {
 }
 
 // TODO: rewrite in effect
-export async function waitForIndexingJobsToFinish(appId, data, authToken) {
+export async function waitForIndexingJobsToFinish(
+  appId,
+  data,
+  authToken,
+  apiURI,
+) {
   const spinnerDefferedPromise = deferred();
   const spinner = new UI.Spinner({
     promise: spinnerDefferedPromise.promise,
@@ -248,6 +249,7 @@ export async function waitForIndexingJobsToFinish(appId, data, authToken) {
       debugName: 'Check indexing status',
       method: 'GET',
       authToken,
+      apiURI,
       path: `/dash/apps/${appId}/indexing-jobs/group/${groupId}`,
       errorMessage: 'Failed to check indexing status.',
       command: 'push',
@@ -307,6 +309,7 @@ export const resolveRenames = async (created, promptData, extraInfo) => {
  * @param {boolean} [options.noLogError]
  * @param {string} [options.command] - The CLI command being executed (e.g., 'push', 'pull', 'login')
  * @param {string} [options.authToken] - Optional auth token to use instead of reading from config
+ * @param {string} options.apiURI - Backend API origin
  * @param {Record<string, string>} [options.headers] - Extra headers to include in the request
  * @returns {Promise<{ ok: boolean; data: any }>}
  */
@@ -320,6 +323,7 @@ async function fetchJson({
   noLogError,
   command,
   authToken: providedAuthToken,
+  apiURI,
   headers: extraHeaders,
 }) {
   const withAuth = !noAuth;
@@ -335,7 +339,7 @@ async function fetchJson({
   const timeoutMs = 1000 * 60 * 5; // 5 minutes
 
   try {
-    const res = await fetch(`${instantBackendOrigin}${path}`, {
+    const res = await fetch(`${apiURI}${path}`, {
       method: method ?? 'GET',
       headers: {
         ...(withAuth ? { Authorization: `Bearer ${authToken}` } : {}),
@@ -430,23 +434,6 @@ export async function readLocalEmailFile(emailPath) {
   if (!res.config) return;
   const relativePath = path.relative(process.cwd(), res.sources[0]);
   return { path: relativePath, email: res.config };
-}
-
-export async function readInstantConfigFile() {
-  return (
-    await loadConfig({
-      sources: [
-        // load from `instant.config.xx`
-        {
-          files: 'instant.config',
-          extensions: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs', 'json'],
-        },
-      ],
-      // if false, the only the first matched will be loaded
-      // if true, all matched will be loaded and deep merged
-      merge: false,
-    })
-  ).config;
 }
 
 async function readConfigAuthToken(allowAdminToken = true) {

--- a/client/packages/cli/src/util/instantConfig.ts
+++ b/client/packages/cli/src/util/instantConfig.ts
@@ -1,0 +1,20 @@
+import { loadConfig } from './loadConfig.ts';
+
+export type InstantConfig = {
+  apiURI?: string;
+  apps?: Record<string, { id: string }>;
+};
+
+export async function readInstantConfigFile() {
+  return (
+    await loadConfig<InstantConfig>({
+      sources: [
+        {
+          files: 'instant.config',
+          extensions: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs', 'json'],
+        },
+      ],
+      merge: false,
+    })
+  ).config;
+}

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.51';
+const version = 'v1.0.52';
 
 export { version };

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -180,6 +180,15 @@ INSTANT_CLI_API_URI=http://localhost:8888 npx instant-cli@latest init
 INSTANT_CLI_API_URI=https://api.myinstant.com npx instant-cli@latest init
 ```
 
+You can also set it in the `instant.config.ts` file.
+
+```typescript
+// instant.config.ts
+export default {
+  apiURI: 'http://127.0.0.1:18987',
+};
+```
+
 ## Horizontal Scaling With Docker Swarm
 
 Docker Swarm allows one or more machines to distribute Docker containers between them.

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -185,7 +185,7 @@ You can also set it in the `instant.config.ts` file.
 ```typescript
 // instant.config.ts
 export default {
-  apiURI: 'http://127.0.0.1:18987',
+  apiURI: 'http://127.0.0.1:8888',
 };
 ```
 


### PR DESCRIPTION
Allows you to set apiURI in the instant.config.ts file to make it easier to use self hosted installations of instantdb