### PR TITLE
[Dash] Fix docs self-hosted link

### DIFF
--- a/client/www/components/dash/TopBar.tsx
+++ b/client/www/components/dash/TopBar.tsx
@@ -10,7 +10,6 @@ import {
 import { useFetchedDash } from './MainDashLayout';
 import { DarkModeToggle } from './DarkModeToggle';
 import { useReadyRouter } from '../clientOnlyPage';
-import { isSelfHosted } from '@/lib/config';
 import useLocalStorage from '@/lib/hooks/useLocalStorage';
 import { getRole, isMinRole } from '@/pages/dash';
 
@@ -24,11 +23,7 @@ export const TopBar: React.FC<{}> = () => {
     dash.data?.currentWorkspaceId !== 'personal'
       ? dash.data?.currentWorkspaceId
       : null;
-  const docsUrl = isSelfHosted
-    ? 'https://instantdb.com/docs'
-    : orgId
-      ? `/docs?org=${orgId}`
-      : '/docs';
+  const docsUrl = orgId ? `/docs?org=${orgId}` : '/docs';
 
   const hasInvites = (dash.data.invites || []).length > 0;
 


### PR DESCRIPTION
I noticed the docs link in the top bar would go to production even if you were in self-hosted.

The Read the Docs section did the right thing

<img width="1404" height="398" alt="CleanShot 2026-07-30 at 17 10 25@2x" src="https://github.com/user-attachments/assets/6d5dab8a-b18a-439e-8440-ab2bd9460541" />

But our top link did the wrong thing

<img width="504" height="112" alt="CleanShot 2026-07-30 at 17 10 52@2x" src="https://github.com/user-attachments/assets/eb99dd5f-697f-46ea-b5a0-e13194090ff4" />

This PR makes the fix!