### PR TITLE
[Self-host] Preserve path for custom s3 public endpoints

### DIFF
--- a/server/src/instant/util/aws_signature.clj
+++ b/server/src/instant/util/aws_signature.clj
@@ -305,6 +305,7 @@
         endpoint-uri (when endpoint (URI/create endpoint))
         scheme (if endpoint-uri (.getScheme endpoint-uri) "https")
         host (if endpoint-uri (uri-host-header endpoint-uri) (s3-host region bucket))
+        endpoint-path (some-> endpoint-uri .getRawPath (str/replace #"/$" ""))
         url-path (if path-style?
                    (str "/" bucket path-with-slash)
                    path-with-slash)
@@ -334,4 +335,4 @@
                                          :payload unsigned-payload})
         signature (->signature sig-request)
         all-query-params (assoc query "X-Amz-Signature" signature)]
-    (str scheme "://" host url-path "?" (->canonical-query-str all-query-params))))
+    (str scheme "://" host endpoint-path url-path "?" (->canonical-query-str all-query-params))))

--- a/server/test/instant/util/aws_signature_test.clj
+++ b/server/test/instant/util/aws_signature_test.clj
@@ -260,5 +260,31 @@
           "response-cache-control=public%2C%20max-age%3D86400%2C%20immutable"]
          (url->pretty put-req)))))
 
+(deftest s3-presign-url-with-endpoint-path
+  (let [object-key (storage-s3/->object-key example-app-id example-location-id)
+        opts {:access-key example-aws-access-key
+              :secret-key example-aws-access-key
+              :region example-region
+              :method :get
+              :bucket example-bucket-name
+              :path-style? true
+              :signing-instant example-signing-instant
+              :expires-duration (Duration/ofSeconds 400)
+              :path object-key}
+        [base-url-without-path & expected-query]
+        (url->pretty (aws-sig/presign-s3-url
+                     (assoc opts :endpoint "https://localhost:5443")))
+        expected-base-url (str "https://localhost:5443/storage/"
+                               example-bucket-name "/" object-key)]
+    (is (= (str "https://localhost:5443/" example-bucket-name "/" object-key)
+           base-url-without-path))
+    (doseq [endpoint ["https://localhost:5443/storage"
+                      "https://localhost:5443/storage/"]]
+      (let [[base-url & query] (url->pretty
+                                (aws-sig/presign-s3-url
+                                 (assoc opts :endpoint endpoint)))]
+        (is (= expected-base-url base-url))
+        (is (= expected-query query))))))
+
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Got a user report that `$files.url` was dropping path prefixes from S3_PUBLIC_ENDPOINT.

Generated URLs now preserve the configured path without changing existing signing behavior!