### PR TITLE
Fix: Remove legacy app_id header to support self-hosting with Caddy

### DIFF
--- a/client/packages/core/src/StorageAPI.ts
+++ b/client/packages/core/src/StorageAPI.ts
@@ -31,7 +31,6 @@ export async function uploadFile({
 }): Promise<UploadFileResponse> {
   const headers = {
     'app-id': appId,
-    app_id: appId,
     path,
     authorization: `Bearer ${refreshToken}`,
     'content-type': contentType || file.type,


### PR DESCRIPTION
### What this PR does
This PR removes the legacy `app_id` header from the `uploadFile` Storage API method, ensuring we only send the compliant `'app-id'` header.

### Why this is necessary
Currently, the `@instantdb/core` client sends the App ID for file uploads using both `'app-id'` and the legacy `app_id` HTTP headers. The `'app-id'` header was recently added on August 6th, but the old underscored header was left behind.

The official self-hosting `docker-compose.yml` uses **Caddy** as the reverse proxy. Caddy has a strict, hardcoded security rule that silently drops any HTTP headers containing underscores, and there is no configuration option to override this behavior. Furthermore, sending headers with underscores can cause other strict reverse proxies (like Nginx) to behave unpredictably or reject requests entirely depending on configuration.

By removing the legacy underscored header, we ensure the client strictly sends the compliant dash version (`app-id`). The InstantDB backend already seamlessly accepts `app-id`, so this cleanup entirely resolves the broken upload flow for self-hosters without requiring any server-side changes.

### Testing
- [x] Verified that removing the legacy `app_id` header and strictly using `app-id` successfully bypasses Caddy and allows file uploads to complete on a self-hosted instance.
