### PR TITLE
Serialize concurrent webhook config updates

### DIFF
--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -458,7 +458,8 @@
   "Creates a unique namespace for a pg advisory lock."
   [k]
   (int (case k
-         :webhook 1)))
+         :webhook 1
+         :webhook-config 2)))
 
 (defn init []
   ;; instantiate the config-map so we can fail early if it's not

--- a/server/src/instant/model/webhook.clj
+++ b/server/src/instant/model/webhook.clj
@@ -8,6 +8,7 @@
    [instant.isn :as isn]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
+   [instant.model.app :as app-model]
    [instant.model.history :as history]
    [instant.reactive.topics :as topics]
    [instant.storage.s3 :as s3]
@@ -330,16 +331,27 @@
 (defn enable-webhooks-config-flag
   "Enables the flag that tells us to include wal-logs for this instance."
   [app-id]
-  (let [config-app-id config/instant-config-app-id
-        attrs (attr-model/get-by-app-id config-app-id)
-        id-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "id"] attrs))
-        setting-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "setting"] attrs))
-        value-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "value"] attrs))]
-    (tx/transact! (aurora/conn-pool :write)
-                  attrs
-                  config-app-id
-                  [[:add-triple [setting-aid "enable-wal-entity-log-apps-map"] id-aid [setting-aid "enable-wal-entity-log-apps-map"]]
-                   [:deep-merge-triple [setting-aid "enable-wal-entity-log-apps-map"] value-aid {(str app-id) true}]])))
+  (let [config-app-id config/instant-config-app-id]
+    (app-model/assert-write-allowed! config-app-id)
+    (next.jdbc/with-transaction [conn (aurora/conn-pool :write)]
+      ;; The add and deep-merge use different SQL statements that can lock the
+      ;; shared lookup and value triples in opposite orders under concurrency.
+      (sql/select ::enable-webhooks-config-flag-lock!
+                  conn
+                  ["select pg_advisory_xact_lock(?::int4, ?::int4)"
+                   (config/pg-lock-ns :webhook-config)
+                   0])
+      (let [attrs (attr-model/get-by-app-id conn config-app-id)
+            id-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "id"] attrs))
+            setting-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "setting"] attrs))
+            value-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "value"] attrs))]
+        (tx/transact-without-tx-conn!
+         conn
+         attrs
+         config-app-id
+         [[:add-triple [setting-aid "enable-wal-entity-log-apps-map"] id-aid [setting-aid "enable-wal-entity-log-apps-map"]]
+          [:deep-merge-triple [setting-aid "enable-wal-entity-log-apps-map"] value-aid {(str app-id) true}]]
+         {:skip-app-status-write-check? true})))))
 
 (defn create!
   "Creates a new webhook, validating that the namespaces are valid, the webhook url is valid,
@@ -414,7 +426,7 @@
                                                  :reason reason}))))))
 
 (def update-q
-  (uhsql/preformat
+  (uhsql/preformat  
    {:update :webhooks
     :set {:sink [:coalesce [:cast :?sink :jsonb] :sink]
           :id-attr-ids [:coalesce [:cast :?id-attr-ids (keyword "uuid[]")] :id-attr-ids]

--- a/server/test/instant/model/webhook_test.clj
+++ b/server/test/instant/model/webhook_test.clj
@@ -1,6 +1,7 @@
 (ns instant.model.webhook-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [instant.config :as config]
    [instant.db.model.attr :as attr-model]
    [instant.db.transaction :as tx]
    [instant.fixtures :refer [with-empty-app]]
@@ -395,6 +396,47 @@
         "The attr_id column should be the third column in the triples table")
     (is (= "pg_size" (:column_name (nth columns webhook/pg-size-column-idx)))
         "The pg_size column should be the 12th column in the triples table")))
+
+(deftest enable-webhooks-config-flag-serializes-concurrent-updates
+  (let [config-app-id config/instant-config-app-id
+        attrs (attr-model/get-by-app-id config-app-id)
+        setting-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "setting"] attrs))
+        value-aid (:id (attr-model/seek-by-fwd-ident-name ["flags" "value"] attrs))
+        setting "enable-wal-entity-log-apps-map"
+        app-ids (repeatedly 20 random-uuid)
+        start-promise (promise)
+        tasks (mapv (fn [app-id]
+                      (future
+                        @start-promise
+                        (webhook/enable-webhooks-config-flag app-id)))
+                    app-ids)]
+    (try
+      (deliver start-promise true)
+      (doseq [task tasks]
+        @task)
+      (let [{:keys [value]}
+            (sql/select-one
+             (aurora/conn-pool :read)
+             ["select v.value
+                 from triples s
+                 join triples v using (app_id, entity_id)
+                where s.app_id = ?::uuid
+                  and s.attr_id = ?::uuid
+                  and s.value = ?::jsonb
+                  and v.attr_id = ?::uuid"
+              config-app-id
+              setting-aid
+              (json/->json setting)
+              value-aid])]
+        (is (every? #(true? (get value (str %))) app-ids)))
+      (finally
+        (tx/transact! (aurora/conn-pool :write)
+                      attrs
+                      config-app-id
+                      [[:deep-merge-triple
+                        [setting-aid setting]
+                        value-aid
+                        (zipmap (map str app-ids) (repeat nil))]])))))
 
 (deftest cant-create-more-than-max-webhooks
   (with-redefs [webhook/maximum-active-webhooks (constantly 10)


### PR DESCRIPTION
**Problem**

add-triple and deep-merge-triple can race and cause deadlocks. This breaks our webhook config flag workflow in tests, since we concurrently try to update this setting. 

As a workaround for now, I added a pg advisory lock for the webhook transaction. 

@dwwoelfel @nezaj