### PR TITLE
Setup infra for copying files to a second bucket

### DIFF
--- a/server/resources/migrations/120_app_files_to_copy.down.sql
+++ b/server/resources/migrations/120_app_files_to_copy.down.sql
@@ -1,0 +1,1 @@
+drop table app_files_to_copy;

--- a/server/resources/migrations/120_app_files_to_copy.up.sql
+++ b/server/resources/migrations/120_app_files_to_copy.up.sql
@@ -1,0 +1,35 @@
+create table app_files_to_copy (
+  id uuid primary key default gen_random_uuid(),
+  app_id uuid not null,
+  location_id text not null,
+  machine_id uuid,
+  -- Non-null marks the file as failed; failed files are skipped when claiming.
+  error text,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now()
+);
+
+-- High-churn queue table (insert -> claim/update -> delete). Make autovacuum
+-- aggressive so dead tuples get reclaimed quickly and the table stays fast.
+alter table app_files_to_copy set (
+  autovacuum_vacuum_scale_factor = 0,
+  autovacuum_vacuum_threshold = 1000,
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 1000,
+  autovacuum_analyze_scale_factor = 0,
+  autovacuum_analyze_threshold = 1000,
+  autovacuum_vacuum_cost_delay = 0,
+  autovacuum_vacuum_cost_limit = 10000
+);
+
+create trigger update_updated_at_trigger
+  before update on app_files_to_copy for each row
+  execute function update_updated_at_column();
+
+-- Claim unclaimed, not-yet-failed files.
+create index app_files_to_copy_unclaimed_idx on app_files_to_copy (id)
+  where machine_id is null and error is null;
+
+-- Reclaim files whose owning machine went away (stale updated_at).
+create index app_files_to_copy_stale_idx on app_files_to_copy (updated_at)
+  where machine_id is not null and error is null;

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -114,6 +114,19 @@
      {}
      targets)))
 
+(defn- parse-copy-files-bucket-flag [targets]
+  (if-not (map? targets)
+    {}
+    (reduce-kv
+     (fn [acc app-id-value target-value]
+       (if-let [app-id (uuid-util/coerce app-id-value)]
+         (assoc acc app-id target-value)
+         (do
+           (log/error "Ignoring invalid app proxy app id" {:app-id app-id-value})
+           acc)))
+     {}
+     targets)))
+
 (defn transform-query-result
   "Function that is called on the query result before it is stored in the
    query-result atom, to make look ups faster."
@@ -182,6 +195,7 @@
                             (assoc acc (keyword setting) value))
                           {}
                           (get result "flags"))
+                  (update :copy-file-bucket parse-copy-files-bucket-flag)
                   (update :app-proxy-targets parse-app-proxy-targets-flag)
                   (update :always-materialize-attr-ids parse-uuids-flag)
                   (update :tika-enabled-apps parse-uuids-flag)
@@ -379,6 +393,11 @@
    without a deploy."
   []
   (flag :app-proxy-targets {}))
+
+(defn copy-file-bucket
+  "Bucket that files for an app should be copied to."
+  [app-id]
+  (get (flag :copy-file-bucket) app-id))
 
 (defn handle-receive-timeout [app-id]
   (get-in (query-result) [:handle-receive-timeout app-id]))

--- a/server/src/instant/jdbc/wal.clj
+++ b/server/src/instant/jdbc/wal.clj
@@ -88,7 +88,7 @@
                                           props)]
     (.unwrap conn PgConnection)))
 
-(defn- get-pg-copy-ready-conn
+(defn get-pg-copy-ready-conn
   "Given a db-spec, return a PGConnection that is suitable for running a
    long-running COPY command."
   ^PgConnection [db-spec]

--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -51,9 +51,18 @@
   (let [location-id (str (random-uuid))
         _ (instant-s3/upload-file-to-s3 (assoc ctx :location-id location-id) file)
         _ (when-let [copy-bucket (flags/copy-file-bucket app-id)]
-            (instant-s3/copy-file {:destination-bucket copy-bucket
-                                   :app-id app-id
-                                   :location-id location-id}))
+            (try
+              (instant-s3/copy-file {:destination-bucket copy-bucket
+                                     :app-id app-id
+                                     :location-id location-id})
+              (catch Throwable e
+                ;; The source object is uploaded but we bail before creating a
+                ;; file record, so delete it (best-effort) to avoid orphaning
+                ;; it in S3, then surface the original copy error.
+                (try
+                  (instant-s3/delete-file! app-id location-id)
+                  (catch Throwable _ nil))
+                (throw e))))
         metadata (instant-s3/get-object-metadata app-id location-id)]
     (try
       (app-file-model/create!

--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -1,5 +1,6 @@
 (ns instant.storage.coordinator
-  (:require [instant.storage.s3 :as instant-s3]
+  (:require [instant.flags :as flags]
+            [instant.storage.s3 :as instant-s3]
             [instant.model.app-file :as app-file-model]
             [instant.model.rule :as rule-model]
             [instant.storage.beta :as storage-beta]
@@ -49,6 +50,10 @@
                                           :current-user current-user}))
   (let [location-id (str (random-uuid))
         _ (instant-s3/upload-file-to-s3 (assoc ctx :location-id location-id) file)
+        _ (when-let [copy-bucket (flags/copy-file-bucket app-id)]
+            (instant-s3/copy-file {:destination-bucket copy-bucket
+                                   :app-id app-id
+                                   :location-id location-id}))
         metadata (instant-s3/get-object-metadata app-id location-id)]
     (try
       (app-file-model/create!

--- a/server/src/instant/storage/copier.clj
+++ b/server/src/instant/storage/copier.clj
@@ -1,0 +1,218 @@
+(ns instant.storage.copier
+  (:require
+   [honey.sql :as hsql]
+   [instant.flags :as flags]
+   [instant.config :as config]
+   [instant.jdbc.aurora :as aurora]
+   [instant.jdbc.copy :as copy]
+   [instant.jdbc.sql :as sql]
+   [instant.jdbc.wal :as wal]
+   [instant.system-catalog :as system-catalog]
+   [instant.storage.s3 :as instant-s3]
+   [instant.util.hsql :as uhsql]
+   [instant.util.s3 :as s3-util]
+   [instant.util.tracer :as tracer])
+  (:import
+   (java.util.concurrent ArrayBlockingQueue)))
+
+(def batch-size 1000) ;; max number of files to process in one loop
+
+(defn dest-bucket [app-id]
+  (flags/copy-file-bucket app-id))
+
+(def claim-files-q (uhsql/preformat {:with [[:to-update
+                                             {:select [:id]
+                                              :from :app-files-to-copy
+                                              :where [:and
+                                                      [:= :machine-id nil]
+                                                      [:= :error nil]]
+                                              :for [:update :skip-locked]
+                                              :limit :?limit}]]
+                                     :update :app-files-to-copy
+                                     :set {:machine-id :?machine-id}
+                                     :from :to-update
+                                     :where [:= :app-files-to-copy.id :to-update.id]
+                                     :returning [:app-files-to-copy.*]}))
+
+(defn claim-files!
+  ([params]
+   (claim-files! (aurora/conn-pool :write) params))
+  ([conn {:keys [limit]}]
+   (sql/execute! ::claim-files!
+                 conn
+                 (uhsql/formatp claim-files-q
+                                {:limit limit
+                                 :machine-id config/machine-id}))))
+
+(defn delete-files!
+  ([params]
+   (delete-files! (aurora/conn-pool :write) params))
+  ([conn {:keys [ids]}]
+   (sql/do-execute! ::delete-files!
+                    conn
+                    (hsql/format
+                     {:delete-from :app-files-to-copy
+                      :where [:in :id ids]}))))
+
+(def mark-failed-q (uhsql/preformat
+                    {:with [[:updates {:select [[[:unnest :?ids] :id]
+                                                [[:unnest :?errors] :error]]}]]
+                     :update :app-files-to-copy
+                     :set {:error :updates.error}
+                     :from [:updates]
+                     :where [:= :app-files-to-copy.id :updates.id]}))
+
+(defn mark-failed!
+  "Marks each failed file with its error in a single statement. `failures` is a
+   seq of {:id :error}."
+  ([params]
+   (mark-failed! (aurora/conn-pool :write) params))
+  ([conn {:keys [failures]}]
+   (sql/do-execute!
+    ::mark-failed!
+    conn
+    (uhsql/formatp mark-failed-q
+                   {:ids (with-meta (mapv :id failures) {:pgtype "uuid[]"})
+                    :errors (with-meta (mapv :error failures) {:pgtype "text[]"})}))))
+
+(defn copy-files!
+  "Copies each file to its destination bucket in parallel via the transfer
+   manager. Returns {:succeeded [id ...] :failed [{:id id :error msg} ...]}.
+   A file whose app has no destination bucket configured is reported as a failure."
+  [files]
+  (let [transfer-manager (instant-s3/s3-transfer-manager)
+        in-flight (mapv (fn [{:keys [id app_id location_id]}]
+                          (let [object-key (instant-s3/->object-key app_id location_id)
+                                dest (dest-bucket app_id)]
+                            (if-not dest
+                              {:id id
+                               :error (str "No destination bucket configured for app " app_id)}
+                              {:id id
+                               :copy (s3-util/transfer-manager-copy
+                                      transfer-manager
+                                      {:source-bucket-name instant-s3/bucket-name
+                                       :destination-bucket-name dest
+                                       :source-key object-key
+                                       :destination-key object-key})})))
+                        files)]
+    (reduce (fn [acc {:keys [id copy error]}]
+              (if error
+                (update acc :failed conj {:id id :error error})
+                (try
+                  @copy
+                  (update acc :succeeded conj id)
+                  (catch Throwable t
+                    (let [cause (or (.getCause t) t)]
+                      (update acc :failed conj {:id id
+                                                :error (or (.getMessage cause)
+                                                           (str cause))}))))))
+            {:succeeded [] :failed []}
+            in-flight)))
+
+(defn process-copy!
+  "Claims a batch of files, copies each to the destination bucket, and removes
+   them from the queue. Returns the number of files copied."
+  ([params]
+   (process-copy! (aurora/conn-pool :write) params))
+  ([conn {:keys [limit]}]
+   (tracer/with-span! {:name "storage-copier/process-copy!"}
+     (let [files (claim-files! conn {:limit limit})]
+       (when (seq files)
+         (let [{:keys [succeeded failed]} (copy-files! files)]
+           (when (seq succeeded)
+             (delete-files! conn {:ids succeeded}))
+           (when (seq failed)
+             (mark-failed! conn {:failures failed}))))
+       (count files)))))
+
+(defn clear-copy-queue!
+  "Drains the copy queue by processing batches until no more files are
+   available. Run manually."
+  ([] (clear-copy-queue! {}))
+  ([params] (clear-copy-queue! (aurora/conn-pool :write) params))
+  ([conn {:keys [limit]
+          :or {limit batch-size}}]
+   (tracer/with-span! {:name "storage-copier/handle-copy!"}
+     (loop [total 0]
+       (let [n-copied (process-copy! conn {:limit limit})
+             total (+ total (long n-copied))]
+         (if (< n-copied limit)
+           total
+           (recur total)))))))
+
+;; The `value` column is jsonb; decoding it yields the plain location-id string.
+(def enqueue-out-columns
+  [{:name "app_id" :pgtype "uuid"}
+   {:name "location_id" :pgtype "jsonb"}])
+
+(def enqueue-in-columns
+  [{:name "app_id" :pgtype "uuid"}
+   {:name "location_id" :pgtype "text"}])
+
+(defn enqueue-app-files!
+  "Streams every $files location for `app-id` out of the triples table with one
+   long-running COPY and enqueues them into `app_files_to_copy`, `write-batch-size`
+   rows per COPY (each its own transaction, so we never push one giant insert onto
+   the WAL). Returns the number of rows enqueued.
+
+   The COPY OUT (producer) and the batched COPY INs (consumer) run concurrently,
+   decoupled by a bounded queue that gives the read side backpressure once it gets
+   too far ahead of the write side.
+
+   Throws if the app has no destination bucket configured in the flags."
+  ([app-id]
+   (enqueue-app-files! app-id 5000))
+  ([app-id write-batch-size]
+   (assert (uuid? app-id))
+   (when-not (dest-bucket app-id)
+     (throw (ex-info "No destination bucket configured for app" {:app-id app-id})))
+   (when (= instant-s3/bucket-name (dest-bucket app-id))
+     (throw (ex-info "Destination bucket is the same as the source bucket"
+                     {:app-id app-id :bucket instant-s3/bucket-name})))
+   (tracer/with-span! {:name "storage-copier/enqueue-app-files!"
+                       :attributes {:app-id app-id
+                                    :write-batch-size write-batch-size}}
+     (let [^ArrayBlockingQueue queue (ArrayBlockingQueue. (* 10 write-batch-size))
+           producer-error (atom nil)
+           producer (future
+                      (try
+                        (with-open [read-conn (wal/get-pg-copy-ready-conn (config/get-aurora-config))]
+                          (doseq [row (copy/copy-seq
+                                       read-conn
+                                       (format "copy (select app_id, value from triples where app_id = '%s' and attr_id = '%s') to stdout with (format binary)"
+                                               app-id
+                                               system-catalog/location-id-attr-id)
+                                       enqueue-out-columns)]
+                            (.put queue row)))
+                        (.put queue ::done)
+                        (catch InterruptedException _ nil)
+                        (catch Throwable t
+                          (reset! producer-error t)
+                          (.put queue ::done))))
+           flush! (fn [write-conn batch]
+                    (when (seq batch)
+                      (copy/copy-in-rows
+                       write-conn
+                       "copy app_files_to_copy (app_id, location_id) from stdin with (format binary)"
+                       enqueue-in-columns
+                       batch)))]
+       (try
+         (with-open [write-conn (wal/get-pg-copy-ready-conn (config/get-aurora-config))]
+           (loop [batch []
+                  total 0]
+             (let [item (.take queue)]
+               (if (= ::done item)
+                 (do (flush! write-conn batch)
+                     (when-let [e @producer-error]
+                       (throw e))
+                     (+ total (count batch)))
+                 (let [batch (conj batch item)]
+                   (if (>= (count batch) write-batch-size)
+                     (do (flush! write-conn batch)
+                         (recur [] (+ total (count batch))))
+                     (recur batch total)))))))
+         (catch Throwable t
+           ;; unblock a producer parked on `.put` (or trip its next `.put`) and
+           ;; let it unwind + close its read conn on its own
+           (future-cancel producer)
+           (throw t)))))))

--- a/server/src/instant/storage/copier.clj
+++ b/server/src/instant/storage/copier.clj
@@ -212,7 +212,5 @@
                          (recur [] (+ total (count batch))))
                      (recur batch total)))))))
          (catch Throwable t
-           ;; unblock a producer parked on `.put` (or trip its next `.put`) and
-           ;; let it unwind + close its read conn on its own
            (future-cancel producer)
            (throw t)))))))

--- a/server/src/instant/storage/copier.clj
+++ b/server/src/instant/storage/copier.clj
@@ -163,7 +163,8 @@
   ([app-id]
    (enqueue-app-files! app-id 5000))
   ([app-id write-batch-size]
-   (assert (uuid? app-id))
+   (when-not (uuid? app-id)
+     (throw (ex-info "app-id must be a uuid" {:app-id app-id})))
    (when-not (dest-bucket app-id)
      (throw (ex-info "No destination bucket configured for app" {:app-id app-id})))
    (when (= instant-s3/bucket-name (dest-bucket app-id))

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -89,7 +89,8 @@
          (doto (NettyNioAsyncHttpClient/builder)
            (.readTimeout Duration/ZERO)
            (.writeTimeout Duration/ZERO)
-           (.tcpKeepAlive Boolean/TRUE)))
+           (.tcpKeepAlive Boolean/TRUE)
+           (.maxConcurrency (int 1024)))) ;; default is 50
         (configure-s3-endpoint-client)
         (.build))))
 
@@ -218,6 +219,15 @@
         (if-let [mock *s3-mock*]
           ((:upload mock) bucket-name ctx* file)
           (s3-util/upload-stream-to-s3 (s3-async-client) bucket-name ctx* file))))))
+
+(defn copy-file [{:keys [app-id
+                         location-id
+                         destination-bucket]}]
+  (let [object-key (->object-key app-id location-id)]
+    (s3-util/copy-object (s3-client) {:source-bucket-name bucket-name
+                                      :destination-bucket-name destination-bucket
+                                      :source-key object-key
+                                      :destination-key object-key})))
 
 (defn format-object [{:keys [object-metadata]}]
   (-> object-metadata

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -27,7 +27,9 @@
                                              PutObjectRequest
                                              S3Object)
    (software.amazon.awssdk.transfer.s3 S3TransferManager)
-   (software.amazon.awssdk.transfer.s3.model UploadRequest)))
+   (software.amazon.awssdk.transfer.s3.model Copy
+                                             CopyRequest
+                                             UploadRequest)))
 
 (set! *warn-on-reflection* true)
 
@@ -89,14 +91,19 @@
            destination-bucket-name
            source-key
            destination-key]}]
-  (let [^CopyObjectRequest req (-> (CopyObjectRequest/builder)
-                                   (.sourceBucket source-bucket-name)
-                                   (.sourceKey source-key)
-                                   (.destinationBucket destination-bucket-name)
-                                   (.destinationKey destination-key)
-                                   (.build))
-        ^CopyObjectResponse resp (.copyObject s3-client req)]
-    resp))
+  (tracer/with-span! {:name "copy-object"
+                      :attributes {:source-bucket source-bucket-name
+                                   :destination-bucket destination-bucket-name
+                                   :source-key source-key
+                                   :destination-key destination-key}}
+    (let [^CopyObjectRequest req (-> (CopyObjectRequest/builder)
+                                     (.sourceBucket source-bucket-name)
+                                     (.sourceKey source-key)
+                                     (.destinationBucket destination-bucket-name)
+                                     (.destinationKey destination-key)
+                                     (.build))
+          ^CopyObjectResponse resp (.copyObject s3-client req)]
+      resp)))
 
 (defn get-object
   ^InputStream [^S3AsyncClient s3-client bucket-name object-key]
@@ -303,6 +310,22 @@
         (-> upload
             (.completionFuture)
             deref)))))
+
+(defn transfer-manager-copy
+  "Server-side copy via the transfer manager. Returns the completion
+   CompletableFuture (does not block)."
+  [^S3TransferManager transfer-manager
+   {:keys [source-bucket-name destination-bucket-name source-key destination-key]}]
+  (let [^CopyObjectRequest req (-> (CopyObjectRequest/builder)
+                                   (.sourceBucket source-bucket-name)
+                                   (.sourceKey source-key)
+                                   (.destinationBucket destination-bucket-name)
+                                   (.destinationKey destination-key)
+                                   (.build))
+        ^CopyRequest copy-req (-> (CopyRequest/builder)
+                                  (.copyObjectRequest req)
+                                  (.build))]
+    (.completionFuture ^Copy (.copy transfer-manager copy-req))))
 
 (defn transfer-manager-upload-stream
   [^S3TransferManager transfer-manager bucket-name ctx ^InputStream stream]


### PR DESCRIPTION
Sets up infrastructure for copying $files to a separate bucket. This will allow us to migrate files to a different bucket on an app-by-app basis.

Right now it's a manual process:

1. confirm that our storage user has write access to the bucket
2. Update the `copy-file-bucket` flag to point an app-id to a new bucket
3. Wait a bit for all in-progress uploads to finish. Now all files will be copied over when they are created.
4. Manually run `instant.storage.copier/enqueue-app-files!`
5. Manually run `instant.storage/clear-copy-queue!` (this can be run on multiple machines to speed up the process)
6. When the process finishes, check that there are no errors or orphaned files (and retry them if so)