### PR TITLE
keep swarm.yml version pinned to latest instead of test tag

### DIFF
--- a/self-hosting/swarm.yml
+++ b/self-hosting/swarm.yml
@@ -86,7 +86,7 @@ services:
         max_attempts: 20
 
   server:
-    image: "ghcr.io/instantdb/server:swarm-test"
+    image: "ghcr.io/instantdb/server:latest"
     networks:
       - caddy
       - default


### PR DESCRIPTION
The image tag for the server service in the swarm.yml file was pinned to test-swarm when I made the swarm pr. Now it should be pinned to latest so that it keeps receiving updates. 