### PR TITLE
Tighten Content-Security-Policy on HTTP responses

### DIFF
--- a/server/src/instant/core.clj
+++ b/server/src/instant/core.clj
@@ -154,11 +154,16 @@
                          "X-Frame-Options" "DENY"
                          ;; Don't leak path info in referrer
                          "Referrer-Policy" "strict-origin"
-                         ;; Only load scripts and assets from ourselves
-                         "Content-Security-Policy" (str "script-src 'self'"
+                         ;; Tight CSP: default deny. Instant clients talking *to*
+                         ;; this API are not governed by this response CSP.
+                         "Content-Security-Policy" (str "default-src 'none'; "
+                                                        "script-src 'self'"
                                                         (when script-shas
                                                           (str " "
-                                                               (clojure.string/join " " script-shas))))
+                                                               (clojure.string/join " " script-shas)))
+                                                        "; object-src 'none'; "
+                                                        "base-uri 'self'; "
+                                                        "frame-ancestors 'none'")
                          ;; Disallow features we don't use
                          "Permissions-Policy" "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
                          ;; Only use the content-type we provide, don't let the

--- a/server/test/instant/core_test.clj
+++ b/server/test/instant/core_test.clj
@@ -1,0 +1,22 @@
+(ns instant.core-test
+  (:require
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing]]
+   [instant.core :as core]))
+
+(defn- csp [resp]
+  (get-in (core/add-security-headers resp) [:headers "Content-Security-Policy"]))
+
+(deftest add-security-headers-csp
+  (testing "denies by default and keeps script-src self"
+    (let [policy (csp {:headers {}})]
+      (is (string/includes? policy "default-src 'none'"))
+      (is (string/includes? policy "script-src 'self'"))
+      (is (string/includes? policy "object-src 'none'"))
+      (is (string/includes? policy "base-uri 'self'"))
+      (is (string/includes? policy "frame-ancestors 'none'"))))
+
+  (testing "hashes inline scripts in script-src"
+    (let [policy (csp {:headers {} :inline-scripts ["alert(1)"]})]
+      (is (re-find #"script-src 'self' 'sha256-[A-Za-z0-9+/=]+'" policy))
+      (is (string/includes? policy "default-src 'none'")))))


### PR DESCRIPTION
## Why

Oneleet flagged a weak CSP on a self-hosted Instant API (`https://api.instantdb.heroui.pro`):

```
Content-Security-Policy: script-src 'self'
```

`script-src 'self'` alone leaves every other directive at the browser default (allow). Missing `default-src`, `object-src`, `base-uri`, and `frame-ancestors`. Severity is Informational; still worth a tight policy on an origin that serves HTML.

## Change

`add-security-headers` in `server/src/instant/core.clj` now sends:

```
default-src 'none'; script-src 'self' [inline sha256 hashes]; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
```

Existing `script-src 'self'` and hashed `:inline-scripts` are kept. Other security headers are unchanged (`X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `X-Content-Type-Options`).

Instant clients talking *to* this API are not governed by this response CSP, so this does not add a wide `connect-src`. This origin’s `/` is a tiny welcome string.

Self-hosts pulling `ghcr.io/instantdb/server` pick this up on the next image.

## Tests

`server/test/instant/core_test.clj` covers the default-deny directives and hashed inline scripts.