### PR TITLE
[Self-host] Prevent system users from logging in to self-hosted deplo…

### DIFF
--- a/server/src/instant/model/instant_user_refresh_token.clj
+++ b/server/src/instant/model/instant_user_refresh_token.clj
@@ -1,13 +1,23 @@
 (ns instant.model.instant-user-refresh-token
   (:require [instant.jdbc.aurora :as aurora]
             [instant.jdbc.sql :as sql]
-            [instant.model.instant-user :as instant-user-model])
+            [instant.model.instant-user :as instant-user-model]
+            [instant.util.exception :as ex])
   (:import
    (java.util UUID)))
 
 (defn create!
   ([params] (create! (aurora/conn-pool :write) params))
   ([conn {:keys [id user-id]}]
+   (ex/assert-permitted!
+    :dashboard-login-enabled
+    user-id
+    (nil? (sql/select-one
+           conn
+           ["SELECT 1 FROM user_flags
+             WHERE user_id = ?::uuid
+               AND flag_name = 'dashboard-login-disabled'"
+            user-id])))
    (sql/execute-one! conn
                      ["INSERT INTO instant_user_refresh_tokens (id, user_id) VALUES (?::uuid, ?::uuid)"
                       id user-id])))
@@ -23,4 +33,3 @@
   (def u (instant-user-model/get-by-email {:email "stopa@instantdb.com"}))
   (def r (create! {:id (UUID/randomUUID) :user-id (:id u)}))
   (delete-by-id! {:id (:id r)}))
-

--- a/server/src/tasks.clj
+++ b/server/src/tasks.clj
@@ -131,6 +131,37 @@
                 "INSTANT_SUPERUSER_EMAIL must be a valid email address."
                 {:value value})))))
 
+(def ^:private self-hosted-bundled-user-emails
+  ["system-catalog-user@instantdb.com"
+   "testuser@instantdb.com"
+   "hello+ephemeralappsdev@instantdb.com"
+   "hello+ephemeralapps@instantdb.com"
+   "stopa@instantdb.com"
+   "hello+getadbapps@instantdb.com"])
+
+(defn- disable-self-hosted-bundled-user-logins! []
+  (let [configured-superuser-email (superuser-email)]
+    (next-jdbc/with-transaction [conn (config/get-aurora-config)]
+      (doseq [user-email self-hosted-bundled-user-emails
+              :when (not= user-email configured-superuser-email)]
+        (sql/execute-one!
+         conn
+         ["INSERT INTO user_flags (id, user_id, flag_name)
+           SELECT gen_random_uuid(), id, 'dashboard-login-disabled'
+           FROM instant_users
+           WHERE email = ?
+           ON CONFLICT (user_id, flag_name) DO NOTHING"
+          user-email]))
+      (when configured-superuser-email
+        (sql/execute-one!
+         conn
+         ["DELETE FROM user_flags
+           USING instant_users
+           WHERE user_flags.user_id = instant_users.id
+             AND user_flags.flag_name = 'dashboard-login-disabled'
+             AND instant_users.email = ?"
+          configured-superuser-email])))))
+
 (defn bootstrap-config-app! []
   (next-jdbc/with-transaction [conn (config/get-aurora-config)]
     (sql/execute-one!
@@ -173,6 +204,7 @@
   (migrate-database)
   (tracer/init)
   (try
+    (disable-self-hosted-bundled-user-logins!)
     (bootstrap-config-app!)
     (finally
       (tracer/shutdown))))

--- a/server/test/instant/model/instant_user_test.clj
+++ b/server/test/instant/model/instant_user_test.clj
@@ -4,7 +4,20 @@
    [instant.fixtures :refer [with-empty-app with-org with-user]]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
-   [instant.model.instant-user :as instant-user]))
+   [instant.model.instant-user :as instant-user]
+   [instant.model.instant-user-refresh-token :as instant-user-refresh-token]))
+
+(deftest disabled-dashboard-login-prevents-token-creation
+  (with-user
+    (fn [user]
+      (sql/execute-one!
+       (aurora/conn-pool :write)
+       ["INSERT INTO user_flags (id, user_id, flag_name)
+         VALUES (?::uuid, ?::uuid, 'dashboard-login-disabled')"
+        (random-uuid) (:id user)])
+      (is (thrown? Exception
+                   (instant-user-refresh-token/create!
+                    {:id (random-uuid) :user-id (:id user)}))))))
 
 (deftest get-by-app-id
   (with-user

--- a/server/test/instant/model/instant_user_test.clj
+++ b/server/test/instant/model/instant_user_test.clj
@@ -5,7 +5,8 @@
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.instant-user :as instant-user]
-   [instant.model.instant-user-refresh-token :as instant-user-refresh-token]))
+   [instant.model.instant-user-refresh-token :as instant-user-refresh-token]
+   [instant.util.test :refer [perm-err?]]))
 
 (deftest disabled-dashboard-login-prevents-token-creation
   (with-user
@@ -15,9 +16,9 @@
        ["INSERT INTO user_flags (id, user_id, flag_name)
          VALUES (?::uuid, ?::uuid, 'dashboard-login-disabled')"
         (random-uuid) (:id user)])
-      (is (thrown? Exception
-                   (instant-user-refresh-token/create!
-                    {:id (random-uuid) :user-id (:id user)}))))))
+      (is (perm-err?
+           (instant-user-refresh-token/create!
+            {:id (random-uuid) :user-id (:id user)}))))))
 
 (deftest get-by-app-id
   (with-user


### PR DESCRIPTION
Instant seeds several internal users that own system-managed apps, such as the system catalog, temporary apps, and the homepage app. These accounts are implementation details and should not behave like normal dashboard users in self-hosted deployments.

Dashboard signup restrictions only apply when creating a new user. Because these internal users already exist, someone controlling one of their email addresses could otherwise sign in even when dashboard signups are restricted.

This PR makes it so these users can't login if dashboard access has been restricted.

### How it works

During self-hosted bootstrap, Instant marks the bundled internal users with a dashboard-login-disabled user flag.

All dashboard authentication methods, including magic codes, Google OAuth, and CLI authentication, ultimately create an Instant dashboard refresh token. Refresh-token creation now checks for this flag and refuses to create a session for flagged users.

The flag is only added during self-hosted bootstrap. Hosted InstantDB, normal local development, tests, and ordinary dashboard users retain their existing behavior. No new environment variable, deployment setting, or database migration is required.