### PR TITLE
Keep dashboard routes out of app proxy

### DIFF
--- a/server/src/instant/app_proxy.clj
+++ b/server/src/instant/app_proxy.clj
@@ -218,6 +218,10 @@
 ;; ----------
 ;; Request routing
 
+(defn- dashboard-path? [path]
+  (or (= "/dash" path)
+      (string/starts-with? path "/dash/")))
+
 (def ^:private target-unavailable-handler
   ;; ProxyHandler falls through to this handler when its target has no
   ;; connectable host. Failing closed matters here: falling back to the local
@@ -324,14 +328,16 @@
                                 (.endExchange callback-exchange))))))]
      (reify HttpHandler
        (handleRequest [_ exchange]
-         (let [table (current-targets)]
-           (if (empty? table)
-             ;; Nothing is being proxied, which is the common case: stay out
-             ;; of the request entirely.
+         (let [table (current-targets)
+               path (.getRequestPath exchange)]
+           (if (or (empty? table)
+                   (dashboard-path? path))
+             ;; Empty routing tables and dashboard control-plane requests stay
+             ;; out of the proxy entirely.
              (.handleRequest local-handler exchange)
              (if-let [app-id (request-app-id exchange table)]
                (route! exchange table app-id)
-               (if (contains? body-inspection-paths (.getRequestPath exchange))
+               (if (contains? body-inspection-paths path)
                  (inspect-body! exchange table)
                  (.handleRequest local-handler exchange))))))))))
 
@@ -366,7 +372,8 @@
   ([handler current-targets]
    (fn [request]
      (let [table (current-targets)
-           app-id (when (seq table)
+           app-id (when (and (seq table)
+                             (not (dashboard-path? (:uri request))))
                     (some #(when (contains? table %) %)
                           (ring-app-id-candidates request)))]
        (if-not app-id

--- a/server/test/instant/app_proxy_test.clj
+++ b/server/test/instant/app_proxy_test.clj
@@ -106,6 +106,21 @@
           (is (= 200 (:status response)))
           (is (= path (get-in response [:body :uri])))))
 
+      (testing "dashboard requests stay on the local handler"
+        (doseq [[path options]
+                [[(str "/dash/apps/" app-id) {}]
+                 ["/dash" {:headers {"app-id" (str app-id)}}]]]
+          (let [response (http/get (str proxy-origin path)
+                                   (assoc options :throw-exceptions false))]
+            (is (= 418 (:status response)))
+            (is (= "local" (:body response))))))
+
+      (testing "dashboard path matching respects the segment boundary"
+        (let [path (str "/dashboard/apps/" app-id)
+              response (http/get (str proxy-origin path) {:as :json})]
+          (is (= 200 (:status response)))
+          (is (= path (get-in response [:body :uri])))))
+
       (testing "unmapped apps stay on the local handler"
         (let [response (http/get
                         (str proxy-origin "/runtime/session?app_id=" (random-uuid))
@@ -197,6 +212,14 @@
       (is (= 503 (:status (handler {:uri "/runtime/oauth/callback"
                                     :headers {}
                                     :params {:state (str app-id (random-uuid))}})))))
+    (testing "dashboard requests for proxied apps pass through"
+      (is (= 200 (:status (handler {:uri (str "/dash/apps/" app-id)
+                                    :headers {}}))))
+      (is (= 200 (:status (handler {:uri "/dash"
+                                    :headers {"app-id" (str app-id)}})))))
+    (testing "dashboard path matching respects the segment boundary"
+      (is (= 503 (:status (handler {:uri (str "/dashboard/apps/" app-id)
+                                    :headers {}})))))
     (testing "unproxied apps and app-less requests pass through"
       (is (= 200 (:status (handler {:uri "/runtime/auth/send_magic_code"
                                     :headers {}


### PR DESCRIPTION
## Summary

- Keep `/dash` and `/dash/*` requests on the Instant backend when an app proxy target is configured
- Apply the same dashboard boundary to the Undertow router and the Ring fail-closed guard
- Cover app IDs from both dashboard paths and headers, including the `/dashboard` segment-boundary case

## Test plan

- `clojure.test/run-tests instant.app-proxy-test` (6 tests, 39 assertions)
- `clj-kondo --lint src/instant/app_proxy.clj test/instant/app_proxy_test.clj`
- `git diff --check`