### PR TITLE
Run nightly backup on a short-lived clone of the prod db

### DIFF
--- a/server/src/instant/backup.clj
+++ b/server/src/instant/backup.clj
@@ -6,6 +6,7 @@
    [instant.dash.ephemeral-app :refer [ephemeral-creator]]
    [instant.db.model.attr :as attr-model]
    [instant.isn]
+   [instant.clone :as clone]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.copy :as copy]
    [instant.jdbc.sql :as sql]
@@ -183,6 +184,32 @@
                                      [:= nil :app.deletion-marked-at]
                                      (when start-app-id
                                        [:>= :t.app_id [:inline (uuid-util/coerce start-app-id)]])]
+                             :order-by [[:t.app_id] [:t.entity_id] [:t.attr_id]]})
+        _ (assert (= 1 (count select)) "The select query cannot have parameters")
+        q (format "/*+ IndexScan(t triples_pkey) */ COPY (%s) to stdout with (format binary)"
+                  (first select))
+        copy-seq (copy/copy-seq conn
+                                q
+                                columns
+                                {:row-fn ->Triple})]
+    copy-seq))
+
+(defn app-triples-seq
+  "Returns a seq of triples for an app, ordered by app-id, entity-id, then attr-id"
+  [^PgConnection conn app-id]
+  (let [select (hsql/format {:select [:t.app_id
+                                      :t.entity_id
+                                      [[:cast :t.value :text] :value]
+                                      :t.created_at
+                                      :a.etype
+                                      :a.label
+                                      [[:= :a.cardinality [:inline "many"]] :many]]
+                             :from [[:triples :t]]
+                             :join [[:attrs :a] [:= :a.id :t.attr_id]
+                                    [:apps :app] [:= :app.id :t.app_id]]
+                             :where [:and
+                                     [:= nil :a.deletion-marked-at]
+                                     [:= :t.app-id [:inline (uuid-util/coerce app-id)]]]
                              :order-by [[:t.app_id] [:t.entity_id] [:t.attr_id]]})
         _ (assert (= 1 (count select)) "The select query cannot have parameters")
         q (format "/*+ IndexScan(t triples_pkey) */ COPY (%s) to stdout with (format binary)"
@@ -564,7 +591,7 @@
                      (inc triple-count)))))
   (on-done))
 
-(defn process []
+(defn process-with-snapshot []
   (let [db-config (config/get-aurora-config)
         process-id (random-uuid)
         slot-name (str "backup_" (.replace (str process-id) "-" "_"))
@@ -672,3 +699,205 @@
                             (abort)
                             (throw t))))
      :abort abort}))
+
+(defn get-clone-lsn [clone-pool]
+  (:lsn (sql/select-one ::clone-lsn
+                        clone-pool
+                        ["select aurora_volume_logical_start_lsn() as lsn"])))
+
+(defn get-eligible-app-ids
+  "Returns non-ephemeral/non-deleted app ids ordered by id."
+  [clone-pool]
+  (map :id (sql/select ::get-eligible
+                       clone-pool
+                       (hsql/format {:select :id
+                                     :from :apps
+                                     :where [:and
+                                             [:not= :creator-id (:id @ephemeral-creator)]
+                                             [:= nil :deletion-marked-at]]
+                                     :order-by [[:id :asc]]
+                                     ;;; XXX
+                                     :limit 400}))))
+
+(defn handle-app
+  "Processes a single app. Delivers the result to `finished-promise` (either
+   a throwable or the {:triple-count <long>} with the number of triples)."
+  [{:keys [clone-pool
+           process-id
+           isn
+           backup-at
+           app-id
+           finished-promise]}]
+  (try
+    (let [triples-queue (LinkedBlockingQueue. 50000)
+          upload-progress-queue (LinkedBlockingQueue.)
+          flush-streams-queue (LinkedBlockingQueue.)
+          done-signal ::done
+          _copy-process (ua/vfuture
+                         (try
+                           (with-open [conn (next.jdbc/get-connection clone-pool)]
+                             (doseq [triple (app-triples-seq (.unwrap conn PgConnection) app-id)]
+                               (.put triples-queue triple))
+                             (.put triples-queue done-signal))
+                           (catch Throwable t
+                             (deliver finished-promise t)
+                             (.put triples-queue done-signal)
+                             (.put flush-streams-queue done-signal)
+                             (throw t))))
+          _upload-process (ua/vfuture
+                           (try
+                             (start-upload-process {:process-id process-id
+                                                    :triples-queue triples-queue
+                                                    :record-progress-queue upload-progress-queue
+                                                    :flush-streams-queue flush-streams-queue
+                                                    :on-done (fn []
+                                                               (.put flush-streams-queue done-signal))
+                                                    :done-signal done-signal})
+                             (catch Throwable t
+                               (deliver finished-promise t)
+                               (.put flush-streams-queue done-signal)
+                               (throw t))))
+          ;; This is a little awkward, since we'll only ever take 1 thing out of the queue,
+          ;; but it allows us to use the same code as `process-with-copy`
+          item (.take flush-streams-queue)]
+      (if (= done-signal item)
+        (when-not (realized? finished-promise)
+          (deliver finished-promise {:triple-count 0}))
+        (with-open [conn (next.jdbc/get-connection clone-pool)]
+          (complete-streams conn
+                            {:backup-id process-id
+                             :isn isn
+                             :backup-at backup-at}
+                            item)
+          (deliver finished-promise
+                   {:triple-count (:triple-count (.take upload-progress-queue))}))))
+    (catch Throwable t
+      (deliver finished-promise t))))
+
+(defn process-with-clone-pool
+  "Similar to process-with-copy, but creates a separate copy command per app.
+   Only works on a clone, since we know that the data in the database will
+   never change."
+  [{:keys [clone-pool
+           clone-lsn
+           ^long process-count
+           backup-at]}]
+  (let [process-id (random-uuid)
+        isn (instant.isn/->ISN config/invalidator-slot-num clone-lsn)
+        _ (insert-backup-job! {:id process-id
+                               :isn isn
+                               :backup-at backup-at
+                               :machine-id config/machine-id})
+        app-ids (get-eligible-app-ids clone-pool)
+        app-queue (LinkedBlockingQueue. process-count)
+        record-progress-queue (LinkedBlockingQueue.)
+        done-signal ::done
+        process-state (atom nil)
+        abort (fn []
+                (when-let [{:keys [distribute-apps-process
+                                   update-progress-process
+                                   handle-app-processes]} @process-state]
+                  (future-cancel distribute-apps-process)
+                  (doseq [p handle-app-processes]
+                    (future-cancel p))
+                  (future-cancel update-progress-process)))
+        ;; Puts app-ids on the app queue and the record-progress-queue
+        ;; when the app-queue is done, it will fulfill its promise with
+        ;; the data the record-progress-queue needs. This allows the
+        ;; queue to move forward so that we can restart from a failed app.
+        distribute-apps-process (ua/vfuture
+                                 (doseq [app-id app-ids]
+                                   (let [item {:app-id app-id
+                                               :finished-promise (promise)}]
+                                     (.put app-queue item)
+                                     (.put record-progress-queue item)))
+                                 (dotimes [_ process-count]
+                                   (.put app-queue done-signal))
+                                 (.put record-progress-queue done-signal))
+        handle-app-processes (mapv (fn [_]
+                                     (ua/vfuture
+                                      (loop [item (.take app-queue)]
+                                        (when (not= done-signal item)
+                                          (try
+                                            (handle-app {:clone-pool clone-pool
+                                                         :process-id process-id
+                                                         :isn isn
+                                                         :backup-at backup-at
+                                                         :app-id (:app-id item)
+                                                         :finished-promise (:finished-promise item)})
+                                            (catch Throwable t
+                                              (deliver (:finished-promise item) t)
+                                              (abort)
+                                              (throw t)))
+                                          (recur (.take app-queue))))))
+                                   (range process-count))
+
+        update-limiter (RateLimiter/create 0.2) ;; every 5 seconds
+        update-progress-process (ua/vfuture
+                                 (loop [item (.take record-progress-queue)
+                                        app-count 1
+                                        triple-count 0]
+                                   (if (= item done-signal)
+                                     (mark-backup-completed! {:id process-id})
+                                     (let [{:keys [app-id finished-promise]} item
+                                           result @finished-promise]
+                                       (when (instance? Throwable result)
+                                         (throw result))
+                                       (let [triple-count (+ triple-count
+                                                             (long (:triple-count result)))]
+                                         (when (or (= (.peek record-progress-queue) done-signal)
+                                                   (.tryAcquire update-limiter))
+                                           (update-backup-progress! {:id process-id
+                                                                     :max-app-id app-id
+                                                                     :triple-count triple-count
+                                                                     :app-count app-count}))
+                                         (recur (.take record-progress-queue)
+                                                (inc app-count)
+                                                triple-count))))))]
+    (reset! process-state {:distribute-apps-process distribute-apps-process
+                           :update-progress-process update-progress-process
+                           :handle-app-processes handle-app-processes})
+    {:distribute-apps-process distribute-apps-process
+     :update-progress-process update-progress-process
+     :handle-app-processes handle-app-processes
+     :abort abort
+     :wait-for-finish (fn []
+                        (try
+                          @distribute-apps-process
+                          (doseq [p handle-app-processes]
+                            @p)
+                          @update-progress-process
+                          (catch Throwable t
+                            (abort)
+                            (throw t))))}))
+
+(defn process-with-clone
+  "Similar to process-with-copy, but creates a clone of the production database.
+   Allows us to process multiple apps concurrently"
+  [{:keys [source-cluster-id]}]
+  (let [clone-config (clone/create-clone! {:instance-class "db.r8gd.xlarge"
+                                           :source-cluster-id source-cluster-id})]
+    (try
+      (let [process-count 200
+            clone-pool (clone/start-clone-pool (* 2 process-count)
+                                               (:cluster-id clone-config))
+            clone-lsn (get-clone-lsn clone-pool)
+            backup-at (:snapshot-time clone-config)
+            process (process-with-clone-pool {:clone-pool clone-pool
+                                              :process-count process-count
+                                              :clone-lsn clone-lsn
+                                              :backup-at backup-at})]
+        (try
+          ((:wait-for-finish process))
+          (finally
+            (clone/stop-clone-pool clone-pool))))
+
+      (finally
+        (clone/delete-clone! (:cluster-id clone-config))))))
+
+(comment
+  ;; To test clone version locally against local db
+  (def -process (process-with-clone-pool {:clone-pool (aurora/conn-pool :write)
+                                          :clone-lsn (:lsn (sql/select-one (aurora/conn-pool :read) ["select pg_current_wal_lsn() as lsn"]))
+                                          :backup-at (Instant/now)
+                                          :process-count 10})))

--- a/server/src/instant/backup.clj
+++ b/server/src/instant/backup.clj
@@ -205,8 +205,7 @@
                                       :a.label
                                       [[:= :a.cardinality [:inline "many"]] :many]]
                              :from [[:triples :t]]
-                             :join [[:attrs :a] [:= :a.id :t.attr_id]
-                                    [:apps :app] [:= :app.id :t.app_id]]
+                             :join [[:attrs :a] [:= :a.id :t.attr_id]]
                              :where [:and
                                      [:= nil :a.deletion-marked-at]
                                      [:= :t.app-id [:inline (uuid-util/coerce app-id)]]]

--- a/server/src/instant/backup.clj
+++ b/server/src/instant/backup.clj
@@ -715,9 +715,7 @@
                                      :where [:and
                                              [:not= :creator-id (:id @ephemeral-creator)]
                                              [:= nil :deletion-marked-at]]
-                                     :order-by [[:id :asc]]
-                                     ;;; XXX
-                                     :limit 400}))))
+                                     :order-by [[:id :asc]]}))))
 
 (defn handle-app
   "Processes a single app. Delivers the result to `finished-promise` (either
@@ -880,15 +878,16 @@
     (try
       (let [process-count 200
             clone-pool (clone/start-clone-pool (* 2 process-count)
-                                               (:cluster-id clone-config))
-            clone-lsn (get-clone-lsn clone-pool)
-            backup-at (:snapshot-time clone-config)
-            process (process-with-clone-pool {:clone-pool clone-pool
-                                              :process-count process-count
-                                              :clone-lsn clone-lsn
-                                              :backup-at backup-at})]
+                                               (:cluster-id clone-config))]
         (try
-          ((:wait-for-finish process))
+          (let [clone-lsn (get-clone-lsn clone-pool)
+                backup-at (:snapshot-time clone-config)
+                process (process-with-clone-pool {:clone-pool clone-pool
+                                                  :process-count process-count
+                                                  :clone-lsn clone-lsn
+                                                  :backup-at backup-at})]
+            ((:wait-for-finish process)))
+
           (finally
             (clone/stop-clone-pool clone-pool))))
 

--- a/server/src/instant/clone.clj
+++ b/server/src/instant/clone.clj
@@ -1,0 +1,367 @@
+(ns instant.clone
+  "Creates a copy-on-write Aurora clone of the production cluster so that we can
+   run long-lived, snapshot-holding reads (e.g. the nightly backup) against a
+   throwaway cluster instead of the primary.
+
+   A clone is a separate cluster with copy-on-write storage: near-instant to
+   create, cheap while it lives, and torn down when we're done. Use `with-clone`
+   so teardown is guaranteed even on failure."
+  (:require
+   [clojure.string]
+   [instant.aurora-config :as aurora-config]
+   [instant.config :as config]
+   [instant.jdbc.aurora :as aurora]
+   [instant.util.coll :as ucoll]
+   [instant.util.tracer :as tracer])
+  (:import
+   (java.time LocalTime ZoneOffset)
+   (java.time.format DateTimeFormatter)
+   (software.amazon.awssdk.services.rds RdsClient)
+   (software.amazon.awssdk.services.rds.model CreateDbInstanceRequest DBCluster DBClusterMember DBInstance DeleteDbClusterRequest DeleteDbInstanceRequest DescribeDbClustersRequest DescribeDbInstancesRequest ModifyDbClusterRequest RestoreDbClusterToPointInTimeRequest Tag VpcSecurityGroupMembership)))
+
+(set! *warn-on-reflection* true)
+
+(def rds-client* (delay (.build (RdsClient/builder))))
+(defn rds-client ^RdsClient []
+  @rds-client*)
+
+;; ---------
+;; describes
+
+(defn describe-cluster ^DBCluster [cluster-id]
+  (let [request (-> (DescribeDbClustersRequest/builder)
+                    (.dbClusterIdentifier cluster-id)
+                    (.build))
+        clusters (-> (.describeDBClusters (rds-client)
+                                          ^DescribeDbClustersRequest request)
+                     (.dbClusters))]
+    (assert (= 1 (count clusters))
+            (format "Expected 1 cluster for %s, found %d." cluster-id (count clusters)))
+    (first clusters)))
+
+(defn describe-instance ^DBInstance [instance-id]
+  (let [request (-> (DescribeDbInstancesRequest/builder)
+                    (.dbInstanceIdentifier instance-id)
+                    (.build))
+        instances (-> (.describeDBInstances (rds-client)
+                                            ^DescribeDbInstancesRequest request)
+                      (.dbInstances))]
+    (assert (= 1 (count instances))
+            (format "Expected 1 instance for %s, found %d." instance-id (count instances)))
+    (first instances)))
+
+(defn writer-instance-id [^DBCluster cluster]
+  (some->> (.dbClusterMembers cluster)
+           ^DBClusterMember (ucoll/seek (fn [^DBClusterMember m]
+                                          (.isClusterWriter m)))
+           (.dbInstanceIdentifier)))
+
+(defn default-source-cluster-id []
+  (or (System/getenv "DATABASE_CLUSTER_ID")
+      (:cluster-id (config/get-aurora-config))))
+
+;; ------
+;; naming
+
+(defn gen-clone-id
+  "RDS identifiers must start with a letter, be <=63 chars, and contain only
+   ASCII letters, digits, and single hyphens."
+  []
+  (str "instant-clone-" (subs (str (random-uuid)) 0 12)))
+
+(def window-fmt (DateTimeFormatter/ofPattern "HH:mm"))
+
+(defn- minutes-since-midnight [^LocalTime t]
+  (+ (* 60 (.getHour t)) (.getMinute t)))
+
+(defn- parse-maintenance-window-times [maintenance-window]
+  (when-let [[_ start end] (some->> maintenance-window
+                                    (re-find #"(?i)[a-z]{3}:(\d\d:\d\d)-[a-z]{3}:(\d\d:\d\d)"))]
+    [(minutes-since-midnight (LocalTime/parse start window-fmt))
+     (minutes-since-midnight (LocalTime/parse end window-fmt))]))
+
+(defn- parse-backup-window-times [backup-window]
+  (when-let [[_ start end] (some->> backup-window
+                                    (re-find #"(\d\d:\d\d)-(\d\d:\d\d)"))]
+    [(minutes-since-midnight (LocalTime/parse start window-fmt))
+     (minutes-since-midnight (LocalTime/parse end window-fmt))]))
+
+(defn- window-segments [[start end]]
+  (if (< start end)
+    [[start end]]
+    [[start (* 24 60)]
+     [0 end]]))
+
+(defn- windows-overlap? [a b]
+  (boolean
+   (some (fn [[a-start a-end]]
+           (some (fn [[b-start b-end]]
+                   (and (< a-start b-end)
+                        (< b-start a-end)))
+                 (window-segments b)))
+         (window-segments a))))
+
+(defn- backup-window [hours-from-now]
+  (let [start (-> (LocalTime/now ZoneOffset/UTC)
+                  (.withMinute 0)
+                  (.withSecond 0)
+                  (.withNano 0)
+                  (.plusHours hours-from-now))
+        end (.plusMinutes start 30)]
+    {:window (str (.format start window-fmt) "-" (.format end window-fmt))
+     :range [(minutes-since-midnight start)
+             (minutes-since-midnight end)]}))
+
+(defn farthest-backup-window
+  "A 30-minute PreferredBackupWindow ~12 hours from now (UTC) — as far from the
+   current time as a 24-hour clock allows. Aurora forces >=1 day of backups, but
+   a short-lived clone is usually deleted before this window arrives. If that
+   overlaps the source's inherited maintenance window, try nearby hours."
+  [^DBCluster source]
+  (let [maintenance-range (parse-maintenance-window-times (.preferredMaintenanceWindow source))]
+    (or (->> (range 12 36)
+             (map backup-window)
+             (ucoll/seek (fn [{:keys [range]}]
+                           (not (and maintenance-range
+                                     (windows-overlap? range maintenance-range)))))
+             :window)
+        (throw (ex-info "Could not choose a backup window that avoids maintenance."
+                        {:source-cluster-id (.dbClusterIdentifier source)
+                         :preferred-maintenance-window (.preferredMaintenanceWindow source)})))))
+
+(defn farthest-maintenance-window
+  "A 30-minute PreferredMaintenanceWindow near the generated backup window, but
+   never overlapping the clone's actual backup window."
+  [^DBCluster clone]
+  (let [backup-range (parse-backup-window-times (.preferredBackupWindow clone))
+        window (or (->> (range 13 37)
+                        (map backup-window)
+                        (ucoll/seek (fn [{:keys [range]}]
+                                      (not (and backup-range
+                                                (windows-overlap? range backup-range)))))
+                        :window)
+                   (throw (ex-info "Could not choose a maintenance window that avoids backups."
+                                   {:clone-cluster-id (.dbClusterIdentifier clone)
+                                    :preferred-backup-window (.preferredBackupWindow clone)})))
+        [start end] (clojure.string/split window #"-")]
+    (str "sun:" start "-sun:" end)))
+
+;; ------
+;; create
+
+(defn- restore-clone-cluster!
+  "Clones `source` as a copy-on-write clone, reusing its networking so the clone
+   is reachable from the same VPC. `useLatestRestorableTime` points the clone at
+   the source's latest restorable volume data — this is the documented way to
+   clone. (A point-in-time RestoreToTime is what's rejected for copy-on-write.)"
+  [{:keys [^DBCluster source clone-cluster-id tags]}]
+  (let [sg-ids (mapv (fn [^VpcSecurityGroupMembership m]
+                       (.vpcSecurityGroupId m))
+                     (.vpcSecurityGroups source))
+        request (-> (RestoreDbClusterToPointInTimeRequest/builder)
+                    (.dbClusterIdentifier clone-cluster-id)
+                    (.sourceDBClusterIdentifier (.dbClusterIdentifier source))
+                    (.restoreType "copy-on-write")
+                    (.useLatestRestorableTime true)
+                    (.preferredBackupWindow (farthest-backup-window source))
+                    (.dbSubnetGroupName (.dbSubnetGroup source))
+                    (.vpcSecurityGroupIds (ucoll/array-of String sg-ids))
+                    (.port (.port source))
+                    (.tags (ucoll/array-of Tag tags))
+                    (.build))]
+    (.restoreDBClusterToPointInTime (rds-client)
+                                    ^RestoreDbClusterToPointInTimeRequest request)))
+
+(defn- add-clone-instance!
+  [{:keys [clone-cluster-id instance-id instance-class engine
+           publicly-accessible availability-zone tags]}]
+  (let [request (-> (CreateDbInstanceRequest/builder)
+                    (.dbInstanceIdentifier instance-id)
+                    (.dbClusterIdentifier clone-cluster-id)
+                    (.dbInstanceClass instance-class)
+                    (.engine engine)
+                    (.publiclyAccessible ^Boolean publicly-accessible)
+                    (.availabilityZone availability-zone)
+                    (.monitoringInterval 0)
+                    (.tags (ucoll/array-of Tag tags))
+                    (.build))]
+    (.createDBInstance (rds-client) ^CreateDbInstanceRequest request)))
+
+(defn- wait-until-cluster-available! [cluster-id]
+  (let [request (-> (DescribeDbClustersRequest/builder)
+                    (.dbClusterIdentifier cluster-id)
+                    (.build))]
+    (-> (.waiter (rds-client))
+        (.waitUntilDBClusterAvailable ^DescribeDbClustersRequest request))))
+
+(defn- wait-until-instance-available! [instance-id]
+  (let [request (-> (DescribeDbInstancesRequest/builder)
+                    (.dbInstanceIdentifier instance-id)
+                    (.build))]
+    (-> (.waiter (rds-client))
+        (.waitUntilDBInstanceAvailable ^DescribeDbInstancesRequest request))))
+
+(defn- enable-managed-master-password!
+  "Gives the clone its own password in a fresh managed Secrets Manager secret,
+   applied immediately, so it never shares the primary's credentials. The
+   restore-to-point-in-time API doesn't support this. Also moves maintenance to
+   a generated window that does not overlap our generated backup window."
+  [clone-cluster-id]
+  (let [clone (describe-cluster clone-cluster-id)
+        request (-> (ModifyDbClusterRequest/builder)
+                    (.dbClusterIdentifier clone-cluster-id)
+                    (.manageMasterUserPassword true)
+                    (.preferredMaintenanceWindow (farthest-maintenance-window clone))
+                    (.applyImmediately true)
+                    (.build))]
+    (.modifyDBCluster (rds-client) ^ModifyDbClusterRequest request)))
+
+(defn- wait-for-master-secret-arn!
+  "Polls the clone's managed master user secret until it's active (RDS creates it
+   asynchronously after we enable a managed password), returning its ARN."
+  [clone-cluster-id]
+  (loop [tries 0]
+    (let [secret (.masterUserSecret (describe-cluster clone-cluster-id))
+          status (some-> secret (.secretStatus))]
+      (cond
+        (= "active" status)
+        (.secretArn secret)
+
+        (>= tries 60)
+        (throw (ex-info "Clone master user secret never became active."
+                        {:clone-cluster-id clone-cluster-id :status status}))
+
+        :else
+        (do (Thread/sleep 5000)
+            (recur (inc tries)))))))
+
+(defn clone-db-config
+  "Shapes a db-config for the clone that mirrors `config/get-aurora-config`, so
+   it's a drop-in for the code that consumes the prod config."
+  [clone-cluster-id]
+  (assoc (aurora-config/rds-cluster-id->db-config clone-cluster-id (config/db-application-name))
+         ;; Make sure we can use this for a copy command that shuttles lots of data
+         ;; More details: https://bugs.openjdk.org/browse/JDK-8329548
+         :sslfactory "instant.jdbc.Tls12SocketFactory"))
+
+(defn start-clone-pool
+  [pool-size clone-cluster-id]
+  (aurora/start-pool pool-size (clone-db-config clone-cluster-id)))
+
+(defn stop-clone-pool [pool]
+  (aurora/close-pool pool))
+
+(defn create-clone!
+  "Creates a copy-on-write clone of `:source-cluster-id` (defaults to the prod
+   cluster) on a `instance-class` instance (e.g. \"db.r8gd.xlarge\" — pass a small
+   one, the clone only serves read-only backup scans), waits until it's
+   queryable, and returns:
+
+     {:cluster-id   <clone cluster id>
+      :instance-id  <clone instance id>
+      :snapshot-time  <Instant the clone was restored to>}
+
+   The clone gets its own managed Secrets Manager secret; it never shares the
+   primary's password.
+
+   The clone reflects the source's current state (copy-on-write clones can't be
+   taken at a historical point-in-time).
+
+   Parameters:
+     :instance-class - aws instance class, e.g. db.r8gd.xlarge
+     :source-cluster-id - id of the cluster to clone"
+  [{:keys [instance-class source-cluster-id]}]
+  (assert instance-class "instance-class is required (e.g. \"db.r8gd.xlarge\")")
+  (assert source-cluster-id "source-cluster-id is required")
+  (let [clone-cluster-id (gen-clone-id)
+        instance-id (str clone-cluster-id "-0")
+        tags [(-> (Tag/builder) (.key "instant:purpose") (.value "clone") (.build))
+              (-> (Tag/builder) (.key "instant:source-cluster") (.value source-cluster-id) (.build))]]
+    (tracer/with-span! {:name "clone/create"
+                        :attributes {:source-cluster-id source-cluster-id
+                                     :clone-cluster-id clone-cluster-id
+                                     :instance-class instance-class}}
+      (let [source (describe-cluster source-cluster-id)
+            writer (describe-instance (writer-instance-id source))
+            publicly-accessible (.publiclyAccessible writer)
+            ;; Put the clone's instance in the same AZ as the source writer.
+            availability-zone (.availabilityZone writer)
+            ;; The clone forks at the source's latest restorable time (we use
+            ;; useLatestRestorableTime), so that — not now() — is the point-in-time
+            ;; the clone's data represents. Read before the restore, so it's a
+            ;; lower bound on the true fork point.
+            snapshot-time (.latestRestorableTime source)]
+        (tracer/with-span! {:name "clone/restore-cluster"}
+          (restore-clone-cluster! {:source source
+                                   :clone-cluster-id clone-cluster-id
+                                   :tags tags}))
+        ;; An instance can only be added once the restored cluster is available.
+        (tracer/with-span! {:name "clone/wait-cluster-available"}
+          (wait-until-cluster-available! clone-cluster-id))
+        (tracer/with-span! {:name "clone/add-instance"
+                            :attributes {:availability-zone availability-zone
+                                         :publicly-accessible publicly-accessible}}
+          (add-clone-instance! {:clone-cluster-id clone-cluster-id
+                                :instance-id instance-id
+                                :instance-class instance-class
+                                :engine (.engine source)
+                                :publicly-accessible publicly-accessible
+                                :availability-zone availability-zone
+                                :tags tags}))
+        (tracer/with-span! {:name "clone/wait-instance-available"}
+          (wait-until-instance-available! instance-id))
+        (tracer/with-span! {:name "clone/enable-managed-password"}
+          (enable-managed-master-password! clone-cluster-id))
+        (tracer/with-span! {:name "clone/wait-master-secret"}
+          (wait-for-master-secret-arn! clone-cluster-id))
+        {:cluster-id clone-cluster-id
+         :instance-id instance-id
+         :snapshot-time snapshot-time}))))
+
+;; ------
+;; delete
+
+(defn- delete-instance! [instance-id]
+  (let [request (-> (DeleteDbInstanceRequest/builder)
+                    (.dbInstanceIdentifier instance-id)
+                    (.skipFinalSnapshot true)
+                    (.deleteAutomatedBackups true)
+                    (.build))]
+    (.deleteDBInstance (rds-client) ^DeleteDbInstanceRequest request)
+    (let [describe (-> (DescribeDbInstancesRequest/builder)
+                       (.dbInstanceIdentifier instance-id)
+                       (.build))]
+      (-> (.waiter (rds-client))
+          (.waitUntilDBInstanceDeleted ^DescribeDbInstancesRequest describe)))))
+
+(defn- delete-cluster! [cluster-id]
+  (let [request (-> (DeleteDbClusterRequest/builder)
+                    (.dbClusterIdentifier cluster-id)
+                    (.skipFinalSnapshot true)
+                    (.deleteAutomatedBackups true)
+                    (.build))]
+    (.deleteDBCluster (rds-client) ^DeleteDbClusterRequest request)))
+
+(defn- cluster-instance-ids [cluster-id]
+  (->> (.dbClusterMembers (describe-cluster cluster-id))
+       (mapv (fn [^DBClusterMember m] (.dbInstanceIdentifier m)))))
+
+(defn delete-clone!
+  "Tears down a clone created by `create-clone!`. Deletes the instance first
+   (waiting for it to drain) since a cluster can't be deleted while it still has
+   members. Asserts the clone has the single instance we create, so we never
+   silently leave one behind."
+  [cluster-id]
+  (tracer/with-span! {:name "clone/delete"
+                      :attributes {:clone-cluster-id cluster-id}}
+    (when cluster-id
+      (let [instance-ids (cluster-instance-ids cluster-id)]
+        (assert (= 1 (count instance-ids))
+                (format "Expected clone %s to have 1 instance, found %d."
+                        cluster-id (count instance-ids)))
+        (tracer/with-span! {:name "clone/delete-instance"
+                            :attributes {:instance-id (first instance-ids)}}
+          (delete-instance! (first instance-ids)))
+        (tracer/with-span! {:name "clone/delete-cluster"
+                            :attributes {:clone-cluster-id cluster-id}}
+          (delete-cluster! cluster-id))))))

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -218,10 +218,13 @@
                             (some-> @config-map :database-cluster-id))]
     (aurora-config/rds-cluster-id->db-config cluster-id application-name)))
 
+(defn db-application-name []
+  (uri/query-encode (format "%s, %s"
+                            @hostname
+                            @process-id)))
+
 (defn get-aurora-config []
-  (let [application-name (uri/query-encode (format "%s, %s"
-                                                   @hostname
-                                                   @process-id))
+  (let [application-name (db-application-name)
         config (or (aurora-config-from-cluster-id application-name)
                    (aurora-config-from-database-url))]
     (assoc config
@@ -238,9 +241,7 @@
     (db-url->config url)))
 
 (defn get-next-aurora-config []
-  (let [application-name (uri/query-encode (format "%s, %s"
-                                                   @hostname
-                                                   @process-id))]
+  (let [application-name (db-application-name)]
     (when-let [config (or (next-aurora-config-from-cluster-id application-name)
                           (next-aurora-config-from-database-url))]
       (assoc config

--- a/server/src/instant/jdbc/aurora.clj
+++ b/server/src/instant/jdbc/aurora.clj
@@ -356,13 +356,15 @@
             (tracer/add-exception! t {:escaping? false})))))
     nil))
 
+(defn close-pool [^HikariDataSource d]
+  (.close d)
+  (.shutdown ^HikariPool (.getHikariPoolMXBean d)))
+
 (defn stop []
   (lang/clear-var! -conn-pool (fn [^HikariDataSource d]
-                                (.close d)
-                                (.shutdown ^HikariPool (.getHikariPoolMXBean d))))
+                                (close-pool d)))
   (lang/clear-var! -replica-conn-pool (fn [^HikariDataSource d]
-                                        (.close d)
-                                        (.shutdown ^HikariPool (.getHikariPoolMXBean d)))))
+                                        (close-pool d))))
 
 (defn restart []
   (stop)


### PR DESCRIPTION
Follow-up to https://github.com/instantdb/instant/pull/2791.

Takes a slightly different approach to backups than the previous PR. Instead of running a copy command on the production db, it creates a short-lived copy-on-write clone of the db and runs the backup on the clone.

The copy process was a little too slow and it eventually failed because the snapshot connection we use to fetch the app's config hit a idle_in_transaction timeout. We could extend that timeout, but I'm taking it as a sign that we should go to plan B.

The new process creates a copy-on-write clone of the db, which means we don't pay any storage costs. We use the smallest "optimized reads" instance and turn on i/o optimized mode, so we also don't pay any i/o costs over the fixed per-hour rate. It should cost us less than a dollar per nightly run, but I'll do some monitoring to see what the actual cost is. We also may need to bump up the instance size if we're cpu constrained.

We're running it on the clone and the clone is static, so we don't need any snapshot connections. We can run multiple apps in parallel, which will allow the process to finish more quickly and could even potentially run across multiple instances.

It reuses a lot of the code from the copy clone to process the triples for an app and upload the files to s3. Most of the changes in this PR are in creating the clone and some changes in `backup.clj` to handle the new process.
