### PR TITLE
Copy s3 files with storage user

### DIFF
--- a/server/src/instant/storage/coordinator.clj
+++ b/server/src/instant/storage/coordinator.clj
@@ -54,7 +54,9 @@
             (try
               (instant-s3/copy-file {:destination-bucket copy-bucket
                                      :app-id app-id
-                                     :location-id location-id})
+                                     :location-id location-id
+                                     :access-key (config/s3-storage-access-key)
+                                     :secret-key (config/s3-storage-secret-key)})
               (catch Throwable e
                 ;; The source object is uploaded but we bail before creating a
                 ;; file record, so delete it (best-effort) to avoid orphaning

--- a/server/src/instant/storage/copier.clj
+++ b/server/src/instant/storage/copier.clj
@@ -93,7 +93,9 @@
                                       {:source-bucket-name instant-s3/bucket-name
                                        :destination-bucket-name dest
                                        :source-key object-key
-                                       :destination-key object-key})})))
+                                       :destination-key object-key
+                                       :access-key (config/s3-storage-access-key)
+                                       :secret-key (config/s3-storage-secret-key)})})))
                         files)]
     (reduce (fn [acc {:keys [id copy error]}]
               (if error

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -245,12 +245,16 @@
 
 (defn copy-file [{:keys [app-id
                          location-id
-                         destination-bucket]}]
+                         destination-bucket
+                         access-key
+                         secret-key]}]
   (let [object-key (->object-key app-id location-id)]
     (s3-util/copy-object (s3-client) {:source-bucket-name bucket-name
                                       :destination-bucket-name destination-bucket
                                       :source-key object-key
-                                      :destination-key object-key})))
+                                      :destination-key object-key
+                                      :access-key access-key
+                                      :secret-key secret-key})))
 
 (defn format-object [{:keys [object-metadata]}]
   (-> object-metadata

--- a/server/src/instant/util/s3.clj
+++ b/server/src/instant/util/s3.clj
@@ -9,6 +9,9 @@
   (:import
    (java.io InputStream)
    (java.time Instant Duration)
+   (software.amazon.awssdk.auth.credentials AwsBasicCredentials
+                                            StaticCredentialsProvider)
+   (software.amazon.awssdk.awscore AwsRequestOverrideConfiguration)
    (software.amazon.awssdk.core.async AsyncRequestBody
                                       AsyncResponseTransformer
                                       BufferedSplittableAsyncRequestBody)
@@ -91,18 +94,31 @@
    {:keys [source-bucket-name
            destination-bucket-name
            source-key
-           destination-key]}]
+           destination-key
+           access-key
+           secret-key]}]
   (tracer/with-span! {:name "copy-object"
                       :attributes {:source-bucket source-bucket-name
                                    :destination-bucket destination-bucket-name
                                    :source-key source-key
                                    :destination-key destination-key}}
-    (let [^CopyObjectRequest req (-> (CopyObjectRequest/builder)
-                                     (.sourceBucket source-bucket-name)
-                                     (.sourceKey source-key)
-                                     (.destinationBucket destination-bucket-name)
-                                     (.destinationKey destination-key)
-                                     (.build))
+    (let [^CopyObjectRequest req
+          (cond-> (CopyObjectRequest/builder)
+            true (.sourceBucket source-bucket-name)
+            true (.sourceKey source-key)
+            true (.destinationBucket destination-bucket-name)
+            true (.destinationKey destination-key)
+            ;; Override the client's default credentials for this one
+            ;; request. All-or-nothing: if only one is set we fall back
+            ;; to the client's default creds.
+            (and access-key secret-key)
+            (.overrideConfiguration
+             (-> (AwsRequestOverrideConfiguration/builder)
+                 (.credentialsProvider
+                  (StaticCredentialsProvider/create
+                   (AwsBasicCredentials/create access-key secret-key)))
+                 (.build)))
+            true (.build))
           ^CopyObjectResponse resp (.copyObject s3-client req)]
       resp)))
 
@@ -316,13 +332,25 @@
   "Server-side copy via the transfer manager. Returns the completion
    CompletableFuture (does not block)."
   [^S3TransferManager transfer-manager
-   {:keys [source-bucket-name destination-bucket-name source-key destination-key]}]
-  (let [^CopyObjectRequest req (-> (CopyObjectRequest/builder)
-                                   (.sourceBucket source-bucket-name)
-                                   (.sourceKey source-key)
-                                   (.destinationBucket destination-bucket-name)
-                                   (.destinationKey destination-key)
-                                   (.build))
+   {:keys [source-bucket-name destination-bucket-name source-key destination-key
+           access-key secret-key]}]
+  (let [^CopyObjectRequest req
+        (cond-> (CopyObjectRequest/builder)
+          true (.sourceBucket source-bucket-name)
+          true (.sourceKey source-key)
+          true (.destinationBucket destination-bucket-name)
+          true (.destinationKey destination-key)
+          ;; Override the client's default credentials for this one
+          ;; request. All-or-nothing: if only one is set we fall back
+          ;; to the client's default creds.
+          (and access-key secret-key)
+          (.overrideConfiguration
+           (-> (AwsRequestOverrideConfiguration/builder)
+               (.credentialsProvider
+                (StaticCredentialsProvider/create
+                 (AwsBasicCredentials/create access-key secret-key)))
+               (.build)))
+          true (.build))
         ^CopyRequest copy-req (-> (CopyRequest/builder)
                                   (.copyObjectRequest req)
                                   (.build))]


### PR DESCRIPTION
Follow-up to https://github.com/instantdb/instant/pull/2814

Updates `copy` to use the storage user. We override the creds for each copy command.

This makes it easier for the destination bucket to accept requests from our user.