### PR TITLE
Include app_id in replica identity

### DIFF
--- a/server/resources/migrations/119_replica_identity.down.sql
+++ b/server/resources/migrations/119_replica_identity.down.sql
@@ -1,0 +1,6 @@
+alter table idents replica identity default;
+alter table attr_sketches replica identity default;
+alter table app_admin_tokens replica identity default;
+alter table app_email_templates replica identity default;
+alter table app_email_verifications replica identity default;
+alter table app_email_senders replica identity default;

--- a/server/resources/migrations/119_replica_identity.up.sql
+++ b/server/resources/migrations/119_replica_identity.up.sql
@@ -1,0 +1,9 @@
+-- Include app_id in the replica identity of the app-scoped tables using existing unique indexes
+alter table idents replica identity using index app_ident_uq;
+alter table attr_sketches replica identity using index attr_sketches_app_id_attr_id_key;
+alter table app_admin_tokens replica identity using index app_admin_tokens_app_id_key;
+alter table app_email_templates replica identity using index app_email_templates_app_id_email_type_key;
+alter table app_email_verifications replica identity using index app_email_verifications_app_id_sender_id_key;
+
+-- app_email_senders has no unique index covering app_id (only unique(email)),
+alter table app_email_senders replica identity full;


### PR DESCRIPTION
Updates the replica identity for a few tables to include the app_id so that we can filter out a single app when migrating them to a new database.