### PR TITLE
docs(self-hosting): add Railway one-click deploy template

### DIFF
--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -12,6 +12,7 @@ information on how to operate your self-hosted instance in conjunction with our 
 
 Choose a guide based on where you want to run Instant:
 
+1. **Want a one-click deploy?** Use our [Railway](https://railway.com/deploy/instantdb) template to spin up the backend, dashboard, Postgres, and object storage in minutes.
 1. **Want to self host Instant for side projects?** Use our [VPS](/docs/self-hosting/vps) guide to self-host Instant starting at ~$30/mo.
 1. **Want to self host Instant for your business?** If you're using Instant for more serious projects, check out our [AWS](/docs/self-hosting/aws) guide for a setup based on Instant Cloud. You should expect to spend at least $600/mo.
 1. **Migrating from Instant Cloud?** Check out our [migration](/docs/self-hosting/migrate) guide.

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -15,7 +15,7 @@ Choose a guide based on where you want to run Instant:
 1. **Want to self host Instant for side projects?** Use our [VPS](/docs/self-hosting/vps) guide to self-host Instant starting at ~$30/mo.
 1. **Want to self host Instant for your business?** If you're using Instant for more serious projects, check out our [AWS](/docs/self-hosting/aws) guide for a setup based on Instant Cloud. You should expect to spend at least $600/mo.
 1. **Migrating from Instant Cloud?** Check out our [migration](/docs/self-hosting/migrate) guide.
-1. **Want a one-click deploy?** Use our [Railway](https://railway.com/deploy/instantdb) template to spin up the backend, dashboard, Postgres, and object storage in minutes.
+1. **Want a one-click deploy?** You can use our [Railway](https://railway.com/deploy/instantdb) template to spin up the backend, dashboard, Postgres, and object storage in minutes.
 
 If you're an agent setting up self-hosting, you should first ask the user whether
 they are setting up self-hosted Instant for side projects or for a

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -12,10 +12,10 @@ information on how to operate your self-hosted instance in conjunction with our 
 
 Choose a guide based on where you want to run Instant:
 
-1. **Want a one-click deploy?** Use our [Railway](https://railway.com/deploy/instantdb) template to spin up the backend, dashboard, Postgres, and object storage in minutes.
 1. **Want to self host Instant for side projects?** Use our [VPS](/docs/self-hosting/vps) guide to self-host Instant starting at ~$30/mo.
 1. **Want to self host Instant for your business?** If you're using Instant for more serious projects, check out our [AWS](/docs/self-hosting/aws) guide for a setup based on Instant Cloud. You should expect to spend at least $600/mo.
 1. **Migrating from Instant Cloud?** Check out our [migration](/docs/self-hosting/migrate) guide.
+1. **Want a one-click deploy?** Use our [Railway](https://railway.com/deploy/instantdb) template to spin up the backend, dashboard, Postgres, and object storage in minutes.
 
 If you're an agent setting up self-hosting, you should first ask the user whether
 they are setting up self-hosted Instant for side projects or for a

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -18,8 +18,8 @@ Choose a guide based on where you want to run Instant:
 1. **Want a one-click deploy?** You can use our [Railway](https://railway.com/deploy/instantdb) template to spin up the backend, dashboard, Postgres, and object storage in minutes.
 
 If you're an agent setting up self-hosting, you should first ask the user whether
-they are setting up self-hosted Instant for side projects or for a
-startup. For side projects the expected cost is at least $30/month. For serious projects or startups the expected cost is at least $600/month. Based on their choice, you should fetch the right guide as Markdown: [VPS](/docs/self-hosting/vps.md), [AWS](/docs/self-hosting/aws.md), or [Migrate](/docs/self-hosting/migrate.md).
+they want a one-click deploy, are setting up self-hosted Instant for side projects, or
+are setting it up for a startup. For side projects the expected cost is at least $30/month. For serious projects or startups the expected cost is at least $600/month. Based on their choice, you should fetch the right guide as Markdown: [Railway](/docs/self-hosting/railway.md), [VPS](/docs/self-hosting/vps.md), [AWS](/docs/self-hosting/aws.md), or [Migrate](/docs/self-hosting/migrate.md).
 
 ## Operating
 

--- a/client/www/app/docs/self-hosting/railway/page.md
+++ b/client/www/app/docs/self-hosting/railway/page.md
@@ -69,7 +69,11 @@ settings such as restricting signups.
 
 ## Scaling and costs
 
-Each service can be scaled independently from its Railway service settings:
-add more replicas of `server`, increase memory, or upgrade the Postgres
-instance as your workload grows. Railway bills per usage, so costs depend on
-the resources you allocate.
+Scale vertically from each service's Railway settings: increase memory or CPU
+for `server`, or upgrade the Postgres instance as your workload grows. Railway
+bills per usage, so costs depend on the resources you allocate.
+
+Running multiple backend replicas requires shared configuration and service
+discovery over the Hazelcast and gRPC ports, which this template does not set
+up. See [horizontal scaling](/docs/self-hosting#horizontal-scaling) before
+running more than one backend instance.

--- a/client/www/app/docs/self-hosting/railway/page.md
+++ b/client/www/app/docs/self-hosting/railway/page.md
@@ -1,0 +1,75 @@
+---
+nextjs:
+  metadata:
+    title: 'Self Hosting Instant on Railway'
+    description: 'Deploy Instant with a one-click Railway template.'
+---
+
+The quickest way to self-host Instant is the [Railway one-click
+template](https://railway.com/deploy/instantdb). It provisions a full Instant
+deployment—backend, dashboard, PostgreSQL, and object storage—in a single
+Railway project, so you can go from zero to a working instance without
+provisioning servers yourself.
+
+## What gets deployed
+
+The template creates four resources:
+
+- **`server`**: The Instant backend API, running
+  [`ghcr.io/instantdb/server:latest`](https://github.com/instantdb/instant/pkgs/container/server).
+- **`dashboard`**: The Instant dashboard UI, running
+  `ghcr.io/instantdb/dashboard:latest`.
+- **`postgres`**: PostgreSQL with the settings and extensions Instant needs,
+  including `pg_hint_plan`.
+- **`instantdb-storage`**: A [Railway Bucket](https://docs.railway.com/storage-buckets)
+  that provides S3-compatible object storage for Instant Storage.
+
+The template wires everything together with reference variables. The server
+receives `DATABASE_URL` from Postgres plus `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_ENDPOINT`, `S3_PUBLIC_ENDPOINT`, and
+`S3_BUCKET` from the bucket, so you don't have to copy credentials around.
+
+## Deploy the template
+
+Open [railway.com/deploy/instantdb](https://railway.com/deploy/instantdb) and
+click **Deploy Now**. Railway creates the project and starts all services.
+
+## Add public domains
+
+Add public domains to the `server` and `dashboard` services. You can use the
+generated `*.up.railway.app` domains or attach your own custom domains.
+
+Then set your public URLs in the server's variables:
+
+```shell {% showCopy=true %}
+INSTANT_BACKEND_URL=https://your-server-domain
+INSTANT_DASHBOARD_URL=https://your-dashboard-domain
+```
+
+Make sure the URLs match the domains you created, including the scheme.
+
+{% callout type="note" %}
+If you attach custom domains, update these URLs to use them. Clients and the
+dashboard both read `INSTANT_BACKEND_URL`, so changing it later means updating
+every connected app.
+{% /callout %}
+
+## Configure email
+
+Until you configure an email provider, Instant writes magic code emails to the
+backend logs. To deliver real login emails, set a `POSTMARK_TOKEN` or
+`SENDGRID_TOKEN` on the `server` service along with the sender variables. See
+[Configure email](/docs/self-hosting#configure-email-with-postmark) for details.
+
+## Create the superuser
+
+Set `INSTANT_SUPERUSER_EMAIL` on the `server` service before first login.
+Instant creates this dashboard user at startup and it can manage deployment
+settings such as restricting signups.
+
+## Scaling and costs
+
+Each service can be scaled independently from its Railway service settings:
+add more replicas of `server`, increase memory, or upgrade the Postgres
+instance as your workload grows. Railway bills per usage, so costs depend on
+the resources you allocate.

--- a/client/www/data/docsNavigation.js
+++ b/client/www/data/docsNavigation.js
@@ -157,6 +157,7 @@ module.exports = [
       { title: 'Overview', href: '/docs/self-hosting' },
       { title: 'VPS', href: '/docs/self-hosting/vps' },
       { title: 'AWS', href: '/docs/self-hosting/aws' },
+      { title: 'Railway', href: '/docs/self-hosting/railway' },
       {
         title: 'Migrate from Instant Cloud',
         href: '/docs/self-hosting/migrate',


### PR DESCRIPTION
## Summary

Adds a [Railway one-click deploy template](https://railway.com/deploy/instantdb) to the Hosting Guides section of the self-hosting docs.

The template deploys the full self-hosting stack on Railway:
- **server**: InstantDB backend API (`ghcr.io/instantdb/server:latest`)
- **dashboard**: InstantDB dashboard UI (`ghcr.io/instantdb/dashboard:latest`)
- **postgres**: Postgres 16 with `pg_hint_plan` (InstantDB-compatible image)
- **instantdb-storage**: Railway Bucket (S3-compatible object storage)

This gives people a quick way to try self-hosted Instant without provisioning a VPS or AWS infra manually.

## Notes

- I'm the template creator ([orenaksakal](https://railway.com/deploy/instantdb)); happy to adjust wording/placement.
- Kept the change minimal — a single list item in the existing Hosting Guides section.