### PR TITLE
[Self-host] Revert path for custom s3 endpoints

### DIFF
--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -108,6 +108,8 @@ The `_DOMAIN` variables are only used by the Caddy reverse proxy, so if you are 
 
 The MinIO bucket is private by default. Files are accessed through Instant-generated signed URLs.
 
+`S3_PUBLIC_ENDPOINT` must be an origin without a path, such as `https://files.myinstant.com` or `https://localhost:9443`. [MinIO does not support](https://github.com/minio/docs/blob/main/source/integrations/setup-nginx-proxy-with-minio.rst?plain=1#L105) serving its S3 API from a subpath such as `/storage`. If MinIO is behind a proxy, use a dedicated hostname or port.
+
 ### Configure the Deployment Superuser
 
 The deployment superuser can manage settings for your entire self-hosted deployment. Set `INSTANT_SUPERUSER_EMAIL` to the email address of the person who should administer it:

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -108,7 +108,7 @@ The `_DOMAIN` variables are only used by the Caddy reverse proxy, so if you are 
 
 The MinIO bucket is private by default. Files are accessed through Instant-generated signed URLs.
 
-`S3_PUBLIC_ENDPOINT` must be an origin without a path, such as `https://files.myinstant.com` or `https://localhost:9443`. [MinIO does not support](https://github.com/minio/docs/blob/main/source/integrations/setup-nginx-proxy-with-minio.rst?plain=1#L105) serving its S3 API from a subpath such as `/storage`. If MinIO is behind a proxy, use a dedicated hostname or port.
+`S3_PUBLIC_ENDPOINT` must be an origin without a path, such as `https://files.myinstant.com` or `https://localhost:9443`. MinIO does not support serving its S3 API from a subpath such as `/storage`. If MinIO is behind a proxy, use a dedicated hostname or port.
 
 ### Configure the Deployment Superuser
 

--- a/self-hosting/.env.example
+++ b/self-hosting/.env.example
@@ -1,6 +1,7 @@
 # Public URLs. Change these when deploying behind a domain or proxy.
 INSTANT_BACKEND_URL=http://localhost:8888
 INSTANT_DASHBOARD_URL=http://localhost:3000
+# Must be an origin without a path. Use a dedicated hostname or port.
 S3_PUBLIC_ENDPOINT=http://localhost:9000
 
 # Domains used by the Caddy compose file. For production, point DNS at this host

--- a/self-hosting/.env.example
+++ b/self-hosting/.env.example
@@ -1,7 +1,7 @@
 # Public URLs. Change these when deploying behind a domain or proxy.
 INSTANT_BACKEND_URL=http://localhost:8888
 INSTANT_DASHBOARD_URL=http://localhost:3000
-# Must be an origin without a path. Use a dedicated hostname or port.
+# S3_PUBLIC_ENDPOINT must be an origin without a path. Use a dedicated hostname or port.
 S3_PUBLIC_ENDPOINT=http://localhost:9000
 
 # Domains used by the Caddy compose file. For production, point DNS at this host

--- a/self-hosting/deploy-swarm.sh
+++ b/self-hosting/deploy-swarm.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")"
 SSH_HOST=root@ip
 DASHBOARD_URL="https://dashboard@example.com"
 SERVER_URL="https://backend.example.com"
+# Must be an origin without a path. Use a dedicated hostname or port.
 S3_PUBLIC_ENDPOINT="https://files.example.com"
 POSTGRES_PASSWORD=changeme
 MINIO_ROOT_PASSWORD=changeme

--- a/self-hosting/deploy-swarm.sh
+++ b/self-hosting/deploy-swarm.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 SSH_HOST=root@ip
 DASHBOARD_URL="https://dashboard@example.com"
 SERVER_URL="https://backend.example.com"
-# Must be an origin without a path. Use a dedicated hostname or port.
+# S3_PUBLIC_ENDPOINT must be an origin without a path. Use a dedicated hostname or port.
 S3_PUBLIC_ENDPOINT="https://files.example.com"
 POSTGRES_PASSWORD=changeme
 MINIO_ROOT_PASSWORD=changeme

--- a/server/src/instant/util/aws_signature.clj
+++ b/server/src/instant/util/aws_signature.clj
@@ -305,7 +305,6 @@
         endpoint-uri (when endpoint (URI/create endpoint))
         scheme (if endpoint-uri (.getScheme endpoint-uri) "https")
         host (if endpoint-uri (uri-host-header endpoint-uri) (s3-host region bucket))
-        endpoint-path (some-> endpoint-uri .getRawPath (str/replace #"/$" ""))
         url-path (if path-style?
                    (str "/" bucket path-with-slash)
                    path-with-slash)
@@ -335,4 +334,4 @@
                                          :payload unsigned-payload})
         signature (->signature sig-request)
         all-query-params (assoc query "X-Amz-Signature" signature)]
-    (str scheme "://" host endpoint-path url-path "?" (->canonical-query-str all-query-params))))
+    (str scheme "://" host url-path "?" (->canonical-query-str all-query-params))))

--- a/server/test/instant/util/aws_signature_test.clj
+++ b/server/test/instant/util/aws_signature_test.clj
@@ -260,31 +260,5 @@
           "response-cache-control=public%2C%20max-age%3D86400%2C%20immutable"]
          (url->pretty put-req)))))
 
-(deftest s3-presign-url-with-endpoint-path
-  (let [object-key (storage-s3/->object-key example-app-id example-location-id)
-        opts {:access-key example-aws-access-key
-              :secret-key example-aws-access-key
-              :region example-region
-              :method :get
-              :bucket example-bucket-name
-              :path-style? true
-              :signing-instant example-signing-instant
-              :expires-duration (Duration/ofSeconds 400)
-              :path object-key}
-        [base-url-without-path & expected-query]
-        (url->pretty (aws-sig/presign-s3-url
-                     (assoc opts :endpoint "https://localhost:5443")))
-        expected-base-url (str "https://localhost:5443/storage/"
-                               example-bucket-name "/" object-key)]
-    (is (= (str "https://localhost:5443/" example-bucket-name "/" object-key)
-           base-url-without-path))
-    (doseq [endpoint ["https://localhost:5443/storage"
-                      "https://localhost:5443/storage/"]]
-      (let [[base-url & query] (url->pretty
-                                (aws-sig/presign-s3-url
-                                 (assoc opts :endpoint endpoint)))]
-        (is (= expected-base-url base-url))
-        (is (= expected-query query))))))
-
 (comment
   (test/run-tests *ns*))


### PR DESCRIPTION
Looks like hosting MinIO at a subpath [will not work with S3](https://github.com/minio/docs/blob/main/source/integrations/setup-nginx-proxy-with-minio.rst?plain=1#L117))

This reverts the earlier change in https://github.com/instantdb/instant/pull/2832 and adds a comment to let folks know they can't use a subpath