### PR TITLE
Add devtool support for self-hosted

### DIFF
--- a/client/packages/core/__tests__/src/devtool.test.ts
+++ b/client/packages/core/__tests__/src/devtool.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { getDevtoolSrc } from '../../src/devtool.ts';
+
+const defaultConfig = {
+  position: 'bottom-right' as const,
+  allowedHosts: ['localhost'],
+};
+
+describe('getDevtoolSrc', () => {
+  test('uses the Instant dashboard by default', () => {
+    expect(getDevtoolSrc('app-id', defaultConfig)).toBe(
+      'https://instantdb.com/_devtool?appId=app-id',
+    );
+  });
+
+  test('uses a configured dashboard URI', () => {
+    expect(
+      getDevtoolSrc('app-id', {
+        ...defaultConfig,
+        dashURI: 'https://dash.instant.example/',
+      }),
+    ).toBe('https://dash.instant.example/_devtool?appId=app-id');
+  });
+});

--- a/client/packages/core/src/coreTypes.ts
+++ b/client/packages/core/src/coreTypes.ts
@@ -43,9 +43,16 @@ export type DevtoolConfig = {
    * @default ['localhost']
    */
   allowedHosts?: string[];
+
+  /**
+   * Dashboard URI used to render the devtool
+   * @default 'https://instantdb.com'
+   */
+  dashURI?: string;
 };
 
 export type StrictDevtoolConfig = {
   position: DevtoolPosition;
   allowedHosts: string[];
+  dashURI?: string;
 };

--- a/client/packages/core/src/devtool.ts
+++ b/client/packages/core/src/devtool.ts
@@ -14,7 +14,7 @@ export function createDevtool(appId: string, config: StrictDevtoolConfig) {
 
   const iframeContrainer = createIframeContainer(config);
   const toggler = createToggler(config, toggleView);
-  const iframe = createIframe(getSrc(appId));
+  const iframe = createIframe(getDevtoolSrc(appId, config));
 
   function onPostMessage(event: MessageEvent) {
     if (event.source !== iframe.element.contentWindow) return;
@@ -70,10 +70,12 @@ export function createDevtool(appId: string, config: StrictDevtoolConfig) {
   return create();
 }
 
-function getSrc(appId: string) {
+export function getDevtoolSrc(appId: string, config: StrictDevtoolConfig) {
   const useLocalDashboard = flags.devBackend || flags.devtoolLocalDashboard;
-  const src = `${useLocalDashboard ? 'http://localhost:3000' : 'https://instantdb.com'}/_devtool?appId=${appId}`;
-  return src;
+  const dashURI =
+    config.dashURI ??
+    (useLocalDashboard ? 'http://localhost:3000' : 'https://instantdb.com');
+  return `${dashURI.replace(/\/+$/, '')}/_devtool?appId=${appId}`;
 }
 
 function createIframe(src: string) {

--- a/client/packages/create-instant-app/src/backendConfig.test.ts
+++ b/client/packages/create-instant-app/src/backendConfig.test.ts
@@ -75,7 +75,7 @@ describe('applyBackendConfig', () => {
     );
   });
 
-  it('adds the dashboard URI to instant.config.ts when provided', () => {
+  it('adds the dashboard URI to the client and instant.config.ts', () => {
     const dir = createTempDir();
     const filePath = path.join(dir, 'src/lib/db.ts');
     fs.outputFileSync(filePath, 'export const db = init({\n});\n');
@@ -87,6 +87,15 @@ describe('applyBackendConfig', () => {
       'https://dash.instant.example',
     );
 
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(
+      'export const db = init({\n' +
+        '  apiURI: "https://api.instant.example",\n' +
+        '  websocketURI: "wss://api.instant.example/runtime/session",\n' +
+        '  devtool: {\n' +
+        '    dashURI: "https://dash.instant.example",\n' +
+        '  },\n' +
+        '});\n',
+    );
     expect(fs.readFileSync(path.join(dir, 'instant.config.ts'), 'utf8')).toBe(
       `export default {
   apiURI: "https://api.instant.example",
@@ -103,12 +112,19 @@ describe('applyBackendConfig', () => {
     fs.outputFileSync(clientPath, 'export const db = init({\n});\n');
     fs.outputFileSync(adminPath, 'export const adminDb = init({\n});\n');
 
-    applyBackendConfig('tanstack-start', dir, 'https://instant.example');
-
-    expect(fs.readFileSync(adminPath, 'utf8')).toContain(
-      'init({\n  apiURI: "https://instant.example",\n',
+    applyBackendConfig(
+      'tanstack-start',
+      dir,
+      'https://api.instant.example',
+      'https://dash.instant.example',
     );
-    expect(fs.readFileSync(adminPath, 'utf8')).not.toContain('websocketURI');
+
+    const adminContents = fs.readFileSync(adminPath, 'utf8');
+    expect(adminContents).toContain(
+      'init({\n  apiURI: "https://api.instant.example",\n',
+    );
+    expect(adminContents).not.toContain('websocketURI');
+    expect(adminContents).not.toContain('devtool');
   });
 
   it('does not update any files if a template cannot be configured', () => {

--- a/client/packages/create-instant-app/src/backendConfig.ts
+++ b/client/packages/create-instant-app/src/backendConfig.ts
@@ -47,11 +47,13 @@ const injectInitConfig = ({
   initializer,
   apiURI,
   websocketURI,
+  dashURI,
 }: {
   contents: string;
   initializer: string;
   apiURI: string;
   websocketURI?: string;
+  dashURI?: string;
 }) => {
   const initStart = `${initializer}({`;
   if (!contents.includes(initStart)) {
@@ -61,6 +63,9 @@ const injectInitConfig = ({
   const config = [
     `  apiURI: ${JSON.stringify(apiURI)},`,
     websocketURI ? `  websocketURI: ${JSON.stringify(websocketURI)},` : null,
+    dashURI
+      ? `  devtool: {\n    dashURI: ${JSON.stringify(dashURI)},\n  },`
+      : null,
   ]
     .filter(Boolean)
     .join('\n');
@@ -85,6 +90,7 @@ const injectBackendConfig = (
   contents: string,
   apiURI: string,
   websocketURI: string,
+  dashURI?: string,
 ) => {
   if (file.type === 'python') {
     return injectPythonConfig(contents, apiURI);
@@ -95,6 +101,7 @@ const injectBackendConfig = (
     initializer: file.initializer,
     apiURI,
     websocketURI: file.websocket ? websocketURI : undefined,
+    dashURI: file.injectDevtoolConfig ? dashURI : undefined,
   });
 };
 
@@ -117,6 +124,7 @@ export const applyBackendConfig = (
         contents,
         normalizedAPIURI,
         websocketURI,
+        dashURI,
       ),
     };
   });

--- a/client/packages/create-instant-app/src/projectBase.ts
+++ b/client/packages/create-instant-app/src/projectBase.ts
@@ -4,6 +4,7 @@ export type BackendConfigFile =
       path: string;
       initializer: string;
       websocket: boolean;
+      injectDevtoolConfig: boolean;
     }
   | {
       type: 'python';
@@ -16,11 +17,15 @@ type ProjectBaseConfig = {
   bundled: boolean;
 };
 
-const clientDb = (path = 'src/lib/db.ts'): BackendConfigFile => ({
+const clientDb = (
+  path = 'src/lib/db.ts',
+  options: { injectDevtoolConfig?: boolean } = {},
+): BackendConfigFile => ({
   type: 'typescript',
   path,
   initializer: 'init',
   websocket: true,
+  injectDevtoolConfig: options.injectDevtoolConfig ?? true,
 });
 
 const adminDb = (initializer = 'init'): BackendConfigFile => ({
@@ -28,6 +33,7 @@ const adminDb = (initializer = 'init'): BackendConfigFile => ({
   path: 'src/lib/adminDb.ts',
   initializer,
   websocket: false,
+  injectDevtoolConfig: false,
 });
 
 export const projectBaseConfig = {
@@ -48,7 +54,7 @@ export const projectBaseConfig = {
   },
   expo: {
     appIdEnvName: 'EXPO_PUBLIC_INSTANT_APP_ID',
-    backendConfigFiles: [clientDb('lib/db.ts')],
+    backendConfigFiles: [clientDb('lib/db.ts', { injectDevtoolConfig: false })],
     bundled: true,
   },
   'tanstack-start': {

--- a/client/packages/version/src/version.ts
+++ b/client/packages/version/src/version.ts
@@ -2,6 +2,6 @@
 // Update the version here and merge your code to main to
 // publish a new version of all of the packages to npm.
 
-const version = 'v1.0.66';
+const version = 'v1.0.67';
 
 export { version };

--- a/client/www/app/docs/devtool/page.md
+++ b/client/www/app/docs/devtool/page.md
@@ -57,6 +57,30 @@ const db = init({
 });
 ```
 
+## Self-hosted dashboards
+
+When connecting to a self-hosted Instant deployment, set `dashURI` to the
+deployment's dashboard URL:
+
+```typescript
+import { init } from '@instantdb/react';
+
+import schema from '../instant.schema.ts';
+
+const db = init({
+  appId: process.env.NEXT_PUBLIC_INSTANT_APP_ID!,
+  schema,
+  apiURI: 'https://api.myinstant.com',
+  websocketURI: 'wss://api.myinstant.com/runtime/session',
+  devtool: {
+    dashURI: 'https://dash.myinstant.com',
+  },
+});
+```
+
+The devtool will use your self-hosted dashboard for authentication and app
+management.
+
 ## Disabling the devtool
 
 If you would like to hide the devtool completely, you can add `devtool: false` in `init`:

--- a/client/www/app/docs/init/page.md
+++ b/client/www/app/docs/init/page.md
@@ -102,7 +102,7 @@ and `schema`. Here are all the options you can provide:
 
 - **apiURI?**: Custom HTTP API endpoint for auth and storage operations. Defaults to `'https://api.instantdb.com'`. Change this for connecting to development or self-hosted instances.
 
-- **devtool?**: Controls the Instant dev tool. Defaults to `true` on localhost. Set to `false` to disable, or configure with `{ position: 'bottom-right', allowedHosts: ['localhost'] }`.
+- **devtool?**: Controls the Instant dev tool. Defaults to `true` on localhost. Set to `false` to disable, or configure its `position`, `allowedHosts`, and `dashURI`. Set `dashURI` when using a self-hosted dashboard.
 
 - **verbose?**: Enables detailed console logging for debugging. When `true`, logs WebSocket messages and internal operations. Helpful for troubleshooting connection and sync issues.
 

--- a/client/www/app/docs/self-hosting/migrate/page.md
+++ b/client/www/app/docs/self-hosting/migrate/page.md
@@ -69,6 +69,9 @@ const db = init({
   appId: 'YOUR_NEW_APP_ID',
   apiURI: 'https://api.myinstant.com',
   websocketURI: 'wss://api.myinstant.com/runtime/session',
+  devtool: {
+    dashURI: 'https://dash.myinstant.com',
+  },
 });
 ```
 

--- a/client/www/app/docs/self-hosting/page.md
+++ b/client/www/app/docs/self-hosting/page.md
@@ -144,27 +144,7 @@ INSTANT_CLI_DASH_URI=https://dash.myinstant.com \
 npx instant-cli@latest login
 ```
 
-After authenticating, you can use the auth token associated with your self-hosted
-Instant in `create-instant-app` by setting `INSTANT_CLI_API_URI`:
-
-```shell
-INSTANT_CLI_API_URI=https://api.myinstant.com npx create-instant-app@latest
-```
-
-As a convenience, this will add an `instant.config.ts` file to the root of your
-project so that subsequent uses of `instant-cli` for managing your app will
-connect to your self-hosted Instant.
-
-```ts
-// instant.config.ts
-export default {
-  apiURI: 'https://api.myinstant.com',
-};
-```
-
-If you include `INSTANT_CLI_DASH_URI` when you call `create-instant-app`,
-your self-hosted dashboard URL will also be added to `instant.config.ts`. This
-can be helpful for authenticating with `instant-cli` if you're not logged in.
+After authenticating, provide both URLs when running `create-instant-app`:
 
 ```shell
 # Run this from your terminal
@@ -173,7 +153,8 @@ INSTANT_CLI_DASH_URI=https://dash.myinstant.com \
 npx create-instant-app@latest
 ```
 
-This will then add the following to your project:
+This connects the generated app to your self-hosted
+deployment and saves the configuration in `instant.config.ts`:
 
 ```ts
 // instant.config.ts

--- a/client/www/next.config.js
+++ b/client/www/next.config.js
@@ -136,11 +136,11 @@ const nextConfig = {
     if (process.env.NEXT_PUBLIC_SELF_HOSTED === 'true') {
       return [
         ...standardRedirects,
-        // redirect any page that isn't /api, /dash, /debug-uri, /docs, /intern, or /logout
+        // redirect any page that isn't /api, /dash, /debug-uri, /docs, /intern, /logout, or /_devtool
         {
           permanent: false,
           source:
-            '/((?!api(?:/.*)?$|dash(?:/.*)?$|debug-uri(?:/.*)?$|docs(?:/.*)?$|intern(?:/.*)?$|logout(?:/.*)?$|.*\\.[^/]+$).*)',
+            '/((?!api(?:/.*)?$|dash(?:/.*)?$|debug-uri(?:/.*)?$|docs(?:/.*)?$|intern(?:/.*)?$|logout(?:/.*)?$|_devtool(?:/.*)?$|.*\\.[^/]+$).*)',
           destination: '/dash',
         },
       ];


### PR DESCRIPTION
Got a report that devtool doesn't play nice with self-hosted Instant. This PR makes it so!

We introduce an optional `dashURI` to the existing `devtool` config. When this is set we'll connect the devtool to the provided dash url instead of localhost or production instant.

Updated `create-instant-app` to inject this config too when invoked with `INSTANT_CLI_DASH_URI` so you don't need to manually edit `init` each time you create an app.