### PR TITLE
Fix error messages in self-hosted

### DIFF
--- a/client/www/app/docs/auth/platform-oauth/page.md
+++ b/client/www/app/docs/auth/platform-oauth/page.md
@@ -28,7 +28,13 @@ You will need the Client ID and Client Secret for subsequent steps.
 
 {% callout type="note" %}
 
-Your OAuth app will start in test mode. Only members of your Instant app will be able to authorize with the app. Once you have your OAuth flow working, [ping us in Discord](https://discord.gg/2rnGtfFQup) to go live.
+Your OAuth app will start in test mode. Only members of your Instant app will be able to authorize with the app.
+
+{% hosted-only %}
+
+Once you have your OAuth flow working, [ping us in Discord](https://discord.gg/2rnGtfFQup) to go live.
+
+{% /hosted-only %}
 
 {% /callout %}
 

--- a/client/www/app/docs/devtool/page.md
+++ b/client/www/app/docs/devtool/page.md
@@ -77,9 +77,9 @@ const db = init({
 
 To quickly toggle the window, you can use the shortcut `ctrl` + `shift` + `0` (zero).
 
-## Feedback?
-
 {% hosted-only %}
+
+## Feedback?
 
 If you have any feedback, let us know on [Discord](https://discord.com/invite/VU53p7uQcE).
 

--- a/client/www/app/docs/devtool/page.md
+++ b/client/www/app/docs/devtool/page.md
@@ -79,4 +79,8 @@ To quickly toggle the window, you can use the shortcut `ctrl` + `shift` + `0` (z
 
 ## Feedback?
 
+{% hosted-only %}
+
 If you have any feedback, let us know on [Discord](https://discord.com/invite/VU53p7uQcE).
+
+{% /hosted-only %}

--- a/client/www/app/docs/next-ssr/page.md
+++ b/client/www/app/docs/next-ssr/page.md
@@ -198,4 +198,8 @@ If your code uses `useUser`, `useAuth`, or `db.SignedIn`/`db.SignedOut`, it will
 
 ## Questions
 
+{% hosted-only %}
+
 This is still a beta. We'd love to hear your feedback on [Discord](https://discord.com/invite/VU53p7uQcE)!
+
+{% /hosted-only %}

--- a/client/www/app/docs/platform-api/page.md
+++ b/client/www/app/docs/platform-api/page.md
@@ -248,4 +248,8 @@ npx instant-cli push schema --token YOUR_ADMIN_TOKEN
 
 ### Questions?
 
+{% hosted-only %}
+
 This is a living document. If you have any questions, reach out to us on [Discord](https://discord.com/invite/VU53p7uQcE)!
+
+{% /hosted-only %}

--- a/client/www/app/docs/workflow/page.md
+++ b/client/www/app/docs/workflow/page.md
@@ -14,7 +14,13 @@ At a high level, here is the recommended workflow for developing with Instant:
    transactions, and permissions.
 1. When you're ready for production, [restrict creating](/docs/patterns#restrict-creating-new-attributes) new attributes.
 1. If you need more help, check out our [patterns page](/docs/patterns) for common
-   recipes or drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).
+   recipes.
+
+{% hosted-only %}
+
+You can also drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).
+
+{% /hosted-only %}
 
 ## Authenticating with Instant in your terminal
 
@@ -125,5 +131,11 @@ We highly recommend going through our docs to understand how Instant works. We
 tried our best to keep them delightful and example-driven!
 
 We've also made a [patterns page](/docs/patterns) with common recipes for using
-InstantDB. If you still have questions, feel free to drop us a line on our
+InstantDB.
+
+{% hosted-only %}
+
+If you still have questions, feel free to drop us a line on our
 [Discord](https://discord.com/invite/VU53p7uQcE).
+
+{% /hosted-only %}

--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -281,8 +281,8 @@ function errorFromVerifyMagicCode(res: InstantIssue): string {
 
 function magicCodeDefaultError() {
   return isSelfHosted
-    ? 'Uh oh, something went wrong sending you a magic code. Contact your deployment administrator.'
-    : 'Uh oh, something went wrong sending you a magic code, please ping us!';
+    ? 'Uh oh, something went wrong. Contact your deployment administrator.'
+    : 'Uh oh, something went wrong, please ping us!';
 }
 
 function errorFromSendMagicCode(res: InstantIssue): string {

--- a/client/www/components/dash/Auth.tsx
+++ b/client/www/components/dash/Auth.tsx
@@ -8,7 +8,7 @@ import {
   ScreenHeading,
   TextInput,
 } from '../ui';
-import config, { isDev } from '@/lib/config';
+import config, { isDev, isSelfHosted } from '@/lib/config';
 import googleIconSvg from '../../public/img/google_g.svg';
 import Image from 'next/image';
 import { InstantIssue } from '@/lib/types';
@@ -275,14 +275,19 @@ function errorFromVerifyMagicCode(res: InstantIssue): string {
     case 'record-expired':
       return 'This code has expired. Please request a new code.';
     default:
-      return 'Uh oh, something went wrong sending you a magic code, please ping us!';
+      return magicCodeDefaultError();
   }
+}
+
+function magicCodeDefaultError() {
+  return isSelfHosted
+    ? 'Uh oh, something went wrong sending you a magic code. Contact your deployment administrator.'
+    : 'Uh oh, something went wrong sending you a magic code, please ping us!';
 }
 
 function errorFromSendMagicCode(res: InstantIssue): string {
   const errorType = res.body?.type;
-  const defaultMsg =
-    'Uh oh, something went wrong sending you a magic code, please ping us!';
+  const defaultMsg = magicCodeDefaultError();
   switch (errorType) {
     case 'param-missing':
       return 'Please enter your email address.';

--- a/client/www/components/dash/Billing.tsx
+++ b/client/www/components/dash/Billing.tsx
@@ -1,7 +1,7 @@
 import { SectionHeading, Button, Content } from '@/components/ui';
 import { friendlyErrorMessage, useAuthedFetch } from '@/lib/auth';
 import { messageFromInstantError } from '@/lib/errors';
-import config, { stripeKey } from '@/lib/config';
+import config, { isSelfHosted, stripeKey } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
 import { AppsSubscriptionResponse, InstantIssue } from '@/lib/types';
@@ -17,6 +17,12 @@ import { useFetchedDash } from './MainDashLayout';
 export const GB_1 = 1024 * 1024 * 1024;
 export const GB_10 = 10 * GB_1;
 export const GB_250 = 250 * GB_1;
+
+function stripeErrorMessage() {
+  return isSelfHosted
+    ? 'Failed to connect w/ Stripe! Try again or contact your deployment administrator if this persists.'
+    : 'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+}
 
 export function roundToDecimal(num: number, decimalPlaces: number) {
   const factor = Math.pow(10, decimalPlaces);
@@ -57,8 +63,7 @@ async function createCheckoutSession(appId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantIssue) ||
-        'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+        messageFromInstantError(err as InstantIssue) || stripeErrorMessage();
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
       console.error(err);
@@ -85,8 +90,7 @@ async function createPortalSession(appId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantIssue) ||
-        'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+        messageFromInstantError(err as InstantIssue) || stripeErrorMessage();
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
       console.error(err);

--- a/client/www/components/dash/OAuthApps.tsx
+++ b/client/www/components/dash/OAuthApps.tsx
@@ -12,7 +12,10 @@ import {
 } from '@/components/ui';
 import { useAuthedFetch, useAuthToken } from '@/lib/auth';
 import { messageFromInstantError } from '@/lib/errors';
-import config, { discordOAuthAppsFeedbackInviteUrl } from '@/lib/config';
+import config, {
+  discordOAuthAppsFeedbackInviteUrl,
+  isSelfHosted,
+} from '@/lib/config';
 import { jsonFetch } from '@/lib/fetch';
 import {
   InstantIssue,
@@ -1014,17 +1017,28 @@ function App({ app }: { app: OAuthApp }) {
       {app.isPublic ? null : (
         <div className="flex max-w-md bg-sky-50 dark:bg-slate-800/60 dark:ring-1 dark:ring-slate-300/10">
           <Content className="prose-a:text-sky-900 prose-code:text-sky-900 dark:prose-code:text-slate-300 m-4 text-sm text-sky-800 [--tw-prose-background:var(--color-sky-50)] dark:text-slate-300">
-            This app is in test mode. Only members of this Instant app will be
-            allowed to auth with it. Once you've built your integration, ping us
-            in{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={discordOAuthAppsFeedbackInviteUrl}
-            >
-              #oauth-apps-feedback on Discord
-            </a>{' '}
-            to release your app to the public.
+            {isSelfHosted ? (
+              <>
+                This app is in test mode. Only members of this Instant app will
+                be allowed to auth with it. Once you've built your integration,
+                contact your deployment administrator to release your app to the
+                public.
+              </>
+            ) : (
+              <>
+                This app is in test mode. Only members of this Instant app will
+                be allowed to auth with it. Once you've built your integration,
+                ping us in{' '}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={discordOAuthAppsFeedbackInviteUrl}
+                >
+                  #oauth-apps-feedback on Discord
+                </a>{' '}
+                to release your app to the public.
+              </>
+            )}
           </Content>
         </div>
       )}

--- a/client/www/components/dash/Onboarding.tsx
+++ b/client/www/components/dash/Onboarding.tsx
@@ -354,7 +354,11 @@ export function Onboarding() {
       (e: AppError) => {
         setProfileCreateState({
           isLoading: false,
-          error: e.body?.message || 'Uh oh, we goofed up. Please ping us',
+          error:
+            e.body?.message ||
+            (isSelfHosted
+              ? 'Uh oh, something went wrong. Contact your deployment administrator.'
+              : 'Uh oh, we goofed up. Please ping us'),
         });
         setDashState({
           ...dashState,
@@ -396,7 +400,11 @@ export function Onboarding() {
         setAppCreateState((prev) => ({
           ...prev,
           isLoading: false,
-          error: e.body?.message || 'Uh oh, we goofed up. Please ping us',
+          error:
+            e.body?.message ||
+            (isSelfHosted
+              ? 'Uh oh, something went wrong. Contact your deployment administrator.'
+              : 'Uh oh, we goofed up. Please ping us'),
         }));
         setDashState({
           ...dashState,

--- a/client/www/components/dash/Orgs.tsx
+++ b/client/www/components/dash/Orgs.tsx
@@ -1,4 +1,4 @@
-import config, { stripeKey } from '@/lib/config';
+import config, { isSelfHosted, stripeKey } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
 import { useContext, useEffect, useState } from 'react';
@@ -9,6 +9,12 @@ import { messageFromInstantError } from '@/lib/errors';
 import { InstantIssue } from '@instantdb/core';
 import { errorToast } from '@/lib/toast';
 import { useFetchedDash } from './MainDashLayout';
+
+function stripeErrorMessage() {
+  return isSelfHosted
+    ? 'Failed to connect w/ Stripe! Try again or contact your deployment administrator if this persists.'
+    : 'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+}
 
 function createOrg(token: string, params: { title: string }) {
   return jsonFetch(`${config.apiURI}/dash/orgs`, {
@@ -51,8 +57,7 @@ async function createPortalSession(orgId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantIssue) ||
-        'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+        messageFromInstantError(err as InstantIssue) || stripeErrorMessage();
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
       console.error(err);
@@ -93,8 +98,7 @@ async function createCheckoutSession(orgId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantIssue) ||
-        'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+        messageFromInstantError(err as InstantIssue) || stripeErrorMessage();
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
       console.error(err);

--- a/client/www/components/dash/Perms.tsx
+++ b/client/www/components/dash/Perms.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
   useDialog,
 } from '@/components/ui';
-import config from '@/lib/config';
+import config, { isSelfHosted } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { useTokenFetch } from '@/lib/auth';
 import { jsonFetch } from '@/lib/fetch';
@@ -494,7 +494,9 @@ async function onEditRules(
         return Promise.reject(validationErr);
       }
       errorToast(
-        "Oh no, we weren't able to save these rules. Please try again or ping us on Discord if you're stuck!",
+        isSelfHosted
+          ? "Oh no, we weren't able to save these rules. Please try again or contact your deployment administrator if you're stuck!"
+          : "Oh no, we weren't able to save these rules. Please try again or ping us on Discord if you're stuck!",
         { autoClose: 3000 },
       );
       return Promise.reject();

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -433,6 +433,7 @@ export function AddClerkClientForm({
     const domain = clerkDomainFromPublishableKey(publishableKey);
     if (!domain) {
       errorToast(clerkDomainError(), { autoClose: 5000 });
+      return;
     }
     try {
       setIsLoading(true);

--- a/client/www/components/dash/auth/Clerk.tsx
+++ b/client/www/components/dash/auth/Clerk.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui';
 import { messageFromInstantError } from '@/lib/errors';
 import { addClient, findName, updateClient, updateClientMeta } from './shared';
+import { isSelfHosted } from '@/lib/config';
 import {
   InstantApp,
   InstantIssue,
@@ -20,6 +21,12 @@ import {
   OAuthServiceProvider,
 } from '@/lib/types';
 import { useDarkMode } from '../DarkModeToggle';
+
+function clerkDomainError() {
+  return isSelfHosted
+    ? 'Could not determine Clerk domain from key. Contact your deployment administrator for help.'
+    : 'Could not determine Clerk domain from key. Ping us in Discord for help.';
+}
 
 function clerkExampleCode({
   appId,
@@ -162,10 +169,7 @@ function ClerkKeyEditor({
     }
     const newDomain = clerkDomainFromPublishableKey(publishableKey);
     if (!newDomain) {
-      errorToast(
-        'Could not determine Clerk domain from key. Ping us in Discord for help.',
-        { autoClose: 5000 },
-      );
+      errorToast(clerkDomainError(), { autoClose: 5000 });
       return;
     }
     try {
@@ -428,10 +432,7 @@ export function AddClerkClientForm({
     }
     const domain = clerkDomainFromPublishableKey(publishableKey);
     if (!domain) {
-      errorToast(
-        'Could not determine Clerk domain from key. Ping us in Discord for help.',
-        { autoClose: 5000 },
-      );
+      errorToast(clerkDomainError(), { autoClose: 5000 });
     }
     try {
       setIsLoading(true);

--- a/client/www/components/dash/org-management/OrgBilling.tsx
+++ b/client/www/components/dash/org-management/OrgBilling.tsx
@@ -1,5 +1,5 @@
 import { useAuthedFetch, friendlyErrorMessage } from '@/lib/auth';
-import config, { stripeKey } from '@/lib/config';
+import config, { isSelfHosted, stripeKey } from '@/lib/config';
 import { TokenContext } from '@/lib/contexts';
 import { jsonFetch } from '@/lib/fetch';
 import { useContext, useState } from 'react';
@@ -17,6 +17,12 @@ import {
   SubsectionHeading,
 } from '@/components/ui';
 import { OrgWorkspace } from '@/lib/hooks/useWorkspace';
+
+function stripeErrorMessage() {
+  return isSelfHosted
+    ? 'Failed to connect w/ Stripe! Try again or contact your deployment administrator if this persists.'
+    : 'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+}
 
 async function createPortalSession(orgId: string, token: string) {
   const sessionPromise = jsonFetch(
@@ -38,8 +44,7 @@ async function createPortalSession(orgId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantIssue) ||
-        'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+        messageFromInstantError(err as InstantIssue) || stripeErrorMessage();
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
       console.error(err);
@@ -66,8 +71,7 @@ async function createCheckoutSession(orgId: string, token: string) {
     })
     .catch((err) => {
       const message =
-        messageFromInstantError(err as InstantIssue) ||
-        'Failed to connect w/ Stripe! Try again or ping us on Discord if this persists.';
+        messageFromInstantError(err as InstantIssue) || stripeErrorMessage();
       const friendlyMessage = friendlyErrorMessage('dash-billing', message);
       errorToast(friendlyMessage);
       console.error(err);

--- a/client/www/markdoc/tags.js
+++ b/client/www/markdoc/tags.js
@@ -16,9 +16,14 @@ import {
   DashboardPath,
   TerminalPath,
 } from '../components/docs/SetupPaths';
+import { isSelfHosted } from '@/lib/config';
 
 function CustomDiv({ className, children }) {
   return <div className={className}>{children}</div>;
+}
+
+function HostedOnly({ children }) {
+  return isSelfHosted ? null : children;
 }
 
 const tags = {
@@ -39,6 +44,9 @@ const tags = {
       },
     },
     render: Callout,
+  },
+  'hosted-only': {
+    render: HostedOnly,
   },
   ansi: {
     attributes: {

--- a/client/www/next.config.js
+++ b/client/www/next.config.js
@@ -130,11 +130,11 @@ const nextConfig = {
     if (process.env.NEXT_PUBLIC_SELF_HOSTED === 'true') {
       return [
         ...standardRedirects,
-        // redirect any page that isn't /api, /dash, /docs, /intern, or /logout
+        // redirect any page that isn't /api, /dash, /debug-uri, /docs, /intern, or /logout
         {
           permanent: false,
           source:
-            '/((?!api(?:/.*)?$|dash(?:/.*)?$|docs(?:/.*)?$|intern(?:/.*)?$|logout(?:/.*)?$|.*\\.[^/]+$).*)',
+            '/((?!api(?:/.*)?$|dash(?:/.*)?$|debug-uri(?:/.*)?$|docs(?:/.*)?$|intern(?:/.*)?$|logout(?:/.*)?$|.*\\.[^/]+$).*)',
           destination: '/dash',
         },
       ];

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -1,7 +1,7 @@
 import { TokenContext } from '@/lib/contexts';
 import { successToast } from '@/lib/toast';
 import { InstantApp } from '@/lib/types';
-import config from '@/lib/config';
+import config, { isSelfHosted } from '@/lib/config';
 import { useSchemaQuery } from '@/lib/hooks/explorer';
 import { jsonFetch } from '@/lib/fetch';
 import { APIResponse, signOut, useAuthToken, useTokenFetch } from '@/lib/auth';
@@ -90,7 +90,10 @@ function DevtoolComp() {
             <p>
               We didn't receive an app ID. Double check that you passed an{' '}
               <Code>appId</Code> paramater in your <Code>init</Code>. If you
-              continue experiencing issues, ping us on Discord.
+              continue experiencing issues,{' '}
+              {isSelfHosted
+                ? 'contact your deployment administrator.'
+                : 'ping us on Discord.'}
             </p>
             <Button
               className="w-full"
@@ -138,17 +141,24 @@ function DevtoolComp() {
                       </div>
                     </div>
                   ) : null}
-                  <p>
-                    We had some trouble loading your app. Please ping us on{' '}
-                    <a
-                      className="font-bold text-blue-500"
-                      href="https://discord.com/invite/VU53p7uQcE"
-                      target="_blank"
-                    >
-                      discord
-                    </a>{' '}
-                    with details.
-                  </p>
+                  {isSelfHosted ? (
+                    <p>
+                      We had some trouble loading your app. Contact your
+                      deployment administrator with details.
+                    </p>
+                  ) : (
+                    <p>
+                      We had some trouble loading your app. Please ping us on{' '}
+                      <a
+                        className="font-bold text-blue-500"
+                        href="https://discord.com/invite/VU53p7uQcE"
+                        target="_blank"
+                      >
+                        discord
+                      </a>{' '}
+                      with details.
+                    </p>
+                  )}
                   <Button
                     className="w-full"
                     size="mini"

--- a/client/www/pages/_devtool/index.tsx
+++ b/client/www/pages/_devtool/index.tsx
@@ -322,18 +322,25 @@ function DevtoolWithData({
               </div>
             ) : null}
             <AppIdLabel appId={appId} />
-            <p>
-              We had some trouble connecting to Instant's backend. Please ping
-              us on{' '}
-              <a
-                className="font-bold text-blue-500"
-                href="https://discord.com/invite/VU53p7uQcE"
-                target="_blank"
-              >
-                discord
-              </a>{' '}
-              with details.
-            </p>
+            {isSelfHosted ? (
+              <p>
+                We had some trouble connecting to Instant's backend. Contact
+                your deployment administrator with details.
+              </p>
+            ) : (
+              <p>
+                We had some trouble connecting to Instant's backend. Please ping
+                us on{' '}
+                <a
+                  className="font-bold text-blue-500"
+                  href="https://discord.com/invite/VU53p7uQcE"
+                  target="_blank"
+                >
+                  discord
+                </a>{' '}
+                with details.
+              </p>
+            )}
             <Button
               className="w-full"
               size="mini"

--- a/client/www/pages/dash/index.tsx
+++ b/client/www/pages/dash/index.tsx
@@ -486,7 +486,11 @@ function Dashboard() {
 
   async function onDeleteApp(app: InstantApp) {
     successToast(
-      `${app.title} is marked for deletion. We will remove all data in 24 hours. Ping us on Discord if you did not mean to do this.`,
+      `${app.title} is marked for deletion. We will remove all data in 24 hours. ${
+        isSelfHosted
+          ? 'Contact your deployment administrator if you did not mean to do this.'
+          : 'Ping us on Discord if you did not mean to do this.'
+      }`,
     );
     const _apps = apps.filter((a) => a.id !== app.id);
     if (dashResponse.data.workspace.type === 'personal') {

--- a/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
+++ b/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
@@ -1,7 +1,7 @@
 import { asClientOnlyPage, useReadyRouter } from '@/components/clientOnlyPage';
 import { Button, Copyable } from '@/components/ui';
 import { useAuthToken } from '@/lib/auth';
-import config, { bugsAndQuestionsInviteUrl } from '@/lib/config';
+import config, { bugsAndQuestionsInviteUrl, isSelfHosted } from '@/lib/config';
 import { jsonFetch } from '@/lib/fetch';
 import { CheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import React, { useEffect, useState } from 'react';
@@ -85,10 +85,12 @@ function AdminInfo({
           {u.query ? <QueryBlock query={u.query} /> : null}
         </div>
       ))}
-      <div className="flex w-full flex-col items-center gap-2">
-        <div>Prompt for agent</div>
-        <QueryBlock query={agentPrompt} />
-      </div>
+      {!isSelfHosted ? (
+        <div className="flex w-full flex-col items-center gap-2">
+          <div>Prompt for agent</div>
+          <QueryBlock query={agentPrompt} />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -99,11 +101,13 @@ function Page() {
   const token = useAuthToken();
 
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [traceId, setTraceId] = useState<string | null>(null);
   const [adminInfo, setAdminInfo] = useState<any | null>(null);
   useEffect(() => {
     setCurrentUrl(window.location.href);
     const spanId = router.query['span-id'] as string;
     const traceId = router.query['trace-id'] as string;
+    setTraceId(traceId);
     if (token) {
       fetchDebugUriInfo({ traceId, spanId }, token).then(
         (res) => setAdminInfo(res),
@@ -126,17 +130,25 @@ function Page() {
       ) : (
         <p>We don't have any additional information about this error.</p>
       )}
-      <p>
-        Ping us with this url in{' '}
-        <a
-          className="text-blue-600 underline hover:text-blue-800"
-          rel="noopener noreferrer"
-          href={bugsAndQuestionsInviteUrl}
-        >
-          #bug-and-questions on Discord
-        </a>{' '}
-        for help.
-      </p>
+      {!isSelfHosted ? (
+        <p>
+          Ping us with this url in{' '}
+          <a
+            className="text-blue-600 underline hover:text-blue-800"
+            rel="noopener noreferrer"
+            href={bugsAndQuestionsInviteUrl}
+          >
+            #bugs-and-questions on Discord
+          </a>{' '}
+          for help.
+        </p>
+      ) : null}
+
+      {traceId ? (
+        <div className="w-96">
+          <Copyable label="TraceID" value={traceId} />
+        </div>
+      ) : null}
 
       {currentUrl ? (
         <div className="w-96">

--- a/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
+++ b/client/www/pages/debug-uri/[trace-id]/[span-id].tsx
@@ -66,6 +66,12 @@ function AdminInfo({
   return (
     <div className="flex w-full max-w-2xl flex-col items-center gap-4">
       <div>Admin URLs</div>
+      {isSelfHosted ? (
+        <div className="flex w-full flex-col items-center gap-2">
+          <div>Search the Instant server logs for this trace ID</div>
+          <QueryBlock query={`docker compose logs server | grep ${traceId}`} />
+        </div>
+      ) : null}
       {urls.map((u) => (
         <div key={u.url} className="flex w-full flex-col items-center gap-2">
           <a

--- a/client/www/pages/platform/oauth/start.tsx
+++ b/client/www/pages/platform/oauth/start.tsx
@@ -3,7 +3,7 @@ import Auth from '@/components/dash/Auth';
 import { AppLogo } from '@/components/dash/OAuthApps';
 import { Button, Content, FullscreenLoading, LogoIcon } from '@/components/ui';
 import { useAuthToken } from '@/lib/auth';
-import config, { discordInviteUrl } from '@/lib/config';
+import config, { discordInviteUrl, isSelfHosted } from '@/lib/config';
 import { messageFromInstantError } from '@/lib/errors';
 import { jsonFetch } from '@/lib/fetch';
 import { InstantIssue } from '@/lib/types';
@@ -42,17 +42,24 @@ function InvalidRedirect({
           {instantError ? (
             <p className="border-l-4 pl-2">{instantError}</p>
           ) : null}
-          <p>
-            Please go back and try again, or ping us on{' '}
-            <a
-              className="font-bold text-blue-500"
-              href={discordInviteUrl}
-              target="_blank"
-            >
-              discord
-            </a>{' '}
-            with details.
-          </p>
+          {isSelfHosted ? (
+            <p>
+              Please go back and try again, or contact your deployment
+              administrator with details.
+            </p>
+          ) : (
+            <p>
+              Please go back and try again, or ping us on{' '}
+              <a
+                className="font-bold text-blue-500"
+                href={discordInviteUrl}
+                target="_blank"
+              >
+                discord
+              </a>{' '}
+              with details.
+            </p>
+          )}
         </Content>
       </div>
     </div>

--- a/server/src/instant/db/app_backup_jobs.clj
+++ b/server/src/instant/db/app_backup_jobs.clj
@@ -171,8 +171,10 @@
         :app-backup-job
         {:app-id app-id}
         [{:message (str "This app is too large to back up from the dashboard. "
-                        "Reach out in Discord and we'll run the backup for you: "
-                        discord-invite-url)}])))))
+                        (if (config/superuser-email)
+                          "Contact your deployment administrator to run the backup manually."
+                          (str "Reach out in Discord and we'll run the backup for you: "
+                               discord-invite-url)))}])))))
 
 (defn create-job!
   ([params] (create-job! (aurora/conn-pool :write) params))

--- a/server/src/instant/reactive/session.clj
+++ b/server/src/instant/reactive/session.clj
@@ -1106,8 +1106,7 @@
                            :status 500
                            :original-event (merge original-event
                                                   debug-info)
-                           :message (str "Yikes, something broke on our end! Sorry about that."
-                                         " Please ping us (Joe and Stopa) on Discord and let us know!")
+                           :message "Yikes, something broke on our end! Sorry about that."
                            :session-id sess-id}))))
 
 (defn handle-receive-attrs [store session event metadata]

--- a/server/src/instant/util/exception.clj
+++ b/server/src/instant/util/exception.clj
@@ -4,6 +4,7 @@
    [clojure.string :as string]
    [clojure.walk :as w]
    [inflections.core :as inflections]
+   [instant.config :as config]
    [instant.jdbc.pgerrors :as pgerrors]
    [instant.util.json :as json :refer [<-json]]
    [instant.util.string :refer [indexes-of safe-name]]
@@ -425,7 +426,9 @@
 
 (defn throw-rate-limited! []
   (throw+ {::type ::rate-limited
-           ::message "You're making too many requests. Please email support@instantdb.com or ask for help in the Discord."}))
+           ::message (if (config/superuser-email)
+                       "You're making too many requests. Please contact your deployment administrator."
+                       "You're making too many requests. Please email support@instantdb.com or ask for help in the Discord.")}))
 
 (defn throw-record-email-rate-limited! []
   (throw+ {::type ::rate-limited

--- a/server/src/instant/util/http.clj
+++ b/server/src/instant/util/http.clj
@@ -186,6 +186,6 @@
             :else (do (tracer/add-exception! e {:escaping? false})
                       (response/internal-server-error
                        (cond-> {:type :unknown
-                                :message "Something went wrong. Please ping `debug-uri` in #bug-and-questions, and we'll take a look. Sorry about this!"
+                                :message "Something went wrong. Sorry about this!"
                                 :hint {:debug-uri (tracer/span-uri)}}
                          trace-id (assoc :trace-id trace-id))))))))))


### PR DESCRIPTION
There are a lot of error messages that say things like "ping Joe and Stopa" or "ping us on discord".

This PR updates the messages in self-hosted to say something like "contact your deployment administrator".

Also enables the `debug-uri` route in self-hosted. If you're an admin, it will show the traceId and include a message that they should search for the traceId in the logs.