### PR TITLE
[Dash] Use configured default sender email

### DIFF
--- a/client/www/components/dash/AppAuth.tsx
+++ b/client/www/components/dash/AppAuth.tsx
@@ -887,7 +887,9 @@ export function AppAuth({
         <Email
           key={emailFormKey}
           app={app}
-          defaultSenderEmail={data.default_sender_email}
+          defaultSenderEmail={
+            data.default_sender_email ?? 'verify@auth-pm.instantdb.com'
+          }
         />
       </AuthDetailLayout>
     );

--- a/client/www/components/dash/AppAuth.tsx
+++ b/client/www/components/dash/AppAuth.tsx
@@ -884,7 +884,11 @@ export function AppAuth({
         title="Magic code email"
         description="The email your users receive with their sign-in code."
       >
-        <Email key={emailFormKey} app={app} />
+        <Email
+          key={emailFormKey}
+          app={app}
+          defaultSenderEmail={data.default_sender_email}
+        />
       </AuthDetailLayout>
     );
   }

--- a/client/www/components/dash/auth/Email.tsx
+++ b/client/www/components/dash/auth/Email.tsx
@@ -22,10 +22,6 @@ import { useFetchedDash } from '../MainDashLayout';
 import { useDarkMode } from '../DarkModeToggle';
 import { useCustomSenderVerification } from '@/lib/hooks/useCustomSenderVerification';
 
-// Shown when the app hasn't set up a custom sender. Matches the server default
-// (config/app-email-sender); env overrides won't change what's actually sent.
-const DEFAULT_SENDER_EMAIL = 'verify@auth-pm.instantdb.com';
-
 export type EmailValues = {
   from: string;
   subject: string;
@@ -85,7 +81,13 @@ export function substituteSampleVars(
     );
 }
 
-export function Email({ app }: { app: InstantApp }) {
+export function Email({
+  app,
+  defaultSenderEmail,
+}: {
+  app: InstantApp;
+  defaultSenderEmail: string;
+}) {
   const dashResponse = useFetchedDash();
   const template = app.magic_code_email_template;
   const token = useContext(TokenContext);
@@ -365,7 +367,7 @@ export function Email({ app }: { app: InstantApp }) {
             ) : (
               <div className="flex items-center justify-between gap-2 rounded-sm bg-gray-50 px-3 py-2 text-sm dark:bg-neutral-800">
                 <span className="text-gray-600 dark:text-neutral-300">
-                  {DEFAULT_SENDER_EMAIL}
+                  {defaultSenderEmail}
                 </span>
                 <button
                   type="button"

--- a/client/www/lib/types.ts
+++ b/client/www/lib/types.ts
@@ -220,6 +220,7 @@ export type AppsAuthResponse = {
   authorized_redirect_origins: AuthorizedOrigin[] | null | undefined;
   oauth_service_providers: OAuthServiceProvider[] | null | undefined;
   oauth_clients: OAuthClient[] | null | undefined;
+  default_sender_email: string;
 };
 
 export type SubscriptionName = 'Free' | 'Pro';

--- a/server/src/instant/model/app_auth_data.clj
+++ b/server/src/instant/model/app_auth_data.clj
@@ -1,5 +1,6 @@
 (ns instant.model.app-auth-data
   (:require
+   [instant.config :as config]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.system-catalog-ops :refer [query-op]]))
@@ -56,4 +57,5 @@
                         $oauthClients)]
        {:data {"oauth_service_providers" providers
                "oauth_clients" clients
-               "authorized_redirect_origins" redirect-origins}}))))
+               "authorized_redirect_origins" redirect-origins
+               "default_sender_email" (:email (config/app-email-sender))}}))))

--- a/server/test/instant/model/app_auth_data_test.clj
+++ b/server/test/instant/model/app_auth_data_test.clj
@@ -1,0 +1,24 @@
+(ns instant.model.app-auth-data-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [instant.config :as config]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.sql :as sql]
+   [instant.model.app-auth-data :as app-auth-data]
+   [instant.system-catalog-ops :as system-catalog-ops]))
+
+(deftest get-dash-auth-data-includes-configured-default-sender-email
+  (with-redefs [config/app-email-sender
+                (constantly {:email "auth@self-hosted.example"})
+                aurora/conn-pool
+                (constantly nil)
+                sql/select-one
+                (constantly {:data {"authorized_redirect_origins" []}})
+                system-catalog-ops/query-op
+                (fn [_conn _query-params f]
+                  (f {:admin-query
+                      (constantly {"$oauthProviders" []
+                                   "$oauthClients" []})}))]
+    (is (= "auth@self-hosted.example"
+           (get-in (app-auth-data/get-dash-auth-data {:app-id (random-uuid)})
+                   [:data "default_sender_email"])))))


### PR DESCRIPTION
On the auth tab we would hardcode the default sender email as `verify@auth-pm.instantdb.com` but for self-hosted this wouldn't make sense.

We'll now actually include the configured default sender email to the dashboard!

**Before**
<img width="1376" height="166" alt="CleanShot 2026-07-30 at 13 39 00@2x" src="https://github.com/user-attachments/assets/2acbf607-7f8c-4612-bace-7d5859ef2805" />

**After**
<img width="1414" height="164" alt="CleanShot 2026-07-30 at 13 39 29@2x" src="https://github.com/user-attachments/assets/81a61897-fb97-462b-9dc0-d7bde850c6a5" />