### PR TITLE
Add rate-limiting to admin query/transact

### DIFF
--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -138,6 +138,14 @@
                          "authorization" "foo"}}
               :data/read))
 
+(defn rate-limit! [app-id type]
+  (when-let [rate-limit-config (flags/app-admin-rate-limit-config app-id)]
+    (rate-limit/consume-user-rate-limit (eph/get-rate-limit)
+                                        {:app-id app-id
+                                         :bucket-key app-id
+                                         :bucket-name (str "__instant-admin-" type)
+                                         :config rate-limit-config})))
+
 ;; ------
 ;; Query
 
@@ -145,12 +153,7 @@
   (let [query (ex/get-param! req [:body :query] #(when (map? %) %))
         inference? (-> req :body :inference? boolean)
         {:keys [app-id] :as perms} (get-perms! req :data/read)
-        _ (when-let [rate-limit-config (flags/app-admin-rate-limit-config app-id)]
-            (rate-limit/consume-user-rate-limit (eph/get-rate-limit)
-                                                {:app-id app-id
-                                                 :bucket-key app-id
-                                                 :bucket-name "__instant-admin-query"
-                                                 :config rate-limit-config}))
+        _ (rate-limit! app-id "query")
         attrs (attr-model/get-by-app-id app-id)
         ctx (merge {:db {:conn-pool (aurora/conn-pool :read)}
                     :app-id app-id
@@ -234,6 +237,7 @@
         _ (when rules-override
             (ex/assert-valid! :rule rules-override
                               (rule-model/validation-errors rules-override)))
+        _ (rate-limit! app-id "query")
         ip-override (ex/get-optional-param! req [:body :ip-override] string-util/coerce-non-blank-str)
         origin-override (ex/get-optional-param! req [:body :origin-override] string-util/coerce-non-blank-str)
         query (ex/get-param! req [:body :query] #(when (map? %) %))
@@ -276,12 +280,6 @@
                                  req
                                  [:body :throw-on-missing-attrs?] boolean)
         {:keys [app-id] :as perms} (get-perms! req :data/write)
-        _ (when-let [rate-limit-config (flags/app-admin-rate-limit-config app-id)]
-            (rate-limit/consume-user-rate-limit (eph/get-rate-limit)
-                                                {:app-id app-id
-                                                 :bucket-key app-id
-                                                 :bucket-name "__instant-admin-transact"
-                                                 :config rate-limit-config}))
         attrs (attr-model/get-by-app-id app-id)
         ctx (merge {:db {:conn-pool (aurora/conn-pool :write)}
                     :app-id app-id
@@ -292,6 +290,7 @@
         tx-steps (admin-model/->tx-steps! {:attrs attrs
                                            :throw-on-missing-attrs? throw-on-missing-attrs?}
                                           steps)
+        _ (rate-limit! app-id "transact")
         use-tx-queue? (flags/admin-tx-queue-enabled? app-id)]
     (tracer/add-data! {:attributes {:use-tx-queue use-tx-queue?}})
     (if-not use-tx-queue?
@@ -370,9 +369,10 @@
         tx-steps (admin-model/->tx-steps! {:attrs attrs
                                            :throw-on-missing-attrs? throw-on-missing-attrs?}
                                           steps)
+        _ (rate-limit! app-id "transact")
         result (binding [*request-info* (cond-> *request-info*
-                                   ip-override (assoc :ip ip-override)
-                                   origin-override (assoc :origin origin-override))]
+                                          ip-override (assoc :ip ip-override)
+                                          origin-override (assoc :origin origin-override))]
                  (permissioned-tx/transact! ctx tx-steps))
         cleaned-result {:tx-id (:id result)
                         :all-checks-ok? (:all-checks-ok? result)
@@ -554,10 +554,10 @@
                          :extra-fields    extra-fields
                          :skip-perm-check? true}))
         user         (app-user-model/create!
-                       {:app-id       app-id
-                        :id           user-id
-                        :type         "guest"
-                        :extra-fields extra-fields})
+                      {:app-id       app-id
+                       :id           user-id
+                       :type         "guest"
+                       :extra-fields extra-fields})
         refresh-token (random-uuid)
         _             (app-user-refresh-token-model/create!
                        {:app-id  app-id

--- a/server/src/instant/admin/routes.clj
+++ b/server/src/instant/admin/routes.clj
@@ -18,6 +18,7 @@
    [instant.model.app-user-refresh-token :as app-user-refresh-token-model]
    [instant.model.rule :as rule-model]
    [instant.model.instant-user :as instant-user-model]
+   [instant.rate-limit :as rate-limit]
    [instant.reactive.receive-queue :as receive-queue]
    [instant.reactive.session :as session]
    [instant.reactive.sse :as sse]
@@ -144,6 +145,12 @@
   (let [query (ex/get-param! req [:body :query] #(when (map? %) %))
         inference? (-> req :body :inference? boolean)
         {:keys [app-id] :as perms} (get-perms! req :data/read)
+        _ (when-let [rate-limit-config (flags/app-admin-rate-limit-config app-id)]
+            (rate-limit/consume-user-rate-limit (eph/get-rate-limit)
+                                                {:app-id app-id
+                                                 :bucket-key app-id
+                                                 :bucket-name "__instant-admin-query"
+                                                 :config rate-limit-config}))
         attrs (attr-model/get-by-app-id app-id)
         ctx (merge {:db {:conn-pool (aurora/conn-pool :read)}
                     :app-id app-id
@@ -269,6 +276,12 @@
                                  req
                                  [:body :throw-on-missing-attrs?] boolean)
         {:keys [app-id] :as perms} (get-perms! req :data/write)
+        _ (when-let [rate-limit-config (flags/app-admin-rate-limit-config app-id)]
+            (rate-limit/consume-user-rate-limit (eph/get-rate-limit)
+                                                {:app-id app-id
+                                                 :bucket-key app-id
+                                                 :bucket-name "__instant-admin-transact"
+                                                 :config rate-limit-config}))
         attrs (attr-model/get-by-app-id app-id)
         ctx (merge {:db {:conn-pool (aurora/conn-pool :write)}
                     :app-id app-id

--- a/server/src/instant/flags.clj
+++ b/server/src/instant/flags.clj
@@ -694,3 +694,17 @@
    users keep team access after we cancel their Stripe subscriptions."
   []
   (sunset-stage-at-least? :signups-closed))
+
+(defn app-admin-rate-limit-config
+  "Config for rate-limiting admin transact and query.
+   The config should look like:
+  {\"limits\": [
+    {\"capacity\": 10,
+     \"refill\": {
+      \"period\": \"1 hour\",
+      \"amount\": 10,
+      \"type\": \"interval\" // or \"greedy\"}}]}
+  Make sure to key by app_id for admin-rate-limit-for-app"
+  [app-id]
+  (or (get (flag :admin-rate-limit-for-app) (str app-id))
+      (flag :global-admin-rate-limit)))


### PR DESCRIPTION
Adds the ability to rate limit admin query and transact.

The rate limit config is set through the `global-admin-rate-limit` flag and can be tuned per app with the `admin-rate-limit-for-app` flag, keyed by app_id.