### PR TITLE
Fix ~5s query when a page is bounded by both cursors (after + before)

### DIFF
--- a/server/src/instant/db/datalog.clj
+++ b/server/src/instant/db/datalog.clj
@@ -2054,6 +2054,14 @@
                   ;; query
                   (not page-info)
 
+                  ;; `not materialized` lets the planner push the ordered index
+                  ;; scan down and stop once it has `limit` rows. A page bounded
+                  ;; on BOTH sides has nothing to stop early for -- the ordered
+                  ;; cte is materialized regardless -- so inlining only buys the
+                  ;; planner the freedom to drive from the (closed, and badly
+                  ;; estimated) range scan instead of the selective join.
+                  (and (:before page-info) (:after page-info))
+
                   ;; skip isNull because it's unlikely to generate a good plan
                   (and (uspec/tagged-as? :function (:v named-p))
                        (:$isNull (uspec/tagged-unwrap (:v named-p))))

--- a/server/test/instant/db/instaql_test.clj
+++ b/server/test/instant/db/instaql_test.clj
@@ -1260,6 +1260,114 @@
                                                 "value"
                                                 0]}}})))))))
 
+(deftest pagination-with-both-cursors-and-a-where-clause
+  ;; A page bounded by BOTH `after` and `before` alongside a `where` is the
+  ;; shape useInfiniteQuery issues on every loadNextPage, to re-subscribe to
+  ;; the page it just scrolled past. It is also the only shape whose join ctes
+  ;; are materialized rather than inlined, so it is worth pinning that the
+  ;; where clause still constrains the range.
+  (with-zeneca-checked-data-app
+    (fn [app _r]
+      (let [id-attr-id (random-uuid)
+            group-attr-id (random-uuid)
+            value-attr-id (random-uuid)
+            ;; "x" and "y" interleave, so a range that ignored the where clause
+            ;; would return the "y" rows too.
+            rows [["a" "x" "1"]
+                  ["b" "y" "2"]
+                  ["c" "x" "3"]
+                  ["d" "y" "4"]
+                  ["e" "x" "5"]
+                  ["f" "y" "6"]]
+            make-ctx (fn []
+                       (let [attrs (attr-model/get-by-app-id (:id app))]
+                         {:db {:conn-pool (aurora/conn-pool :write)}
+                          :app-id (:id app)
+                          :attrs attrs}))
+            run-query (fn [q]
+                        (let [ctx (make-ctx)]
+                          (->> (iq/permissioned-query ctx q)
+                               (instaql-nodes->object-tree ctx)
+                               (#(get % "etype"))
+                               (map #(parse-uuid (get % "id"))))))
+            cursor (fn [label value]
+                     [(stuid label) value-attr-id value 0])]
+        (tx/transact! (aurora/conn-pool :write)
+                      (attr-model/get-by-app-id (:id app))
+                      (:id app)
+                      (concat
+                       [[:add-attr {:id id-attr-id
+                                    :forward-identity [(random-uuid) "etype" "id"]
+                                    :unique? true
+                                    :index? true
+                                    :value-type :blob
+                                    :checked-data-type :string
+                                    :cardinality :one}]
+                        [:add-attr {:id group-attr-id
+                                    :forward-identity [(random-uuid) "etype" "group"]
+                                    :unique? false
+                                    :index? true
+                                    :value-type :blob
+                                    :checked-data-type :string
+                                    :cardinality :one}]
+                        [:add-attr {:id value-attr-id
+                                    :forward-identity [(random-uuid) "etype" "value"]
+                                    :unique? true
+                                    :index? true
+                                    :value-type :blob
+                                    :checked-data-type :string
+                                    :cardinality :one}]]
+                       (mapcat
+                        (fn [[label group value]]
+                          (let [id (stuid label)]
+                            [[:add-triple id id-attr-id (str id)]
+                             [:add-triple id group-attr-id group]
+                             [:add-triple id value-attr-id value]]))
+                        rows)))
+
+        (testing "the same range without a where clause spans both groups"
+          (is (= [(stuid "a") (stuid "b") (stuid "c") (stuid "d") (stuid "e")]
+                 (run-query {:etype {:$ {:order {:value :asc}
+                                         :afterInclusive true
+                                         :beforeInclusive true
+                                         :after (cursor "a" "1")
+                                         :before (cursor "e" "5")}}}))))
+
+        (testing "both cursors + where"
+          (is (= [(stuid "a") (stuid "c") (stuid "e")]
+                 (run-query {:etype {:$ {:where {:group "x"}
+                                         :order {:value :asc}
+                                         :afterInclusive true
+                                         :beforeInclusive true
+                                         :after (cursor "a" "1")
+                                         :before (cursor "e" "5")}}}))))
+
+        (testing "both cursors + where, exclusive bounds"
+          (is (= [(stuid "c")]
+                 (run-query {:etype {:$ {:where {:group "x"}
+                                         :order {:value :asc}
+                                         :after (cursor "a" "1")
+                                         :before (cursor "e" "5")}}}))))
+
+        (testing "both cursors + where, descending"
+          (is (= [(stuid "e") (stuid "c") (stuid "a")]
+                 (run-query {:etype {:$ {:where {:group "x"}
+                                         :order {:value :desc}
+                                         :afterInclusive true
+                                         :beforeInclusive true
+                                         :after (cursor "e" "5")
+                                         :before (cursor "a" "1")}}}))))
+
+        (testing "both cursors + where, with a limit"
+          (is (= [(stuid "a") (stuid "c")]
+                 (run-query {:etype {:$ {:where {:group "x"}
+                                         :order {:value :asc}
+                                         :limit 2
+                                         :afterInclusive true
+                                         :beforeInclusive true
+                                         :after (cursor "a" "1")
+                                         :before (cursor "e" "5")}}}))))))))
+
 (deftest pagination-with-null-values
   (with-zeneca-checked-data-app
     (fn [app r]


### PR DESCRIPTION
A query carrying **both** `after` and `before` costs ~5s where either cursor alone costs ~250ms, on any namespace ordered by a user attribute. Since the server's own `handle-receive` timeout is 5000ms, it fails more often than it succeeds.

This is not an exotic shape: `db.useInfiniteQuery` issues it on **every** `loadNextPage()`, to re-subscribe to ("freeze") the page just scrolled past. And because the SDK's error handler is global — one failing page subscription emits `{data: undefined, error}` — the whole list disappears. That is how we found it: a WhatsApp-style chat in our app loaded fine, the user scrolled up, page 2 arrived, and ~5s later the entire conversation blanked to an empty state.

Reproduces on Instant Cloud and self-hosted alike, with or without a `where` clause, and even when the result is zero rows. Ordering by `serverCreatedAt` is unaffected.

## Where the time goes

Not the network (4.47s measured on the box itself) and not permissions (identical with an admin token, perms bypassed). It is the Postgres plan.

`joining-with` emits the where-clause CTEs as `not materialized` whenever a query is paginated:

```clojure
(if (or (always-materialize? named-p)
        ;; only use `not materialized` when we're in the middle of an ordered
        ;; query
        (not page-info)
        ...)
  :materialized
  :not-materialized)
```

so Postgres inlines them and is free to reorder the join. With one cursor that is exactly right — walk the ordered index, stop after `limit`.

With **both** cursors the ordered scan becomes a closed range, which makes `triples_date_type_idx` usable as a range scan. The planner then prefers to drive from the range:

```
CTE m_2_with_next
  -> Unique  (actual rows=50)
       -> Incremental Sort  (actual rows=50)
            -> Nested Loop  (cost=1.69..2038.05 rows=1) (actual rows=50)
                 Join Filter: (t0.entity_id = ((t1.value ->> 0))::uuid)
                 Rows Removed by Join Filter: 758505
                 -> Nested Loop  (rows=5) (actual rows=758555)
                      -> Index Scan Backward using triples_date_type_idx on triples t2
                           (cost=0.56..1682.63 rows=123) (actual rows=758555)
                           Index Cond: (app_id = ... AND attr_id = ...
                                        AND triples_extract_date_value(value) <= ...
                                        AND triples_extract_date_value(value) >= ...)
                      -> Index Scan using triples_pkey on triples t1
                           (actual rows=1 loops=758555)
                 -> Materialize  (actual rows=1)
                      -> Index Scan using av_index on triples t0  (actual rows=1)
  Buffers: shared hit=4555876
```

**`rows=123` estimated, `actual rows=758555`** — off by ~6,000x. Statistics for `triples_extract_date_value(value)` are pooled across every date attribute of every app in the shared `triples` table, so a three-month window on one attribute looks tiny. The result is that it scans every `conversation_messages` row in the app whose `createdAt` falls in the range, joins each one to its conversation, and throws away 758,505 of them — 4.5M shared buffer hits — instead of driving from the `av_index` lookup that selects 95 rows.

## The change

A closed range has nothing to stop early for. The ordered CTE is `materialized` regardless, so inlining the join CTEs buys the planner only the freedom to pick that plan. So: treat "both cursors set" like the unpaginated case and materialize.

It is inert everywhere else. Single-cursor pagination is untouched, and a two-cursor query with no `where` has no join CTEs to materialize in the first place.

## Numbers

Against a production dataset (100M triples, one app), same query, byte-identical results:

| | stock | patched |
|---|---|---|
| `after` only (control) | 250ms | 250ms |
| `before` only (control) | 249ms | 249ms |
| **`after` + `before`** | **4412ms** | **11ms** |

Measured two ways. First directly in psql, changing only `m_1 AS NOT MATERIALIZED` to `MATERIALIZED` in the generated SQL — 4412ms → 11ms, `cmp`-identical output. Then end-to-end, by building the patched server and running it against a `pg_basebackup` clone of the same database (physical, so `pg_statistic` is identical — a logical restore would need a fresh `ANALYZE` and might not reproduce the misestimate at all):

```
                                  stock:8888   patched:8889
after only (control) run1    0.017363s   0.028477s
after only (control) run2    0.018371s   0.028188s
after only (control) run3    0.018730s   0.028368s
AFTER+BEFORE         run1    4.522677s   0.019450s
AFTER+BEFORE         run2    4.500170s   0.020515s
AFTER+BEFORE         run3    4.508509s   0.019344s

results IDENTICAL (87389 bytes)
```

The control shape is *slower* on the patched instance (it has a smaller `shared_buffers`), so the win is not an artifact of the test rig.

Finally, through the actual JS client: every freeze query now completes in ~250ms and the SDK's chunks reach `frozen` status, where before they errored with `Operation timed out: handle-receive` and blanked the list.

## Test

Added `pagination-with-both-cursors-and-a-where-clause` to `instaql_test.clj`. The existing `pagination-with-same-values` does exercise both cursors, but with no `where` clause — so it has no join CTEs and never touches the branch this changes. The new test covers inclusive and exclusive bounds, both directions, and a `limit`, and pins that the `where` still constrains the range (the fixture interleaves two groups, so a range that ignored the `where` would return the other group's rows too).

It is a semantics guard rather than a demonstration of the bug — this change is meant to be behaviour-preserving, so the test passes with and without it. `clojure -M:test -n instant.db.instaql-test` against `ghcr.io/instantdb/postgresql:postgresql-17-pg-hint-plan`:

```
with the fix:     Ran 62 tests containing 538 assertions.  0 failures, 0 errors.
test only, no fix: Ran 62 tests containing 538 assertions.  0 failures, 0 errors.
```

I could not get your CI to run on the fork (workflows are `on: push` and forks do not register them without the Actions tab click), so this was run locally against the same Postgres image and migrations your workflow uses.

## Notes for review

- The condition is on `(:before page-info)` and `(:after page-info)` in `joining-with`; `add-page-info` already destructures both from the same map.
- The underlying misestimate is worth a separate look — extended statistics on `(triples_extract_date_value(value), attr_id)` might repair it more generally — but that is a bigger change with wider blast radius, and this one is provably inert outside the shape it fixes.
- Happy to adjust the shape of the fix if you would rather solve it another way; the diagnosis is the part I am most confident about.
