### PR TITLE
Triples size sweep improvements

### DIFF
--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -623,6 +623,9 @@
 (defn triples-size-collection-max-loops []
   (flag :triples-size-collection-max-loops 1000))
 
+(defn triples-size-collection-loop-limit-alert-threshold []
+  (flag :triples-size-collection-loop-limit-alert-threshold 10))
+
 (defn disable-triples-size-collection? []
   ;; Defaults to disabled so that we can bootstrap before
   ;; we start the process.

--- a/server/src/instant/model/triples_size_updates.clj
+++ b/server/src/instant/model/triples_size_updates.clj
@@ -82,14 +82,13 @@
              (discord/send-error-async! (str (:instateam discord/mention-constants)
                                              " collect triples size is backed up after " loops " iterations"
                                              " (" hits " runs in a row)."))))
-         (let [{:keys [deleted_count aggregated_count]} (collect-batch!)]
-           ;; Drain on queue rows removed, not aggregate rows written: an
-           ;; orphan-only batch deletes rows but writes 0 aggregates.
-           (if (zero? (long deleted_count))
+         (let [batch-size (flags/triples-size-collection-batch-size)
+               {:keys [deleted_count aggregated_count]} (collect-batch! (aurora/conn-pool :write) batch-size)]
+           (if (< (long deleted_count) batch-size)
              (do
                (reset! consecutive-limit-hits 0)
-               (tracer/add-data! {:attributes {:total-collected total-collected
-                                               :total-aggregated total-aggregated
+               (tracer/add-data! {:attributes {:total-collected (+ total-collected (long deleted_count))
+                                               :total-aggregated (+ total-aggregated (long aggregated_count))
                                                :loops loops}}))
              (recur (inc loops)
                     (+ total-collected (long deleted_count))

--- a/server/src/instant/model/triples_size_updates.clj
+++ b/server/src/instant/model/triples_size_updates.clj
@@ -18,6 +18,7 @@
    {:with [[:ids {:select :id
                   :from :triples-size-updates
                   :for [:update :skip-locked]
+                  :order-by :id
                   :limit '?batch-size}]
            [:deletes {:delete-from :triples-size-updates
                       :using :ids

--- a/server/src/instant/model/triples_size_updates.clj
+++ b/server/src/instant/model/triples_size_updates.clj
@@ -23,34 +23,39 @@
            [:deletes {:delete-from :triples-size-updates
                       :using :ids
                       :where [:= :triples-size-updates.id :ids.id]
-                      :returning [:app-id :attr-id :pg-size :files-size]}]]
+                      :returning [:app-id :attr-id :pg-size :files-size]}]
+           [:aggregate {:insert-into [[:triples_size_aggregate [:app-id :attr-id :pg-size :files-size]]
+                                      {:select [:deletes.app-id :deletes.attr-id [[:sum :deletes.pg_size] :pg-size] [[:sum :deletes.files-size] :files-size]]
+                                       :from :deletes
+                                       ;; Join filters out (app_id, attr_id) whose parent was deleted mid-batch.
+                                       :join [:apps [:= :apps.id  :deletes.app-id]
+                                              :attrs [:= :attrs.id :deletes.attr-id]]
+                                       :group-by [:deletes.app-id :deletes.attr-id]
+                                       ;; sort to avoid deadlock
+                                       :order-by [:deletes.app-id :deletes.attr-id]}]
+                        :on-conflict {:on-constraint :triples_size_aggregate_pkey}
+                        :do-update-set {:pg-size [:+
+                                                  :triples_size_aggregate.pg_size
+                                                  :excluded.pg_size]
+                                        ;; Update files-size only if one of the arguments is non-null
+                                        :files-size [:coalesce
+                                                     [:+
+                                                      :triples_size_aggregate.files_size
+                                                      :excluded.files_size]
+                                                     :triples_size_aggregate.files_size
+                                                     :excluded.files_size]}
+                        ;; RETURNING makes this CTE referenceable below, which
+                        ;; forces Postgres to execute it.
+                        :returning [:1]}]]
+    :select [[{:select [[[:count :*]]] :from :deletes} :deleted-count]
+             [{:select [[[:count :*]]] :from :aggregate} :aggregated-count]]}))
 
-    :insert-into [[:triples_size_aggregate [:app-id :attr-id :pg-size :files-size]]
-                  {:select [:deletes.app-id :deletes.attr-id [[:sum :deletes.pg_size] :pg-size] [[:sum :deletes.files-size] :files-size]]
-                   :from :deletes
-                   ;; Join filters out (app_id, attr_id) whose parent was deleted mid-batch.
-                   :join [:apps [:= :apps.id  :deletes.app-id]
-                          :attrs [:= :attrs.id :deletes.attr-id]]
-                   :group-by [:deletes.app-id :deletes.attr-id]
-                   ;; sort to avoid deadlock
-                   :order-by [:deletes.app-id :deletes.attr-id]}]
-    :on-conflict {:on-constraint :triples_size_aggregate_pkey}
-    :do-update-set {:pg-size [:+
-                              :triples_size_aggregate.pg_size
-                              :excluded.pg_size]
-                    ;; Update files-size only if one of the arguments is non-null
-                    :files-size [:coalesce
-                                 [:+
-                                  :triples_size_aggregate.files_size
-                                  :excluded.files_size]
-                                 :triples_size_aggregate.files_size
-                                 :excluded.files_size]}}))
 (defn collect-batch!
   ([] (collect-batch! (aurora/conn-pool :write) (flags/triples-size-collection-batch-size)))
   ([conn batch-size]
-   (sql/do-execute! ::collect-batch!
-                    conn
-                    (uhsql/formatp collect-batch-q {:batch-size batch-size}))))
+   (sql/execute-one! ::collect-batch!
+                     conn
+                     (uhsql/formatp collect-batch-q {:batch-size batch-size}))))
 
 (defn collect-batches!
   "Adds triples_size_updates to the triples_size_aggregates table and deletes them.
@@ -64,10 +69,12 @@
    (tracer/with-span! {:name ::collect-batches
                        :attributes {:max-loops max-loops}}
      (loop [loops 0
-            total-collected 0]
+            total-collected 0
+            total-aggregated 0]
        (if (= loops max-loops)
          (let [hits (swap! consecutive-limit-hits inc)]
            (tracer/add-data! {:attributes {:total-collected total-collected
+                                           :total-aggregated total-aggregated
                                            :loops loops
                                            :consecutive-limit-hits hits}})
            (when (and (config/prod?)
@@ -75,14 +82,18 @@
              (discord/send-error-async! (str (:instateam discord/mention-constants)
                                              " collect triples size is backed up after " loops " iterations"
                                              " (" hits " runs in a row)."))))
-         (let [update-count (:next.jdbc/update-count (first (collect-batch!)))]
-           (if (zero? update-count)
+         (let [{:keys [deleted_count aggregated_count]} (collect-batch!)]
+           ;; Drain on queue rows removed, not aggregate rows written: an
+           ;; orphan-only batch deletes rows but writes 0 aggregates.
+           (if (zero? (long deleted_count))
              (do
                (reset! consecutive-limit-hits 0)
                (tracer/add-data! {:attributes {:total-collected total-collected
+                                               :total-aggregated total-aggregated
                                                :loops loops}}))
              (recur (inc loops)
-                    (+ total-collected (long update-count))))))))))
+                    (+ total-collected (long deleted_count))
+                    (+ total-aggregated (long aggregated_count))))))))))
 
 (defn start []
   (let [consecutive-limit-hits (atom 0)

--- a/server/src/instant/model/triples_size_updates.clj
+++ b/server/src/instant/model/triples_size_updates.clj
@@ -54,35 +54,47 @@
 
 (defn collect-batches!
   "Adds triples_size_updates to the triples_size_aggregates table and deletes them.
-   Turn it off with the `disable-triples-size-collection` feature flag."
-  [max-loops]
-  (tracer/with-span! {:name ::collect-batches
-                      :attributes {:max-loops max-loops}}
-    (loop [loops 0
-           total-collected 0]
-      (if (= loops max-loops)
-        (do
-          (tracer/add-data! {:attributes {:total-collected total-collected
-                                          :loops loops}})
-          (when (config/prod?)
-            (discord/send-error-async! (str (:instateam discord/mention-constants)
-                                            " collect triples size is backed up after " loops " iterations."))))
-        (let [update-count (:next.jdbc/update-count (first (collect-batch!)))]
-          (if (zero? update-count)
-            (tracer/add-data! {:attributes {:total-collected total-collected
-                                            :loops loops}})
-            (recur (inc loops)
-                   (+ total-collected (long update-count)))))))))
+   Turn it off with the `disable-triples-size-collection` feature flag.
+
+   `consecutive-limit-hits` is an atom tracking how many runs in a row have hit
+   `max-loops`; we only alert once it exceeds the alert threshold so a transient
+   backup doesn't page. It's reset whenever a run drains cleanly."
+  ([max-loops] (collect-batches! max-loops (atom 0)))
+  ([max-loops consecutive-limit-hits]
+   (tracer/with-span! {:name ::collect-batches
+                       :attributes {:max-loops max-loops}}
+     (loop [loops 0
+            total-collected 0]
+       (if (= loops max-loops)
+         (let [hits (swap! consecutive-limit-hits inc)]
+           (tracer/add-data! {:attributes {:total-collected total-collected
+                                           :loops loops
+                                           :consecutive-limit-hits hits}})
+           (when (and (config/prod?)
+                      (> hits (flags/triples-size-collection-loop-limit-alert-threshold)))
+             (discord/send-error-async! (str (:instateam discord/mention-constants)
+                                             " collect triples size is backed up after " loops " iterations"
+                                             " (" hits " runs in a row)."))))
+         (let [update-count (:next.jdbc/update-count (first (collect-batch!)))]
+           (if (zero? update-count)
+             (do
+               (reset! consecutive-limit-hits 0)
+               (tracer/add-data! {:attributes {:total-collected total-collected
+                                               :loops loops}}))
+             (recur (inc loops)
+                    (+ total-collected (long update-count))))))))))
 
 (defn start []
-  (let [chime (chime.core/chime-at (chime.core/periodic-seq (Instant/now)
+  (let [consecutive-limit-hits (atom 0)
+        chime (chime.core/chime-at (chime.core/periodic-seq (Instant/now)
                                                             (Duration/ofMinutes (if (config/dev?)
                                                                                   60
                                                                                   5)))
                                    (fn [_]
                                      (when-not (or (flags/failing-over?)
                                                    (flags/disable-triples-size-collection?))
-                                       (collect-batches! (flags/triples-size-collection-max-loops)))))]
+                                       (collect-batches! (flags/triples-size-collection-max-loops)
+                                                         consecutive-limit-hits))))]
     {:shutdown (fn []
                  (.close chime))}))
 

--- a/server/test/instant/model/triples_size_updates_test.clj
+++ b/server/test/instant/model/triples_size_updates_test.clj
@@ -4,6 +4,7 @@
    [instant.db.model.attr :as attr-model]
    [instant.db.transaction :as tx]
    [instant.fixtures :refer [with-empty-app]]
+   [instant.flags :as flags]
    [instant.jdbc.aurora :as aurora]
    [instant.jdbc.sql :as sql]
    [instant.model.triples-size-updates :as tsu]
@@ -249,6 +250,47 @@
         (testing "after collect, aggregate files_size is 0"
           (assert-files-size-aggregate-matches-actual! (:id app))
           (is (zero? (files-size-aggregate (:id app)))))))))
+
+(defn insert-orphan-rows!
+  "Inserts queue rows whose (app_id, attr_id) don't exist in apps/attrs, to
+   simulate rows left behind when a parent app/attr is deleted mid-batch.
+   These get filtered out by the aggregate INSERT's join."
+  [n]
+  (let [orphan-app (random-uuid)
+        orphan-attr (random-uuid)]
+    (dotimes [_ n]
+      (sql/do-execute!
+       (aurora/conn-pool :write)
+       ["insert into triples_size_updates (app_id, attr_id, pg_size, files_size)
+         values (?::uuid, ?::uuid, 123, 0)"
+        orphan-app orphan-attr]))))
+
+(deftest orphan-only-batch-does-not-halt-collection
+  ;; An orphan-only batch deletes queue rows but writes 0 aggregate rows. The
+  ;; loop must drain on queue rows removed (not aggregate rows written), or it
+  ;; stops early and leaves valid rows behind.
+  (with-empty-app
+    (fn [app]
+      (let [name-attr (make-blob-attr "users" "name")
+            eid       (random-uuid)]
+        (add-attrs! app [name-attr])
+        (drain!) ;; empty the queue so we control what's in it
+
+        ;; Lowest ids: an orphan-only first batch.
+        (insert-orphan-rows! 2)
+        ;; Higher ids: a valid update that must still be processed afterward.
+        (transact! app [[:add-triple eid (:id name-attr) "Alice"]])
+        (is (seq (queue-rows (:id app))))
+
+        ;; batch-size 2 => batch 1 is the two orphans (0 aggregates), batch 2 is
+        ;; the valid row.
+        (with-redefs [flags/triples-size-collection-batch-size (constantly 2)]
+          (tsu/collect-batches! 1000))
+
+        (testing "valid update is processed after the orphan-only batch"
+          (is (empty? (queue-rows (:id app))))
+          (assert-aggregate-matches-actual! (:id app))
+          (is (pos? (get (aggregate-by-attr (:id app)) (:id name-attr) 0))))))))
 
 (deftest collect-is-noop-on-empty-queue
   (with-empty-app

--- a/server/test/instant/model/triples_size_updates_test.clj
+++ b/server/test/instant/model/triples_size_updates_test.clj
@@ -300,3 +300,13 @@
       ;; calling again on an empty queue should be a no-op, not error
       (drain!)
       (is (empty? (queue-rows (:id app)))))))
+
+(deftest final-batch-drain-does-not-count-as-limit-hit
+  (with-empty-app
+    (fn [_app]
+      (drain!) ;; start from an empty queue
+      (insert-orphan-rows! 1)
+      (let [hits (atom 5)]
+        (with-redefs [flags/triples-size-collection-batch-size (constantly 100)]
+          (tsu/collect-batches! 1 hits))
+        (is (zero? @hits))))))


### PR DESCRIPTION
Orders the `triples_size_updates` table by id when we claim the updates to delete. Right now it's doing a seq scan and it spends a lot of time going over dead tuples.

Also fixes a bug where we were looking at the number of aggregates we updated instead of the number of `triples_size_updates` rows we deleted when we determined if we had done any work. If we were processing a ton of rows for a deleted app, we would have stopped early.

Only alerts us if we exceed the loop limit 10 times in a row.