### PR TITLE
Enable size sweeper by default, prevent deadlocks

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -626,4 +626,4 @@
 (defn disable-triples-size-collection? []
   ;; Defaults to disabled so that we can bootstrap before
   ;; we start the process.
-  (flag :disable-triples-size-collection true))
+  (flag :disable-triples-size-collection false))

--- a/server/src/instant/model/triples_size_updates.clj
+++ b/server/src/instant/model/triples_size_updates.clj
@@ -30,7 +30,9 @@
                    ;; Join filters out (app_id, attr_id) whose parent was deleted mid-batch.
                    :join [:apps [:= :apps.id  :deletes.app-id]
                           :attrs [:= :attrs.id :deletes.attr-id]]
-                   :group-by [:deletes.app-id :deletes.attr-id]}]
+                   :group-by [:deletes.app-id :deletes.attr-id]
+                   ;; sort to avoid deadlock
+                   :order-by [:deletes.app-id :deletes.attr-id]}]
     :on-conflict {:on-constraint :triples_size_aggregate_pkey}
     :do-update-set {:pg-size [:+
                               :triples_size_aggregate.pg_size


### PR DESCRIPTION
Enables the triples_size_updates sweeper by default (we use it to show storage and db usage).

Also sorts the updates to the aggregate table to prevent deadlocks.