### PR TITLE
catch and log persistedObject GC errors (#2799) [bump to v1.0.53]

### DIFF
--- a/client/packages/core/src/utils/PersistedObject.ts
+++ b/client/packages/core/src/utils/PersistedObject.ts
@@ -485,7 +485,9 @@ export class PersistedObject<K extends string, T, SerializedT> {
       () => {
         safeIdleCallback(() => {
           this._nextGc = null;
-          this._gc();
+          this._gc().catch((e) =>
+            this._log.error('Persisted Object GC Failed:', e),
+          );
         }, 30 * 1000);
       },
       // 1 minute + some jitter to keep multiple tabs from running at same time

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.52';
+const version = 'v1.0.53';
 
 export { version };


### PR DESCRIPTION
fixes: #2795 
If indexeddb was unavailable for whatever reason, the scheduled 60s garbage collection would throw an uncaught error. This catches the error and logs it instead. 