### PR TITLE
[Explorer] Render boolean values

### DIFF
--- a/client/packages/components/src/components/explorer/__tests__/format-value.test.ts
+++ b/client/packages/components/src/components/explorer/__tests__/format-value.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { formatVal } from '../format-value';
+
+describe('formatVal', () => {
+  test('formats boolean values as visible text', () => {
+    expect(formatVal(true)).toBe('true');
+    expect(formatVal(false)).toBe('false');
+  });
+});

--- a/client/packages/components/src/components/explorer/format-value.ts
+++ b/client/packages/components/src/components/explorer/format-value.ts
@@ -1,0 +1,9 @@
+import { isObject } from 'lodash';
+
+export function formatVal(data: any, pretty?: boolean): string {
+  if (isObject(data)) {
+    return JSON.stringify(data, null, pretty ? 2 : undefined);
+  }
+
+  return String(data);
+}

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -86,6 +86,7 @@ import { isObject } from 'lodash';
 import { EditNamespaceDialog } from './edit-namespace-dialog';
 import { EditRowDialog, isEditableExplorerAttr } from './edit-row-dialog';
 import copy from 'copy-to-clipboard';
+import { formatVal } from './format-value';
 
 const fallbackItems: any[] = [];
 
@@ -539,10 +540,7 @@ export const InnerExplorer: React.FC<{
               return info.row.original[attr.name];
             }
           }
-          if (isObject(info.row.original[attr.name])) {
-            return <Val data={info.row.original[attr.name]}></Val>;
-          }
-          return info.row.original[attr.name];
+          return formatVal(info.row.original[attr.name]);
         },
       });
     });
@@ -1468,14 +1466,6 @@ export const InnerExplorer: React.FC<{
     </>
   );
 };
-
-function formatVal(data: any, pretty?: boolean): string {
-  if (isObject(data)) {
-    return JSON.stringify(data, null, pretty ? 2 : undefined);
-  }
-
-  return String(data);
-}
 
 function Val({ data, pretty }: { data: any; pretty?: boolean }) {
   const props = useExplorerProps();

--- a/client/packages/components/src/components/explorer/table-components.tsx
+++ b/client/packages/components/src/components/explorer/table-components.tsx
@@ -29,6 +29,7 @@ import { isObject } from 'lodash';
 import copy from 'copy-to-clipboard';
 import { useExplorerDialog, useExplorerProps, useExplorerState } from '.';
 import { TableColMeta } from './inner-explorer';
+import { formatVal } from './format-value';
 
 export const TableHeader = ({
   header,
@@ -395,14 +396,6 @@ function isCopyableCellValue(
     return value.trim().length > 0;
   }
   return true;
-}
-
-function formatVal(data: any, pretty?: boolean): string {
-  if (isObject(data)) {
-    return JSON.stringify(data, null, pretty ? 2 : undefined);
-  }
-
-  return String(data);
 }
 
 function Val({ data, pretty }: { data: any; pretty?: boolean }) {

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.58';
+const version = 'v1.0.59';
 
 export { version };


### PR DESCRIPTION
Noticed the explorer wasn't rendering boolean values if they were set as "Any" -- now it will!

**Before**
<img width="1748" height="396" alt="CleanShot 2026-08-03 at 17 34 33@2x" src="https://github.com/user-attachments/assets/a47c50bd-1f9a-42b7-b901-59d92b2d4dd8" />

**After**
<img width="1662" height="326" alt="CleanShot 2026-08-03 at 17 28 20@2x" src="https://github.com/user-attachments/assets/eb1ac6d9-f551-424b-8962-2fc7a08b8e8f" />
