### PR TITLE
Allow edits to OAuth providers on the dashboard

### DIFF
--- a/client/www/components/dash/AppAuth.tsx
+++ b/client/www/components/dash/AppAuth.tsx
@@ -330,7 +330,13 @@ function ClientItem({
         />
       );
     case 'apple':
-      return <AppleClient client={client} />;
+      return (
+        <AppleClient
+          app={app}
+          client={client}
+          onUpdateClient={onUpdateClient}
+        />
+      );
     case 'github':
       return (
         <GitHubClient
@@ -356,7 +362,13 @@ function ClientItem({
         />
       );
     case 'firebase':
-      return <FirebaseClient app={app} client={client} />;
+      return (
+        <FirebaseClient
+          app={app}
+          client={client}
+          onUpdateClient={onUpdateClient}
+        />
+      );
     default:
       return null;
   }

--- a/client/www/components/dash/auth/Apple.tsx
+++ b/client/www/components/dash/auth/Apple.tsx
@@ -1,13 +1,11 @@
 import { FormEventHandler, useContext, useState } from 'react';
-import { errorToast } from '@/lib/toast';
+import { errorToast, successToast } from '@/lib/toast';
 import { TokenContext } from '@/lib/contexts';
 import { Button, Copyable, TextInput, TextArea } from '@/components/ui';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
-import logo from '../../../public/img/apple_logo_black.svg';
-import Image from 'next/image';
 import { messageFromInstantError } from '@/lib/errors';
-import { addProvider, addClient, findName } from './shared';
+import { addProvider, addClient, findName, updateClient } from './shared';
 import {
   InstantApp,
   InstantIssue,
@@ -20,20 +18,213 @@ import {
   APPLE_TOKEN_ENDPOINT,
 } from '@instantdb/platform';
 
-export function AppleClient({ client }: { client: OAuthClient }) {
+// Editor for an Apple client's credentials. The Services ID, Team ID, and Key
+// ID are readable and prefilled; the Private Key is write-only (never returned
+// to the dashboard), so leaving it blank keeps the current key. The private key
+// and the Team/Key IDs are combined server-side only at web sign-in time, so
+// each can be updated independently.
+function AppleCredentialsEditor({
+  app,
+  client,
+  onUpdateClient,
+}: {
+  app: InstantApp;
+  client: OAuthClient;
+  onUpdateClient: (client: OAuthClient) => void;
+}) {
+  const token = useContext(TokenContext);
+  const [isEditing, setIsEditing] = useState(false);
+  const [servicesId, setServicesId] = useState<string>(client.client_id || '');
+  const [teamId, setTeamId] = useState<string>(client.meta?.teamId || '');
+  const [keyId, setKeyId] = useState<string>(client.meta?.keyId || '');
+  const [privateKey, setPrivateKey] = useState<string>('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const resetFields = () => {
+    setServicesId(client.client_id || '');
+    setTeamId(client.meta?.teamId || '');
+    setKeyId(client.meta?.keyId || '');
+    setPrivateKey('');
+  };
+
+  const openEditor = () => {
+    resetFields();
+    setIsEditing(true);
+  };
+
+  const cancel = () => {
+    setIsEditing(false);
+    resetFields();
+  };
+
+  const validationError = () => {
+    if (!servicesId) {
+      return 'Missing Apple Services ID';
+    }
+    // Team ID and Key ID are only meaningful together (web redirect flow).
+    if ((teamId || keyId) && !(teamId && keyId)) {
+      return 'Both Team ID and Key ID are required for the Web redirect flow.';
+    }
+  };
+
+  const handleSave = async () => {
+    const err = validationError();
+    if (err) {
+      errorToast(err, { autoClose: 5000 });
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const resp = await updateClient({
+        token,
+        appId: app.id,
+        oauthClientID: client.id,
+        body: {
+          client_id: servicesId,
+          meta: { teamId, keyId },
+          ...(privateKey ? { client_secret: privateKey } : {}),
+        },
+      });
+      onUpdateClient(resp.client);
+      cancel();
+      successToast('Credentials updated');
+    } catch (e) {
+      console.error(e);
+      const msg =
+        messageFromInstantError(e as InstantIssue) ||
+        'Error updating credentials.';
+      errorToast(msg, { autoClose: 5000 });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <div className="flex flex-col gap-4">
+        <Copyable label="Services ID" value={client.client_id || ''} />
+
+        {client.meta?.teamId ? (
+          <Copyable label="Team ID" value={client.meta?.teamId} />
+        ) : null}
+
+        {client.meta?.keyId ? (
+          <Copyable label="Key ID" value={client.meta?.keyId} />
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button variant="secondary" size="mini" onClick={openEditor}>
+            Update credentials
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+      autoComplete="off"
+      data-lpignore="true"
+      data-1p-ignore="true"
+      data-bwignore="true"
+      data-form-type="other"
+    >
+      <TextInput
+        value={servicesId}
+        onChange={setServicesId}
+        label={
+          <>
+            Services ID from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://developer.apple.com/account/resources/identifiers/list/serviceId"
+            >
+              Identifiers
+            </a>
+          </>
+        }
+      />
+      <TextInput
+        value={teamId}
+        onChange={setTeamId}
+        label={
+          <>
+            Team ID from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://developer.apple.com/account#MembershipDetailsCard"
+            >
+              Membership details
+            </a>
+          </>
+        }
+      />
+      <TextInput
+        value={keyId}
+        onChange={setKeyId}
+        label={
+          <>
+            Key ID from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://developer.apple.com/account/resources/authkeys/list"
+            >
+              Keys
+            </a>
+          </>
+        }
+      />
+      <TextArea
+        value={privateKey}
+        onChange={setPrivateKey}
+        label="Private Key"
+        rows={6}
+        placeholder={'-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----'}
+      />
+      <p className="text-sm text-gray-500 dark:text-neutral-400">
+        Leave the private key blank to keep the current one.
+      </p>
+      <div className="flex gap-2">
+        <Button loading={isSaving} type="submit">
+          Save
+        </Button>
+        <Button variant="secondary" onClick={cancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export function AppleClient({
+  app,
+  client,
+  onUpdateClient,
+}: {
+  app: InstantApp;
+  client: OAuthClient;
+  onUpdateClient: (client: OAuthClient) => void;
+}) {
   return (
     <div className="flex flex-col gap-4">
       <Copyable label="Client Name" value={client.client_name} />
 
-      <Copyable label="Services ID" value={client.client_id || ''} />
-
-      {client.meta?.teamId ? (
-        <Copyable label="Team ID" value={client.meta?.teamId} />
-      ) : null}
-
-      {client.meta?.keyId ? (
-        <Copyable label="Key ID" value={client.meta?.keyId} />
-      ) : null}
+      <AppleCredentialsEditor
+        app={app}
+        client={client}
+        onUpdateClient={onUpdateClient}
+      />
 
       <a
         className="underline"

--- a/client/www/components/dash/auth/Apple.tsx
+++ b/client/www/components/dash/auth/Apple.tsx
@@ -81,7 +81,7 @@ function AppleCredentialsEditor({
         oauthClientID: client.id,
         body: {
           client_id: servicesId,
-          meta: { teamId, keyId },
+          ...(teamId && keyId ? { meta: { teamId, keyId } } : {}),
           ...(privateKey ? { client_secret: privateKey } : {}),
         },
       });

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -1,6 +1,6 @@
 import { FormEventHandler, useContext, useState } from 'react';
 import { clerkDomainFromPublishableKey } from '@instantdb/platform';
-import { errorToast } from '@/lib/toast';
+import { errorToast, successToast } from '@/lib/toast';
 import { TokenContext } from '@/lib/contexts';
 import {
   Button,
@@ -12,7 +12,7 @@ import {
   TextInput,
 } from '@/components/ui';
 import { messageFromInstantError } from '@/lib/errors';
-import { addClient, findName, updateClientMeta } from './shared';
+import { addClient, findName, updateClient, updateClientMeta } from './shared';
 import {
   InstantApp,
   InstantIssue,
@@ -118,6 +118,136 @@ function App() {
 export default App;`;
 }
 
+// Editor for a Clerk client's publishable key. Updating the key also rewrites
+// the discovery endpoint, which is derived from the key's domain (same as the
+// add form). meta is deep-merged server-side, so other meta keys (e.g.
+// allowUnverifiedEmail) are preserved.
+function ClerkKeyEditor({
+  app,
+  client,
+  onUpdateClient,
+}: {
+  app: InstantApp;
+  client: OAuthClient;
+  onUpdateClient: (client: OAuthClient) => void;
+}) {
+  const token = useContext(TokenContext);
+  const [isEditing, setIsEditing] = useState(false);
+  const currentKey = client.meta?.clerkPublishableKey || '';
+  const [publishableKey, setPublishableKey] = useState<string>(currentKey);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const domain = currentKey ? clerkDomainFromPublishableKey(currentKey) : null;
+
+  const openEditor = () => {
+    setPublishableKey(currentKey);
+    setIsEditing(true);
+  };
+
+  const cancel = () => {
+    setIsEditing(false);
+    setPublishableKey(currentKey);
+  };
+
+  const handleSave = async () => {
+    if (!publishableKey) {
+      errorToast('Missing Clerk publishable key', { autoClose: 5000 });
+      return;
+    }
+    if (!publishableKey.startsWith('pk_')) {
+      errorToast('Invalid publishable key. It should start with "pk_".', {
+        autoClose: 5000,
+      });
+      return;
+    }
+    const newDomain = clerkDomainFromPublishableKey(publishableKey);
+    if (!newDomain) {
+      errorToast(
+        'Could not determine Clerk domain from key. Ping us in Discord for help.',
+        { autoClose: 5000 },
+      );
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const resp = await updateClient({
+        token,
+        appId: app.id,
+        oauthClientID: client.id,
+        body: {
+          meta: { clerkPublishableKey: publishableKey },
+          discovery_endpoint: `https://${newDomain}/.well-known/openid-configuration`,
+        },
+      });
+      onUpdateClient(resp.client);
+      cancel();
+      successToast('Clerk publishable key updated');
+    } catch (e) {
+      console.error(e);
+      const msg =
+        messageFromInstantError(e as InstantIssue) ||
+        'Error updating publishable key.';
+      errorToast(msg, { autoClose: 5000 });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <div className="flex flex-col gap-2">
+        {currentKey ? (
+          <Copyable label="Clerk publishable key" value={currentKey} />
+        ) : null}
+        {domain ? <Copyable label="Clerk domain" value={domain} /> : null}
+        <div className="flex justify-end">
+          <Button variant="secondary" size="mini" onClick={openEditor}>
+            Update publishable key
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+      autoComplete="off"
+      data-lpignore="true"
+    >
+      <TextInput
+        value={publishableKey}
+        onChange={setPublishableKey}
+        label={
+          <>
+            Clerk publishable key from your{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://dashboard.clerk.com/last-active?path=api-keys"
+            >
+              Clerk dashboard
+            </a>
+          </>
+        }
+      />
+      <div className="flex gap-2">
+        <Button loading={isSaving} type="submit">
+          Save
+        </Button>
+        <Button variant="secondary" onClick={cancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
 export function ClerkClient({
   app,
   client,
@@ -136,10 +266,6 @@ export function ClerkClient({
   const clerkPublishableKey = client.meta?.clerkPublishableKey;
 
   const allowUnverifiedEmail = client.meta?.allowUnverifiedEmail;
-
-  const domain = clerkPublishableKey
-    ? clerkDomainFromPublishableKey(clerkPublishableKey)
-    : null;
 
   const exampleCode = clerkExampleCode({
     appId: app.id,
@@ -170,10 +296,11 @@ export function ClerkClient({
   return (
     <div className="flex flex-col gap-4">
       <Copyable label="Client name" value={client.client_name} />
-      {clerkPublishableKey ? (
-        <Copyable label="Clerk publishable key" value={clerkPublishableKey} />
-      ) : null}
-      {domain ? <Copyable label="Clerk domain" value={domain} /> : null}
+      <ClerkKeyEditor
+        app={app}
+        client={client}
+        onUpdateClient={onUpdateClient}
+      />
 
       {showUpdateVerified ? (
         <div className="flex flex-col gap-2 rounded-sm border bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950">

--- a/client/www/components/dash/auth/Firebase.tsx
+++ b/client/www/components/dash/auth/Firebase.tsx
@@ -1,9 +1,8 @@
 import { FormEventHandler, useContext, useState } from 'react';
-import { errorToast } from '@/lib/toast';
+import { errorToast, successToast } from '@/lib/toast';
 import { TokenContext } from '@/lib/contexts';
 import {
   Button,
-  Checkbox,
   Content,
   Copyable,
   Fence,
@@ -11,7 +10,7 @@ import {
   TextInput,
 } from '@/components/ui';
 import { messageFromInstantError } from '@/lib/errors';
-import { addClient, findName } from './shared';
+import { addClient, findName, updateClient } from './shared';
 import {
   InstantApp,
   InstantIssue,
@@ -60,18 +59,132 @@ function App() {
 }`;
 }
 
-export function FirebaseClient({
+// Firebase clients have no client id/secret; the project ID is encoded in the
+// discovery endpoint. Editing the project ID rewrites that endpoint (same shape
+// as the add form).
+function FirebaseProjectEditor({
   app,
   client,
+  onUpdateClient,
 }: {
   app: InstantApp;
   client: OAuthClient;
+  onUpdateClient: (client: OAuthClient) => void;
+}) {
+  const token = useContext(TokenContext);
+  const currentProjectId =
+    client.discovery_endpoint?.match(
+      /^https:\/\/securetoken\.google\.com\/(.+)\/\.well-known\/openid-configuration$/,
+    )?.[1] || '';
+  const [isEditing, setIsEditing] = useState(false);
+  const [projectId, setProjectId] = useState<string>(currentProjectId);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const openEditor = () => {
+    setProjectId(currentProjectId);
+    setIsEditing(true);
+  };
+
+  const cancel = () => {
+    setIsEditing(false);
+    setProjectId(currentProjectId);
+  };
+
+  const handleSave = async () => {
+    if (!projectId) {
+      errorToast('Missing Firebase project ID', { autoClose: 5000 });
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const resp = await updateClient({
+        token,
+        appId: app.id,
+        oauthClientID: client.id,
+        body: {
+          discovery_endpoint: `https://securetoken.google.com/${projectId}/.well-known/openid-configuration`,
+        },
+      });
+      onUpdateClient(resp.client);
+      cancel();
+      successToast('Firebase project ID updated');
+    } catch (e) {
+      console.error(e);
+      const msg =
+        messageFromInstantError(e as InstantIssue) ||
+        'Error updating project ID.';
+      errorToast(msg, { autoClose: 5000 });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <div className="flex flex-col gap-2">
+        {currentProjectId ? (
+          <Copyable label="Firebase Project ID" value={currentProjectId} />
+        ) : null}
+        <div className="flex justify-end">
+          <Button variant="secondary" size="mini" onClick={openEditor}>
+            Update project ID
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+      autoComplete="off"
+      data-lpignore="true"
+    >
+      <TextInput
+        value={projectId}
+        onChange={setProjectId}
+        label={
+          <>
+            Firebase <code>Project ID</code> from your Project Settings page on
+            the{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://console.firebase.google.com/"
+            >
+              Firebase dashboard
+            </a>
+            .
+          </>
+        }
+      />
+      <div className="flex gap-2">
+        <Button loading={isSaving} type="submit">
+          Save
+        </Button>
+        <Button variant="secondary" onClick={cancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export function FirebaseClient({
+  app,
+  client,
+  onUpdateClient,
+}: {
+  app: InstantApp;
+  client: OAuthClient;
+  onUpdateClient: (client: OAuthClient) => void;
 }) {
   const { darkMode } = useDarkMode();
-
-  const projectId = client.discovery_endpoint?.match(
-    /^https:\/\/securetoken\.google\.com\/(.+)\/\.well-known\/openid-configuration$/,
-  )?.[1];
 
   const exampleCode = firebaseExampleCode({
     appId: app.id,
@@ -81,9 +194,11 @@ export function FirebaseClient({
   return (
     <div className="flex flex-col gap-4">
       <Copyable label="Client name" value={client.client_name} />
-      {projectId ? (
-        <Copyable label="Firebase Project ID" value={projectId} />
-      ) : null}
+      <FirebaseProjectEditor
+        app={app}
+        client={client}
+        onUpdateClient={onUpdateClient}
+      />
 
       <SubsectionHeading>Setup and usage</SubsectionHeading>
 

--- a/client/www/components/dash/auth/GitHub.tsx
+++ b/client/www/components/dash/auth/GitHub.tsx
@@ -6,7 +6,6 @@ import {
   Copyable,
   Copytext,
   Fence,
-  SectionHeading,
   SubsectionHeading,
   TextInput,
 } from '@/components/ui';
@@ -23,6 +22,7 @@ import {
   RedirectUrlInput,
   EditableRedirectUrl,
   RedirectForwardingNote,
+  OAuthCredentialsEditor,
 } from './shared';
 import { errorToast } from '@/lib/toast';
 import { messageFromInstantError } from '@/lib/errors';
@@ -207,7 +207,39 @@ export function GitHubClient({
   return (
     <div className="flex flex-col gap-4">
       <Copyable label="Client name" value={client.client_name} />
-      <Copyable label="GitHub Client ID" value={client.client_id || ''} />
+      <OAuthCredentialsEditor
+        app={app}
+        client={client}
+        token={token}
+        onUpdateClient={onUpdateClient}
+        clientIdCopyLabel="GitHub Client ID"
+        clientIdLabel={
+          <>
+            Client ID from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://github.com/settings/developers"
+            >
+              GitHub OAuth Apps
+            </a>
+          </>
+        }
+        clientSecretLabel={
+          <>
+            Client secret from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://github.com/settings/developers"
+            >
+              GitHub OAuth Apps
+            </a>
+          </>
+        }
+      />
       <EditableRedirectUrl
         app={app}
         client={client}

--- a/client/www/components/dash/auth/LinkedIn.tsx
+++ b/client/www/components/dash/auth/LinkedIn.tsx
@@ -27,6 +27,7 @@ import {
   RedirectUrlInput,
   EditableRedirectUrl,
   RedirectForwardingNote,
+  OAuthCredentialsEditor,
 } from './shared';
 import { errorToast } from '@/lib/toast';
 import { messageFromInstantError } from '@/lib/errors';
@@ -215,7 +216,39 @@ export function LinkedInClient({
   return (
     <div className="flex flex-col gap-4">
       <Copyable label="Client name" value={client.client_name} />
-      <Copyable label="LinkedIn client ID" value={client.client_id || ''} />
+      <OAuthCredentialsEditor
+        app={app}
+        client={client}
+        token={token}
+        onUpdateClient={onUpdateClient}
+        clientIdCopyLabel="LinkedIn client ID"
+        clientIdLabel={
+          <>
+            Client ID from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.linkedin.com/developers/apps"
+            >
+              LinkedIn developer portal
+            </a>
+          </>
+        }
+        clientSecretLabel={
+          <>
+            Client secret from{' '}
+            <a
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.linkedin.com/developers/apps"
+            >
+              LinkedIn developer portal
+            </a>
+          </>
+        }
+      />
       <EditableRedirectUrl
         app={app}
         client={client}

--- a/client/www/components/dash/auth/shared.tsx
+++ b/client/www/components/dash/auth/shared.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { jsonFetch } from '@/lib/fetch';
 import config, { defaultOAuthCallbackURL } from '@/lib/config';
 import {
@@ -185,6 +185,7 @@ export function updateClient({
     client_secret?: string;
     meta?: Record<string, any>;
     redirect_to?: string | null;
+    discovery_endpoint?: string;
     use_shared_credentials?: boolean;
   };
 }): Promise<{ client: OAuthClient }> {
@@ -443,5 +444,126 @@ export function EditableRedirectUrl({
         </Button>
       </div>
     </div>
+  );
+}
+
+// Editor for a client's ID + secret, used by providers whose credentials are a
+// plain client id / client secret pair (GitHub, LinkedIn). The existing secret
+// is never returned to the dashboard, so this only ever sets a new value:
+// leaving the secret field blank keeps the current secret unchanged.
+export function OAuthCredentialsEditor({
+  app,
+  client,
+  token,
+  onUpdateClient,
+  clientIdCopyLabel,
+  clientIdLabel,
+  clientSecretLabel,
+}: {
+  app: InstantApp;
+  client: OAuthClient;
+  token: string;
+  onUpdateClient: (client: OAuthClient) => void;
+  clientIdCopyLabel: string;
+  clientIdLabel: ReactNode;
+  clientSecretLabel: ReactNode;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [clientId, setClientId] = useState(client.client_id || '');
+  const [clientSecret, setClientSecret] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const openEditor = () => {
+    setClientId(client.client_id || '');
+    setClientSecret('');
+    setIsEditing(true);
+  };
+
+  const cancel = () => {
+    setIsEditing(false);
+    setClientId(client.client_id || '');
+    setClientSecret('');
+  };
+
+  const handleSave = async () => {
+    if (!clientId) {
+      errorToast('Missing client id', { autoClose: 5000 });
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const resp = await updateClient({
+        token,
+        appId: app.id,
+        oauthClientID: client.id,
+        body: {
+          client_id: clientId,
+          ...(clientSecret ? { client_secret: clientSecret } : {}),
+        },
+      });
+      onUpdateClient(resp.client);
+      cancel();
+      successToast('Credentials updated');
+    } catch (e) {
+      console.error(e);
+      const msg =
+        messageFromInstantError(e as InstantIssue) ||
+        'Error updating credentials.';
+      errorToast(msg, { autoClose: 5000 });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Copyable label={clientIdCopyLabel} value={client.client_id || ''} />
+        <div className="flex justify-end">
+          <Button variant="secondary" size="mini" onClick={openEditor}>
+            Update credentials
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+      autoComplete="off"
+      data-lpignore="true"
+      data-1p-ignore="true"
+      data-bwignore="true"
+      data-form-type="other"
+    >
+      <TextInput
+        value={clientId}
+        onChange={setClientId}
+        label={clientIdLabel}
+      />
+      <TextInput
+        type="sensitive"
+        value={clientSecret}
+        onChange={setClientSecret}
+        label={clientSecretLabel}
+        placeholder="Enter a new secret to replace the current one"
+      />
+      <p className="text-sm text-gray-500 dark:text-neutral-400">
+        Leave the secret blank to keep the current one.
+      </p>
+      <div className="flex gap-2">
+        <Button loading={isSaving} type="submit">
+          Save
+        </Button>
+        <Button variant="secondary" onClick={cancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/server/src/instant/auth/jwt.clj
+++ b/server/src/instant/auth/jwt.clj
@@ -1,11 +1,12 @@
 (ns instant.auth.jwt
   (:require
    [chime.core :as chime-core]
-   [clj-http.client :as clj-http]
    [instant.util.cache :as cache]
    [instant.util.exception :as ex]
+   [instant.util.json :as json]
    [instant.util.lang :as lang]
-   [instant.util.tracer :as tracer])
+   [instant.util.tracer :as tracer]
+   [instant.webhook-sender :as webhook-sender])
   (:import
    (com.auth0.jwk Jwk SigningKeyNotFoundException)
    (com.auth0.jwt JWT)
@@ -28,11 +29,17 @@
 (defn- get-keys [jwks-uri]
   (tracer/with-span! {:name "jwt/get-keys"
                       :jwks-uri jwks-uri}
-    (let [resp (clj-http/get jwks-uri {:as :json-string-keys})
-          expires (if-let [expires-header (get-in resp [:headers "expires"])]
+    ;; jwks-uri comes from the untrusted discovery doc; use the SSRF-guarded client.
+    (let [resp (webhook-sender/safe-get jwks-uri)
+          _ (when-not (:success? resp)
+              (throw (ex-info "Unable to fetch JWKS."
+                              {:jwks-uri jwks-uri :status (:status resp)})))
+          headers (:headers resp)
+          body (json/<-json (:body resp))
+          expires (if-let [expires-header (get headers "expires")]
                     (parse-rfc822 expires-header)
-                    (if-let [max-age (some-> resp
-                                             (get-in [:headers "cache-control"])
+                    (if-let [max-age (some-> headers
+                                             (get "cache-control")
                                              (#(re-find #"max-age=(\d+)" %))
                                              second)]
                       (.plus (Instant/now)
@@ -41,7 +48,7 @@
                                           :attributes {:jwks-uri jwks-uri}}
                         ;; Just set it to one hour if there is no expires header
                         (.plus (Instant/now) 1 ChronoUnit/HOURS))))
-          body-keys (let [keys (get-in resp [:body "keys"])]
+          body-keys (let [keys (get body "keys")]
                       (if (< 100 (count keys))
                         (tracer/with-span!
                           {:name "jwk/too-many-keys"

--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -10,7 +10,8 @@
    [instant.util.lang :as lang]
    [instant.util.json :as json]
    [instant.util.tracer :as tracer]
-   [instant.util.url :as url])
+   [instant.util.url :as url]
+   [instant.webhook-sender :as webhook-sender])
   (:import
    (clojure.lang PersistentHashSet)
    (instant.util.crypt Secret)
@@ -293,13 +294,15 @@
        :imageURL imageURL})))
 
 (defn fetch-discovery [endpoint]
-  (let [resp (clj-http/get endpoint {:throw-exceptions false
-                                     :as :json
-                                     ;; for https://account.apple.com/.well-known/openid-configuration
-                                     :headers {"User-Agent" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15"}})]
-    (if (clj-http/success? resp)
+  ;; Uses the webhook-sender client so discovery fetches are SSRF-guarded: the
+  ;; endpoint is user-supplied, so a plain fetch could target internal hosts.
+  (let [resp (webhook-sender/safe-get
+              endpoint
+              ;; for https://account.apple.com/.well-known/openid-configuration
+              :headers {"User-Agent" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15"})]
+    (if (:success? resp)
       {:date (Instant/now)
-       :data (:body resp)}
+       :data (json/<-json (:body resp) true)}
       (do
         (tracer/record-exception-span! (ex-info "Error fetching discovery"
                                                 {:status   (:status resp)

--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -157,7 +157,9 @@
                  :code code
                  :grant_type "authorization_code"
                  :redirect_uri redirect-url})
-          resp-body (some-> (:body resp) (json/<-json true))]
+          resp-body (try
+                      (some-> (:body resp) (json/<-json true))
+                      (catch Exception _ nil))]
       (if-not (:success? resp)
         {:type :error :message (get resp-body :error_description "Error exchanging code for token.")}
         (let [id-token (try

--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -148,21 +148,21 @@
 
                    #_else
                    (.value client-secret))
-          resp (clj-http/post token-endpoint
-                              {:throw-exceptions false
-                               :as :json
-                               :coerce :always
-                               :form-params {:client_id client-id
-                                             :client_secret secret
-                                             :code code
-                                             :grant_type "authorization_code"
-                                             :redirect_uri redirect-url}})]
-      (if-not (clj-http/success? resp)
-        {:type :error :message (get-in resp [:body :error_description] "Error exchanging code for token.")}
+          ;; token-endpoint comes from the untrusted discovery doc; use the
+          ;; SSRF-guarded client (validated in assert-safe-discovery-endpoints!).
+          resp (webhook-sender/safe-post-form
+                token-endpoint
+                {:client_id client-id
+                 :client_secret secret
+                 :code code
+                 :grant_type "authorization_code"
+                 :redirect_uri redirect-url})
+          resp-body (some-> (:body resp) (json/<-json true))]
+      (if-not (:success? resp)
+        {:type :error :message (get resp-body :error_description "Error exchanging code for token.")}
         (let [id-token (try
                          ;; extract the id token data that has the email and sub from the id_token JWT
-                         (some-> resp
-                                 :body
+                         (some-> resp-body
                                  :id_token
                                  (string/split #"\.")
                                  ^String (second)
@@ -171,19 +171,17 @@
                                  (json/<-json true))
                          (catch IllegalArgumentException _e
                            (tracer/with-span! {:name "oauth/invalid-id_token"
-                                               :attributes {:id_token (-> resp :body :id_token)}})))
-              access-token (-> resp
-                               :body
-                               :access_token)
+                                               :attributes {:id_token (:id_token resp-body)}})))
+              access-token (:access_token resp-body)
 
               id-token (or id-token
                            (when (and access-token userinfo-endpoint)
                              (try
-                               (-> (clj-http/get userinfo-endpoint
-                                                 {:headers {:Authorization (str "Bearer " access-token)}
-                                                  :as :json
-                                                  :coerce :always})
-                                   :body)
+                               (let [ui-resp (webhook-sender/safe-get
+                                              userinfo-endpoint
+                                              :headers {"Authorization" (str "Bearer " access-token)})]
+                                 (when (:success? ui-resp)
+                                   (some-> (:body ui-resp) (json/<-json true))))
                                (catch Exception e
                                  (tracer/record-exception-span! e {:name "oauth/invalid-user-info-from-endpoint"})
                                  nil))))]
@@ -320,6 +318,19 @@
 (defn get-discovery [endpoint]
   (:data (cache/get discovery-endpoint-cache endpoint)))
 
+(defn assert-safe-discovery-endpoints!
+  "Rejects a discovery document whose server-fetched endpoints (token, userinfo,
+   jwks) point at unsafe (SSRF) hosts. The discovery-endpoint URL is
+   user-supplied, so its document is untrusted."
+  [{:keys [token_endpoint userinfo_endpoint jwks_uri] :as discovery-data}]
+  (when token_endpoint
+    (webhook-sender/assert-safe-url! token_endpoint))
+  (when userinfo_endpoint
+    (webhook-sender/assert-safe-url! userinfo_endpoint))
+  (when jwks_uri
+    (webhook-sender/assert-safe-url! jwks_uri))
+  discovery-data)
+
 (defn generic-oauth-client-from-discovery-url [{:keys [app-id
                                                        provider-id
                                                        client-id
@@ -332,7 +343,8 @@
                 issuer
                 id_token_signing_alg_values_supported
 
-                userinfo_endpoint]} (get-discovery discovery-endpoint)]
+                userinfo_endpoint]} (assert-safe-discovery-endpoints!
+                                     (get-discovery discovery-endpoint))]
     (map->GenericOAuthClient {:app-id app-id
                               :provider-id provider-id
                               :client-id client-id

--- a/server/src/instant/webhook_sender.clj
+++ b/server/src/instant/webhook_sender.clj
@@ -189,3 +189,23 @@
         (throw (Exception. "Could not resolve URL.")))
       (catch Exception _
         (ex/throw-validation-err! :webhook {:url input-url} [{:message "Could not resolve URL."}])))))
+
+(defn safe-get
+  "SSRF-safe HTTP GET using the guarded client (SSRF-defending DNS resolver plus
+   literal-IP check, no redirects). Returns {:success? bool :status int :body
+   string}. Throws for an unparseable URL, an unsafe host, or a network error."
+  [^String url & {:keys [headers]}]
+  (let [parsed-url (HttpUrl/parse url)]
+    (when (nil? parsed-url)
+      (ex/throw-validation-err! :url {:url url} [{:message "Invalid URL."}]))
+    (ensure-safe-host! parsed-url)
+    (let [builder (doto (Request$Builder.)
+                    (.url parsed-url))]
+      (doseq [[k v] headers]
+        (.header builder ^String k ^String v))
+      (with-open [response (.. client
+                               (newCall (.build builder))
+                               (execute))]
+        {:success? (.isSuccessful response)
+         :status (.code response)
+         :body (some-> (.body response) (.string))}))))

--- a/server/src/instant/webhook_sender.clj
+++ b/server/src/instant/webhook_sender.clj
@@ -17,7 +17,7 @@
    (java.util.concurrent Callable ExecutorService TimeUnit)
    (java.util.function Predicate)
    (javax.net.ssl SSLException)
-   (okhttp3 ConnectionPool Dispatcher Dns FormBody$Builder Headers HttpUrl MediaType OkHttpClient OkHttpClient$Builder Request$Builder RequestBody)
+   (okhttp3 ConnectionPool Dispatcher Dns FormBody$Builder Headers HttpUrl MediaType OkHttpClient OkHttpClient$Builder Request$Builder RequestBody Response)
    (okhttp3.dnsoverhttps DnsOverHttps DnsOverHttps$Builder)))
 
 (def ^{:tag 'bytes} period-bytes (.getBytes "." StandardCharsets/UTF_8))
@@ -203,6 +203,23 @@
 (defn- response-headers->map [^Headers hs]
   (into {} (map (fn [^String n] [(.toLowerCase n) (.get hs n)])) (.names hs)))
 
+(def max-response-bytes
+  "Upper bound on bytes read from a guarded response body, to bound memory for
+   hostile endpoints that return unbounded/oversized responses."
+  (* 5 1024 1024))
+
+(defn- read-capped-body ^String [^Response response]
+  (when (.body response)
+    ;; peekBody buffers at most (inc limit) bytes without reading the rest, so
+    ;; an oversized/unbounded body is capped even with no Content-Length header.
+    (let [bytes (.. response
+                    (peekBody (inc (long max-response-bytes)))
+                    (bytes))]
+      (when (> (alength bytes) max-response-bytes)
+        (throw (ex-info "Response body exceeds size limit"
+                        {:limit max-response-bytes})))
+      (String. bytes StandardCharsets/UTF_8))))
+
 (defn- execute-response [^Request$Builder builder headers]
   (doseq [[k v] headers]
     (.header builder ^String k ^String v))
@@ -212,7 +229,7 @@
     {:success? (.isSuccessful response)
      :status (.code response)
      :headers (response-headers->map (.headers response))
-     :body (some-> (.body response) (.string))}))
+     :body (read-capped-body response)}))
 
 (defn safe-get
   "SSRF-safe HTTP GET using the guarded client (SSRF-defending DNS resolver plus

--- a/server/src/instant/webhook_sender.clj
+++ b/server/src/instant/webhook_sender.clj
@@ -17,7 +17,7 @@
    (java.util.concurrent Callable ExecutorService TimeUnit)
    (java.util.function Predicate)
    (javax.net.ssl SSLException)
-   (okhttp3 ConnectionPool Dispatcher Dns HttpUrl MediaType OkHttpClient OkHttpClient$Builder Request$Builder RequestBody)
+   (okhttp3 ConnectionPool Dispatcher Dns FormBody$Builder Headers HttpUrl MediaType OkHttpClient OkHttpClient$Builder Request$Builder RequestBody)
    (okhttp3.dnsoverhttps DnsOverHttps DnsOverHttps$Builder)))
 
 (def ^{:tag 'bytes} period-bytes (.getBytes "." StandardCharsets/UTF_8))
@@ -190,22 +190,47 @@
       (catch Exception _
         (ex/throw-validation-err! :webhook {:url input-url} [{:message "Could not resolve URL."}])))))
 
+(defn assert-safe-url!
+  "Parses url and rejects it if unparseable or if its host is an unsafe (SSRF)
+   literal IP. Does not make a request. Returns the parsed HttpUrl."
+  ^HttpUrl [^String url]
+  (let [parsed-url (HttpUrl/parse url)]
+    (when (nil? parsed-url)
+      (ex/throw-validation-err! :url {:url url} [{:message "Invalid URL."}]))
+    (ensure-safe-host! parsed-url)
+    parsed-url))
+
+(defn- response-headers->map [^Headers hs]
+  (into {} (map (fn [^String n] [(.toLowerCase n) (.get hs n)])) (.names hs)))
+
+(defn- execute-response [^Request$Builder builder headers]
+  (doseq [[k v] headers]
+    (.header builder ^String k ^String v))
+  (with-open [response (.. client
+                           (newCall (.build builder))
+                           (execute))]
+    {:success? (.isSuccessful response)
+     :status (.code response)
+     :headers (response-headers->map (.headers response))
+     :body (some-> (.body response) (.string))}))
+
 (defn safe-get
   "SSRF-safe HTTP GET using the guarded client (SSRF-defending DNS resolver plus
    literal-IP check, no redirects). Returns {:success? bool :status int :body
    string}. Throws for an unparseable URL, an unsafe host, or a network error."
   [^String url & {:keys [headers]}]
-  (let [parsed-url (HttpUrl/parse url)]
-    (when (nil? parsed-url)
-      (ex/throw-validation-err! :url {:url url} [{:message "Invalid URL."}]))
-    (ensure-safe-host! parsed-url)
-    (let [builder (doto (Request$Builder.)
-                    (.url parsed-url))]
-      (doseq [[k v] headers]
-        (.header builder ^String k ^String v))
-      (with-open [response (.. client
-                               (newCall (.build builder))
-                               (execute))]
-        {:success? (.isSuccessful response)
-         :status (.code response)
-         :body (some-> (.body response) (.string))}))))
+  (let [parsed-url (assert-safe-url! url)]
+    (execute-response (doto (Request$Builder.) (.url parsed-url)) headers)))
+
+(defn safe-post-form
+  "SSRF-safe form-encoded HTTP POST using the guarded client. form-params is a
+   map of name -> value. Same return/throw contract as safe-get."
+  [^String url form-params & {:keys [headers]}]
+  (let [parsed-url (assert-safe-url! url)
+        form (FormBody$Builder.)]
+    (doseq [[k v] form-params]
+      (.add form (name k) (str v)))
+    (execute-response (doto (Request$Builder.)
+                        (.url parsed-url)
+                        (.post (.build form)))
+                      headers)))

--- a/server/test/instant/auth/oauth_test.clj
+++ b/server/test/instant/auth/oauth_test.clj
@@ -15,3 +15,25 @@
     (is (thrown? Exception
                  (oauth/fetch-discovery
                   "http://127.0.0.1/.well-known/openid-configuration")))))
+
+(deftest rejects-discovery-doc-with-unsafe-token-endpoint
+  (testing "a safe discovery endpoint but unsafe token_endpoint is rejected"
+    (is (thrown? Exception
+                 (oauth/assert-safe-discovery-endpoints!
+                  {:token_endpoint "http://169.254.169.254/token"
+                   :userinfo_endpoint "https://safe.example.com/userinfo"}))))
+  (testing "an unsafe userinfo_endpoint is rejected"
+    (is (thrown? Exception
+                 (oauth/assert-safe-discovery-endpoints!
+                  {:token_endpoint "https://safe.example.com/token"
+                   :userinfo_endpoint "http://127.0.0.1/userinfo"}))))
+  (testing "an unsafe jwks_uri is rejected"
+    (is (thrown? Exception
+                 (oauth/assert-safe-discovery-endpoints!
+                  {:token_endpoint "https://safe.example.com/token"
+                   :jwks_uri "http://169.254.169.254/jwks"}))))
+  (testing "a fully safe discovery document is accepted"
+    (is (oauth/assert-safe-discovery-endpoints!
+         {:token_endpoint "https://safe.example.com/token"
+          :userinfo_endpoint "https://safe.example.com/userinfo"
+          :jwks_uri "https://safe.example.com/jwks"}))))

--- a/server/test/instant/auth/oauth_test.clj
+++ b/server/test/instant/auth/oauth_test.clj
@@ -1,0 +1,17 @@
+(ns instant.auth.oauth-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [instant.auth.oauth :as oauth]))
+
+(deftest fetch-discovery-throws-on-invalid-urls
+  (testing "unparseable / non-http(s) urls are rejected before any request"
+    (is (thrown? Exception (oauth/fetch-discovery "not-a-url")))
+    (is (thrown? Exception (oauth/fetch-discovery "ftp://example.com/x")))
+    (is (thrown? Exception (oauth/fetch-discovery "file:///etc/passwd"))))
+  (testing "urls whose host is an unsafe (SSRF) literal ip are rejected"
+    (is (thrown? Exception
+                 (oauth/fetch-discovery
+                  "http://169.254.169.254/latest/meta-data/")))
+    (is (thrown? Exception
+                 (oauth/fetch-discovery
+                  "http://127.0.0.1/.well-known/openid-configuration")))))

--- a/server/test/instant/webhook_sender_test.clj
+++ b/server/test/instant/webhook_sender_test.clj
@@ -212,3 +212,29 @@
                               (crypt-util/random-hex 16) "."
                               (crypt-util/random-hex 16))))
       "non-resolvable host is rejected"))
+
+(deftest safe-get-caps-response-body
+  ;; Bypass smokescreen so we can route to a local MockWebServer via nip.io, and
+  ;; shrink the cap so we don't have to allocate a multi-MB body.
+  (with-redefs [smokescreen/bad-ip? (constantly false)
+                webhook-sender/max-response-bytes 16]
+    (let [server (doto (MockWebServer.) (.start))]
+      (try
+        (.enqueue server (.. (MockResponse$Builder.) (body "small body") (build)))
+        (let [url (str "http://127.0.0.1.nip.io:" (.getPort server) "/ok")
+              resp (webhook-sender/safe-get url)]
+          (is (= {:success? true :status 200 :body "small body"}
+                 (select-keys resp [:success? :status :body]))
+              "a body within the cap is returned intact"))
+
+        ;; chunked transfer encoding => no Content-Length header
+        (.enqueue server (.. (MockResponse$Builder.)
+                             (chunkedBody ^String (apply str (repeat 100 \a)) 8)
+                             (build)))
+        (let [url (str "http://127.0.0.1.nip.io:" (.getPort server) "/big")]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"exceeds size limit"
+                                (webhook-sender/safe-get url))
+              "a body over the cap is rejected even without Content-Length"))
+        (finally
+          (.close server))))))


### PR DESCRIPTION
We had the ability to edit the google oauth client, now you can edit credentials for the rest of the clients.

