### PR TITLE
Disable analytics for self-hosted dashboard

### DIFF
--- a/client/www/app/layout.tsx
+++ b/client/www/app/layout.tsx
@@ -111,7 +111,7 @@ export default async function RootLayout({
           />
         )}
         <Providers>{children}</Providers>
-        {!isDev && <GoogleScripts />}
+        {!isDev && !isSelfHosted && <GoogleScripts />}
       </body>
     </html>
   );

--- a/client/www/pages/_app.tsx
+++ b/client/www/pages/_app.tsx
@@ -7,7 +7,7 @@ import { NuqsAdapter } from 'nuqs/adapters/next/pages';
 import Head from 'next/head';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Button } from '@/components/ui';
-import { isDev } from '@/lib/config';
+import { isDev, isSelfHosted } from '@/lib/config';
 import { Dev } from '@/components/Dev';
 import {
   patchFirefoxClicks,
@@ -65,7 +65,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
           <NuqsAdapter>{mainEl}</NuqsAdapter>
         </SWRConfig>
       </ErrorBoundary>
-      {isDev ? null : <GoogleScripts />}
+      {!isDev && !isSelfHosted && <GoogleScripts />}
       {isDev ? <Dev /> : null}
     </PostHogProvider>
   );


### PR DESCRIPTION
## Summary

- Prevent Google Analytics scripts from loading in self-hosted dashboard builds
- Apply the condition to both the Pages Router and App Router entry points

## Testing

- pnpm exec prettier --check pages/_app.tsx app/layout.tsx
- pnpm exec tsc --noEmit
- pnpm test