### PR TITLE
Update self-hosting to use postgres 17

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -110,7 +110,7 @@ jobs:
 
     services:
       postgres:
-        image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+        image: ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan
         ports:
           - 5432:5432
         env:

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -2,4 +2,4 @@
 
 Documentation for self hosting is available at [www.instantdb.com/docs/self-hosting](https://instantdb.com/docs/self-hosting)
 
-See UPGRADE_DB.md for instructions on upgrading existing backends from postgres 16 to 17.
+See [UPGRADE_DB.md](UPGRADE_DB.md) for instructions on upgrading existing backends from postgres 16 to 17.

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -1,3 +1,5 @@
 # Self Hosting InstantDB
 
 Documentation for self hosting is available at [www.instantdb.com/docs/self-hosting](https://instantdb.com/docs/self-hosting)
+
+See UPGRADE_DB.md for instructions on upgrading existing backends from postgres 16 to 17.

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -50,15 +50,19 @@ echo "Resolved PostgreSQL data volume: $PG_VOLUME"
 ```
 
 Confirm the printed name is the PostgreSQL data volume you intend to delete
-before continuing. This step is destructive and irreversible. If you would
-rather leave your PostgreSQL 16 volume untouched, use the alternative at the end
-of this guide instead of deleting anything.
+before continuing. If that line printed a blank name, stop and re-run the
+resolve step while the container is still up, rather than deleting anything.
+This step is destructive and irreversible. If you would rather leave your
+PostgreSQL 16 volume untouched, use the alternative at the end of this guide
+instead of deleting anything.
 
 ```bash
 docker compose down
 # only after you have verified $PG_VOLUME above:
 docker volume rm "$PG_VOLUME"
-# now pull / check out the PostgreSQL 17 compose files
+# return to the revision that ships PostgreSQL 17 before starting again, so the
+# fresh database comes up on 17 (you may have checked out PG16 for the dump):
+git checkout <pg17-revision>   # e.g. main
 docker compose up -d postgres
 # wait until it reports healthy (this creates a fresh, empty `instant` database)
 ```
@@ -86,7 +90,7 @@ Verify the app comes up and your data is present, then you can delete
 > ```bash
 > docker compose down
 > # restore the PostgreSQL 16 compose file and image tag, e.g. by checking out
-> # the previous revision (adjust the ref/path to your setup):
+> # the previous revision (use your own compose file if it isn't the default):
 > git checkout <previous-revision> -- docker-compose.yml
 > # the untouched backend-db volume is still attached by that compose file,
 > # so do NOT run `docker volume rm` against it

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -90,7 +90,8 @@ it, but **don't** bring up the rest of the stack yet — step 4 has to run befor
 the server starts:
 
 ```bash
-docker compose exec -T postgres pg_restore -U instant -d instant --clean --if-exists --single-transaction < instant-pg16.dump
+docker compose exec -T postgres sh -c \
+  'pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists --single-transaction' < instant-pg16.dump
 ```
 
 ### 4. Reset the aggregator replication slot
@@ -113,10 +114,12 @@ can recreate the slot at the database's current position and point
 aggregator simply resumes streaming from here:
 
 ```bash
-docker compose exec -T postgres psql -U instant -d instant -c \
-  "UPDATE wal_aggregator_status
-      SET lsn = (SELECT lsn FROM pg_create_logical_replication_slot('aggregator', 'wal2json'))
-    WHERE slot_name = 'aggregator';"
+docker compose exec -T postgres sh -c \
+  'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
+UPDATE wal_aggregator_status
+    SET lsn = (SELECT lsn FROM pg_create_logical_replication_slot('aggregator', 'wal2json'))
+  WHERE slot_name = 'aggregator';
+SQL
 ```
 
 This should print `UPDATE 1`. If it prints `UPDATE 0`, this deployment never

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -85,8 +85,48 @@ docker compose up -d --wait postgres
 
 ### 3. Restore the dump
 
+Only the `postgres` service is running at this point (from step 2). Restore into
+it, but **don't** bring up the rest of the stack yet — step 4 has to run before
+the server starts:
+
 ```bash
 docker compose exec -T postgres pg_restore -U instant -d instant --clean --if-exists --single-transaction < instant-pg16.dump
+```
+
+### 4. Reset the aggregator replication slot
+
+The server keeps an internal count of your data (the "attr sketches") up to date
+by streaming Postgres' write-ahead log from a logical replication slot named
+`aggregator`, remembering how far it has read in the `wal_aggregator_status`
+table.
+
+`pg_dump`/`pg_restore` copies the sketches and the `wal_aggregator_status` row,
+but the dump does not include the replication slots. On the fresh PostgreSQL 17
+database the sketches are current, yet the `aggregator` slot is gone and
+`wal_aggregator_status` still points at a position in the old PostgreSQL 16
+slot that no longer exists. If you start the server as-is it can't resume the
+stream.
+
+Because the whole stack is down (no writes happen between the dump and now), you
+can recreate the slot at the database's current position and point
+`wal_aggregator_status` at it. The restored sketches are already accurate, so the
+aggregator simply resumes streaming from here:
+
+```bash
+docker compose exec -T postgres psql -U instant -d instant -c \
+  "UPDATE wal_aggregator_status
+      SET lsn = (SELECT lsn FROM pg_create_logical_replication_slot('aggregator', 'wal2json'))
+    WHERE slot_name = 'aggregator';"
+```
+
+This should print `UPDATE 1`. If it prints `UPDATE 0`, this deployment never
+initialized the aggregator (no status row) — the slot is left uncreated and the
+server will bootstrap it itself on first start, which is fine; continue to
+step 5.
+
+### 5. Start the rest of the stack
+
+```bash
 docker compose up -d
 ```
 

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -62,16 +62,25 @@ instead of deleting anything.
 ```bash
 docker compose down
 
-# Check out and validate the PostgreSQL 17 config before deleting the old volume,
-# so a failed checkout or bad compose file can't leave you with no database. Stop
-# here if either command fails (you may have checked out PG16 for the dump above):
-git checkout <pg17-revision>       # e.g. main
-docker compose config >/dev/null   # validates the compose file; errors are fatal
+# Check out the PostgreSQL 17 revision, then validate its compose config and
+# print the resolved postgres image, all before deleting the old volume so a bad
+# checkout can't leave you with no database (you may have checked out PG16 for
+# the dump above). Stop here if either command fails:
+git checkout <pg17-revision>              # e.g. main
+docker compose config >/dev/null          # validates the compose file; errors are fatal
+docker compose config --images postgres   # prints the resolved postgres image
+```
 
-# Only now that the PG17 config is confirmed, and $PG_VOLUME is verified above:
+Confirm that image tag denotes PostgreSQL 17 (e.g. `postgres:17`). If it still
+shows 16, your checkout didn't switch revisions, so fix that before deleting the
+volume.
+
+```bash
+# Only now that the PG17 config and image are confirmed, and $PG_VOLUME is
+# verified above:
 docker volume rm "$PG_VOLUME"
-docker compose up -d postgres
-# wait until it reports healthy (this creates a fresh, empty `instant` database)
+docker compose up -d --wait postgres
+# --wait blocks until the fresh, empty `instant` database is healthy
 ```
 
 ### 3. Restore the dump

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -19,8 +19,11 @@ DETAIL: The data directory was initialized by PostgreSQL version 16, which is no
 
 Run this migration **once**, using dump/restore. The commands below assume the
 default `docker-compose.yml`, the user `instant`, and the database `instant`.
-Pass `-f <file>` if you use a different compose file, and wherever you see
-`instant` substitute the `POSTGRES_USER` / `POSTGRES_DB` values you configured.
+If your deployment uses a different compose file or project name, add the same
+`-f`/`-p` options to **every** `docker compose` command below, including the one
+nested inside the volume-lookup in step 2 and the ones in the rollback notes.
+Wherever you see `instant`, substitute the `POSTGRES_USER` / `POSTGRES_DB`
+values you configured.
 
 ### 1. Dump the database while still on PostgreSQL 16
 
@@ -58,11 +61,15 @@ instead of deleting anything.
 
 ```bash
 docker compose down
-# only after you have verified $PG_VOLUME above:
+
+# Check out and validate the PostgreSQL 17 config before deleting the old volume,
+# so a failed checkout or bad compose file can't leave you with no database. Stop
+# here if either command fails (you may have checked out PG16 for the dump above):
+git checkout <pg17-revision>       # e.g. main
+docker compose config >/dev/null   # validates the compose file; errors are fatal
+
+# Only now that the PG17 config is confirmed, and $PG_VOLUME is verified above:
 docker volume rm "$PG_VOLUME"
-# return to the revision that ships PostgreSQL 17 before starting again, so the
-# fresh database comes up on 17 (you may have checked out PG16 for the dump):
-git checkout <pg17-revision>   # e.g. main
 docker compose up -d postgres
 # wait until it reports healthy (this creates a fresh, empty `instant` database)
 ```

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -12,15 +12,15 @@ A PostgreSQL major version cannot read an older major version's data directory,
 so if you pull these images on top of an existing PostgreSQL 16 volume the
 container will refuse to start with:
 
-```
+```text
 FATAL: database files are incompatible with server
 DETAIL: The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.x.
 ```
 
-Run this migration **once**, using dump/restore. Substitute your compose file
-with `-f` if you are not using the default `docker-compose.yml`, and set the
-`instant`/`instant`/`pass` names to whatever you configured via
-`POSTGRES_USER` / `POSTGRES_DB` / `POSTGRES_PASSWORD`.
+Run this migration **once**, using dump/restore. The commands below assume the
+default `docker-compose.yml`, the user `instant`, and the database `instant`.
+Pass `-f <file>` if you use a different compose file, and wherever you see
+`instant` substitute the `POSTGRES_USER` / `POSTGRES_DB` values you configured.
 
 ### 1. Dump the database while still on PostgreSQL 16
 
@@ -38,20 +38,35 @@ Keep `instant-pg16.dump` somewhere safe.
 
 ### 2. Start PostgreSQL 17 on a fresh data directory
 
+Postgres stores its data in a Docker volume. Get that volume's exact name
+straight from the running container, so you delete the right one. Run this
+before `docker compose down`, while the container still exists:
+
+```bash
+# Read the volume backing /var/lib/postgresql/data straight from the container
+PG_VOLUME=$(docker inspect "$(docker compose ps -aq postgres)" \
+  --format '{{ range .Mounts }}{{ if eq .Destination "/var/lib/postgresql/data" }}{{ .Name }}{{ end }}{{ end }}')
+echo "Resolved PostgreSQL data volume: $PG_VOLUME"
+```
+
+Confirm the printed name is the PostgreSQL data volume you intend to delete
+before continuing. This step is destructive and irreversible. If you would
+rather leave your PostgreSQL 16 volume untouched, use the alternative at the end
+of this guide instead of deleting anything.
+
 ```bash
 docker compose down
-# remove ONLY the postgres volume; the leading name is your compose project
-# (usually the directory name). `docker volume ls` shows the exact name.
-docker volume rm "$(basename "$PWD")_backend-db"
+# only after you have verified $PG_VOLUME above:
+docker volume rm "$PG_VOLUME"
 # now pull / check out the PostgreSQL 17 compose files
 docker compose up -d postgres
-# wait until it reports healthy — this creates a fresh, empty `instant` database
+# wait until it reports healthy (this creates a fresh, empty `instant` database)
 ```
 
 ### 3. Restore the dump
 
 ```bash
-docker compose exec -T postgres pg_restore -U instant -d instant --clean --if-exists < instant-pg16.dump
+docker compose exec -T postgres pg_restore -U instant -d instant --clean --if-exists --single-transaction < instant-pg16.dump
 docker compose up -d
 ```
 
@@ -62,3 +77,18 @@ Verify the app comes up and your data is present, then you can delete
 > brand-new volume (e.g. `backend-db-17`) instead of `backend-db` and restore
 > the dump into it. That keeps the untouched PostgreSQL 16 volume around as a
 > rollback.
+>
+> To roll back to PostgreSQL 16 after using the alternative volume, stop the
+> stack, restore the previous compose/image configuration, and start it again
+> against the original `backend-db` volume. **Never delete `backend-db`**. It
+> still holds your PostgreSQL 16 data:
+>
+> ```bash
+> docker compose down
+> # restore the PostgreSQL 16 compose file and image tag, e.g. by checking out
+> # the previous revision (adjust the ref/path to your setup):
+> git checkout <previous-revision> -- docker-compose.yml
+> # the untouched backend-db volume is still attached by that compose file,
+> # so do NOT run `docker volume rm` against it
+> docker compose up -d
+> ```

--- a/self-hosting/UPGRADE_DB.md
+++ b/self-hosting/UPGRADE_DB.md
@@ -1,0 +1,64 @@
+# Upgrading a self-hosted InstantDB
+
+You can ignore this guide if you are creating a new self-hosted Instant deployment.
+This doc is only for deployments that were using postgres 16 and want to update.
+
+## PostgreSQL 16 → 17 (one-time migration)
+
+The compose files ship PostgreSQL 17, but reuse the same `backend-db` volume that
+older deployments populated with PostgreSQL 16.
+
+A PostgreSQL major version cannot read an older major version's data directory,
+so if you pull these images on top of an existing PostgreSQL 16 volume the
+container will refuse to start with:
+
+```
+FATAL: database files are incompatible with server
+DETAIL: The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.x.
+```
+
+Run this migration **once**, using dump/restore. Substitute your compose file
+with `-f` if you are not using the default `docker-compose.yml`, and set the
+`instant`/`instant`/`pass` names to whatever you configured via
+`POSTGRES_USER` / `POSTGRES_DB` / `POSTGRES_PASSWORD`.
+
+### 1. Dump the database while still on PostgreSQL 16
+
+Do this **before** pulling the PostgreSQL 17 image. Check out the previous
+revision if you have already pulled it, so the `postgres` service is still
+`postgresql-16-...`, then:
+
+```bash
+docker compose up -d postgres
+# wait until it reports healthy
+docker compose exec -T postgres pg_dump -U instant -Fc instant > instant-pg16.dump
+```
+
+Keep `instant-pg16.dump` somewhere safe.
+
+### 2. Start PostgreSQL 17 on a fresh data directory
+
+```bash
+docker compose down
+# remove ONLY the postgres volume; the leading name is your compose project
+# (usually the directory name). `docker volume ls` shows the exact name.
+docker volume rm "$(basename "$PWD")_backend-db"
+# now pull / check out the PostgreSQL 17 compose files
+docker compose up -d postgres
+# wait until it reports healthy — this creates a fresh, empty `instant` database
+```
+
+### 3. Restore the dump
+
+```bash
+docker compose exec -T postgres pg_restore -U instant -d instant --clean --if-exists < instant-pg16.dump
+docker compose up -d
+```
+
+Verify the app comes up and your data is present, then you can delete
+`instant-pg16.dump`.
+
+> If you would rather not migrate in place, point the `postgres` service at a
+> brand-new volume (e.g. `backend-db-17`) instead of `backend-db` and restore
+> the dump into it. That keeps the untouched PostgreSQL 16 volume around as a
+> rollback.

--- a/self-hosting/docker-compose.local.yml
+++ b/self-hosting/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    image: ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan
     ports:
       - "8890:5432"
     environment:

--- a/self-hosting/docker-compose.with-caddy.yml
+++ b/self-hosting/docker-compose.with-caddy.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    image: ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
       POSTGRES_USER: ${POSTGRES_USER:-instant}

--- a/self-hosting/docker-compose.yml
+++ b/self-hosting/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    image: ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan
     ports:
       - "8890:5432"
     environment:

--- a/self-hosting/swarm.yml
+++ b/self-hosting/swarm.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-go/master/schema/compose-spec.json
 services:
   postgres:
-    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    image: ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan
     ports:
       - "8890:5432"
     environment:

--- a/server/dev-postgres/Dockerfile
+++ b/server/dev-postgres/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:16
+FROM postgres:17
 
 RUN apt-get update && \
     apt-get install -y \
       build-essential \
-      postgresql-server-dev-16 \
-      postgresql-16-pg-hint-plan \
+      postgresql-server-dev-17 \
+      postgresql-17-pg-hint-plan \
       wget && \
     mkdir build && cd build && \
     wget https://github.com/eulerto/wal2json/archive/refs/tags/wal2json_2_6.tar.gz && \
@@ -16,7 +16,7 @@ RUN apt-get update && \
     rm -rf build && \
     apt-get remove -y \
     build-essential \
-    postgresql-server-dev-16 \
+    postgresql-server-dev-17 \
     wget && \
     apt-get autoremove -y && \
     apt-get clean

--- a/server/dev-postgres/Makefile
+++ b/server/dev-postgres/Makefile
@@ -6,4 +6,4 @@ github-login:
 
 build-and-push-image:
 	docker buildx build --platform linux/amd64,linux/arm64 --push \
-		-t ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan .
+		-t ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan .

--- a/server/docker-compose-dev.yml
+++ b/server/docker-compose-dev.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/instantdb/postgresql:postgresql-16-pg-hint-plan
+    image: ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan
     ports:
       - '8890:5432'
     environment:


### PR DESCRIPTION
I didn't spin up a self-hosted instance, but the tests in CI use the new container so it should be good to go.