### PR TITLE
ci: read branch refs from env in both Set branch name steps

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -342,11 +342,14 @@ jobs:
           bb --version
 
       - name: Set branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+            BRANCH_NAME="$HEAD_REF"
           else
-            BRANCH_NAME="${{ github.ref_name }}"
+            BRANCH_NAME="$REF_NAME"
           fi
           # Sanitize branch name for npm version compatibility
           # Replace / and other invalid characters with -
@@ -490,11 +493,14 @@ jobs:
     - name: Pull Vercel Environment Information
       run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
     - name: Set branch name
+      env:
+        HEAD_REF: ${{ github.head_ref }}
+        REF_NAME: ${{ github.ref_name }}
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          branch="${{ github.head_ref }}"
+          branch="$HEAD_REF"
         else
-          branch="${{ github.ref_name }}"
+          branch="$REF_NAME"
         fi
         echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
         safeBranch=$(echo "$branch" | sed 's/[^a-zA-Z0-9-]/-/g')


### PR DESCRIPTION
Hi, and thanks for Instant.

`.github/workflows/js.yml` has two "Set branch name" steps that read the ref by interpolation — around line 347 and again around line 495:

```yaml
run: |
  if [ "${{ github.event_name }}" = "pull_request" ]; then
    BRANCH_NAME="${{ github.head_ref }}"
  else
    BRANCH_NAME="${{ github.ref_name }}"
  fi
```

Actions expands `${{ ... }}` into the script text before bash runs, so on a pull request the branch name — chosen by whoever opened it — becomes part of the script rather than a value. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` runs inside double quotes.

The first of the two already does the right thing immediately afterwards:

```yaml
SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g')
```

That sanitiser is correct — it just runs one line after the value has already been part of the command, so it cannot help with this particular problem.

The change binds both refs to step-level environment variables in both steps:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
  REF_NAME: ${{ github.ref_name }}
run: |
  ...
    BRANCH_NAME="$HEAD_REF"
  ...
    BRANCH_NAME="$REF_NAME"
```

The `SAFE_BRANCH_NAME` slugifying, both `$GITHUB_ENV` writes and everything downstream are untouched, so the values produced are identical. I left `github.event_name` interpolated deliberately — it is a fixed GitHub-controlled string, not free text.

On scope: these run on `pull_request`, so a fork PR gets a read-only token and no secrets. Hardening rather than a live exploit.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read both steps myself.
