### PR TITLE
[Self-host] Fail dashboard on missing configuration

### DIFF
--- a/client/Dockerfile.www
+++ b/client/Dockerfile.www
@@ -65,12 +65,27 @@ set -eu
 node <<'NODE'
 const fs = require('fs');
 
-const apiURI = process.env.INSTANT_API_URI || process.env.INSTANT_BACKEND_URL;
-const config = apiURI ? { apiURI } : {};
+const apiURI = (
+  process.env.INSTANT_API_URI ||
+  process.env.INSTANT_BACKEND_URL ||
+  ''
+).trim();
+
+try {
+  const url = new URL(apiURI);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Unsupported protocol');
+  }
+} catch (_e) {
+  console.error(
+    'INSTANT_API_URI or INSTANT_BACKEND_URL must be a valid HTTP(S) URL.',
+  );
+  process.exit(1);
+}
 
 fs.writeFileSync(
   '/app/www/public/publicSelfHostedVariables.js',
-  `window.__instantConfig = ${JSON.stringify(config)};\n`,
+  `window.__instantConfig = ${JSON.stringify({ apiURI })};\n`,
 );
 NODE
 

--- a/client/www/lib/config.test.ts
+++ b/client/www/lib/config.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest';
+import { configFromApiURI, requireSelfHostedConfig } from './config';
+
+test('builds dashboard config from an API URI', () => {
+  expect(configFromApiURI('https://api.example.com')).toEqual({
+    apiURI: 'https://api.example.com',
+    websocketURI: 'wss://api.example.com/runtime/session',
+  });
+  expect(configFromApiURI('http://api.example.com')).toEqual({
+    apiURI: 'http://api.example.com',
+    websocketURI: 'ws://api.example.com/runtime/session',
+  });
+});
+
+test('requires valid self-hosted dashboard config', () => {
+  expect(() => requireSelfHostedConfig(undefined)).toThrow(
+    'Self-hosted dashboard requires INSTANT_API_URI or INSTANT_BACKEND_URL to be a valid HTTP(S) URL.',
+  );
+  expect(() => requireSelfHostedConfig('not a url')).toThrow(
+    'Self-hosted dashboard requires INSTANT_API_URI or INSTANT_BACKEND_URL to be a valid HTTP(S) URL.',
+  );
+  expect(() => requireSelfHostedConfig('ftp://api.example.com')).toThrow(
+    'Self-hosted dashboard requires INSTANT_API_URI or INSTANT_BACKEND_URL to be a valid HTTP(S) URL.',
+  );
+});

--- a/client/www/lib/config.ts
+++ b/client/www/lib/config.ts
@@ -12,6 +12,9 @@ type DashboardConfig = {
 
 type RuntimeDashboardConfig = Partial<DashboardConfig>;
 
+const selfHostedConfigError =
+  'Self-hosted dashboard requires INSTANT_API_URI or INSTANT_BACKEND_URL to be a valid HTTP(S) URL.';
+
 declare global {
   interface Window {
     __instantConfig?: RuntimeDashboardConfig;
@@ -20,6 +23,9 @@ declare global {
 
 function websocketURIFromApiURI(apiURI: string) {
   const url = new URL(apiURI);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('API URI must use HTTP or HTTPS.');
+  }
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   url.pathname = '/runtime/session';
   url.search = '';
@@ -27,7 +33,7 @@ function websocketURIFromApiURI(apiURI: string) {
   return url.toString();
 }
 
-function configFromApiURI(apiURI: string | undefined | null) {
+export function configFromApiURI(apiURI: string | undefined | null) {
   if (!apiURI) {
     return null;
   }
@@ -38,18 +44,26 @@ function configFromApiURI(apiURI: string | undefined | null) {
   };
 }
 
-function getRuntimeConfig() {
-  try {
-    if (isBrowser) {
-      return configFromApiURI(window.__instantConfig?.apiURI);
-    }
-
-    return configFromApiURI(
-      process.env.INSTANT_API_URI || process.env.INSTANT_BACKEND_URL,
-    );
-  } catch (_e) {
-    return null;
+function getRuntimeApiURI() {
+  if (isBrowser) {
+    return window.__instantConfig?.apiURI;
   }
+
+  return process.env.INSTANT_API_URI || process.env.INSTANT_BACKEND_URL;
+}
+
+export function requireSelfHostedConfig(
+  apiURI: string | undefined | null,
+): DashboardConfig {
+  try {
+    const config = configFromApiURI(apiURI);
+    if (config) {
+      return config;
+    }
+  } catch (_e) {
+    // Throw the same actionable error for missing and malformed URLs.
+  }
+  throw new Error(selfHostedConfigError);
 }
 
 const devBackend = getLocal('devBackend');
@@ -67,9 +81,20 @@ const defaultApiURI = devBackend
   ? `http://localhost:${localPort}`
   : `https://${isStaging ? 'api-staging' : 'api'}.instantdb.com`;
 
+function getSelfHostedConfig() {
+  const apiURI = getRuntimeApiURI();
+  if (apiURI || isBrowser) {
+    return requireSelfHostedConfig(apiURI);
+  }
+
+  // The build evaluates this module before the container has runtime config.
+  // Container startup validates the URL before serving the dashboard.
+  return configFromApiURI(`http://localhost:${localPort}`)!;
+}
+
 export const config =
   isSelfHosted && !devBackend
-    ? getRuntimeConfig() || configFromApiURI(defaultApiURI)!
+    ? getSelfHostedConfig()
     : configFromApiURI(defaultApiURI)!;
 
 // In dev mode, sync the devBackend flag to a cookie so server components


### PR DESCRIPTION
Previously, if a self-hosted dashboard was missing INSTANT_API_URI or INSTANT_BACKEND_URL, it silently fell back to api.instantdb.com.

This change requires INSTANT_API_URI to be set and fails with a clear configuration error instead of connecting to Instant Cloud.