### PR TITLE
Show proxied connections on the overview page

### DIFF
--- a/client/www/pages/intern/overview.tsx
+++ b/client/www/pages/intern/overview.tsx
@@ -33,7 +33,12 @@ type AppSessions = {
 };
 type MachineSessions = Record<AppId, AppSessions>;
 type SessionReports = Record<MachineId, MachineSessions>;
-type MinuteOverview = { 'session-reports': SessionReports };
+type ProxiedConnection = { count: number; target: string | null };
+type ProxiedConnections = Record<MachineId, Record<AppId, ProxiedConnection>>;
+type MinuteOverview = {
+  'session-reports': SessionReports;
+  'proxied-connections': ProxiedConnections | null;
+};
 
 async function fetchMinuteOverview(token: string): Promise<MinuteOverview> {
   return jsonFetch(`${config.apiURI}/dash/overview/minute`, {
@@ -169,6 +174,29 @@ function flattenedSessionReports(machineToReport: SessionReports) {
   }
   const items = Object.values(res);
   return items;
+}
+
+type FlatProxiedConnection = {
+  'app-id': AppId;
+  target: string | null;
+  count: number;
+};
+
+function flattenedProxiedConnections(
+  machineToConnections: ProxiedConnections | null,
+): FlatProxiedConnection[] {
+  const res: Record<AppId, FlatProxiedConnection> = {};
+  for (const machineId in machineToConnections) {
+    const machineConnections = machineToConnections[machineId];
+    for (const appId in machineConnections) {
+      const curr = machineConnections[appId];
+      const prev = res[appId];
+      res[appId] = prev
+        ? { ...prev, count: prev.count + curr.count }
+        : { 'app-id': appId, target: curr.target, count: curr.count };
+    }
+  }
+  return Object.values(res).toSorted((a, b) => b.count - a.count);
 }
 
 function makeMachineSummary(
@@ -390,6 +418,14 @@ const MinuteStatsSection = ({
   );
   const totalApps = Object.keys(sessions).length;
 
+  const proxiedConnections = flattenedProxiedConnections(
+    minute.data['proxied-connections'],
+  );
+  const totalProxied = proxiedConnections.reduce(
+    (acc: number, x) => acc + x.count,
+    0,
+  );
+
   return (
     <div className={wrapperClass}>
       <button
@@ -428,6 +464,33 @@ const MinuteStatsSection = ({
           <div>Active Apps</div>
         </div>
       </div>
+      {proxiedConnections.length > 0 && (
+        <div className="flex flex-col">
+          <div className="flex items-baseline space-x-2">
+            <h3 className="font-bold">Proxied Connections</h3>
+            <span className="text-gray-500">
+              {Intl.NumberFormat().format(totalProxied)} across{' '}
+              {proxiedConnections.length} app
+              {proxiedConnections.length > 1 ? 's' : ''}
+            </span>
+          </div>
+          <div className="mt-1 max-h-48 overflow-y-scroll border">
+            <table className="w-full">
+              <tbody>
+                {proxiedConnections.map((conn) => (
+                  <tr key={conn['app-id']}>
+                    <td className="px-4 py-2 text-right">
+                      {Intl.NumberFormat().format(conn.count)}
+                    </td>
+                    <td className="px-4 py-2">{conn['app-id']}</td>
+                    <td className="px-4 py-2">{conn.target || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
       <div className="mt-4 overflow-y-scroll border">
         <table className="w-full">
           <tbody>

--- a/server/src/instant/app_proxy.clj
+++ b/server/src/instant/app_proxy.clj
@@ -172,6 +172,19 @@
                      (into [] cat (vals @proxied-websockets))
                      opts))
 
+(defn local-proxied-connections
+  "Summarizes the WebSocket connections this instance is currently proxying to
+   another backend, keyed by app id. The target comes from the live routing
+   table so it reflects the current config."
+  []
+  (let [table (flags/app-proxy-targets)]
+    (reduce-kv
+     (fn [acc app-id connections]
+       (assoc acc app-id {:count (count connections)
+                          :target (some-> ^URI (get table app-id) str)}))
+     {}
+     @proxied-websockets)))
+
 (defn- changed-app-ids [old-targets new-targets]
   ;; Includes apps that were added or removed as well as apps whose target
   ;; origin changed.

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -383,9 +383,15 @@
 (defn admin-overview-minute-get [req]
   (let [{:keys [email]} (req->auth-user! req)
         _ (assert-admin-email! email)
-        session-reports (machine-summaries/get-session-reports-cached)]
+        session-reports (machine-summaries/get-session-reports-cached)
+        ;; Gate the cross-machine task behind a flag: older machines that
+        ;; predate proxied-connections-task can't run it, so only fan out once
+        ;; every machine has been updated and the flag is flipped on.
+        proxied-connections (when (flags/flag :proxied-connections-overview-enabled false)
+                              (machine-summaries/get-proxied-connections-cached))]
     (response/ok
-     {:session-reports session-reports})))
+     {:session-reports session-reports
+      :proxied-connections proxied-connections})))
 
 (defn app-stats-get [req]
   (let [{{app-id :id} :app} (req->app-and-user! :collaborator req)

--- a/server/src/instant/machine_summaries.clj
+++ b/server/src/instant/machine_summaries.clj
@@ -1,5 +1,6 @@
 (ns instant.machine-summaries
   (:require
+   [instant.app-proxy :as app-proxy]
    [instant.flags :as flags]
    [instant.reactive.ephemeral :as eph]
    [instant.reactive.store :as rs]
@@ -58,6 +59,32 @@
                :session-reports
                (fn [_]
                  (get-session-reports (eph/get-hz))))))
+
+;; proxied connections
+
+(defn proxied-connections-task
+  []
+  (app-proxy/local-proxied-connections))
+
+(defn get-proxied-connections [hz]
+  (let [executor (HazelcastInstance/.getExecutorService hz "proxied-connections-executor")
+        futures (IExecutorService/.submitToAllMembers executor (hz/->Task #'proxied-connections-task))]
+    (into {} (for [[member fut] futures]
+               [(str (or (Member/.getAttribute member "instance-id")
+                         (Member/.getAddress member)))
+                @fut]))))
+
+(comment
+  (get-proxied-connections (eph/get-hz)))
+
+(def proxied-connections-cache
+  (cache/make
+   {:ttl 5000
+    :value-fn (fn [_]
+                (get-proxied-connections (eph/get-hz)))}))
+
+(defn get-proxied-connections-cached []
+  (cache/get proxied-connections-cache :proxied-connections))
 
 ;; num sessions
 


### PR DESCRIPTION
Shows the number of proxied connections on the minute section of the /intern/overview page.

#### Deployment plan
1. Wait for PR to fully deploy and for all old machines to scale out
2. Flip the `proxied-connections-overview-enabled` flag to `true`