### PR TITLE
Experiment 1: Explicitly commit IndexedDB write transactions

### DIFF
--- a/client/packages/core/__tests__/src/utils/PersistedObject.test.ts
+++ b/client/packages/core/__tests__/src/utils/PersistedObject.test.ts
@@ -1,5 +1,5 @@
 import 'fake-indexeddb/auto';
-import { test, expect, describe } from 'vitest';
+import { test, expect, describe, vi } from 'vitest';
 import { PersistedObject } from '../../../src/utils/PersistedObject';
 import { IndexedDBStorage } from '../../../src';
 import { randomUUID } from 'crypto';
@@ -422,4 +422,25 @@ test('IndexedDBStorage recovers when the database connection closes', async () =
 
   await idb.removeItem('key4');
   expect(await idb.getItem('key4')).toBe(null);
+});
+
+test('IndexedDBStorage explicitly commits write transactions', async () => {
+  const commitSpy = vi.spyOn(IDBTransaction.prototype, 'commit');
+  try {
+    const idb = new IndexedDBStorage(randomUUID(), 'kv');
+
+    await idb.setItem('key1', 'value1');
+    await idb.multiSet([
+      ['key2', 'value2'],
+      ['key3', 'value3'],
+    ]);
+    await idb.removeItem('key3');
+
+    expect(commitSpy).toHaveBeenCalledTimes(3);
+    expect(await idb.getItem('key1')).toBe('value1');
+    expect(await idb.getItem('key2')).toBe('value2');
+    expect(await idb.getItem('key3')).toBe(null);
+  } finally {
+    commitSpy.mockRestore();
+  }
 });

--- a/client/packages/core/src/IndexedDBStorage.ts
+++ b/client/packages/core/src/IndexedDBStorage.ts
@@ -300,6 +300,7 @@ export default class IndexedDBStorage extends StoreInterface {
         transaction.oncomplete = () => resolve();
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error);
+        transaction.commit?.();
       });
     });
   }
@@ -316,6 +317,7 @@ export default class IndexedDBStorage extends StoreInterface {
         transaction.oncomplete = () => resolve();
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error);
+        transaction.commit?.();
       });
     });
   }
@@ -330,6 +332,7 @@ export default class IndexedDBStorage extends StoreInterface {
         transaction.oncomplete = () => resolve();
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error);
+        transaction.commit?.();
       });
     });
   }

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.63';
+const version = 'v1.0.64';
 
 export { version };


### PR DESCRIPTION
# Problem 

If you background a tab in android, sometimes it causes active tabs to freeze

# Reason 

We open a transaction on IndexedDB when we save pending mutations. If Chrome decides to _freeze_ while the tx is open, all other transactions to IndexedDB will be blocked, waiting for that transaction 

# Solution 

Unfortunately there is no easy way to _tell_ IndexedDB to time out when we are sending a tx. 

But one thing we can do is to commit the transaction faster: 

We call `IDBTransaction.commit()` after `setItem`, `multiSet`, and `removeItem` right away. 

This lets IDB commit the transaction, before having to send back a "done" result to our callback. 

When running tests, this reduced the number of noticed blocks from 4/6 to 1/6 


Detailed explainer: https://instant-frozen-tab-idb.stopa.chatgpt.site

# Future Work 

This still may not be enough. It's still possible that we try to do a very large write (with lots of pending mutations), and just at that moment Android freezes us. 

To avoid this, we would have to start saving each transaction as a separate row, so we could start to bound writes to pendingMutations. 

This may be a bit more involved, so I wanted to first ship this version, before experimenting with a full on rewrite.

@dwwoelfel @nezaj 