### PR TITLE
log url on instant-cli errors (#2806) [bump to v1.0.55]

### DIFF
--- a/client/packages/cli/src/commands/info.ts
+++ b/client/packages/cli/src/commands/info.ts
@@ -1,6 +1,6 @@
 import { HttpClientResponse } from '@effect/platform';
 import { Effect, Schema, Option } from 'effect';
-import { InstantHttpAuthed } from '../lib/http.ts';
+import { getBaseUrl, InstantHttpAuthed } from '../lib/http.ts';
 import { version } from '@instantdb/version';
 import { CurrentApp } from '../context/currentApp.ts';
 
@@ -21,6 +21,7 @@ export const DashAppResponse = Schema.Struct({
 
 export const infoCommand = () =>
   Effect.gen(function* () {
+    const baseUrl = yield* getBaseUrl;
     const authedHttp = yield* Effect.serviceOption(InstantHttpAuthed).pipe(
       Effect.map(Option.getOrNull),
     );
@@ -32,7 +33,10 @@ export const infoCommand = () =>
       const meData = yield* authedHttp.get('/dash/me').pipe(
         Effect.flatMap(HttpClientResponse.schemaBodyJson(DashMeResponse)),
         Effect.mapError(
-          (e) => new Error("Couldn't get user information.", { cause: e }),
+          (e) =>
+            new Error(`Couldn't get user information (${baseUrl}).`, {
+              cause: e,
+            }),
         ),
       );
 

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.54';
+const version = 'v1.0.55';
 
 export { version };


### PR DESCRIPTION
Shows the url on errors for the info command. For any InstantHttpError, the url is already part of the error message. 

<img width="1200" height="241" alt="image" src="https://github.com/user-attachments/assets/b486bd90-bbda-4f29-b2d8-8936b6c88eb7" />
