### PR TITLE
Lightweight check for aggregator slot

### DIFF
--- a/server/src/instant/custodian.clj
+++ b/server/src/instant/custodian.clj
@@ -39,7 +39,9 @@
 ;; Config
 
 (defn- batch-size [] (flags/flag :custodian-batch-size 1000))
-(defn- idle-sleep-ms [] (flags/flag :custodian-idle-sleep-ms 5000))
+(defn- idle-sleep-ms [] (flags/flag :custodian-idle-sleep-ms (if (config/dev?)
+                                                               (* 1000 60 10)
+                                                               5000)))
 
 ;; Attrs are deleted one at a time: each attr delete cascades to that attr's
 ;; triples, and right after the triple sweep those are dead-but-not-yet-vacuumed

--- a/server/src/instant/reactive/aggregator.clj
+++ b/server/src/instant/reactive/aggregator.clj
@@ -7,6 +7,7 @@
    [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.copy :as copy]
+   [instant.jdbc.sql :as sql]
    [instant.jdbc.wal :as wal]
    [instant.util.async :as ua]
    [instant.util.cache :as cache]
@@ -458,6 +459,18 @@
 
 (def slot-type :aggregator)
 
+(defn fast-active-slot-check
+  "Just checks the db to see if the slot is active. It only works when we're not
+   in the middle of switching db instances, but we check for that."
+  [{:keys [get-conn-config
+           slot-type
+           slot-suffix]}]
+  (when (:same-as-read-conn (meta get-conn-config))
+    (let [slot-name (wal/full-slot-name slot-type slot-suffix)]
+      (:active (sql/select-one ::fast-active-slot-check
+                               (aurora/conn-pool :read)
+                               ["select active from pg_replication_slots where slot_name = ?" slot-name])))))
+
 (defn start-slot-listener
   "Starts process that will try to acquire the aggregation wal slot every
   `acquire-slot-interval-ms`.
@@ -485,8 +498,12 @@
         (a/go
           (loop [timeout-ch (a/timeout 0)]
             (when (= timeout-ch (second (a/alts! [shutdown-chan timeout-ch])))
-              (if (check-disabled)
+              (if (or (check-disabled)
+                      (fast-active-slot-check {:get-conn-config get-conn-config
+                                               :slot-type slot-type
+                                               :slot-suffix slot-suffix}))
                 (recur (a/timeout acquire-slot-interval-ms))
+
                 (if-let [lsn (cms/get-start-lsn (aurora/conn-pool :read)
                                                 {:slot-name slot-name})]
                   (let [{:keys [wal-chan worker-chan flush-lsn-chan close-signal-chan]}
@@ -605,8 +622,13 @@
                          :skip-empty-updates skip-empty-updates
                          :check-disabled (fn []
                                            (flags/toggled? :disable-aggregator))
-                         :get-conn-config (fn []
-                                            (config/get-aurora-config))
+                         :get-conn-config (with-meta
+                                            (fn []
+                                              (config/get-aurora-config))
+                                            ;; When we're not transitioning to a new cluster,
+                                            ;; this lets us check if the slot is active without
+                                            ;; creating a new connection.
+                                            {:same-as-read-conn true})
                          :slot-num global-slot-num})))
 
 (defn start-global []

--- a/server/test/instant/reactive/aggregator_test.clj
+++ b/server/test/instant/reactive/aggregator_test.clj
@@ -20,6 +20,33 @@
 
 (def ^:dynamic *in-test* false)
 
+(deftest fast-active-slot-check-test
+  (testing "checks the read connection when it matches the WAL connection"
+    (let [query (atom nil)
+          get-conn-config (with-meta (constantly {:host "primary"})
+                            {:same-as-read-conn true})]
+      (with-redefs [aurora/conn-pool (fn [pool]
+                                      (is (= :read pool))
+                                      :read-pool)
+                    sql/select-one (fn [_query-name conn sql-params]
+                                     (reset! query [conn sql-params])
+                                     {:active true})]
+        (is (true? (agg/fast-active-slot-check
+                    {:get-conn-config get-conn-config
+                     :slot-type agg/slot-type
+                     :slot-suffix "test"})))
+        (is (= [:read-pool
+                ["select active from pg_replication_slots where slot_name = ?"
+                 "aggregator_test"]]
+               @query)))))
+
+  (testing "does not query while the WAL connection may differ from the read connection"
+    (with-redefs [sql/select-one (fn [& _]
+                                  (throw (ex-info "unexpected query" {})))]
+      (is (nil? (agg/fast-active-slot-check
+                 {:get-conn-config (constantly {:host "transitioning"})
+                  :slot-type agg/slot-type}))))))
+
 (defn copy-sql-for-app-ids
   "copy command that only copies the app we are interested in"
   [app-ids]


### PR DESCRIPTION
When we built the singleton invalidator, we introduced a lighter-weight check to see if the slot was active. This PR applies that same strategy to the aggregator slot.

Each machine will periodically try to take the aggregator slot, unless it's the machine currently holding the slot.

Before this PR, the machine would try to create replication stream. That requires creating a new postgres connection issuing a `START REPLICATION` command. When it fails (which it will do most of the time), it logs a noisy error into the postgres log. 

After the PR, we'll just issue a query with the existing connection pool to check if the slot is active. If it's not, then we'll go to the trouble of creating the postgres connection and starting replication.