### PR TITLE
Fix file uploads with non-ASCII filenames

### DIFF
--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -845,13 +845,6 @@ const isNodeReadable = (v: any): v is Readable =>
 const isWebReadable = (v: any): v is ReadableStream =>
   v && typeof v.getReader === 'function';
 
-/**
- * Whether `value` can be safely sent as a raw HTTP header value. Header
- * values must be ISO-8859-1; filenames often aren't (e.g. macOS decomposes
- * accented characters into combining marks that fall outside that range),
- * so callers should prefer sending such values as an encoded query param
- * instead.
- */
 function isHeaderSafe(value: string): boolean {
   return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
 }
@@ -884,8 +877,6 @@ class Storage {
     const headers = {
       ...authorizedHeaders(this.config, this.impersonationOpts),
     };
-    // Kept for backwards compatibility with servers that only read `path`
-    // from a header; the query param below is the source of truth.
     if (isHeaderSafe(path)) {
       headers['path'] = path;
     }

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -845,6 +845,15 @@ const isNodeReadable = (v: any): v is Readable =>
 const isWebReadable = (v: any): v is ReadableStream =>
   v && typeof v.getReader === 'function';
 
+// HTTP header values must be ISO-8859-1. Filenames often aren't (e.g.
+// macOS decomposes accented characters into combining marks that fall
+// outside that range), so we prefer sending `path` as an encoded query
+// param and only mirror it into a header when it's safe to do so, for
+// compatibility with older self-hosted servers that only look at headers.
+function isHeaderSafe(value: string): boolean {
+  return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
+}
+
 /**
  * Functions to manage file storage.
  */
@@ -872,10 +881,16 @@ class Storage {
   ): Promise<UploadFileResponse> => {
     const headers = {
       ...authorizedHeaders(this.config, this.impersonationOpts),
-      path,
     };
+    // Kept for backwards compatibility with servers that only read `path`
+    // from a header; the query param below is the source of truth.
+    if (isHeaderSafe(path)) {
+      headers['path'] = path;
+    }
     if (metadata.contentDisposition) {
-      headers['content-disposition'] = metadata.contentDisposition;
+      if (isHeaderSafe(metadata.contentDisposition)) {
+        headers['content-disposition'] = metadata.contentDisposition;
+      }
     }
 
     // headers.content-type will become "undefined" (string)
@@ -906,10 +921,12 @@ class Storage {
       ...(duplex && { duplex }),
     };
 
-    return jsonFetch(
-      `${this.config.apiURI}/admin/storage/upload?app_id=${this.config.appId}`,
-      options,
-    );
+    let url = `${this.config.apiURI}/admin/storage/upload?app_id=${encodeURIComponent(this.config.appId)}&path=${encodeURIComponent(path)}`;
+    if (metadata.contentDisposition) {
+      url += `&content-disposition=${encodeURIComponent(metadata.contentDisposition)}`;
+    }
+
+    return jsonFetch(url, options);
   };
 
   /**

--- a/client/packages/admin/src/index.ts
+++ b/client/packages/admin/src/index.ts
@@ -845,11 +845,13 @@ const isNodeReadable = (v: any): v is Readable =>
 const isWebReadable = (v: any): v is ReadableStream =>
   v && typeof v.getReader === 'function';
 
-// HTTP header values must be ISO-8859-1. Filenames often aren't (e.g.
-// macOS decomposes accented characters into combining marks that fall
-// outside that range), so we prefer sending `path` as an encoded query
-// param and only mirror it into a header when it's safe to do so, for
-// compatibility with older self-hosted servers that only look at headers.
+/**
+ * Whether `value` can be safely sent as a raw HTTP header value. Header
+ * values must be ISO-8859-1; filenames often aren't (e.g. macOS decomposes
+ * accented characters into combining marks that fall outside that range),
+ * so callers should prefer sending such values as an encoded query param
+ * instead.
+ */
 function isHeaderSafe(value: string): boolean {
   return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
 }

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -1490,6 +1490,15 @@ export async function jsonFetch(
     : Promise.reject({ status: res.status, body: json });
 }
 
+// HTTP header values must be ISO-8859-1. Filenames often aren't (e.g.
+// macOS decomposes accented characters into combining marks that fall
+// outside that range), so we prefer sending `path` as an encoded query
+// param and only mirror it into a header when it's safe to do so, for
+// compatibility with older self-hosted servers that only look at headers.
+function isHeaderSafe(value: string): boolean {
+  return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
+}
+
 async function upload(
   token: string,
   appId: string,
@@ -1497,15 +1506,22 @@ async function upload(
   customFilename: string,
   apiUri: string,
 ): Promise<boolean> {
-  const headers = {
+  const path = customFilename || file.name;
+  const headers: Record<string, string> = {
     'app-id': appId,
     app_id: appId,
-    path: customFilename || file.name,
     authorization: `Bearer ${token}`,
     'content-type': file.type,
   };
+  // Kept for backwards compatibility with servers that only read `path`
+  // from a header; the query param below is the source of truth.
+  if (isHeaderSafe(path)) {
+    headers['path'] = path;
+  }
 
-  const data = await jsonFetch(`${apiUri}/dash/apps/${appId}/storage/upload`, {
+  const url = `${apiUri}/dash/apps/${appId}/storage/upload?path=${encodeURIComponent(path)}`;
+
+  const data = await jsonFetch(url, {
     method: 'PUT',
     headers,
     body: file,

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -1490,15 +1490,23 @@ export async function jsonFetch(
     : Promise.reject({ status: res.status, body: json });
 }
 
-// HTTP header values must be ISO-8859-1. Filenames often aren't (e.g.
-// macOS decomposes accented characters into combining marks that fall
-// outside that range), so we prefer sending `path` as an encoded query
-// param and only mirror it into a header when it's safe to do so, for
-// compatibility with older self-hosted servers that only look at headers.
+/**
+ * Whether `value` can be safely sent as a raw HTTP header value. Header
+ * values must be ISO-8859-1; filenames often aren't (e.g. macOS decomposes
+ * accented characters into combining marks that fall outside that range),
+ * so callers should prefer sending such values as an encoded query param
+ * instead.
+ */
 function isHeaderSafe(value: string): boolean {
   return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
 }
 
+/**
+ * Uploads `file` to the dashboard's storage explorer for `appId`, at either
+ * `customFilename` or the file's own name. The filename is sent as an
+ * encoded query param (and mirrored into a header only when
+ * ISO-8859-1-safe) so that non-ASCII filenames don't break the request.
+ */
 async function upload(
   token: string,
   appId: string,

--- a/client/packages/components/src/components/explorer/inner-explorer.tsx
+++ b/client/packages/components/src/components/explorer/inner-explorer.tsx
@@ -1490,23 +1490,10 @@ export async function jsonFetch(
     : Promise.reject({ status: res.status, body: json });
 }
 
-/**
- * Whether `value` can be safely sent as a raw HTTP header value. Header
- * values must be ISO-8859-1; filenames often aren't (e.g. macOS decomposes
- * accented characters into combining marks that fall outside that range),
- * so callers should prefer sending such values as an encoded query param
- * instead.
- */
 function isHeaderSafe(value: string): boolean {
   return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
 }
 
-/**
- * Uploads `file` to the dashboard's storage explorer for `appId`, at either
- * `customFilename` or the file's own name. The filename is sent as an
- * encoded query param (and mirrored into a header only when
- * ISO-8859-1-safe) so that non-ASCII filenames don't break the request.
- */
 async function upload(
   token: string,
   appId: string,
@@ -1521,8 +1508,6 @@ async function upload(
     authorization: `Bearer ${token}`,
     'content-type': file.type,
   };
-  // Kept for backwards compatibility with servers that only read `path`
-  // from a header; the query param below is the source of truth.
   if (isHeaderSafe(path)) {
     headers['path'] = path;
   }

--- a/client/packages/core/src/StorageAPI.ts
+++ b/client/packages/core/src/StorageAPI.ts
@@ -1,12 +1,5 @@
 import { jsonFetch } from './utils/fetch.js';
 
-/**
- * Whether `value` can be safely sent as a raw HTTP header value. Header
- * values must be ISO-8859-1; filenames often aren't (e.g. macOS decomposes
- * accented characters into combining marks that fall outside that range),
- * so callers should prefer sending such values as an encoded query param
- * instead.
- */
 function isHeaderSafe(value: string): boolean {
   return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
 }
@@ -23,12 +16,6 @@ export type DeleteFileResponse = {
   };
 };
 
-/**
- * Uploads `file` to Instant Storage at `path`. `path` and
- * `contentDisposition` are sent as encoded query params (and mirrored into
- * headers only when ISO-8859-1-safe) so that non-ASCII filenames don't
- * break the request.
- */
 export async function uploadFile({
   apiURI,
   appId,
@@ -52,8 +39,6 @@ export async function uploadFile({
     authorization: `Bearer ${refreshToken}`,
     'content-type': contentType || file.type,
   };
-  // Kept for backwards compatibility with servers that only read `path`
-  // from a header; the query param below is the source of truth.
   if (isHeaderSafe(path)) {
     headers['path'] = path;
   }

--- a/client/packages/core/src/StorageAPI.ts
+++ b/client/packages/core/src/StorageAPI.ts
@@ -1,5 +1,14 @@
 import { jsonFetch } from './utils/fetch.js';
 
+// HTTP header values must be ISO-8859-1. Filenames often aren't (e.g.
+// macOS decomposes accented characters into combining marks that fall
+// outside that range), so we prefer sending `path` as an encoded query
+// param and only mirror it into a header when it's safe to do so, for
+// compatibility with older self-hosted servers that only look at headers.
+function isHeaderSafe(value: string): boolean {
+  return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
+}
+
 export type UploadFileResponse = {
   data: {
     id: string;
@@ -32,15 +41,24 @@ export async function uploadFile({
   const headers = {
     'app-id': appId,
     app_id: appId,
-    path,
     authorization: `Bearer ${refreshToken}`,
     'content-type': contentType || file.type,
   };
-  if (contentDisposition) {
+  // Kept for backwards compatibility with servers that only read `path`
+  // from a header; the query param below is the source of truth.
+  if (isHeaderSafe(path)) {
+    headers['path'] = path;
+  }
+  if (contentDisposition && isHeaderSafe(contentDisposition)) {
     headers['content-disposition'] = contentDisposition;
   }
 
-  const data = await jsonFetch(`${apiURI}/storage/upload`, {
+  let url = `${apiURI}/storage/upload?app_id=${encodeURIComponent(appId)}&path=${encodeURIComponent(path)}`;
+  if (contentDisposition) {
+    url += `&content-disposition=${encodeURIComponent(contentDisposition)}`;
+  }
+
+  const data = await jsonFetch(url, {
     method: 'PUT',
     headers,
     body: file,

--- a/client/packages/core/src/StorageAPI.ts
+++ b/client/packages/core/src/StorageAPI.ts
@@ -1,10 +1,12 @@
 import { jsonFetch } from './utils/fetch.js';
 
-// HTTP header values must be ISO-8859-1. Filenames often aren't (e.g.
-// macOS decomposes accented characters into combining marks that fall
-// outside that range), so we prefer sending `path` as an encoded query
-// param and only mirror it into a header when it's safe to do so, for
-// compatibility with older self-hosted servers that only look at headers.
+/**
+ * Whether `value` can be safely sent as a raw HTTP header value. Header
+ * values must be ISO-8859-1; filenames often aren't (e.g. macOS decomposes
+ * accented characters into combining marks that fall outside that range),
+ * so callers should prefer sending such values as an encoded query param
+ * instead.
+ */
 function isHeaderSafe(value: string): boolean {
   return /^[\x20-\x7e\xa0-\xff]*$/.test(value);
 }
@@ -21,6 +23,12 @@ export type DeleteFileResponse = {
   };
 };
 
+/**
+ * Uploads `file` to Instant Storage at `path`. `path` and
+ * `contentDisposition` are sent as encoded query params (and mirrored into
+ * headers only when ISO-8859-1-safe) so that non-ASCII filenames don't
+ * break the request.
+ */
 export async function uploadFile({
   apiURI,
   appId,

--- a/client/www/app/docs/http-api/page.md
+++ b/client/www/app/docs/http-api/page.md
@@ -323,10 +323,8 @@ You can also manage your app's [storage](/docs/storage) with the HTTP API.
 Upload a file with `PUT /admin/storage/upload`:
 
 ```shell
-curl -X PUT "https://api.instantdb.com/admin/storage/upload" \
+curl -X PUT "https://api.instantdb.com/admin/storage/upload?app_id=$APP_ID&path=snippets/demo.txt" \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "App-Id: $APP_ID" \
-  -H "Path: snippets/demo.txt" \
   -H "Content-Type: text/plain" \
   --data-binary "@demo.txt"
 ```

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -627,11 +627,17 @@
 
 (defn upload-put [req]
   (let [{:keys [app-id] :as perms} (get-perms! req :storage/write)
-        params (:headers req)
-        path (ex/get-param! params ["path"] string-util/coerce-non-blank-str)
+        ;; `path` (and `content-disposition`) may arrive either as a query
+        ;; param (preferred, URL-decoded by Ring) or as a raw header (kept
+        ;; for backwards compatibility with older clients). Query params
+        ;; take priority since they can carry values headers can't (e.g.
+        ;; non-ISO-8859-1 filenames).
+        params (merge (w/keywordize-keys (:headers req))
+                      (:params req))
+        path (ex/get-param! params [:path] string-util/coerce-non-blank-str)
         file (ex/get-param! req [:body] identity)
-        content-type (storage-coordinator/coerce-content-type (get params "content-type"))
-        content-disposition (ex/get-optional-param! params ["content-disposition"] string-util/coerce-non-blank-str)
+        content-type (storage-coordinator/coerce-content-type (:content-type params))
+        content-disposition (ex/get-optional-param! params [:content-disposition] string-util/coerce-non-blank-str)
         data (storage-coordinator/upload-file! {:app-id app-id
                                                 :path path
                                                 :content-type content-type

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -625,13 +625,14 @@
 ;; ---
 ;; Storage
 
-(defn upload-put [req]
+(defn upload-put
+  "Uploads a file from the request body. `path` (and `content-disposition`)
+   may arrive either as a query param (preferred, URL-decoded by Ring) or
+   as a raw header (kept for backwards compatibility with older clients).
+   Query params take priority since they can carry values headers can't
+   (e.g. non-ISO-8859-1 filenames)."
+  [req]
   (let [{:keys [app-id] :as perms} (get-perms! req :storage/write)
-        ;; `path` (and `content-disposition`) may arrive either as a query
-        ;; param (preferred, URL-decoded by Ring) or as a raw header (kept
-        ;; for backwards compatibility with older clients). Query params
-        ;; take priority since they can carry values headers can't (e.g.
-        ;; non-ISO-8859-1 filenames).
         params (merge (w/keywordize-keys (:headers req))
                       (:params req))
         path (ex/get-param! params [:path] string-util/coerce-non-blank-str)

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -625,13 +625,7 @@
 ;; ---
 ;; Storage
 
-(defn upload-put
-  "Uploads a file from the request body. `path` (and `content-disposition`)
-   may arrive either as a query param (preferred, URL-decoded by Ring) or
-   as a raw header (kept for backwards compatibility with older clients).
-   Query params take priority since they can carry values headers can't
-   (e.g. non-ISO-8859-1 filenames)."
-  [req]
+(defn upload-put [req]
   (let [{:keys [app-id] :as perms} (get-perms! req :storage/write)
         params (merge (w/keywordize-keys (:headers req))
                       (:params req))

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1764,8 +1764,14 @@
   (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :collaborator
                                                                          :apps/read
                                                                          req)
-        params (:headers req)
-        path (ex/get-param! params ["path"] string-util/coerce-non-blank-str)
+        ;; `path` may arrive either as a query param (preferred,
+        ;; URL-decoded by Ring) or as a raw header (kept for backwards
+        ;; compatibility with older clients). Query params take priority
+        ;; since they can carry values headers can't (e.g. non-ISO-8859-1
+        ;; filenames).
+        params (merge (w/keywordize-keys (:headers req))
+                      (:params req))
+        path (ex/get-param! params [:path] string-util/coerce-non-blank-str)
         file (ex/get-param! req [:body] identity)
         content-type (storage-coordinator/coerce-content-type (:content-type req))
         data (storage-coordinator/upload-file!

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1760,13 +1760,7 @@
 ;; ---
 ;; Storage
 
-(defn upload-put
-  "Uploads a file from the request body. `path` may arrive either as a
-   query param (preferred, URL-decoded by Ring) or as a raw header (kept
-   for backwards compatibility with older clients). Query params take
-   priority since they can carry values headers can't (e.g.
-   non-ISO-8859-1 filenames)."
-  [req]
+(defn upload-put [req]
   (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :collaborator
                                                                          :apps/read
                                                                          req)

--- a/server/src/instant/dash/routes.clj
+++ b/server/src/instant/dash/routes.clj
@@ -1760,15 +1760,16 @@
 ;; ---
 ;; Storage
 
-(defn upload-put [req]
+(defn upload-put
+  "Uploads a file from the request body. `path` may arrive either as a
+   query param (preferred, URL-decoded by Ring) or as a raw header (kept
+   for backwards compatibility with older clients). Query params take
+   priority since they can carry values headers can't (e.g.
+   non-ISO-8859-1 filenames)."
+  [req]
   (let [{{app-id :id} :app} (req->app-accepting-superadmin-or-ref-token! :collaborator
                                                                          :apps/read
                                                                          req)
-        ;; `path` may arrive either as a query param (preferred,
-        ;; URL-decoded by Ring) or as a raw header (kept for backwards
-        ;; compatibility with older clients). Query params take priority
-        ;; since they can carry values headers can't (e.g. non-ISO-8859-1
-        ;; filenames).
         params (merge (w/keywordize-keys (:headers req))
                       (:params req))
         path (ex/get-param! params [:path] string-util/coerce-non-blank-str)

--- a/server/src/instant/storage/routes.clj
+++ b/server/src/instant/storage/routes.clj
@@ -26,13 +26,7 @@
      :content-length content-length
      :content-disposition (ex/get-optional-param! params [:content-disposition] string-util/coerce-non-blank-str)}))
 
-(defn upload-put
-  "Uploads a file from the request body. `path` (and `content-disposition`)
-   may arrive either as a query param (preferred, URL-decoded by Ring) or
-   as a raw header (kept for backwards compatibility with older clients).
-   Query params take priority since they can carry values headers can't
-   (e.g. non-ISO-8859-1 filenames)."
-  [req]
+(defn upload-put [req]
   (let [params (merge (w/keywordize-keys (:headers req))
                       (:params req))
         ctx (req->app-file! req params)

--- a/server/src/instant/storage/routes.clj
+++ b/server/src/instant/storage/routes.clj
@@ -26,13 +26,14 @@
      :content-length content-length
      :content-disposition (ex/get-optional-param! params [:content-disposition] string-util/coerce-non-blank-str)}))
 
-(defn upload-put [req]
-  (let [;; `path` (and `content-disposition`) may arrive either as a query
-        ;; param (preferred, URL-decoded by Ring) or as a raw header (kept
-        ;; for backwards compatibility with older clients). Query params
-        ;; take priority since they can carry values headers can't (e.g.
-        ;; non-ISO-8859-1 filenames).
-        params (merge (w/keywordize-keys (:headers req))
+(defn upload-put
+  "Uploads a file from the request body. `path` (and `content-disposition`)
+   may arrive either as a query param (preferred, URL-decoded by Ring) or
+   as a raw header (kept for backwards compatibility with older clients).
+   Query params take priority since they can carry values headers can't
+   (e.g. non-ISO-8859-1 filenames)."
+  [req]
+  (let [params (merge (w/keywordize-keys (:headers req))
                       (:params req))
         ctx (req->app-file! req params)
         file (ex/get-param! req [:body] identity)

--- a/server/src/instant/storage/routes.clj
+++ b/server/src/instant/storage/routes.clj
@@ -27,7 +27,13 @@
      :content-disposition (ex/get-optional-param! params [:content-disposition] string-util/coerce-non-blank-str)}))
 
 (defn upload-put [req]
-  (let [params (w/keywordize-keys (:headers req))
+  (let [;; `path` (and `content-disposition`) may arrive either as a query
+        ;; param (preferred, URL-decoded by Ring) or as a raw header (kept
+        ;; for backwards compatibility with older clients). Query params
+        ;; take priority since they can carry values headers can't (e.g.
+        ;; non-ISO-8859-1 filenames).
+        params (merge (w/keywordize-keys (:headers req))
+                      (:params req))
         ctx (req->app-file! req params)
         file (ex/get-param! req [:body] identity)
         data (storage-coordinator/upload-file! ctx file)]

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -1089,9 +1089,6 @@
               (is (some? (-> ret :body :data :id)))))
 
           (testing "admin can upload a file with a non-ASCII filename via query params"
-            ;; Filenames with accents (e.g. macOS's NFD-decomposed "café.txt")
-            ;; can't be sent as raw HTTP header values, so clients send them
-            ;; as an encoded query param instead.
             (let [ret (upload-put
                        {:body (make-file-content)
                         :params {:path "café à noite.txt"}

--- a/server/test/instant/admin/routes_test.clj
+++ b/server/test/instant/admin/routes_test.clj
@@ -1088,6 +1088,20 @@
               (is (= 200 (:status ret)))
               (is (some? (-> ret :body :data :id)))))
 
+          (testing "admin can upload a file with a non-ASCII filename via query params"
+            ;; Filenames with accents (e.g. macOS's NFD-decomposed "café.txt")
+            ;; can't be sent as raw HTTP header values, so clients send them
+            ;; as an encoded query param instead.
+            (let [ret (upload-put
+                       {:body (make-file-content)
+                        :params {:path "café à noite.txt"}
+                        :headers {"app-id" app-id
+                                  "authorization" (str "Bearer " admin-token)
+                                  "content-type" "text/plain"}
+                        :content-length 5})]
+              (is (= 200 (:status ret)))
+              (is (some? (-> ret :body :data :id)))))
+
           (testing "user with email can upload"
             (let [ret (upload-put
                        {:body (make-file-content)

--- a/server/test/instant/storage/routes_test.clj
+++ b/server/test/instant/storage/routes_test.clj
@@ -4,10 +4,6 @@
             [instant.storage.coordinator :as storage-coordinator]))
 
 (deftest upload-put-reads-path-from-query-params
-  ;; Filenames with accents (e.g. macOS's NFD-decomposed "café.txt") can't
-  ;; be sent as raw HTTP header values, so clients send them as an encoded
-  ;; query param (already URL-decoded by Ring's wrap-params) instead. The
-  ;; route should prefer that over the legacy `path` header.
   (let [captured-ctx (atom nil)
         app-id (random-uuid)]
     (with-redefs [storage-coordinator/upload-file!

--- a/server/test/instant/storage/routes_test.clj
+++ b/server/test/instant/storage/routes_test.clj
@@ -1,0 +1,48 @@
+(ns instant.storage.routes-test
+  (:require [clojure.test :as test :refer [deftest is testing]]
+            [instant.storage.routes :as storage-routes]
+            [instant.storage.coordinator :as storage-coordinator]))
+
+(deftest upload-put-reads-path-from-query-params
+  ;; Filenames with accents (e.g. macOS's NFD-decomposed "café.txt") can't
+  ;; be sent as raw HTTP header values, so clients send them as an encoded
+  ;; query param (already URL-decoded by Ring's wrap-params) instead. The
+  ;; route should prefer that over the legacy `path` header.
+  (let [captured-ctx (atom nil)
+        app-id (random-uuid)]
+    (with-redefs [storage-coordinator/upload-file!
+                  (fn [ctx _file]
+                    (reset! captured-ctx ctx)
+                    {:id "fake-file-id"})]
+      (testing "path comes from query params when present"
+        (let [ret (storage-routes/upload-put
+                   {:body "file-contents"
+                    :params {:app_id (str app-id)
+                             :path "café à noite.txt"}
+                    :headers {"app-id" (str app-id)
+                              "content-type" "text/plain"}
+                    :content-length 5})]
+          (is (= 200 (:status ret)))
+          (is (= "café à noite.txt" (:path @captured-ctx)))))
+
+      (testing "path still works from the legacy header for ASCII filenames"
+        (let [ret (storage-routes/upload-put
+                   {:body "file-contents"
+                    :params {}
+                    :headers {"app-id" (str app-id)
+                              "path" "legacy-file.txt"
+                              "content-type" "text/plain"}
+                    :content-length 5})]
+          (is (= 200 (:status ret)))
+          (is (= "legacy-file.txt" (:path @captured-ctx)))))
+
+      (testing "query param takes priority over the header when both are present"
+        (let [ret (storage-routes/upload-put
+                   {:body "file-contents"
+                    :params {:path "café.txt"}
+                    :headers {"app-id" (str app-id)
+                              "path" "stale-ascii-name.txt"
+                              "content-type" "text/plain"}
+                    :content-length 5})]
+          (is (= 200 (:status ret)))
+          (is (= "café.txt" (:path @captured-ctx))))))))


### PR DESCRIPTION
## Summary

- `uploadFile()` sent the file's `path` in a raw HTTP header, but header values must be ISO-8859-1. Filenames with accents (e.g. macOS's NFD-decomposed `café.txt`, where `à` is `a` + a combining grave accent) fall outside that range, so `fetch()` throws a `TypeError` before the request even goes out. `content-disposition` has the same problem.
- `deleteFile()` and `getDownloadUrl()` already avoid this by sending the filename as an encoded query param — `uploadFile()` was the odd one out. The same bug exists in three places: the core SDK, the admin SDK, and the dashboard's storage explorer (each with its own server handler).
- Fix: clients now send `path` (and `content-disposition`) as an encoded query param, and only mirror them into a header when the value is safe to encode as ISO-8859-1. Servers now merge headers and query params (query params win) when reading these, matching how `file-delete` / `signed-download-url-get` already read theirs. This keeps compatibility in both directions: newer clients still work against servers that only read headers, and older clients still work against the updated servers.

### Client
- `client/packages/core/src/StorageAPI.ts` — `uploadFile`
- `client/packages/admin/src/index.ts` — `Storage.uploadFile`
- `client/packages/components/src/components/explorer/inner-explorer.tsx` — dashboard storage explorer upload (this is the path that breaks when uploading a file from the dashboard UI)

### Server
- `server/src/instant/storage/routes.clj` — `upload-put`
- `server/src/instant/admin/routes.clj` — `upload-put`
- `server/src/instant/dash/routes.clj` — `upload-put`

### Docs
- `client/www/app/docs/http-api/page.md` — updated the `curl` example to use the query param form.

## Test plan

- [x] `pnpm run build-packages` (typecheck across all client packages) passes
- [x] `pnpm run check-format` passes on the changed files
- [x] `pnpm run test` — existing suite passes (206 tests, 1 pre-existing unrelated failure from a missing local Playwright browser binary)
- [x] Added `server/test/instant/storage/routes_test.clj` covering that `upload-put` reads `path` from query params, still falls back to the legacy header, and that query params win when both are present
- [x] Added a regression case to `storage-impersonation-test` in `server/test/instant/admin/routes_test.clj` uploading a file with an accented filename via query params
