### PR TITLE
[Self-host] Gate ephemeral app creation

### DIFF
--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -128,6 +128,12 @@ By default, anyone can create a dashboard account. To limit access, open **Deplo
 
 Existing dashboard users can always sign in.
 
+### Temporary Apps
+
+Instant supports spinning up temporary apps without authentication. Because these apps do not require a dashboard account, the signup restrictions above do not apply to them. Anyone who can reach your backend API can create temporary apps by default.
+
+To disable temporary app creation, open **Deployment Settings** and turn off **Allow temporary app creation** under **Temporary apps**.
+
 ### Configure Google Dashboard Login (Optional)
 
 To let users log in to the Instant dashboard with Google, create an OAuth client in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) with the application type **Web application**.

--- a/client/www/pages/intern/deployment-settings.tsx
+++ b/client/www/pages/intern/deployment-settings.tsx
@@ -1,4 +1,10 @@
-import { Button, FullscreenLoading, Select, TextInput } from '@/components/ui';
+import {
+  Button,
+  FullscreenLoading,
+  Select,
+  Switch,
+  TextInput,
+} from '@/components/ui';
 import { useAuthToken } from '@/lib/auth';
 import config from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
@@ -29,6 +35,10 @@ const flagSettings = {
     setting: 'dashboard-signups',
     description:
       'Controls who can create dashboard accounts for this Instant deployment.',
+  },
+  ephemeralAppsEnabled: {
+    setting: 'ephemeral-apps-enabled',
+    description: 'Controls whether clients can create temporary apps.',
   },
   magicCodeRateLimit: {
     setting: 'magic-code-rate-limit-per-hour',
@@ -318,6 +328,9 @@ function InstantConfigSettingsContent({
     ? (storedMode as SignupMode)
     : 'open';
   const allowedEmails = stringListValue(dashboardSignupsValue.allowedEmails);
+  const ephemeralAppsEnabled =
+    flagBySetting.get(flagSettings.ephemeralAppsEnabled.setting)?.value !==
+    false;
   const magicCodeRateLimit = integerValue(
     flagBySetting.get(flagSettings.magicCodeRateLimit.setting)?.value,
     defaults.magicCodeRateLimit,
@@ -429,6 +442,20 @@ function InstantConfigSettingsContent({
       successToast('App authentication settings updated.');
     } catch {
       errorToast('Could not update app authentication settings.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateEphemeralAppsEnabled = async (enabled: boolean) => {
+    setSaving(true);
+    try {
+      await db.transact(flagUpdate(flagSettings.ephemeralAppsEnabled, enabled));
+      successToast(
+        enabled ? 'Temporary apps enabled.' : 'Temporary apps disabled.',
+      );
+    } catch {
+      errorToast('Could not update temporary app settings.');
     } finally {
       setSaving(false);
     }
@@ -650,6 +677,28 @@ function InstantConfigSettingsContent({
             </div>
           </div>
         )}
+      </SettingsSection>
+
+      <SettingsSection
+        title="Temporary apps"
+        description="Allow clients to create temporary apps without signing in. Enabled by default."
+      >
+        <div className="flex items-center justify-between gap-4">
+          <label
+            htmlFor="ephemeral-apps-enabled"
+            className="text-sm font-medium"
+          >
+            Allow temporary app creation
+          </label>
+          <Switch
+            id="ephemeral-apps-enabled"
+            checked={ephemeralAppsEnabled}
+            disabled={saving}
+            onCheckedChange={(checked) => {
+              void updateEphemeralAppsEnabled(checked);
+            }}
+          />
+        </div>
       </SettingsSection>
 
       <SettingsSection

--- a/server/src/instant/dash/ephemeral_app.clj
+++ b/server/src/instant/dash/ephemeral_app.clj
@@ -51,6 +51,9 @@
 ;; HTTP Handler
 
 (defn http-post-handler [req]
+  (ex/assert-permitted! :ephemeral-app-creation
+                        nil
+                        (flags/ephemeral-apps-enabled?))
   (let [title (ex/get-param! req [:body :title] string-util/coerce-non-blank-str)
         schema (get-in req [:body :schema])
         rules-code (ex/get-optional-param! req [:body :rules :code] w/stringify-keys)

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -429,6 +429,9 @@
          (get key not-found))
      (get-in (query-result) [:flags key] not-found))))
 
+(defn ephemeral-apps-enabled? []
+  (not (false? (flag :ephemeral-apps-enabled true))))
+
 (defn app-proxy-targets
   "The app proxy routing table. Emptying the flag turns off all routing
    without a deploy."

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -430,7 +430,7 @@
      (get-in (query-result) [:flags key] not-found))))
 
 (defn ephemeral-apps-enabled? []
-  (not (false? (flag :ephemeral-apps-enabled true))))
+  (flag :ephemeral-apps-enabled true))
 
 (defn app-proxy-targets
   "The app proxy routing table. Emptying the flag turns off all routing

--- a/server/test/instant/dash/ephemeral_app_test.clj
+++ b/server/test/instant/dash/ephemeral_app_test.clj
@@ -6,7 +6,7 @@
    [instant.util.exception :as ex]))
 
 (deftest create-is-denied-when-ephemeral-apps-are-disabled
-  (with-redefs [flags/ephemeral-apps-enabled? (constantly false)]
+  (binding [flags/*flag-overrides* {:ephemeral-apps-enabled false}]
     (try
       (ephemeral-app/http-post-handler {:body {:title "test-app"}})
       (is false "Expected temporary app creation to be denied")

--- a/server/test/instant/dash/ephemeral_app_test.clj
+++ b/server/test/instant/dash/ephemeral_app_test.clj
@@ -1,0 +1,15 @@
+(ns instant.dash.ephemeral-app-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [instant.dash.ephemeral-app :as ephemeral-app]
+   [instant.flags :as flags]
+   [instant.util.exception :as ex]))
+
+(deftest create-is-denied-when-ephemeral-apps-are-disabled
+  (with-redefs [flags/ephemeral-apps-enabled? (constantly false)]
+    (try
+      (ephemeral-app/http-post-handler {:body {:title "test-app"}})
+      (is false "Expected temporary app creation to be denied")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= ::ex/permission-denied
+               (::ex/type (ex-data e))))))))

--- a/server/test/instant/flags_test.clj
+++ b/server/test/instant/flags_test.clj
@@ -59,3 +59,15 @@
     (doseq [value [nil 0 -1 1.5 "10"]]
       (with-redefs [flags/flag (constantly value)]
         (is (= 20 (flags/magic-code-rate-limit-per-hour)))))))
+
+(deftest ephemeral-apps-enabled
+  (testing "temporary apps are enabled by default"
+    (with-redefs [flags/flag (fn [_key not-found] not-found)]
+      (is (true? (flags/ephemeral-apps-enabled?)))))
+
+  (testing "only false disables temporary apps"
+    (doseq [value [nil true "false" 0]]
+      (with-redefs [flags/flag (constantly value)]
+        (is (true? (flags/ephemeral-apps-enabled?)))))
+    (with-redefs [flags/flag (constantly false)]
+      (is (false? (flags/ephemeral-apps-enabled?))))))

--- a/server/test/instant/flags_test.clj
+++ b/server/test/instant/flags_test.clj
@@ -65,9 +65,6 @@
     (with-redefs [flags/flag (fn [_key not-found] not-found)]
       (is (true? (flags/ephemeral-apps-enabled?)))))
 
-  (testing "only false disables temporary apps"
-    (doseq [value [nil true "false" 0]]
-      (with-redefs [flags/flag (constantly value)]
-        (is (true? (flags/ephemeral-apps-enabled?)))))
+  (testing "temporary apps can be disabled"
     (with-redefs [flags/flag (constantly false)]
       (is (false? (flags/ephemeral-apps-enabled?))))))


### PR DESCRIPTION
Adds a flag to the config app to enable/disable un-authenticated ephemeral app creation. By default this is set to true (matching our open signups pattern).

**Deployment settings**
<img width="1446" height="228" alt="CleanShot 2026-08-03 at 15 56 18@2x" src="https://github.com/user-attachments/assets/558e1861-b63d-4b6c-b5fd-6ec4d04dfd68" />

**Docs**
<img width="1412" height="426" alt="CleanShot 2026-08-03 at 15 56 45@2x" src="https://github.com/user-attachments/assets/74192fdc-86a8-48c6-a740-b8812dcb5c8c" />