### PR TITLE
[Easy] Disable welcome email in self-host

### DIFF
--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -171,28 +171,29 @@
 ;; Outreach
 
 (defn ping-for-outreach [user-id]
-  (let [{user-id :id email :email} (instant-user-model/get-by-id! {:id user-id})
-        outreach (outreach-model/get-by-user-id {:user-id user-id})
-        turn (rand-nth ["Stopa" "Joe"])]
-    (if outreach
-      (log/infof "ignoring outreach for user = %s" user-id)
-      (do
-        (outreach-model/create! {:user-id user-id})
-        (discord/send!
-         config/discord-signups-channel-id
-         (str "🎉 A new user signed up! Say hi to " "`" email "`"))
-        (postmark/send!
-         {:from "Instant Assistant <hello@pm.instantdb.com>"
-          :to "founders@instantdb.com"
-          :reply-to email
-          :subject (str "New sign up! " email " -- turn: " turn)
-          :html
-          (str
-           "<div>
-              <p>Hey hey! We just got a new sign up</p>
-              <p>Email: <a href=\"mailto:" email "\">" email "</a></p>
-              <p>" turn ", it's on you to send the ping :). Research and let's find out why they're peeking at Instant!</p>
-            </div>")})))))
+  (when (config/prod?)
+    (let [{user-id :id email :email} (instant-user-model/get-by-id! {:id user-id})
+          outreach (outreach-model/get-by-user-id {:user-id user-id})
+          turn (rand-nth ["Stopa" "Joe"])]
+      (if outreach
+        (log/infof "ignoring outreach for user = %s" user-id)
+        (do
+          (outreach-model/create! {:user-id user-id})
+          (discord/send!
+           config/discord-signups-channel-id
+           (str "🎉 A new user signed up! Say hi to " "`" email "`"))
+          (postmark/send!
+           {:from "Instant Assistant <hello@pm.instantdb.com>"
+            :to "founders@instantdb.com"
+            :reply-to email
+            :subject (str "New sign up! " email " -- turn: " turn)
+            :html
+            (str
+             "<div>
+                <p>Hey hey! We just got a new sign up</p>
+                <p>Email: <a href=\"mailto:" email "\">" email "</a></p>
+                <p>" turn ", it's on you to send the ping :). Research and let's find out why they're peeking at Instant!</p>
+              </div>")}))))))
 
 (comment
   (def u (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))

--- a/server/test/instant/dash/routes_test.clj
+++ b/server/test/instant/dash/routes_test.clj
@@ -3,9 +3,10 @@
    [clj-http.client :as http]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [instant.config :as config]
-   [instant.fixtures :refer [random-email with-empty-app with-org with-pro-app with-startup-org with-free-org with-user]]
    [instant.dash.ephemeral-app :as ephemeral-app]
    [instant.dash.get-a-db :as get-a-db]
+   [instant.dash.routes :as routes]
+   [instant.fixtures :refer [random-email with-empty-app with-org with-pro-app with-startup-org with-free-org with-user]]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.app :as app-model]
@@ -30,6 +31,10 @@
     (f)))
 
 (use-fixtures :each silence-routes-exceptions)
+
+(deftest signup-outreach-does-not-run-outside-production
+  (with-redefs [config/prod? (constantly false)]
+    (is (nil? (routes/ping-for-outreach (random-uuid))))))
 
 (deftest app-invites-work
   (with-redefs [config/postmark-send-enabled? (constantly false)]


### PR DESCRIPTION
Adds a guard to attempt the outreach email only in production / non self-hosted environment!