### PR TITLE
use unique ids for hazelcast in swarm mode

### DIFF
--- a/server/src/instant/reactive/ephemeral.clj
+++ b/server/src/instant/reactive/ephemeral.clj
@@ -152,7 +152,10 @@
         aws-config           (.getAwsConfig join-config)
         serialization-config (.getSerializationConfig config)
         metrics-config       (.getMetricsConfig config)
-        instance-id          (or @config/instance-id "dev")
+        instance-id          (or @config/instance-id
+                                 (when (config/using-swarm?)
+                                   (str config/machine-id))
+                                 "dev")
         member-attribute-config (doto (com.hazelcast.config.MemberAttributeConfig.)
                                   (.setAttribute "instance-id" instance-id)
                                   (.setAttribute "machine-id" (str config/machine-id)))]


### PR DESCRIPTION
In self hosted mode with 2 instances of the backend server, hazelcast was using "dev" as instance ids which tricked the servers into seeing each other's sessions as orphaned and deleting them. 

This fixes it so that if docker swarm mode is enabled, the hazelcast instance will use random uuids as machine ids. 