### PR TITLE
[Docs] Specify INSTANT_CLI_DASH_URI

### DIFF
--- a/client/packages/cli/src/lib/http.ts
+++ b/client/packages/cli/src/lib/http.ts
@@ -167,12 +167,26 @@ export const getDashUrl = Effect.gen(function* () {
   const setEnv = yield* Config.string('INSTANT_CLI_DASH_URI').pipe(
     Config.option,
   );
-  const dev = Option.getOrNull(
-    yield* Config.boolean('INSTANT_CLI_DEV').pipe(Config.option),
+  const dev = yield* Config.boolean('INSTANT_CLI_DEV').pipe(
+    Config.withDefault(false),
   );
 
-  return Option.match(setEnv, {
-    onSome: (url) => url,
-    onNone: () => (dev ? 'http://localhost:3000' : 'https://instantdb.com'),
-  });
+  if (Option.isSome(setEnv)) {
+    return setEnv.value;
+  }
+
+  const instantConfig = yield* Effect.tryPromise(readInstantConfigFile);
+  if (instantConfig?.dashURI !== undefined) {
+    yield* Schema.decodeUnknown(HttpUrl)(instantConfig.dashURI).pipe(
+      Effect.mapError(() =>
+        BadArgsError.make({
+          message:
+            'Invalid dashURI in instant.config.ts. Expected a valid HTTP(S) URL.',
+        }),
+      ),
+    );
+    return instantConfig.dashURI;
+  }
+
+  return dev ? 'http://localhost:3000' : 'https://instantdb.com';
 });

--- a/client/packages/cli/src/util/instantConfig.ts
+++ b/client/packages/cli/src/util/instantConfig.ts
@@ -2,6 +2,7 @@ import { loadConfig } from './loadConfig.ts';
 
 export type InstantConfig = {
   apiURI?: string;
+  dashURI?: string;
   apps?: Record<string, { id: string }>;
 };
 

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.55';
+const version = 'v1.0.56';
 
 export { version };

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -170,22 +170,27 @@ docker compose logs server -n 50
 
 ### Using the self-hosted instance with instant-cli
 
-To use the Instant CLI with your local backend, you can set the `INSTANT_CLI_API_URI` environment variable to `http://localhost:8888`. For example:
+To use the Instant CLI with your self-hosted instance, set `INSTANT_CLI_API_URI` to the backend URL and `INSTANT_CLI_DASH_URI` to the dashboard URL. For example:
 
 ```shell {% showCopy=true %}
 # Local Machine Deployment
-INSTANT_CLI_API_URI=http://localhost:8888 npx instant-cli@latest init
+INSTANT_CLI_API_URI=http://localhost:8888 \
+INSTANT_CLI_DASH_URI=http://localhost:3000 \
+npx instant-cli@latest init
 
 # Server Deployment
-INSTANT_CLI_API_URI=https://api.myinstant.com npx instant-cli@latest init
+INSTANT_CLI_API_URI=https://api.myinstant.com \
+INSTANT_CLI_DASH_URI=https://dash.myinstant.com \
+npx instant-cli@latest init
 ```
 
-You can also set it in the `instant.config.ts` file.
+You can also set both URLs in the `instant.config.ts` file.
 
 ```typescript
 // instant.config.ts
 export default {
   apiURI: 'http://127.0.0.1:8888',
+  dashURI: 'http://localhost:3000',
 };
 ```
 


### PR DESCRIPTION
When using the CLI with self hosted you also need to specify INSTANT_CLI_DASH_URI otherwise you won't connect to the right dashboard to authenticate.

This updates the docs and also updates so our `instant.config.ts` can accept this param too

<img width="1392" height="1106" alt="CleanShot 2026-07-30 at 17 19 20@2x" src="https://github.com/user-attachments/assets/4ec99426-931d-4678-a5e1-28fb0924bfbd" />
