### PR TITLE
Set next database cluster

### DIFF
--- a/server/resources/config/prod.edn
+++ b/server/resources/config/prod.edn
@@ -48,4 +48,4 @@
 
  :database-cluster-id "aurora-instant-cluster"
 
- :next-database-cluster-id "aurora-instant-cluster"}
+ :next-database-cluster-id "instant-8"}


### PR DESCRIPTION
Set the next database cluster in preparation for a database upgrade.

We'll run slot failover and the next PR will update the slot-num in code.

Then we can run failover and deploy a PR to promote the replica to the primary.